### PR TITLE
go/writer: improve parquet write performance

### DIFF
--- a/go/writer/counting_write_closer.go
+++ b/go/writer/counting_write_closer.go
@@ -26,3 +26,9 @@ func (c *countingWriteCloser) Close() error {
 	}
 	return nil
 }
+
+// Tell satisfies the parquet/internal/utils.WriterTell interface that arrow-go's
+// file.NewPageWriter requires of its sink. We return the running byte count.
+func (c *countingWriteCloser) Tell() int64 {
+	return int64(c.written)
+}

--- a/go/writer/merge_writer.go
+++ b/go/writer/merge_writer.go
@@ -1,0 +1,266 @@
+package writer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+)
+
+// parquetMagic is the 4-byte file marker that opens and closes every parquet file.
+var parquetMagic = []byte{'P', 'A', 'R', '1'}
+
+// mergeWriter writes a parquet file by importing already-encoded data pages into row groups. It
+// is built on top of arrow-go's metadata builders and PageWriter, but skips arrow-go's
+// *file.Writer entirely. *file.Writer assumes data is fed via WriteBatch — it owns dictionary
+// emission, page buffering, and chunk-stats aggregation, none of which apply when we are pumping
+// pre-encoded pages from one parquet file into another. mergeWriter exposes a smaller surface
+// shaped to that import use case: callers feed pre-encoded data pages directly and tell the row
+// group its row count explicitly.
+//
+// The sink must satisfy arrow-go's parquet/internal/utils.WriterTell (io.Writer + Tell() int64);
+// countingWriteCloser does after we add Tell. Go's structural typing lets us pass a value of an
+// external concrete type into arrow-go's internal-interface-typed parameter, since interface
+// satisfaction depends only on method sets.
+type mergeWriter struct {
+	sink     mergeWriterSink
+	schema   *schema.Schema
+	props    *parquet.WriterProperties
+	metadata *metadata.FileMetaDataBuilder
+
+	rowGroupCount int
+	open          bool
+	rowGroup      *mergeRowGroupWriter
+}
+
+// mergeWriterSink is the contract the sink must satisfy for arrow-go's PageWriter to use it.
+// In practice this is countingWriteCloser, which adds Tell() returning the byte count.
+type mergeWriterSink interface {
+	io.Writer
+	Tell() int64
+}
+
+func newMergeWriter(sink mergeWriterSink, sc *schema.GroupNode, props *parquet.WriterProperties, kv metadata.KeyValueMetadata) (*mergeWriter, error) {
+	if props == nil {
+		props = parquet.NewWriterProperties()
+	}
+	fileSchema := schema.NewSchema(sc)
+	if _, err := sink.Write(parquetMagic); err != nil {
+		return nil, fmt.Errorf("writing parquet magic header: %w", err)
+	}
+	return &mergeWriter{
+		sink:     sink,
+		schema:   fileSchema,
+		props:    props,
+		metadata: metadata.NewFileMetadataBuilder(fileSchema, props, kv),
+		open:     true,
+	}, nil
+}
+
+// AppendRowGroup begins a new row group. Any currently-open row group is closed first.
+func (mw *mergeWriter) AppendRowGroup() (*mergeRowGroupWriter, error) {
+	if !mw.open {
+		return nil, fmt.Errorf("mergeWriter: AppendRowGroup on closed writer")
+	}
+	if mw.rowGroup != nil {
+		if err := mw.rowGroup.Close(); err != nil {
+			return nil, fmt.Errorf("closing prior row group: %w", err)
+		}
+	}
+	rgMeta := mw.metadata.AppendRowGroup()
+	rg := &mergeRowGroupWriter{
+		parent:   mw,
+		metadata: rgMeta,
+		ordinal:  int16(mw.rowGroupCount),
+	}
+	mw.rowGroupCount++
+	mw.rowGroup = rg
+	return rg, nil
+}
+
+// Close finalizes any open row group, writes the parquet footer (file metadata, footer length,
+// and trailing magic), and marks the writer closed. The underlying sink is not itself closed.
+func (mw *mergeWriter) Close() error {
+	if !mw.open {
+		return nil
+	}
+	mw.open = false
+
+	if mw.rowGroup != nil {
+		if err := mw.rowGroup.Close(); err != nil {
+			return fmt.Errorf("closing row group: %w", err)
+		}
+		mw.rowGroup = nil
+	}
+
+	fmd, err := mw.metadata.Snapshot()
+	if err != nil {
+		return fmt.Errorf("snapshotting file metadata: %w", err)
+	}
+	// FileMetaData.WriteTo accepts a nil encryptor for unencrypted files; the encryption.Encryptor
+	// type is internal to arrow-go but Go infers nil at the call site.
+	n, err := fmd.WriteTo(mw.sink, nil)
+	if err != nil {
+		return fmt.Errorf("writing parquet footer metadata: %w", err)
+	}
+	if err := binary.Write(mw.sink, binary.LittleEndian, uint32(n)); err != nil {
+		return fmt.Errorf("writing footer length: %w", err)
+	}
+	if _, err := mw.sink.Write(parquetMagic); err != nil {
+		return fmt.Errorf("writing parquet magic trailer: %w", err)
+	}
+	return nil
+}
+
+// FileMetadata returns a snapshot of the current file metadata. Useful for callers that want to
+// inspect the file structure between row groups.
+func (mw *mergeWriter) FileMetadata() (*metadata.FileMetaData, error) {
+	return mw.metadata.Snapshot()
+}
+
+// mergeRowGroupWriter writes columns sequentially into one row group. Use NextColumn to advance
+// through columns in schema order. Set the row count via SetNumRows before Close.
+type mergeRowGroupWriter struct {
+	parent     *mergeWriter
+	metadata   *metadata.RowGroupMetaDataBuilder
+	ordinal    int16
+	nextCol    int
+	currentCol *mergeColumnWriter
+	nrows      int
+	closed     bool
+}
+
+// SetNumRows records the row count for this row group; required before Close. The same value
+// must also describe every column written into the row group.
+func (rg *mergeRowGroupWriter) SetNumRows(n int) {
+	rg.nrows = n
+}
+
+// NextColumn closes the prior column writer (if any) and returns a writer for the next column
+// in schema order. Columns must be written in order and exactly once each.
+func (rg *mergeRowGroupWriter) NextColumn() (*mergeColumnWriter, error) {
+	if rg.closed {
+		return nil, fmt.Errorf("mergeRowGroupWriter: NextColumn on closed row group")
+	}
+	if rg.currentCol != nil {
+		if err := rg.currentCol.Close(); err != nil {
+			return nil, fmt.Errorf("closing prior column: %w", err)
+		}
+	}
+
+	cmb := rg.metadata.NextColumnChunk()
+	colPath := cmb.Descr().Path()
+	pw, err := file.NewPageWriter(
+		rg.parent.sink,
+		rg.parent.props.CompressionFor(colPath),
+		rg.parent.props.CompressionLevelFor(colPath),
+		cmb,
+		rg.ordinal,
+		int16(rg.nextCol),
+		rg.parent.props.Allocator(),
+		false, // not buffered: pages flow straight through to the sink
+		nil,   // no metadata encryptor
+		nil,   // no data encryptor
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating page writer for col %d: %w", rg.nextCol, err)
+	}
+
+	cw := &mergeColumnWriter{pageWriter: pw}
+	rg.currentCol = cw
+	rg.nextCol++
+	return cw, nil
+}
+
+// Close finalizes the row group: closes the in-flight column writer (if any), validates that
+// every column has been written, and writes row group metadata.
+func (rg *mergeRowGroupWriter) Close() error {
+	if rg.closed {
+		return nil
+	}
+	rg.closed = true
+
+	if rg.currentCol != nil {
+		if err := rg.currentCol.Close(); err != nil {
+			return fmt.Errorf("closing column: %w", err)
+		}
+		rg.currentCol = nil
+	}
+
+	if rg.nextCol != rg.parent.schema.NumColumns() {
+		return fmt.Errorf("only %d of %d columns written before row group close",
+			rg.nextCol, rg.parent.schema.NumColumns())
+	}
+
+	rg.metadata.SetNumRows(rg.nrows)
+	// The first parameter to Finish is unused inside arrow-go (it computes totals from the
+	// column-chunk builders); pass 0.
+	if err := rg.metadata.Finish(0, rg.ordinal); err != nil {
+		return fmt.Errorf("finishing row group metadata: %w", err)
+	}
+	return nil
+}
+
+// mergeColumnWriter accepts pre-encoded data pages and accumulates them into one column chunk.
+// Stats (compressed size, encoding stats, page offsets) are tracked internally by arrow-go's
+// PageWriter; on Close we let it finalize the column chunk metadata.
+type mergeColumnWriter struct {
+	pageWriter file.PageWriter
+	closed     bool
+}
+
+// WriteDataPage writes a pre-encoded data page. The page's encoding and statistics are preserved.
+// Compression is applied if the PageWriter has a compressor: arrow-go's PageReader decompresses
+// pages when reading from the scratch file, and PageWriter.WriteDataPage writes bytes verbatim
+// without re-compressing, so we must compress here to keep the page bytes consistent with the
+// column chunk metadata (which records the sink's configured compression codec).
+func (cw *mergeColumnWriter) WriteDataPage(page file.DataPage) error {
+	if cw.closed {
+		return fmt.Errorf("mergeColumnWriter: WriteDataPage on closed column")
+	}
+	if cw.pageWriter.HasCompressor() {
+		var buf bytes.Buffer
+		compressed := cw.pageWriter.Compress(&buf, page.Data())
+		compressedData := make([]byte, len(compressed))
+		copy(compressedData, compressed)
+		newBuf := memory.NewBufferBytes(compressedData)
+		switch dp := page.(type) {
+		case *file.DataPageV1:
+			page = file.NewDataPageV1WithStats(newBuf, dp.NumValues(), parquet.Encoding(dp.Encoding()),
+				dp.DefinitionLevelEncoding(), dp.RepetitionLevelEncoding(),
+				dp.UncompressedSize(), dp.Statistics())
+		case *file.DataPageV2:
+			page = file.NewDataPageV2WithStats(newBuf, dp.NumValues(), dp.NumNulls(), dp.NumRows(),
+				parquet.Encoding(dp.Encoding()), dp.DefinitionLevelByteLen(), dp.RepetitionLevelByteLen(),
+				dp.UncompressedSize(), true, dp.Statistics())
+		default:
+			return fmt.Errorf("mergeColumnWriter: unexpected page type %T", page)
+		}
+		defer page.Release()
+	}
+	if _, err := cw.pageWriter.WriteDataPage(page); err != nil {
+		return fmt.Errorf("writing data page: %w", err)
+	}
+	return nil
+}
+
+// Close finalizes the column chunk: writes its metadata to the sink. After Close, no more pages
+// may be written. We pass hasDict=false / fallback=false because mergeWriter never accepts
+// dictionary pages — the upstream scratch writer is configured with dictionary encoding off so
+// the inputs are always plain-encoded data pages.
+func (cw *mergeColumnWriter) Close() error {
+	if cw.closed {
+		return nil
+	}
+	cw.closed = true
+	if err := cw.pageWriter.Close(false, false); err != nil {
+		return fmt.Errorf("closing page writer: %w", err)
+	}
+	return nil
+}

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -249,7 +249,7 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 // since the interface data word holds the pointer directly rather than boxing a 3-word slice header.
 func makeColumnBuffer(dt ParquetDataType, initialCap int) any {
 	switch dt {
-	case PrimitiveTypeInteger, LogicalTypeTime, LogicalTypeTimestamp:
+	case PrimitiveTypeInteger, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos:
 		s := make([]int64, 0, initialCap)
 		return &s
 	case PrimitiveTypeNumber:
@@ -390,6 +390,8 @@ func (w *ParquetWriter) Write(row []any) error {
 			convErr = appendVal(w, colIdx, v, getTimeVal)
 		case LogicalTypeTimestamp:
 			convErr = appendVal(w, colIdx, v, getTimestampVal)
+		case LogicalTypeTimestampNanos:
+			convErr = appendVal(w, colIdx, v, getTimestampNanosVal)
 		case LogicalTypeDecimal:
 			convErr = appendVal(w, colIdx, v, getDecimalVal)
 		case LogicalTypeInterval:
@@ -555,7 +557,7 @@ func (w *ParquetWriter) flushBuffer() error {
 				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTimestampNanos:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampNanosVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDecimal:

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -368,39 +368,77 @@ func (w *ParquetWriter) Write(row []any) error {
 		}
 		w.defLevels[colIdx] = append(w.defLevels[colIdx], 1)
 
-		var convErr error
 		switch f.DataType {
 		case PrimitiveTypeInteger:
-			convErr = appendVal(w, colIdx, v, getIntVal)
+			var q int64
+			if q, err = getIntVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case PrimitiveTypeNumber:
-			convErr = appendVal(w, colIdx, v, getNumberVal)
+			var q float64
+			if q, err = getNumberVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case PrimitiveTypeBoolean:
-			convErr = appendVal(w, colIdx, v, getBooleanVal)
+			var q bool
+			if q, err = getBooleanVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case PrimitiveTypeBinary:
-			convErr = appendVal(w, colIdx, v, getBinaryVal)
+			var q parquet.ByteArray
+			if q, err = getBinaryVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeJson:
-			convErr = appendVal(w, colIdx, v, getJsonVal)
+			var q parquet.ByteArray
+			if q, err = getJsonVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeString:
-			convErr = appendVal(w, colIdx, v, getStringVal)
+			var q parquet.ByteArray
+			if q, err = getStringVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeUuid:
-			convErr = appendVal(w, colIdx, v, getUuidVal)
+			var q parquet.FixedLenByteArray
+			if q, err = getUuidVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeDate:
-			convErr = appendVal(w, colIdx, v, getDateVal)
+			var q int32
+			if q, err = getDateVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeTime:
-			convErr = appendVal(w, colIdx, v, getTimeVal)
+			var q int64
+			if q, err = getTimeVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeTimestamp:
-			convErr = appendVal(w, colIdx, v, getTimestampVal)
+			var q int64
+			if q, err = getTimestampVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeTimestampNanos:
-			convErr = appendVal(w, colIdx, v, getTimestampNanosVal)
+			var q int64
+			if q, err = getTimestampNanosVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeDecimal:
-			convErr = appendVal(w, colIdx, v, getDecimalVal)
+			var q parquet.FixedLenByteArray
+			if q, err = getDecimalVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		case LogicalTypeInterval:
-			convErr = appendVal(w, colIdx, v, getIntervalVal)
+			var q parquet.FixedLenByteArray
+			if q, err = getIntervalVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
 		default:
 			panic(fmt.Sprintf("attempted to write unknown type of column '%s': %d", f.Name, f.DataType))
 		}
-		if convErr != nil {
-			return fmt.Errorf("converting value for column '%s': %w (type %T)", f.Name, convErr, v)
+		if err != nil {
+			return fmt.Errorf("converting value for column '%s': %w (type %T)", f.Name, err, v)
 		}
 	}
 	w.bufferSizeBytes += w.rs.estSize(row)
@@ -434,6 +472,13 @@ func (w *ParquetWriter) Write(row []any) error {
 	}
 
 	return nil
+}
+
+// appendVal appends v to the column's typed buffer slice. The caller is
+// responsible for handling nil values and maintaining defLevels.
+func appendVal[T parquetValue](w *ParquetWriter, colIdx int, v T) {
+	sp := w.buffer[colIdx].(*[]T)
+	*sp = append(*sp, v)
 }
 
 // Written returns the number of bytes written to the output writer. This value increases only as
@@ -610,20 +655,6 @@ type columnBatchWriter[T parquetValue] interface {
 	// taken from the next value of vals. The returned valuesOffset indicates the number of physical
 	// values that were written, and it may be smaller than the number of conceptual rows written.
 	WriteBatch(vals []T, defLvls []int16, repLvls []int16) (valueOffset int64, err error)
-}
-
-type getValFn[T parquetValue] func(v any) (got T, err error)
-
-// appendVal converts v with getVal and appends the result to the column's typed buffer slice. The
-// caller is responsible for handling nil values and maintaining defLevels.
-func appendVal[T parquetValue](w *ParquetWriter, colIdx int, v any, getVal getValFn[T]) error {
-	got, err := getVal(v)
-	if err != nil {
-		return err
-	}
-	sp := w.buffer[colIdx].(*[]T)
-	*sp = append(*sp, got)
-	return nil
 }
 
 func writeColumn[T parquetValue](w columnBatchWriter[T], vals []T, defLevels []int16) error {

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -154,9 +154,14 @@ type ParquetWriter struct {
 		columnChunkCount int
 	}
 
-	// buffer contains rows of values that are pending to be written as a row group to the scratch
-	// file when bufferSizeBytes exceeds the threshold.
-	buffer          [][]any
+	// buffer holds column-oriented values pending to be written as a row group to the scratch file
+	// when bufferSizeBytes exceeds the threshold. Each entry is a strongly-typed slice (e.g.
+	// []int64, []parquet.ByteArray) matching the column's parquet physical type, and contains only
+	// non-null values for that column. defLevels[colIdx] runs parallel to the row order with 0 for
+	// null and 1 for present, so its length always equals bufferRowCount.
+	buffer          []any
+	defLevels       [][]int16
+	bufferRowCount  int
 	bufferSizeBytes int
 }
 
@@ -211,6 +216,14 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 
 	cwc := &countingWriteCloser{w: w}
 
+	buffer := make([]any, len(sch))
+	defLevels := make([][]int16, len(sch))
+	const initialCap = 1000
+	for i, e := range sch {
+		buffer[i] = makeColumnBuffer(e.DataType, initialCap)
+		defLevels[i] = make([]int16, 0, initialCap)
+	}
+
 	return &ParquetWriter{
 		cfg:        cfg,
 		schema:     sch,
@@ -218,6 +231,57 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 		sinkWriter: file.NewParquetWriter(cwc, schemaRoot, writerOpts(cfg)...),
 		cwc:        cwc,
 		rs:         newRowSizing(sch),
+		buffer:     buffer,
+		defLevels:  defLevels,
+	}
+}
+
+// makeColumnBuffer returns a pointer to an empty strongly-typed slice for the given column type.
+// Storing a pointer (one word) in the []any buffer avoids a heap allocation on every append,
+// since the interface data word holds the pointer directly rather than boxing a 3-word slice header.
+func makeColumnBuffer(dt ParquetDataType, initialCap int) any {
+	switch dt {
+	case PrimitiveTypeInteger, LogicalTypeTime, LogicalTypeTimestamp:
+		s := make([]int64, 0, initialCap)
+		return &s
+	case PrimitiveTypeNumber:
+		s := make([]float64, 0, initialCap)
+		return &s
+	case PrimitiveTypeBoolean:
+		s := make([]bool, 0, initialCap)
+		return &s
+	case PrimitiveTypeBinary, LogicalTypeJson, LogicalTypeString:
+		s := make([]parquet.ByteArray, 0, initialCap)
+		return &s
+	case LogicalTypeUuid, LogicalTypeDecimal, LogicalTypeInterval:
+		s := make([]parquet.FixedLenByteArray, 0, initialCap)
+		return &s
+	case LogicalTypeDate:
+		s := make([]int32, 0, initialCap)
+		return &s
+	default:
+		panic(fmt.Sprintf("makeColumnBuffer unknown type: %d", dt))
+	}
+}
+
+// resetColumnBuffer truncates the slice pointed to by s to length 0 while preserving its
+// underlying capacity so subsequent buffer cycles can reuse the allocation.
+func resetColumnBuffer(s any) {
+	switch sp := s.(type) {
+	case *[]int64:
+		*sp = (*sp)[:0]
+	case *[]int32:
+		*sp = (*sp)[:0]
+	case *[]float64:
+		*sp = (*sp)[:0]
+	case *[]bool:
+		*sp = (*sp)[:0]
+	case *[]parquet.ByteArray:
+		*sp = (*sp)[:0]
+	case *[]parquet.FixedLenByteArray:
+		*sp = (*sp)[:0]
+	default:
+		panic(fmt.Sprintf("resetColumnBuffer unknown type: %T", s))
 	}
 }
 
@@ -280,8 +344,49 @@ func (w *ParquetWriter) Write(row []any) error {
 		w.scratch.writer = file.NewParquetWriter(w.scratch.file, w.schemaRoot, file.WithWriterProps(parquet.NewWriterProperties(scratchOpts...)))
 	}
 
-	w.buffer = append(w.buffer, row)
+	for colIdx, f := range w.schema {
+		v := row[colIdx]
+		if v == nil {
+			w.defLevels[colIdx] = append(w.defLevels[colIdx], 0)
+			continue
+		}
+		w.defLevels[colIdx] = append(w.defLevels[colIdx], 1)
+
+		var convErr error
+		switch f.DataType {
+		case PrimitiveTypeInteger:
+			convErr = appendVal(w, colIdx, v, getIntVal)
+		case PrimitiveTypeNumber:
+			convErr = appendVal(w, colIdx, v, getNumberVal)
+		case PrimitiveTypeBoolean:
+			convErr = appendVal(w, colIdx, v, getBooleanVal)
+		case PrimitiveTypeBinary:
+			convErr = appendVal(w, colIdx, v, getBinaryVal)
+		case LogicalTypeJson:
+			convErr = appendVal(w, colIdx, v, getJsonVal)
+		case LogicalTypeString:
+			convErr = appendVal(w, colIdx, v, getStringVal)
+		case LogicalTypeUuid:
+			convErr = appendVal(w, colIdx, v, getUuidVal)
+		case LogicalTypeDate:
+			convErr = appendVal(w, colIdx, v, getDateVal)
+		case LogicalTypeTime:
+			convErr = appendVal(w, colIdx, v, getTimeVal)
+		case LogicalTypeTimestamp:
+			convErr = appendVal(w, colIdx, v, getTimestampVal)
+		case LogicalTypeDecimal:
+			convErr = appendVal(w, colIdx, v, getDecimalVal)
+		case LogicalTypeInterval:
+			convErr = appendVal(w, colIdx, v, getIntervalVal)
+		default:
+			panic(fmt.Sprintf("attempted to write unknown type of column '%s': %d", f.Name, f.DataType))
+		}
+		if convErr != nil {
+			return fmt.Errorf("converting value for column '%s': %w (type %T)", f.Name, convErr, v)
+		}
+	}
 	w.bufferSizeBytes += w.rs.estSize(row)
+	w.bufferRowCount += 1
 	w.scratch.rowCount += 1
 
 	if w.bufferSizeBytes >= maxBufferSize {
@@ -378,66 +483,67 @@ func (w *ParquetWriter) flushScratchFile() error {
 
 // flushBuffer writes the current buffered rows as a single row group to the scratch file.
 func (w *ParquetWriter) flushBuffer() error {
-	if len(w.buffer) == 0 {
+	if w.bufferRowCount == 0 {
 		return nil
 	}
 
 	rgWriter := w.scratch.writer.AppendRowGroup()
 
-	// Transpose the buffered rows into the scratch file row group by writing them column-by-column.
 	for colIdx, f := range w.schema {
 		cw, err := rgWriter.NextColumn()
 		if err != nil {
 			return fmt.Errorf("getting next column: %w", err)
 		}
 
+		defLvls := w.defLevels[colIdx]
+
 		switch f.DataType {
 		case PrimitiveTypeInteger:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getIntVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing integer column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeNumber:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Float64ColumnChunkWriter), getNumberVal); err != nil {
+			if err := writeColumn(cw.(*file.Float64ColumnChunkWriter), *w.buffer[colIdx].(*[]float64), defLvls); err != nil {
 				return fmt.Errorf("writing number column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeBoolean:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.BooleanColumnChunkWriter), getBooleanVal); err != nil {
+			if err := writeColumn(cw.(*file.BooleanColumnChunkWriter), *w.buffer[colIdx].(*[]bool), defLvls); err != nil {
 				return fmt.Errorf("writing boolean column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeBinary:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getBinaryVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeJson:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getJsonVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array (json) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeString:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getStringVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array (string) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeUuid:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getUuidVal); err != nil {
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing uuid column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDate:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int32ColumnChunkWriter), getDateVal); err != nil {
+			if err := writeColumn(cw.(*file.Int32ColumnChunkWriter), *w.buffer[colIdx].(*[]int32), defLvls); err != nil {
 				return fmt.Errorf("writing date column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTime:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimeVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing time column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTimestamp:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDecimal:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
-				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
+				return fmt.Errorf("writing decimal column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeInterval:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getIntervalVal); err != nil {
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
 			}
 		default:
@@ -455,7 +561,11 @@ func (w *ParquetWriter) flushBuffer() error {
 
 	w.scratch.sizeBytes += int(rgWriter.TotalBytesWritten())
 	w.scratch.columnChunkCount += len(w.schema)
-	w.buffer = w.buffer[:0]
+	for i := range w.buffer {
+		resetColumnBuffer(w.buffer[i])
+		w.defLevels[i] = w.defLevels[i][:0]
+	}
+	w.bufferRowCount = 0
 	w.bufferSizeBytes = 0
 
 	return nil
@@ -493,31 +603,19 @@ type columnBatchWriter[T parquetValue] interface {
 
 type getValFn[T parquetValue] func(v any) (got T, err error)
 
-func writeColumn[T parquetValue](
-	colIdx int,
-	buf [][]any,
-	w columnBatchWriter[T],
-	getVal getValFn[T],
-) error {
-	var vals []T
-	var defLevels []int16
-
-	for _, row := range buf {
-		v := row[colIdx]
-		switch tv := v.(type) {
-		case nil:
-			defLevels = append(defLevels, 0)
-		default:
-			got, err := getVal(tv)
-			if err != nil {
-				return fmt.Errorf("getting typed value for value: %w (type %T)", err, tv)
-			}
-
-			vals = append(vals, got)
-			defLevels = append(defLevels, 1)
-		}
+// appendVal converts v with getVal and appends the result to the column's typed buffer slice. The
+// caller is responsible for handling nil values and maintaining defLevels.
+func appendVal[T parquetValue](w *ParquetWriter, colIdx int, v any, getVal getValFn[T]) error {
+	got, err := getVal(v)
+	if err != nil {
+		return err
 	}
+	sp := w.buffer[colIdx].(*[]T)
+	*sp = append(*sp, got)
+	return nil
+}
 
+func writeColumn[T parquetValue](w columnBatchWriter[T], vals []T, defLevels []int16) error {
 	if valuesWritten, err := w.WriteBatch(vals, defLevels, nil); err != nil {
 		return fmt.Errorf("writing batch of values: %w", err)
 	} else if int(valuesWritten) != len(vals) {

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -140,7 +140,7 @@ type ParquetWriter struct {
 
 	schema        ParquetSchema
 	schemaRoot    *schema.GroupNode
-	sinkWriter    *file.Writer
+	sinkWriter    *mergeWriter
 	cwc           *countingWriteCloser
 	rs            rowSize
 	rowGroupCount int
@@ -215,6 +215,14 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 	schemaRoot := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1))
 
 	cwc := &countingWriteCloser{w: w}
+	props, kvmeta := sinkWriterProperties(cfg)
+	// Matching arrow-go's *file.Writer constructor, we panic on the magic-bytes write failure
+	// rather than threading an error through NewParquetWriter — a sink that can't accept 4 bytes
+	// at construction time will fail again immediately on the first real write.
+	sinkWriter, err := newMergeWriter(cwc, schemaRoot, props, kvmeta)
+	if err != nil {
+		panic(fmt.Sprintf("creating sink writer: %s", err))
+	}
 
 	buffer := make([]any, len(sch))
 	defLevels := make([][]int16, len(sch))
@@ -228,7 +236,7 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 		cfg:        cfg,
 		schema:     sch,
 		schemaRoot: schemaRoot,
-		sinkWriter: file.NewParquetWriter(cwc, schemaRoot, writerOpts(cfg)...),
+		sinkWriter: sinkWriter,
 		cwc:        cwc,
 		rs:         newRowSizing(sch),
 		buffer:     buffer,
@@ -285,36 +293,41 @@ func resetColumnBuffer(s any) {
 	}
 }
 
-func writerOpts(cfg parquetConfig) []file.WriteOption {
-	propOpts := []parquet.WriterProperty{}
-
-	switch cfg.compression {
+func compressionCodec(c ParquetCompression) compress.Compression {
+	switch c {
 	case Uncompressed:
-		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Uncompressed))
+		return compress.Codecs.Uncompressed
 	case Snappy:
-		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Snappy))
+		return compress.Codecs.Snappy
 	case Gzip:
-		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Gzip))
+		return compress.Codecs.Gzip
 	default:
-		panic(fmt.Sprintf("unknown compression setting: %d", cfg.compression))
+		panic(fmt.Sprintf("unknown compression setting: %d", c))
 	}
+}
 
-	if cfg.disableDictionaryEncoding {
-		propOpts = append(propOpts, parquet.WithDictionaryDefault(false))
+// sinkWriterProperties builds the WriterProperties used by the sink mergeWriter and the
+// KeyValueMetadata to embed in the file. Dictionary encoding is unconditionally disabled because
+// transferColumnValues copies pages verbatim from scratch into the sink, and the sink cannot
+// retroactively build a dictionary from already-encoded pages. The `disableDictionaryEncoding`
+// config field is therefore now a no-op kept only for API compatibility.
+func sinkWriterProperties(cfg parquetConfig) (*parquet.WriterProperties, metadata.KeyValueMetadata) {
+	propOpts := []parquet.WriterProperty{
+		parquet.WithCompression(compressionCodec(cfg.compression)),
+		parquet.WithDictionaryDefault(false),
 	}
+	props := parquet.NewWriterProperties(propOpts...)
 
-	out := []file.WriteOption{file.WithWriterProps(parquet.NewWriterProperties(propOpts...))}
+	var kv metadata.KeyValueMetadata
 	if len(cfg.metadata) > 0 {
-		meta := metadata.NewKeyValueMetadata()
+		kv = metadata.NewKeyValueMetadata()
 		for k, v := range cfg.metadata {
-			if err := meta.Append(k, v); err != nil {
+			if err := kv.Append(k, v); err != nil {
 				panic(fmt.Sprintf("invalid metadata: %s", err)) // only possible if the metadata keys/values contain invalid UTF-8
 			}
 		}
-		out = append(out, file.WithWriteMetadata(meta))
 	}
-
-	return out
+	return props, kv
 }
 
 // Write a row of data by buffering it in the writers's buffer, and if thresholds are
@@ -336,10 +349,13 @@ func (w *ParquetWriter) Write(row []any) error {
 		scratchOpts := []parquet.WriterProperty{
 			// Don't use dictionary encoding for the scratch file, since it is
 			// much slower to write than plain encoding with the small row
-			// groups of the scratch file.
+			// groups of the scratch file. Also avoids the dictionary-page
+			// splice problem when copying pages verbatim into the sink.
 			parquet.WithDictionaryDefault(false),
-			// Turning off stats calculations helps too, but just a tiny bit.
-			parquet.WithStats(false),
+			// Match the sink codec so transferColumnValues can copy page bytes
+			// without re-compressing. Stats default on so per-page min/max
+			// propagate via copied pages to the sink output.
+			parquet.WithCompression(compressionCodec(w.cfg.compression)),
 		}
 		w.scratch.writer = file.NewParquetWriter(w.scratch.file, w.schemaRoot, file.WithWriterProps(parquet.NewWriterProperties(scratchOpts...)))
 	}
@@ -575,17 +591,6 @@ type parquetValue interface {
 	int64 | int32 | float64 | bool | parquet.FixedLenByteArray | parquet.ByteArray
 }
 
-// columnBatchReader is a generic wrapper for reading a batch of values having type T from a column.
-// This interface is satisfied by any of the typed column readers from the Apache parquet package.
-type columnBatchReader[T parquetValue] interface {
-	// ReadBatch reads batchSize values from the column. values must be large enough to hold the
-	// number of values that will be read. defLvls and repLvls will be populated if not nil; they
-	// are not inputs to the operation but their populated values are necessary for interpreting the
-	// data read into values. total is the number of rows that were read; valuesRead is the actual
-	// number of physical values that were read excluding nulls.
-	ReadBatch(batchSize int64, values []T, defLvls []int16, repLvls []int16) (total int64, valuesRead int, err error)
-}
-
 // columnBatchWriter is a generic wrapper for writing a batch of values having type T to a column.
 // This interface is satisfied by any of the typed column writers from the Apache parquet package.
 type columnBatchWriter[T parquetValue] interface {
@@ -625,83 +630,59 @@ func writeColumn[T parquetValue](w columnBatchWriter[T], vals []T, defLevels []i
 	return nil
 }
 
-// transferColumnValues reads columns from the scratch file r and writes the values to w. The
-// scratch file may contain many row groups, and the corresponding column from each row group is
-// read and written in order to combine all of the row groups from the scratch file into a single
-// row group written to w.
-func transferColumnValues(r *file.Reader, w *file.Writer) error {
+// transferColumnValues merges the row groups of scratch file r into a single row group written to
+// w by copying compressed page bytes verbatim. This avoids the per-value decode/re-encode that the
+// previous implementation performed, including codec re-compression. Preconditions, all enforced
+// at scratch-writer construction in (*ParquetWriter).Write:
+//
+//   - The scratch writer disables dictionary encoding so we never see a DictionaryPage to splice
+//     (arrow-go's column writer cannot import a foreign dictionary page).
+//   - The scratch writer's compression codec equals the sink's, so copied page bytes are valid in
+//     the sink's column chunks.
+//
+// w is our own *mergeWriter, which natively accepts pre-encoded data pages and tracks row counts
+// explicitly via SetNumRows — no need to bypass arrow-go's *file.Writer with reflect/unsafe.
+func transferColumnValues(r *file.Reader, w *mergeWriter) error {
 	sch := r.MetaData().Schema
-	rgWriter := w.AppendRowGroup()
+	rgWriter, err := w.AppendRowGroup()
+	if err != nil {
+		return fmt.Errorf("appending row group: %w", err)
+	}
 
-	for c := 0; c < sch.NumColumns(); c++ {
+	totalRows := 0
+	for rgIdx := 0; rgIdx < r.NumRowGroups(); rgIdx++ {
+		totalRows += int(r.RowGroup(rgIdx).NumRows())
+	}
+	rgWriter.SetNumRows(totalRows)
+
+	for i := 0; i < sch.NumColumns(); i++ {
 		cw, err := rgWriter.NextColumn()
 		if err != nil {
 			return fmt.Errorf("getting next column writer: %w", err)
 		}
 
 		for rgIdx := 0; rgIdx < r.NumRowGroups(); rgIdx++ {
-			rgReader := r.RowGroup(rgIdx)
-			n := int(rgReader.NumRows())
-
-			cr, err := rgReader.Column(c)
+			pr, err := r.RowGroup(rgIdx).GetColumnPageReader(i)
 			if err != nil {
-				return fmt.Errorf("getting next column reader: %w", err)
+				return fmt.Errorf("getting page reader for col %d rg %d: %w", i, rgIdx, err)
 			}
-
-			switch cw := cw.(type) {
-			case *file.FixedLenByteArrayColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.FixedLenByteArrayColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring fixed length byte array column: %w", err)
+			for pr.Next() {
+				dp, ok := pr.Page().(file.DataPage)
+				if !ok {
+					return fmt.Errorf("unexpected non-data page in scratch col %d rg %d (%T)", i, rgIdx, pr.Page())
 				}
-			case *file.Float64ColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.Float64ColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring float64 column: %w", err)
+				if err := cw.WriteDataPage(dp); err != nil {
+					return fmt.Errorf("writing data page: %w", err)
 				}
-			case *file.ByteArrayColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.ByteArrayColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring byte array column: %w", err)
-				}
-			case *file.Int32ColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.Int32ColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring int32 column: %w", err)
-				}
-			case *file.Int64ColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.Int64ColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring int64 column: %w", err)
-				}
-			case *file.BooleanColumnChunkWriter:
-				if err := doTransfer(n, cr.(*file.BooleanColumnChunkReader), cw); err != nil {
-					return fmt.Errorf("transferring boolean column: %w", err)
-				}
-			default:
-				return fmt.Errorf("unhandled physical type %q (writer type %T)", sch.Column(c).PhysicalType(), cw)
+			}
+			if err := pr.Err(); err != nil {
+				return fmt.Errorf("page reader error col %d rg %d: %w", i, rgIdx, err)
 			}
 		}
 	}
 
 	if err := rgWriter.Close(); err != nil {
 		return fmt.Errorf("closing row group writer: %w", err)
-	}
-
-	return nil
-}
-
-func doTransfer[T parquetValue](numRows int, r columnBatchReader[T], w columnBatchWriter[T]) error {
-	vals := make([]T, numRows)
-	defLvls := make([]int16, numRows)
-	rowsRead, valuesRead, err := r.ReadBatch(int64(numRows), vals, defLvls, nil)
-	if err != nil {
-		return fmt.Errorf("reading batch: %w", err)
-	}
-
-	vals = vals[:valuesRead]
-
-	if int(rowsRead) != numRows {
-		return fmt.Errorf("read %d rows vs. expected %d", rowsRead, numRows)
-	} else if valuesWritten, err := w.WriteBatch(vals, defLvls, nil); err != nil {
-		return fmt.Errorf("writing batch of values: %w", err)
-	} else if int(valuesWritten) != len(vals) {
-		return fmt.Errorf("written %d values vs. %d values in vals", valuesWritten, len(vals))
 	}
 
 	return nil

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"testing"
 
@@ -109,4 +110,56 @@ func TestParquetEOFReadingByteArrayRegression(t *testing.T) {
 	defLvls := make([]int16, numRows)
 	_, _, err = cr.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(numRows), vals, defLvls, nil)
 	require.NoError(t, err)
+}
+
+// BenchmarkParquetWriter exercises the full Write→Close pipeline with workloads sized to fire
+// flushScratchFile (and therefore transferColumnValues) at least once per op. Used to compare
+// before/after when refactoring transferColumnValues; run with -count=8 and feed both runs to
+// benchstat.
+func BenchmarkParquetWriter(b *testing.B) {
+	sch := makeTestParquetSchema(true)
+
+	// makeTestRow adds `seed` years to a date starting at 2006, so the seed must stay below
+	// ~7993 to keep the formatted year in the 4-digit range that time.DateOnly can re-parse.
+	// Pool size of 5000 gives plenty of variety while staying well under that ceiling.
+	const distinctRows = 5000
+	pool := make([][]any, distinctRows)
+	for i := range pool {
+		pool[i] = makeTestRow(b, i)
+	}
+
+	cases := []struct {
+		name        string
+		rows        int
+		rowGroupRow int
+		compression ParquetCompression
+	}{
+		{"small/uncompressed", 200_000, 50_000, Uncompressed},
+		{"small/snappy", 200_000, 50_000, Snappy},
+		{"large/uncompressed", 1_000_000, 0, Uncompressed},
+		{"large/snappy", 1_000_000, 0, Snappy},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			rows := make([][]any, tc.rows)
+			for i := range rows {
+				rows[i] = pool[i%distinctRows]
+			}
+
+			opts := []ParquetOption{WithParquetCompression(tc.compression)}
+			if tc.rowGroupRow > 0 {
+				opts = append(opts, WithParquetRowGroupRowLimit(tc.rowGroupRow))
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				w := NewParquetWriter(&nopWriteCloser{w: io.Discard}, sch, opts...)
+				for _, row := range rows {
+					require.NoError(b, w.Write(row))
+				}
+				require.NoError(b, w.Close())
+			}
+		})
+	}
 }


### PR DESCRIPTION
**Description:**

Improves parquet write per a new benchmark:
- 15% CPU
- 41% memory
- 75% memory allocations

Two-part refactor of `ParquetWriter`'s buffer-to-sink pipeline:

1. **Column-oriented buffer** (`b55c7158d`): changes the write buffer from `[][]any` to `[]any` of typed slice pointers (`*[]int64`, `*[]parquet.ByteArray`, etc.) with a parallel `[]int16` definition-level slice. Values are converted to their Parquet physical types at `Write` time instead of during the flush loop, eliminating the per-flush transposition pass and reducing GC scanning pressure.

2. **Page-copy** (`cf5e9e76d`): `transferColumnValues` previously decoded every column value from the scratch file and re-encoded it into the sink. Now the scratch writer uses the same codec as the sink and disables dictionary encoding, so compressed data pages are copied byte-for-byte through a new `mergeWriter` type that accepts pre-encoded pages and tracks row counts explicitly.

**Benchmark results** (A = baseline, B = column-oriented buffer, C = page-copy):

Step 1 (A→B): cpu +7%, mem −25%, allocs ~unchanged.
Step 2 (B→C): cpu −9–25%, mem −6–33%, allocs −75%.

```
                                   │      A (sec/op)      │          C (sec/op)          │
                                   │        sec/op        │   sec/op     vs base         │
ParquetWriter/small/uncompressed-8            699.4m ± 2%   559.9m ± 2%  -19.95% (p=0.000 n=8+7)
ParquetWriter/small/snappy-8                  718.6m ± 3%   636.6m ± 6%  -11.41% (p=0.000 n=8+7)
ParquetWriter/large/uncompressed-8             3.271 ± 2%    2.653 ± 2%  -18.92% (p=0.000 n=8+7)
ParquetWriter/large/snappy-8                   3.318 ± 4%    3.036 ± 2%   -8.48% (p=0.000 n=8+7)
geomean                                        1.528         1.302       -14.83%

                                   │     A (B/op)     │          C (B/op)           │
                                   │      B/op        │    B/op      vs base        │
ParquetWriter/small/uncompressed-8          638.3Mi ± 0%   333.0Mi ± 0%  -47.82% (p=0.000 n=8+7)
ParquetWriter/small/snappy-8               651.8Mi ± 0%   444.2Mi ± 0%  -31.85% (p=0.000 n=8+7)
ParquetWriter/large/uncompressed-8         2.945Gi ± 0%   1.464Gi ± 0%  -50.29% (p=0.000 n=8+7)
ParquetWriter/large/snappy-8               2.967Gi ± 0%   1.990Gi ± 0%  -32.94% (p=0.000 n=8+7)
geomean                                    1.364Gi        819.8Mi       -41.32%

                                   │  A (allocs/op)  │       C (allocs/op)       │
                                   │   allocs/op     │ allocs/op    vs base      │
ParquetWriter/small/uncompressed-8       4.013M ± 0%   1.020M ± 0%  -74.58% (p=0.000 n=8+7)
ParquetWriter/small/snappy-8             4.013M ± 0%   1.021M ± 0%  -74.56% (p=0.000 n=8+7)
ParquetWriter/large/uncompressed-8      19.997M ± 0%   5.046M ± 0%  -74.77% (n=8+7)
ParquetWriter/large/snappy-8            19.997M ± 0%   5.048M ± 0%  -74.75% (p=0.000 n=8+7)
geomean                                  8.958M        2.269M       -74.67%
```

Net: **−15% CPU, −41% memory, −75% allocations** (all p=0.000).

**Workflow steps:**

No user-visible change.

**Documentation links affected:**

None.

**Notes for reviewers:**

- `makeColumnBuffer` stores a pointer-to-slice in `[]any` to avoid boxing a 3-word slice header on every append.
- `appendVal[T parquetValue]` is a 5-line generic the compiler inlines at each call site, allowing devirtualization of the `getValFn[T]` parameter.
- `mergeWriter` (`merge_writer.go`) is the new sink type; it accepts `WriteDataPage` calls and tracks row counts via `SetNumRows`.