### PR TITLE
source-pendo: escape `"` and `\` in filter expressions

### DIFF
--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -39,6 +39,15 @@ def _ms_to_dt(ms: int) -> datetime:
 def base_url(host: PendoHost) -> str:
     return f"https://{host}/api/v1"
 
+def _escape_filter_string(value: str) -> str:
+    # Pendo's filter grammar is documented as "basic C expression syntax" but doesn't
+    # spell out string escape rules, so we only escape the two characters we know
+    # break the filter: "  and \. Order matters, so we escape backslashes
+    # first so the \" we insert isn't re-escaped into \\".
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _generate_time_series(
         period: str,
         lower_bound: int,
@@ -89,7 +98,7 @@ def generate_events_body(
     #                    there are more events in Pendo with the same lastTime than we can retrieve in
     #                    a single API query.
     if last_seen_id:
-        filter_condition = f"guideTimestamp == {lower_bound} && {identifying_field} >= \"{last_seen_id}\""
+        filter_condition = f"guideTimestamp == {lower_bound} && {identifying_field} >= {_escape_filter_string(last_seen_id)}"
     else:
         filter_condition = f"guideTimestamp >= {lower_bound}"
         if upper_bound:
@@ -161,7 +170,7 @@ def generate_event_aggregates_body(
     #              hour: The bottom of the hour for the aggregate. Ensures we don't get "in-progress"
     #                    aggregates for the current hour.
     if last_seen_id:
-        filter_condition = f"lastTime == {lower_bound} && {identifying_field} >= \"{last_seen_id}\" && hour < {current_hour}"
+        filter_condition = f"lastTime == {lower_bound} && {identifying_field} >= {_escape_filter_string(last_seen_id)} && hour < {current_hour}"
     else:
         filter_condition = f"lastTime >= {lower_bound} && hour < {current_hour}"
         if upper_bound:
@@ -227,7 +236,7 @@ def generate_resources_body(
     #                    there are more resources in Pendo with the same updated_at_field than we can retrieve in
     #                    a single API query.
     if last_seen_id:
-        filter_condition = f"{updated_at_field} == {lower_bound} && {identifying_field} >= \"{last_seen_id}\""
+        filter_condition = f"{updated_at_field} == {lower_bound} && {identifying_field} >= {_escape_filter_string(last_seen_id)}"
     else:
         filter_condition = f"{updated_at_field} >= {lower_bound}"
         if upper_bound:

--- a/source-pendo/tests/test_api.py
+++ b/source-pendo/tests/test_api.py
@@ -1,0 +1,18 @@
+from source_pendo.api import _escape_filter_string
+
+
+def test_escape_filter_string_simple_value_is_just_quoted():
+    assert _escape_filter_string("acct-123") == '"acct-123"'
+
+
+def test_escape_filter_string_escapes_embedded_double_quotes():
+    # accountIds from XSS-scan payloads contain literal " characters that would
+    # otherwise terminate the filter expression's string literal and 400 the request.
+    xss_id = 'javascript:xssdetected(1)//*/"/*onmouseover=...'
+    assert _escape_filter_string(xss_id) == r'"javascript:xssdetected(1)//*/\"/*onmouseover=..."'
+
+
+def test_escape_filter_string_escapes_backslashes_before_quotes():
+    # A literal \" in the data must become \\\" so Pendo's parser reads it as
+    # an escaped backslash followed by an escaped quote, not a closing delimiter.
+    assert _escape_filter_string('a\\"b') == r'"a\\\"b"'


### PR DESCRIPTION
**Description:**

Some users have identifiers in Pendo that contain the special character `"`, and it's suspected that not escaping `"` in these identifiers is causing issues with aggregation requests:

```
capture.Account.incremental: Encountered HTTP error status 400 which cannot be retried.
URL: https://us1.app.pendo.io/api/v1/aggregation
Response:
Cannot parse filter expression
```

This commit escapes `"` and `\` when using identifiers in aggregation requests, which should fix the issue.

Note: I saw this [Pendo doc](https://support.pendo.io/hc/en-us/articles/21326198721563-Choose-IDs-and-metadata) states:
> Don't use \ or " or invalid UTF-8 characters in an Account ID. These characters can result in errors in Pendo.

So... it's possible some other Pendo side error will occur & this won't unblock captures for users who use `\` or `"` in their account ids. If that's the case, we'll need to revisit & investigate further.

**Notes for reviewers:**

I'm unable to reproduce the issue since we don't have a dev Pendo account, so this is based purely off of the details provided in the user's bug report. The bug makes sense & definitely seems like an issue, but I wasn't able to directly confirm that the bug is what's causing the `Cannot parse filter expression` failure.
