### PR TITLE
capture/bigquery: Translate infs to strings

### DIFF
--- a/go/capture/bigquery/datatypes/translate.go
+++ b/go/capture/bigquery/datatypes/translate.go
@@ -80,6 +80,10 @@ func TranslateValue(val any, fieldSchema *bigquery.FieldSchema) (any, error) {
 	case float64:
 		if math.IsNaN(val) {
 			return "NaN", nil
+		} else if math.IsInf(val, +1) {
+			return "Infinity", nil
+		} else if math.IsInf(val, -1) {
+			return "-Infinity", nil
 		}
 	}
 	return val, nil

--- a/source-bigquery-batch/.snapshots/TestSpecialFloatValues-Capture
+++ b/source-bigquery-batch/.snapshots/TestSpecialFloatValues-Capture
@@ -1,0 +1,156 @@
+# ================================
+# Collection "acmeCo/test/specialfloatvalues_738713": 4 Documents
+# ================================
+{
+  "type": "object",
+  "required": [
+    "_meta",
+    "float_val",
+    "id"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "_meta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
+      "properties": {
+        "polled": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Polled Timestamp",
+          "description": "The time at which the update query which produced this document as executed."
+        },
+        "index": {
+          "type": "integer",
+          "title": "Result Index",
+          "description": "The index of this document within the query execution which produced it."
+        },
+        "row_id": {
+          "type": "integer",
+          "title": "Row ID",
+          "description": "Row ID of the Document"
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "c",
+            "u",
+            "d"
+          ],
+          "title": "Change Operation",
+          "description": "Operation type (c: Create / u: Update / d: Delete)",
+          "default": "u"
+        },
+        "source": {
+          "properties": {
+            "resource": {
+              "type": "string",
+              "description": "Resource name of the binding from which this document was captured."
+            },
+            "schema": {
+              "type": "string",
+              "description": "Database schema from which the document was read."
+            },
+            "table": {
+              "type": "string",
+              "description": "Database table from which the document was read."
+            },
+            "tag": {
+              "type": "string",
+              "description": "Optional 'Source Tag' property as defined in the endpoint configuration."
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "resource"
+          ]
+        }
+      },
+      "type": "object",
+      "required": [
+        "polled",
+        "index",
+        "row_id",
+        "source"
+      ],
+      "additionalProperties": false
+    },
+    "float_val": {
+      "format": "number",
+      "description": "(source type: FLOAT64)",
+      "type": [
+        "number",
+        "string"
+      ]
+    },
+    "id": {
+      "description": "(source type: INT64)",
+      "type": [
+        "integer"
+      ]
+    }
+  },
+  "x-infer-schema": true
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 99,
+    "row_id": 99,
+    "source": {
+      "resource": "specialfloatvalues_738713",
+      "schema": "testdata",
+      "table": "specialfloatvalues_738713"
+    }
+  },
+  "float_val": "-Infinity",
+  "id": 3
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 99,
+    "row_id": 99,
+    "source": {
+      "resource": "specialfloatvalues_738713",
+      "schema": "testdata",
+      "table": "specialfloatvalues_738713"
+    }
+  },
+  "float_val": "Infinity",
+  "id": 2
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 99,
+    "row_id": 99,
+    "source": {
+      "resource": "specialfloatvalues_738713",
+      "schema": "testdata",
+      "table": "specialfloatvalues_738713"
+    }
+  },
+  "float_val": "NaN",
+  "id": 1
+}
+{
+  "_meta": {
+    "polled": "<TIMESTAMP>",
+    "index": 99,
+    "row_id": 99,
+    "source": {
+      "resource": "specialfloatvalues_738713",
+      "schema": "testdata",
+      "table": "specialfloatvalues_738713"
+    }
+  },
+  "float_val": 1.5,
+  "id": 4
+}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"specialfloatvalues_738713":{"CursorNames":["id"],"CursorValues":[4],"DocumentCount":4,"LastPolled":"<TIMESTAMP>"}}}
+

--- a/source-bigquery-batch/.snapshots/TestSpecialFloatValues-Discovery
+++ b/source-bigquery-batch/.snapshots/TestSpecialFloatValues-Discovery
@@ -1,0 +1,113 @@
+Binding 0:
+{
+    "resource_config_json": {
+      "name": "specialfloatvalues_738713",
+      "schema": "testdata",
+      "table": "specialfloatvalues_738713",
+      "cursor": [
+        "id"
+      ]
+    },
+    "resource_path": [
+      "specialfloatvalues_738713"
+    ],
+    "collection": {
+      "name": "acmeCo/test/specialfloatvalues_738713",
+      "read_schema_json": {
+        "type": "object",
+        "required": [
+          "_meta",
+          "id"
+        ],
+        "properties": {
+          "_meta": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-bigquery-batch/document-metadata",
+            "properties": {
+              "polled": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Polled Timestamp",
+                "description": "The time at which the update query which produced this document as executed."
+              },
+              "index": {
+                "type": "integer",
+                "title": "Result Index",
+                "description": "The index of this document within the query execution which produced it."
+              },
+              "row_id": {
+                "type": "integer",
+                "title": "Row ID",
+                "description": "Row ID of the Document"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "c",
+                  "u",
+                  "d"
+                ],
+                "title": "Change Operation",
+                "description": "Operation type (c: Create / u: Update / d: Delete)",
+                "default": "u"
+              },
+              "source": {
+                "properties": {
+                  "resource": {
+                    "type": "string",
+                    "description": "Resource name of the binding from which this document was captured."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema from which the document was read."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table from which the document was read."
+                  },
+                  "tag": {
+                    "type": "string",
+                    "description": "Optional 'Source Tag' property as defined in the endpoint configuration."
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "resource"
+                ]
+              }
+            },
+            "type": "object",
+            "required": [
+              "polled",
+              "index",
+              "row_id",
+              "source"
+            ]
+          },
+          "float_val": {
+            "format": "number",
+            "description": "(source type: FLOAT64)",
+            "type": [
+              "number",
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "description": "(source type: INT64)",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "x-infer-schema": true
+      },
+      "key": [
+        "/id"
+      ],
+      "projections": null
+    },
+    "state_key": "specialfloatvalues_738713"
+  }
+

--- a/source-bigquery-batch/main_test.go
+++ b/source-bigquery-batch/main_test.go
@@ -433,6 +433,35 @@ func TestNumericTypes(t *testing.T) {
 	})
 }
 
+// TestSpecialFloatValues verifies that the special FLOAT64 values NaN, +Infinity,
+// and -Infinity are translated into JSON-safe string representations rather than
+// producing serialization errors.
+func TestSpecialFloatValues(t *testing.T) {
+	var ctx, cs, control = context.Background(), testCaptureSpec(t), testBigQueryClient(t)
+	var tableName, uniqueID = testTableName(t, uniqueTableID(t))
+	createTestTable(ctx, t, control, tableName, `(
+        id          INTEGER PRIMARY KEY NOT ENFORCED,
+        float_val   FLOAT64
+    )`)
+
+	cs.Bindings = discoverBindings(ctx, t, cs, regexp.MustCompile(uniqueID))
+	setCursorColumns(t, cs.Bindings[0], "id")
+	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
+
+	t.Run("Capture", func(t *testing.T) {
+		setShutdownAfterQuery(t, true)
+
+		require.NoError(t, executeSetupQuery(ctx, t, control, fmt.Sprintf(
+			`INSERT INTO %s VALUES `+
+				`(1, CAST('NaN' AS FLOAT64)), `+
+				`(2, CAST('Infinity' AS FLOAT64)), `+
+				`(3, CAST('-Infinity' AS FLOAT64)), `+
+				`(4, 1.5)`, tableName)))
+		cs.Capture(ctx, t, nil)
+		cupaloy.SnapshotT(t, cs.Summary())
+	})
+}
+
 // TestStringTypes exercises discovery and capture of the string types
 // STRING and STRING(L).
 func TestStringTypes(t *testing.T) {


### PR DESCRIPTION
**Description:**

Impacts both source-ga4-bigquery and source-bigquery-batch, but I only added a test to source-bigquery-batch since the actual value translation logic is shared and source-bigquery-batch is the one where we can easily do round-trip testing.