### PR TITLE
go/writer: add nanosecond timestamp and variant parquet types

### DIFF
--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -83,8 +83,11 @@ func newRowSizing(sch ParquetSchema) rowSize {
 		case PrimitiveTypeBinary, LogicalTypeJson, LogicalTypeDecimal:
 			rs.fixed += 24 // slice header
 			rs.calcLen = append(rs.calcLen, idx)
-		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeInterval:
+		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos, LogicalTypeInterval:
 			rs.fixed += 16 // string header
+			rs.calcLen = append(rs.calcLen, idx)
+		case LogicalTypeVariant:
+			rs.fixed += 48 // two slice headers, for the value and metadata byte slices
 			rs.calcLen = append(rs.calcLen, idx)
 		default:
 			panic(fmt.Sprintf("newRowSizing unknown type: %d", e.DataType))
@@ -105,6 +108,12 @@ func (rs rowSize) estSize(row []any) int {
 			out += len(v)
 		case json.RawMessage:
 			out += len(v)
+		case VariantValue:
+			out += len(v.Value) + len(v.Metadata)
+		case *VariantValue:
+			if v != nil {
+				out += len(v.Value) + len(v.Metadata)
+			}
 		case nil:
 			// No additional overhead is assumed for nil values.
 		default:
@@ -432,6 +441,31 @@ func (w *ParquetWriter) flushBuffer() error {
 			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampVal); err != nil {
 				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
 			}
+		case LogicalTypeTimestampNanos:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampNanosVal); err != nil {
+				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeVariant:
+			// Variant elements occupy two physical parquet columns: the first NextColumn() call
+			// above returned the "value" writer; we must finish writing it before requesting the
+			// "metadata" writer.
+			values, metadatas, defLevels, err := collectVariantBatch(colIdx, w.buffer)
+			if err != nil {
+				return fmt.Errorf("collecting variant column '%s': %w", f.Name, err)
+			}
+			if err := writeByteArrayBatch(cw.(*file.ByteArrayColumnChunkWriter), values, defLevels); err != nil {
+				return fmt.Errorf("writing variant value column '%s': %w", f.Name, err)
+			}
+			metaCw, err := rgWriter.NextColumn()
+			if err != nil {
+				return fmt.Errorf("getting next column for variant metadata: %w", err)
+			}
+			if err := writeByteArrayBatch(metaCw.(*file.ByteArrayColumnChunkWriter), metadatas, defLevels); err != nil {
+				return fmt.Errorf("writing variant metadata column '%s': %w", f.Name, err)
+			}
+			if err := metaCw.Close(); err != nil {
+				return fmt.Errorf("closing variant metadata column writer: %w", err)
+			}
 		case LogicalTypeDecimal:
 			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
 				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
@@ -454,7 +488,7 @@ func (w *ParquetWriter) flushBuffer() error {
 	}
 
 	w.scratch.sizeBytes += int(rgWriter.TotalBytesWritten())
-	w.scratch.columnChunkCount += len(w.schema)
+	w.scratch.columnChunkCount += w.schema.physicalColumnCount()
 	w.buffer = w.buffer[:0]
 	w.bufferSizeBytes = 0
 
@@ -489,6 +523,59 @@ type columnBatchWriter[T parquetValue] interface {
 	// taken from the next value of vals. The returned valuesOffset indicates the number of physical
 	// values that were written, and it may be smaller than the number of conceptual rows written.
 	WriteBatch(vals []T, defLvls []int16, repLvls []int16) (valueOffset int64, err error)
+}
+
+// VariantValue is the per-row input for a LogicalTypeVariant column. Value and Metadata are the
+// already-encoded Parquet Variant binary fields; this package writes them verbatim into the
+// "value" and "metadata" child columns of the variant group. JSON-to-Variant encoding is the
+// caller's responsibility.
+type VariantValue struct {
+	Value    []byte
+	Metadata []byte
+}
+
+// collectVariantBatch walks the buffered rows for a variant column and returns the value+metadata
+// byte slices and their shared def-level vector. The two child columns of the variant group share
+// the same nullability: when the variant slot is nil, both children carry defLevel 0; otherwise
+// both carry defLevel 1.
+func collectVariantBatch(colIdx int, buf [][]any) ([]parquet.ByteArray, []parquet.ByteArray, []int16, error) {
+	var values []parquet.ByteArray
+	var metadatas []parquet.ByteArray
+	var defLevels []int16
+
+	for _, row := range buf {
+		v := row[colIdx]
+		switch tv := v.(type) {
+		case nil:
+			defLevels = append(defLevels, 0)
+		case VariantValue:
+			values = append(values, tv.Value)
+			metadatas = append(metadatas, tv.Metadata)
+			defLevels = append(defLevels, 1)
+		case *VariantValue:
+			if tv == nil {
+				defLevels = append(defLevels, 0)
+				continue
+			}
+			values = append(values, tv.Value)
+			metadatas = append(metadatas, tv.Metadata)
+			defLevels = append(defLevels, 1)
+		default:
+			return nil, nil, nil, fmt.Errorf("unhandled type %T for variant column", tv)
+		}
+	}
+
+	return values, metadatas, defLevels, nil
+}
+
+func writeByteArrayBatch(w columnBatchWriter[parquet.ByteArray], vals []parquet.ByteArray, defLevels []int16) error {
+	written, err := w.WriteBatch(vals, defLevels, nil)
+	if err != nil {
+		return fmt.Errorf("writing batch of values: %w", err)
+	} else if int(written) != len(vals) {
+		return fmt.Errorf("written %d values vs. %d values in vals", written, len(vals))
+	}
+	return nil
 }
 
 type getValFn[T parquetValue] func(v any) (got T, err error)
@@ -800,6 +887,22 @@ func getTimestampVal(val any) (got int64, err error) {
 		}
 	default:
 		err = fmt.Errorf("getTimestampVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getTimestampNanosVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case string:
+		v = strings.Replace(v, "z", "Z", 1)
+		if d, parseErr := time.Parse(time.RFC3339Nano, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as timestamp: %w", v, parseErr)
+		} else {
+			got = d.UnixNano()
+		}
+	default:
+		err = fmt.Errorf("getTimestampNanosVal unhandled type: %T", v)
 	}
 
 	return

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -20,6 +20,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/apache/arrow-go/v18/parquet/variant"
 	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
 	iso8601 "github.com/senseyeio/duration"
@@ -108,12 +109,8 @@ func (rs rowSize) estSize(row []any) int {
 			out += len(v)
 		case json.RawMessage:
 			out += len(v)
-		case VariantValue:
-			out += len(v.Value) + len(v.Metadata)
-		case *VariantValue:
-			if v != nil {
-				out += len(v.Value) + len(v.Metadata)
-			}
+		case variant.Value:
+			out += len(v.Bytes()) + len(v.Metadata().Bytes())
 		case nil:
 			// No additional overhead is assumed for nil values.
 		default:
@@ -449,22 +446,17 @@ func (w *ParquetWriter) flushBuffer() error {
 			// Variant elements occupy two physical parquet columns: the first NextColumn() call
 			// above returned the "value" writer; we must finish writing it before requesting the
 			// "metadata" writer.
-			values, metadatas, defLevels, err := collectVariantBatch(colIdx, w.buffer)
-			if err != nil {
-				return fmt.Errorf("collecting variant column '%s': %w", f.Name, err)
-			}
-			if err := writeByteArrayBatch(cw.(*file.ByteArrayColumnChunkWriter), values, defLevels); err != nil {
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getVariantValueVal); err != nil {
 				return fmt.Errorf("writing variant value column '%s': %w", f.Name, err)
 			}
-			metaCw, err := rgWriter.NextColumn()
-			if err != nil {
+			if err := cw.Close(); err != nil {
+				return fmt.Errorf("closing variant value column writer: %w", err)
+			}
+			if cw, err = rgWriter.NextColumn(); err != nil {
 				return fmt.Errorf("getting next column for variant metadata: %w", err)
 			}
-			if err := writeByteArrayBatch(metaCw.(*file.ByteArrayColumnChunkWriter), metadatas, defLevels); err != nil {
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getVariantMetadataVal); err != nil {
 				return fmt.Errorf("writing variant metadata column '%s': %w", f.Name, err)
-			}
-			if err := metaCw.Close(); err != nil {
-				return fmt.Errorf("closing variant metadata column writer: %w", err)
 			}
 		case LogicalTypeDecimal:
 			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
@@ -525,57 +517,27 @@ type columnBatchWriter[T parquetValue] interface {
 	WriteBatch(vals []T, defLvls []int16, repLvls []int16) (valueOffset int64, err error)
 }
 
-// VariantValue is the per-row input for a LogicalTypeVariant column. Value and Metadata are the
-// already-encoded Parquet Variant binary fields; this package writes them verbatim into the
-// "value" and "metadata" child columns of the variant group. JSON-to-Variant encoding is the
-// caller's responsibility.
-type VariantValue struct {
-	Value    []byte
-	Metadata []byte
+// Callers supply a parquet/variant.Value (typically from variant.ParseJSON or variant.Builder);
+// the writer unpacks its two byte slices into the "value" and "metadata" child columns of the
+// variant group. They share nullability: a nil row slot produces defLevel 0 on both children.
+func getVariantValueVal(val any) (got parquet.ByteArray, err error) {
+	switch v := val.(type) {
+	case variant.Value:
+		got = v.Bytes()
+	default:
+		err = fmt.Errorf("getVariantValueVal unhandled type: %T", v)
+	}
+	return
 }
 
-// collectVariantBatch walks the buffered rows for a variant column and returns the value+metadata
-// byte slices and their shared def-level vector. The two child columns of the variant group share
-// the same nullability: when the variant slot is nil, both children carry defLevel 0; otherwise
-// both carry defLevel 1.
-func collectVariantBatch(colIdx int, buf [][]any) ([]parquet.ByteArray, []parquet.ByteArray, []int16, error) {
-	var values []parquet.ByteArray
-	var metadatas []parquet.ByteArray
-	var defLevels []int16
-
-	for _, row := range buf {
-		v := row[colIdx]
-		switch tv := v.(type) {
-		case nil:
-			defLevels = append(defLevels, 0)
-		case VariantValue:
-			values = append(values, tv.Value)
-			metadatas = append(metadatas, tv.Metadata)
-			defLevels = append(defLevels, 1)
-		case *VariantValue:
-			if tv == nil {
-				defLevels = append(defLevels, 0)
-				continue
-			}
-			values = append(values, tv.Value)
-			metadatas = append(metadatas, tv.Metadata)
-			defLevels = append(defLevels, 1)
-		default:
-			return nil, nil, nil, fmt.Errorf("unhandled type %T for variant column", tv)
-		}
+func getVariantMetadataVal(val any) (got parquet.ByteArray, err error) {
+	switch v := val.(type) {
+	case variant.Value:
+		got = v.Metadata().Bytes()
+	default:
+		err = fmt.Errorf("getVariantMetadataVal unhandled type: %T", v)
 	}
-
-	return values, metadatas, defLevels, nil
-}
-
-func writeByteArrayBatch(w columnBatchWriter[parquet.ByteArray], vals []parquet.ByteArray, defLevels []int16) error {
-	written, err := w.WriteBatch(vals, defLevels, nil)
-	if err != nil {
-		return fmt.Errorf("writing batch of values: %w", err)
-	} else if int(written) != len(vals) {
-		return fmt.Errorf("written %d values vs. %d values in vals", written, len(vals))
-	}
-	return nil
+	return
 }
 
 type getValFn[T parquetValue] func(v any) (got T, err error)
@@ -933,6 +895,7 @@ func getIntervalVal(val any) (got parquet.FixedLenByteArray, err error) {
 }
 
 func getDecimalVal(val any) (got parquet.FixedLenByteArray, err error) {
+
 	switch v := val.(type) {
 	case decimal128.Num:
 		got = slices.Grow(got, 16)[:16]

--- a/go/writer/parquet_schema.go
+++ b/go/writer/parquet_schema.go
@@ -14,6 +14,21 @@ import (
 // required, and what are representation of the data type should be.
 type ParquetSchema []ParquetSchemaElement
 
+// physicalColumnCount reports the number of leaf parquet columns the schema produces. Most
+// elements correspond to one leaf column, but LogicalTypeVariant is a group with two children.
+func (s ParquetSchema) physicalColumnCount() int {
+	n := 0
+	for _, e := range s {
+		switch e.DataType {
+		case LogicalTypeVariant:
+			n += 2
+		default:
+			n++
+		}
+	}
+	return n
+}
+
 type ParquetSchemaElement struct {
 	Name     string
 	DataType ParquetDataType
@@ -56,19 +71,21 @@ type ParquetSchemaElement struct {
 type ParquetDataType int
 
 const (
-	PrimitiveTypeInteger ParquetDataType = iota // INT64 primitive type
-	PrimitiveTypeNumber                         // DOUBLE primitive type, which is a 64-bit float
-	PrimitiveTypeBoolean                        // BOOLEAN primitive type
-	PrimitiveTypeBinary                         // BYTE_ARRAY primitive type
-	LogicalTypeString                           // Extends BYTE_ARRAY
-	LogicalTypeJson                             // Extends BYTE_ARRAY
-	LogicalTypeDate                             // Extends BYTE_ARRAY
-	LogicalTypeTime                             // Extends INT64
-	LogicalTypeTimestamp                        // Extends INT64
-	LogicalTypeUuid                             // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
-	LogicalTypeDecimal                          // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
-	LogicalTypeInterval                         // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
-	LogicalTypeUnknown                          // Must always be nil
+	PrimitiveTypeInteger      ParquetDataType = iota // INT64 primitive type
+	PrimitiveTypeNumber                              // DOUBLE primitive type, which is a 64-bit float
+	PrimitiveTypeBoolean                             // BOOLEAN primitive type
+	PrimitiveTypeBinary                              // BYTE_ARRAY primitive type
+	LogicalTypeString                                // Extends BYTE_ARRAY
+	LogicalTypeJson                                  // Extends BYTE_ARRAY
+	LogicalTypeDate                                  // Extends BYTE_ARRAY
+	LogicalTypeTime                                  // Extends INT64
+	LogicalTypeTimestamp                             // Extends INT64, microsecond precision
+	LogicalTypeTimestampNanos                        // Extends INT64, nanosecond precision
+	LogicalTypeUuid                                  // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeDecimal                               // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeInterval                              // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
+	LogicalTypeUnknown                               // Must always be nil
+	LogicalTypeVariant                               // GROUP of two required BYTE_ARRAY children "value" and "metadata"
 )
 
 // makeNode translates a ParquetSchemaElement into an actual parquet schema node.
@@ -145,6 +162,25 @@ func makeNode(e ParquetSchemaElement) schema.Node {
 			-1,
 			fieldId,
 		))
+	case LogicalTypeTimestampNanos:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewTimestampLogicalType(true, schema.TimeUnitNanos),
+			parquet.Types.Int64,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeVariant:
+		value := schema.NewByteArrayNode("value", parquet.Repetitions.Required, -1)
+		metadata := schema.NewByteArrayNode("metadata", parquet.Repetitions.Required, -1)
+		return schema.MustGroup(schema.NewGroupNodeLogical(
+			e.Name,
+			repetition,
+			schema.FieldList{value, metadata},
+			schema.VariantLogicalType{},
+			fieldId,
+		))
 	case LogicalTypeInterval:
 		return schema.Must(schema.NewPrimitiveNodeLogical(
 			e.Name,
@@ -183,6 +219,9 @@ type parquetSchemaConfig struct {
 	objectAsString   bool
 	timeAsString     bool
 	uuidAsString     bool
+	timestampAsNanos bool
+	objectAsVariant  bool
+	arrayAsVariant   bool
 }
 
 type ParquetSchemaOption func(*parquetSchemaConfig)
@@ -195,13 +234,37 @@ func WithParquetSchemaDurationAsString() ParquetSchemaOption {
 
 func WithParquetSchemaArrayAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
+		if cfg.arrayAsVariant {
+			panic("cannot both WithParquetSchemaArrayAsString and WithParquetSchemaArrayAsVariant")
+		}
 		cfg.arrayAsString = true
+	}
+}
+
+func WithParquetSchemaArrayAsVariant() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		if cfg.arrayAsString {
+			panic("cannot both WithParquetSchemaArrayAsVariant and WithParquetSchemaArrayAsString")
+		}
+		cfg.arrayAsVariant = true
 	}
 }
 
 func WithParquetSchemaObjectAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
+		if cfg.objectAsVariant {
+			panic("cannot both WithParquetSchemaObjectAsString and WithParquetSchemaObjectAsVariant")
+		}
 		cfg.objectAsString = true
+	}
+}
+
+func WithParquetSchemaObjectAsVariant() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		if cfg.objectAsString {
+			panic("cannot both WithParquetSchemaObjectAsVariant and WithParquetSchemaObjectAsString")
+		}
+		cfg.objectAsVariant = true
 	}
 }
 
@@ -214,6 +277,12 @@ func WithParquetTimeAsString() ParquetSchemaOption {
 func WithParquetUUIDAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
 		cfg.uuidAsString = true
+	}
+}
+
+func WithParquetTimestampAsNanoseconds() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.timestampAsNanos = true
 	}
 }
 
@@ -250,7 +319,7 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 		}
 
 		if hadType {
-			out.DataType = typeOrString(LogicalTypeJson, cfg.objectAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.objectAsString), cfg.objectAsVariant)
 			break
 		}
 
@@ -258,9 +327,9 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 
 		switch t {
 		case "array":
-			out.DataType = typeOrString(LogicalTypeJson, cfg.arrayAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.arrayAsString), cfg.arrayAsVariant)
 		case "object":
-			out.DataType = typeOrString(LogicalTypeJson, cfg.objectAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.objectAsString), cfg.objectAsVariant)
 		case "boolean":
 			out.DataType = PrimitiveTypeBoolean
 		case "integer":
@@ -277,7 +346,11 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 			case "date":
 				out.DataType = LogicalTypeDate
 			case "date-time":
-				out.DataType = LogicalTypeTimestamp
+				if cfg.timestampAsNanos {
+					out.DataType = LogicalTypeTimestampNanos
+				} else {
+					out.DataType = LogicalTypeTimestamp
+				}
 			case "duration":
 				out.DataType = typeOrString(LogicalTypeInterval, cfg.durationAsString)
 			case "time":
@@ -297,9 +370,16 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 	return out
 }
 
-func typeOrString[T ParquetDataType](base T, shouldString bool) T {
+func typeOrString(base ParquetDataType, shouldString bool) ParquetDataType {
 	if shouldString {
-		return T(LogicalTypeString)
+		return LogicalTypeString
+	}
+	return base
+}
+
+func typeOrVariant(base ParquetDataType, shouldVariant bool) ParquetDataType {
+	if shouldVariant {
+		return LogicalTypeVariant
 	}
 	return base
 }

--- a/go/writer/parquet_schema_test.go
+++ b/go/writer/parquet_schema_test.go
@@ -103,6 +103,18 @@ func TestMakeNode(t *testing.T) {
 			},
 		},
 		{
+			name:         "LogicalTypeTimestampNanos",
+			elem:         ParquetSchemaElement{Name: "tsNanosField", DataType: LogicalTypeTimestampNanos, Required: false, FieldId: ptrTo(fid)},
+			wantPhysical: parquet.Types.Int64,
+			wantTypeLen:  -1,
+			checkLogical: func(t *testing.T, lt schema.LogicalType) {
+				tl, ok := lt.(schema.TimestampLogicalType)
+				require.True(t, ok, "expected TimestampLogicalType, got %T", lt)
+				require.True(t, tl.IsAdjustedToUTC())
+				require.Equal(t, schema.TimeUnitNanos, tl.TimeUnit())
+			},
+		},
+		{
 			name:         "LogicalTypeUuid",
 			elem:         ParquetSchemaElement{Name: "uuidField", DataType: LogicalTypeUuid, Required: true, FieldId: ptrTo(fid)},
 			wantPhysical: parquet.Types.FixedLenByteArray,
@@ -187,6 +199,7 @@ func TestMakeNodeNilFieldId(t *testing.T) {
 		LogicalTypeDate,
 		LogicalTypeTime,
 		LogicalTypeTimestamp,
+		LogicalTypeTimestampNanos,
 		LogicalTypeUuid,
 		LogicalTypeDecimal,
 		LogicalTypeInterval,
@@ -196,6 +209,49 @@ func TestMakeNodeNilFieldId(t *testing.T) {
 		t.Run(fmt.Sprintf("dataType=%d", dt), func(t *testing.T) {
 			node := makeNode(ParquetSchemaElement{Name: "f", DataType: dt, Required: true, Scale: 0})
 			require.EqualValues(t, -1, node.FieldID())
+		})
+	}
+}
+
+func TestMakeNodeVariant(t *testing.T) {
+	const fid = int32(7)
+
+	for _, required := range []bool{true, false} {
+		t.Run(fmt.Sprintf("required=%v", required), func(t *testing.T) {
+			node := makeNode(ParquetSchemaElement{
+				Name:     "variantField",
+				DataType: LogicalTypeVariant,
+				Required: required,
+				FieldId:  ptrTo(fid),
+			})
+
+			gn, ok := node.(*schema.GroupNode)
+			require.True(t, ok, "expected *schema.GroupNode, got %T", node)
+
+			require.Equal(t, "variantField", gn.Name())
+			require.EqualValues(t, fid, gn.FieldID())
+			wantRep := parquet.Repetitions.Optional
+			if required {
+				wantRep = parquet.Repetitions.Required
+			}
+			require.Equal(t, wantRep, gn.RepetitionType())
+
+			_, ok = gn.LogicalType().(schema.VariantLogicalType)
+			require.True(t, ok, "expected VariantLogicalType, got %T", gn.LogicalType())
+
+			require.Equal(t, 2, gn.NumFields())
+
+			valueNode, ok := gn.Field(0).(*schema.PrimitiveNode)
+			require.True(t, ok)
+			require.Equal(t, "value", valueNode.Name())
+			require.Equal(t, parquet.Types.ByteArray, valueNode.PhysicalType())
+			require.Equal(t, parquet.Repetitions.Required, valueNode.RepetitionType())
+
+			metadataNode, ok := gn.Field(1).(*schema.PrimitiveNode)
+			require.True(t, ok)
+			require.Equal(t, "metadata", metadataNode.Name())
+			require.Equal(t, parquet.Types.ByteArray, metadataNode.PhysicalType())
+			require.Equal(t, parquet.Repetitions.Required, metadataNode.RepetitionType())
 		})
 	}
 }
@@ -585,6 +641,59 @@ func TestProjectionToParquetSchemaElement(t *testing.T) {
 			wantRequired: true,
 		},
 		{
+			name: "WithParquetTimestampAsNanoseconds flips date-time to nanos",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists:  pf.Inference_MUST,
+					Types:   []string{"string"},
+					String_: &pf.Inference_String{Format: "date-time"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetTimestampAsNanoseconds()},
+			wantType:     LogicalTypeTimestampNanos,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetSchemaArrayAsVariant flips array to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"array"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaArrayAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetSchemaObjectAsVariant flips object to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"object"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaObjectAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetSchemaObjectAsVariant flips multi-type fallback to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"integer", "boolean"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaObjectAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
 			name: "WithParquetUUIDAsString flips uuid to string",
 			projection: pf.Projection{
 				Field: "f",
@@ -606,6 +715,41 @@ func TestProjectionToParquetSchemaElement(t *testing.T) {
 			require.Equal(t, tt.projection.Field, got.Name)
 			require.Equal(t, tt.wantType, got.DataType)
 			require.Equal(t, tt.wantRequired, got.Required)
+		})
+	}
+}
+
+func TestProjectionToParquetSchemaElementConflictingOptionsPanic(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      []ParquetSchemaOption
+		wantPanic string
+	}{
+		{
+			name:      "object as string and as variant",
+			opts:      []ParquetSchemaOption{WithParquetSchemaObjectAsString(), WithParquetSchemaObjectAsVariant()},
+			wantPanic: "cannot both WithParquetSchemaObjectAsVariant and WithParquetSchemaObjectAsString",
+		},
+		{
+			name:      "array as string and as variant",
+			opts:      []ParquetSchemaOption{WithParquetSchemaArrayAsString(), WithParquetSchemaArrayAsVariant()},
+			wantPanic: "cannot both WithParquetSchemaArrayAsVariant and WithParquetSchemaArrayAsString",
+		},
+	}
+
+	proj := pf.Projection{
+		Field: "f",
+		Inference: pf.Inference{
+			Exists: pf.Inference_MUST,
+			Types:  []string{"object"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.PanicsWithValue(t, tt.wantPanic, func() {
+				ProjectionToParquetSchemaElement(proj, false, tt.opts...)
+			})
 		})
 	}
 }

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/apache/arrow-go/v18/parquet/variant"
 	"github.com/bradleyjkemp/cupaloy"
 	"github.com/stretchr/testify/require"
 )
@@ -62,36 +63,28 @@ func TestParquetWriter(t *testing.T) {
 	}
 }
 
-func TestParquetWriterTimestampNanosAndVariant(t *testing.T) {
+func TestParquetWriterTimestampNanos(t *testing.T) {
 	dir := t.TempDir()
 	sink, err := os.CreateTemp(dir, "*.parquet")
 	require.NoError(t, err)
 
 	sch := ParquetSchema{
 		{Name: "tsField", DataType: LogicalTypeTimestampNanos, Required: false},
-		{Name: "variantField", DataType: LogicalTypeVariant, Required: false},
 	}
 
-	rows := []struct {
-		ts      string
-		variant *VariantValue
-	}{
-		{"2024-01-02T03:04:05.123456789Z", &VariantValue{Value: []byte{0x0a}, Metadata: []byte{0x01, 0x00, 0x00}}},
-		{"1970-01-01T00:00:00.000000001Z", &VariantValue{Value: []byte{0x0b, 0x0c}, Metadata: []byte{0x01, 0x00, 0x00}}},
-		{"", nil},
+	tsStrings := []string{
+		"2024-01-02T03:04:05.123456789Z",
+		"1970-01-01T00:00:00.000000001Z",
+		"", // null
 	}
 
 	w := NewParquetWriter(sink, sch)
-	for _, r := range rows {
-		var tsVal any
-		if r.ts != "" {
-			tsVal = r.ts
+	for _, ts := range tsStrings {
+		var v any
+		if ts != "" {
+			v = ts
 		}
-		var varVal any
-		if r.variant != nil {
-			varVal = *r.variant
-		}
-		require.NoError(t, w.Write([]any{tsVal, varVal}))
+		require.NoError(t, w.Write([]any{v}))
 	}
 	require.NoError(t, w.Close())
 
@@ -99,45 +92,67 @@ func TestParquetWriterTimestampNanosAndVariant(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	// The variant group adds a column; the schema root contains both leaf columns of the variant
-	// plus the timestamp.
-	require.Equal(t, 3, f.MetaData().Schema.NumColumns())
+	require.Equal(t, 1, f.MetaData().Schema.NumColumns())
+	col := f.MetaData().Schema.Column(0)
+	require.Equal(t, parquet.Types.Int64, col.PhysicalType())
+	lt, ok := col.LogicalType().(schema.TimestampLogicalType)
+	require.True(t, ok, "expected TimestampLogicalType, got %T", col.LogicalType())
+	require.Equal(t, schema.TimeUnitNanos, lt.TimeUnit())
 
-	tsCol := f.MetaData().Schema.Column(0)
-	require.Equal(t, parquet.Types.Int64, tsCol.PhysicalType())
-	tsLogical, ok := tsCol.LogicalType().(schema.TimestampLogicalType)
-	require.True(t, ok, "expected TimestampLogicalType, got %T", tsCol.LogicalType())
-	require.Equal(t, schema.TimeUnitNanos, tsLogical.TimeUnit())
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(tsStrings), rg.NumRows())
 
-	// Variant group is reached via its leaf columns; the parent is the variant group node.
-	variantValueCol := f.MetaData().Schema.Column(1)
-	require.Equal(t, "value", variantValueCol.Name())
-	require.Equal(t, parquet.Types.ByteArray, variantValueCol.PhysicalType())
-	variantMetaCol := f.MetaData().Schema.Column(2)
-	require.Equal(t, "metadata", variantMetaCol.Name())
-	require.Equal(t, parquet.Types.ByteArray, variantMetaCol.PhysicalType())
+	r, err := rg.Column(0)
+	require.NoError(t, err)
+	vals := make([]int64, len(tsStrings))
+	def := make([]int16, len(tsStrings))
+	_, _, err = r.(*file.Int64ColumnChunkReader).ReadBatch(int64(len(tsStrings)), vals, def, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []int16{1, 1, 0}, def)
+	want0, err := time.Parse(time.RFC3339Nano, tsStrings[0])
+	require.NoError(t, err)
+	require.Equal(t, want0.UnixNano(), vals[0])
+	want1, err := time.Parse(time.RFC3339Nano, tsStrings[1])
+	require.NoError(t, err)
+	require.Equal(t, want1.UnixNano(), vals[1])
+}
+
+func TestParquetWriterVariant(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "variantField", DataType: LogicalTypeVariant, Required: false},
+	}
+
+	v0, err := variant.New([]byte{0x01, 0x00, 0x00}, []byte{0x0a})
+	require.NoError(t, err)
+	v1, err := variant.New([]byte{0x01, 0x00, 0x00}, []byte{0x0b, 0x0c})
+	require.NoError(t, err)
+	rows := []any{v0, v1, nil}
+
+	w := NewParquetWriter(sink, sch)
+	for _, v := range rows {
+		require.NoError(t, w.Write([]any{v}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.Equal(t, 2, f.MetaData().Schema.NumColumns())
+	valueCol := f.MetaData().Schema.Column(0)
+	require.Equal(t, "value", valueCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, valueCol.PhysicalType())
+	metaCol := f.MetaData().Schema.Column(1)
+	require.Equal(t, "metadata", metaCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, metaCol.PhysicalType())
 
 	rg := f.RowGroup(0)
 	require.EqualValues(t, len(rows), rg.NumRows())
-
-	tsReader, err := rg.Column(0)
-	require.NoError(t, err)
-	tsVals := make([]int64, len(rows))
-	tsDef := make([]int16, len(rows))
-	_, _, err = tsReader.(*file.Int64ColumnChunkReader).ReadBatch(int64(len(rows)), tsVals, tsDef, nil)
-	require.NoError(t, err)
-
-	// First two rows have non-null timestamps; third row is null.
-	require.Equal(t, int16(1), tsDef[0])
-	require.Equal(t, int16(1), tsDef[1])
-	require.Equal(t, int16(0), tsDef[2])
-
-	wantTs0, err := time.Parse(time.RFC3339Nano, rows[0].ts)
-	require.NoError(t, err)
-	require.Equal(t, wantTs0.UnixNano(), tsVals[0])
-	wantTs1, err := time.Parse(time.RFC3339Nano, rows[1].ts)
-	require.NoError(t, err)
-	require.Equal(t, wantTs1.UnixNano(), tsVals[1])
 
 	readByteArrays := func(col int) ([]parquet.ByteArray, []int16) {
 		r, err := rg.Column(col)
@@ -149,15 +164,15 @@ func TestParquetWriterTimestampNanosAndVariant(t *testing.T) {
 		return vals, def
 	}
 
-	valueVals, valueDef := readByteArrays(1)
-	metaVals, metaDef := readByteArrays(2)
+	valueVals, valueDef := readByteArrays(0)
+	metaVals, metaDef := readByteArrays(1)
 
 	require.Equal(t, []int16{1, 1, 0}, valueDef)
 	require.Equal(t, []int16{1, 1, 0}, metaDef)
-	require.Equal(t, []byte(rows[0].variant.Value), []byte(valueVals[0]))
-	require.Equal(t, []byte(rows[1].variant.Value), []byte(valueVals[1]))
-	require.Equal(t, []byte(rows[0].variant.Metadata), []byte(metaVals[0]))
-	require.Equal(t, []byte(rows[1].variant.Metadata), []byte(metaVals[1]))
+	require.Equal(t, v0.Bytes(), []byte(valueVals[0]))
+	require.Equal(t, v1.Bytes(), []byte(valueVals[1]))
+	require.Equal(t, v0.Metadata().Bytes(), []byte(metaVals[0]))
+	require.Equal(t, v1.Metadata().Bytes(), []byte(metaVals[1]))
 }
 
 // This is a regression test for a bug in arrow-go 18.5.2, added test so we

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
@@ -59,6 +60,104 @@ func TestParquetWriter(t *testing.T) {
 			cupaloy.SnapshotT(t, duckdbReadFile(t, sink.Name(), "JSON"))
 		})
 	}
+}
+
+func TestParquetWriterTimestampNanosAndVariant(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "tsField", DataType: LogicalTypeTimestampNanos, Required: false},
+		{Name: "variantField", DataType: LogicalTypeVariant, Required: false},
+	}
+
+	rows := []struct {
+		ts      string
+		variant *VariantValue
+	}{
+		{"2024-01-02T03:04:05.123456789Z", &VariantValue{Value: []byte{0x0a}, Metadata: []byte{0x01, 0x00, 0x00}}},
+		{"1970-01-01T00:00:00.000000001Z", &VariantValue{Value: []byte{0x0b, 0x0c}, Metadata: []byte{0x01, 0x00, 0x00}}},
+		{"", nil},
+	}
+
+	w := NewParquetWriter(sink, sch)
+	for _, r := range rows {
+		var tsVal any
+		if r.ts != "" {
+			tsVal = r.ts
+		}
+		var varVal any
+		if r.variant != nil {
+			varVal = *r.variant
+		}
+		require.NoError(t, w.Write([]any{tsVal, varVal}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// The variant group adds a column; the schema root contains both leaf columns of the variant
+	// plus the timestamp.
+	require.Equal(t, 3, f.MetaData().Schema.NumColumns())
+
+	tsCol := f.MetaData().Schema.Column(0)
+	require.Equal(t, parquet.Types.Int64, tsCol.PhysicalType())
+	tsLogical, ok := tsCol.LogicalType().(schema.TimestampLogicalType)
+	require.True(t, ok, "expected TimestampLogicalType, got %T", tsCol.LogicalType())
+	require.Equal(t, schema.TimeUnitNanos, tsLogical.TimeUnit())
+
+	// Variant group is reached via its leaf columns; the parent is the variant group node.
+	variantValueCol := f.MetaData().Schema.Column(1)
+	require.Equal(t, "value", variantValueCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, variantValueCol.PhysicalType())
+	variantMetaCol := f.MetaData().Schema.Column(2)
+	require.Equal(t, "metadata", variantMetaCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, variantMetaCol.PhysicalType())
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(rows), rg.NumRows())
+
+	tsReader, err := rg.Column(0)
+	require.NoError(t, err)
+	tsVals := make([]int64, len(rows))
+	tsDef := make([]int16, len(rows))
+	_, _, err = tsReader.(*file.Int64ColumnChunkReader).ReadBatch(int64(len(rows)), tsVals, tsDef, nil)
+	require.NoError(t, err)
+
+	// First two rows have non-null timestamps; third row is null.
+	require.Equal(t, int16(1), tsDef[0])
+	require.Equal(t, int16(1), tsDef[1])
+	require.Equal(t, int16(0), tsDef[2])
+
+	wantTs0, err := time.Parse(time.RFC3339Nano, rows[0].ts)
+	require.NoError(t, err)
+	require.Equal(t, wantTs0.UnixNano(), tsVals[0])
+	wantTs1, err := time.Parse(time.RFC3339Nano, rows[1].ts)
+	require.NoError(t, err)
+	require.Equal(t, wantTs1.UnixNano(), tsVals[1])
+
+	readByteArrays := func(col int) ([]parquet.ByteArray, []int16) {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(rows))
+		def := make([]int16, len(rows))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(rows)), vals, def, nil)
+		require.NoError(t, err)
+		return vals, def
+	}
+
+	valueVals, valueDef := readByteArrays(1)
+	metaVals, metaDef := readByteArrays(2)
+
+	require.Equal(t, []int16{1, 1, 0}, valueDef)
+	require.Equal(t, []int16{1, 1, 0}, metaDef)
+	require.Equal(t, []byte(rows[0].variant.Value), []byte(valueVals[0]))
+	require.Equal(t, []byte(rows[1].variant.Value), []byte(valueVals[1]))
+	require.Equal(t, []byte(rows[0].variant.Metadata), []byte(metaVals[0]))
+	require.Equal(t, []byte(rows[1].variant.Metadata), []byte(metaVals[1]))
 }
 
 // This is a regression test for a bug in arrow-go 18.5.2, added test so we


### PR DESCRIPTION
**Description:**

Adds two new parquet logical types to `go/writer` and matching opt-in `ProjectionToParquetSchemaElement` options:

- `LogicalTypeTimestampNanos` / `WithParquetTimestampAsNanoseconds`
- `LogicalTypeVariant` / `WithParquetSchemaObjectAsVariant`, `WithParquetSchemaArrayAsVariant` (callers pass pre-encoded `VariantValue{Value, Metadata []byte}`; variant-binary encoding is the caller's responsibility)

No caller invokes the new behavior yet. Existing connectors are unchanged until they explicitly pass the new options.

Helps #4462, #4466.

**Workflow steps:**

No connector behavior change; callers opt in via the new schema options.

**Documentation links affected:**

None.

**Notes for reviewers:**

`flushBuffer` now advances `NextColumn()` twice for variant elements (group with `value` + `metadata` children). `transferColumnValues` works unchanged since it iterates by leaf-column count.
