### PR TITLE
go/writer: add nanosecond timestamp parquet type

### DIFF
--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -83,7 +83,7 @@ func newRowSizing(sch ParquetSchema) rowSize {
 		case PrimitiveTypeBinary, LogicalTypeJson, LogicalTypeDecimal:
 			rs.fixed += 24 // slice header
 			rs.calcLen = append(rs.calcLen, idx)
-		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeInterval:
+		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos, LogicalTypeInterval:
 			rs.fixed += 16 // string header
 			rs.calcLen = append(rs.calcLen, idx)
 		default:
@@ -431,6 +431,10 @@ func (w *ParquetWriter) flushBuffer() error {
 		case LogicalTypeTimestamp:
 			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampVal); err != nil {
 				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeTimestampNanos:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampNanosVal); err != nil {
+				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDecimal:
 			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
@@ -824,6 +828,22 @@ func getIntervalVal(val any) (got parquet.FixedLenByteArray, err error) {
 		}
 	default:
 		err = fmt.Errorf("getIntervalVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getTimestampNanosVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case string:
+		v = strings.Replace(v, "z", "Z", 1)
+		if d, parseErr := time.Parse(time.RFC3339Nano, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as timestamp: %w", v, parseErr)
+		} else {
+			got = d.UnixNano()
+		}
+	default:
+		err = fmt.Errorf("getTimestampNanosVal unhandled type: %T", v)
 	}
 
 	return

--- a/go/writer/parquet_schema.go
+++ b/go/writer/parquet_schema.go
@@ -64,7 +64,8 @@ const (
 	LogicalTypeJson                             // Extends BYTE_ARRAY
 	LogicalTypeDate                             // Extends BYTE_ARRAY
 	LogicalTypeTime                             // Extends INT64
-	LogicalTypeTimestamp                        // Extends INT64
+	LogicalTypeTimestamp                        // Extends INT64, microsecond precision
+	LogicalTypeTimestampNanos                   // Extends INT64, nanosecond precision
 	LogicalTypeUuid                             // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
 	LogicalTypeDecimal                          // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
 	LogicalTypeInterval                         // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
@@ -145,6 +146,15 @@ func makeNode(e ParquetSchemaElement) schema.Node {
 			-1,
 			fieldId,
 		))
+	case LogicalTypeTimestampNanos:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewTimestampLogicalType(true, schema.TimeUnitNanos),
+			parquet.Types.Int64,
+			-1,
+			fieldId,
+		))
 	case LogicalTypeInterval:
 		return schema.Must(schema.NewPrimitiveNodeLogical(
 			e.Name,
@@ -183,6 +193,7 @@ type parquetSchemaConfig struct {
 	objectAsString   bool
 	timeAsString     bool
 	uuidAsString     bool
+	timestampAsNanos bool
 }
 
 type ParquetSchemaOption func(*parquetSchemaConfig)
@@ -214,6 +225,12 @@ func WithParquetTimeAsString() ParquetSchemaOption {
 func WithParquetUUIDAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
 		cfg.uuidAsString = true
+	}
+}
+
+func WithParquetTimestampAsNanoseconds() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.timestampAsNanos = true
 	}
 }
 
@@ -277,7 +294,11 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 			case "date":
 				out.DataType = LogicalTypeDate
 			case "date-time":
-				out.DataType = LogicalTypeTimestamp
+				if cfg.timestampAsNanos {
+					out.DataType = LogicalTypeTimestampNanos
+				} else {
+					out.DataType = LogicalTypeTimestamp
+				}
 			case "duration":
 				out.DataType = typeOrString(LogicalTypeInterval, cfg.durationAsString)
 			case "time":

--- a/go/writer/parquet_schema_test.go
+++ b/go/writer/parquet_schema_test.go
@@ -103,6 +103,18 @@ func TestMakeNode(t *testing.T) {
 			},
 		},
 		{
+			name:         "LogicalTypeTimestampNanos",
+			elem:         ParquetSchemaElement{Name: "tsNanosField", DataType: LogicalTypeTimestampNanos, Required: false, FieldId: ptrTo(fid)},
+			wantPhysical: parquet.Types.Int64,
+			wantTypeLen:  -1,
+			checkLogical: func(t *testing.T, lt schema.LogicalType) {
+				tl, ok := lt.(schema.TimestampLogicalType)
+				require.True(t, ok, "expected TimestampLogicalType, got %T", lt)
+				require.True(t, tl.IsAdjustedToUTC())
+				require.Equal(t, schema.TimeUnitNanos, tl.TimeUnit())
+			},
+		},
+		{
 			name:         "LogicalTypeUuid",
 			elem:         ParquetSchemaElement{Name: "uuidField", DataType: LogicalTypeUuid, Required: true, FieldId: ptrTo(fid)},
 			wantPhysical: parquet.Types.FixedLenByteArray,
@@ -187,6 +199,7 @@ func TestMakeNodeNilFieldId(t *testing.T) {
 		LogicalTypeDate,
 		LogicalTypeTime,
 		LogicalTypeTimestamp,
+		LogicalTypeTimestampNanos,
 		LogicalTypeUuid,
 		LogicalTypeDecimal,
 		LogicalTypeInterval,
@@ -596,6 +609,20 @@ func TestProjectionToParquetSchemaElement(t *testing.T) {
 			},
 			opts:         []ParquetSchemaOption{WithParquetUUIDAsString()},
 			wantType:     LogicalTypeString,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetTimestampAsNanoseconds flips date-time to nanos",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists:  pf.Inference_MUST,
+					Types:   []string{"string"},
+					String_: &pf.Inference_String{Format: "date-time"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetTimestampAsNanoseconds()},
+			wantType:     LogicalTypeTimestampNanos,
 			wantRequired: true,
 		},
 	}

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
@@ -59,6 +60,62 @@ func TestParquetWriter(t *testing.T) {
 			cupaloy.SnapshotT(t, duckdbReadFile(t, sink.Name(), "JSON"))
 		})
 	}
+}
+
+func TestParquetWriterTimestampNanos(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "tsField", DataType: LogicalTypeTimestampNanos, Required: false},
+	}
+
+	rows := []string{"2024-01-02T03:04:05.123456789Z", "1970-01-01T00:00:00.000000001Z", ""}
+
+	w := NewParquetWriter(sink, sch)
+	for _, ts := range rows {
+		var val any
+		if ts != "" {
+			val = ts
+		}
+		require.NoError(t, w.Write([]any{val}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.Equal(t, 1, f.MetaData().Schema.NumColumns())
+
+	col := f.MetaData().Schema.Column(0)
+	require.Equal(t, parquet.Types.Int64, col.PhysicalType())
+	tsLogical, ok := col.LogicalType().(schema.TimestampLogicalType)
+	require.True(t, ok)
+	require.Equal(t, schema.TimeUnitNanos, tsLogical.TimeUnit())
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(rows), rg.NumRows())
+
+	cr, err := rg.Column(0)
+	require.NoError(t, err)
+	vals := make([]int64, len(rows))
+	def := make([]int16, len(rows))
+	_, _, err = cr.(*file.Int64ColumnChunkReader).ReadBatch(int64(len(rows)), vals, def, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int16(1), def[0])
+	require.Equal(t, int16(1), def[1])
+	require.Equal(t, int16(0), def[2])
+
+	wantTs0, err := time.Parse(time.RFC3339Nano, rows[0])
+	require.NoError(t, err)
+	require.Equal(t, wantTs0.UnixNano(), vals[0])
+
+	wantTs1, err := time.Parse(time.RFC3339Nano, rows[1])
+	require.NoError(t, err)
+	require.Equal(t, wantTs1.UnixNano(), vals[1])
 }
 
 // This is a regression test for a bug in arrow-go 18.5.2, added test so we


### PR DESCRIPTION
**Description:**

Adds support for nanosecond-precision timestamps in the Parquet writer. A new `LogicalTypeTimestampNanos` logical type (INT64, nanosecond unit) is introduced alongside the existing microsecond `LogicalTypeTimestamp`, selectable via a new `WithParquetTimestampAsNanoseconds()` schema option.

**Workflow steps:**

Materializations that emit Parquet can opt into nanosecond timestamp precision by passing `WithParquetTimestampAsNanoseconds()` when building the schema. Default behavior (microsecond precision) is unchanged.

**Documentation links affected:**

None.

**Notes for reviewers:**

Covered by unit tests in `parquet_schema_test.go` and `parquet_test.go`.