### PR TITLE
source-*-batch: Checkpoint between cursor values

### DIFF
--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -522,6 +523,15 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	var rowValues []any
 	var serializedDocument []byte
 
+	// Partial-progress checkpoint state. For incremental bindings we only checkpoint
+	// at boundaries between distinct cursor values, persisting the previous row's
+	// cursor: that guarantees every row sharing the persisted cursor has been emitted,
+	// so the next poll's `WHERE cursor > @persisted` resume query won't skip rows
+	// which happen to share a cursor value with the checkpoint. Full-refresh bindings
+	// don't have this constraint and just checkpoint every K rows.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+
 	for {
 		var row []bigquery.Value
 		if err := rows.Next(&row); err == iterator.Done {
@@ -557,6 +567,48 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			// plus the `_meta` property we add.
 			rowValues = make([]any, len(row)+1)
 		}
+		for idx, val := range row {
+			var translatedValue, err = datatypes.TranslateValue(val, rows.Schema[idx])
+			if err != nil {
+				return fmt.Errorf("error translating column %q value: %w", string(rows.Schema[idx].Name), err)
+			}
+			rowValues[idx+1] = translatedValue
+		}
+
+		// Extract this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				currentCursorValues[i] = rowValues[j]
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				// Update CursorValues and DocumentCount in lockstep
+				state.CursorValues = prevCursorValues
+				state.DocumentCount = nextRowID
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
+
 		var metadata = &documentMetadata{
 			RowID:  nextRowID,
 			Polled: pollTime,
@@ -581,14 +633,6 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		}
 		rowValues[0] = metadata
 
-		for idx, val := range row {
-			var translatedValue, err = datatypes.TranslateValue(val, rows.Schema[idx])
-			if err != nil {
-				return fmt.Errorf("error translating column %q value: %w", string(rows.Schema[idx].Name), err)
-			}
-			rowValues[idx+1] = translatedValue
-		}
-
 		serializedDocument, err = shape.Encode(serializedDocument[:0], rowValues)
 		if err != nil {
 			return fmt.Errorf("error serializing document: %w", err)
@@ -596,35 +640,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			cursorValues[i] = rowValues[j]
-		}
-		state.CursorValues = cursorValues
-
+		prevCursorValues = currentCursorValues
 		count++
 		nextRowID++
+		documentsSinceLastCheckpoint++
 
-		if count%documentsPerCheckpoint == 0 {
-			// When a full-refresh binding outputs into a collection with key `/_meta/row_id`
-			// we rely on the persisted DocumentCount not being updated until after the whole
-			// update query completes successfully, so that we can infer deletions of any rows
-			// between the last rowID of the latest query and the persisted DocumentCount.
-			//
-			// But when emitting partial-progress updates on a _non_ full-refresh binding, we
-			// need to update the persisted DocumentCount on each partial progress checkpoint
-			// so that the rowID the next poll resumes from will match the persisted cursor.
-			if !isFullRefresh {
-				state.DocumentCount = nextRowID
-			}
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
 		if count%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
@@ -670,10 +690,27 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 
 	state.LastPolled = pollTime
 	state.DocumentCount = nextRowID // Always update persisted count on successful completion
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -575,6 +576,15 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	var rowValues []any
 	var serializedDocument []byte
 
+	// Partial-progress checkpoint state. For incremental bindings we only checkpoint
+	// at boundaries between distinct cursor values, persisting the previous row's
+	// cursor: that guarantees every row sharing the persisted cursor has been emitted,
+	// so the next poll's `WHERE cursor > @persisted` resume query won't skip rows
+	// which happen to share a cursor value with the checkpoint. Full-refresh bindings
+	// don't have this constraint and just checkpoint every K rows.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+
 	if err := stmt.ExecuteSelectStreaming(&result, func(row []mysql.FieldValue) error {
 		watchdog.Reset(pollingWatchdogTimeout) // Reset the no-data watchdog timeout after each row received
 
@@ -605,6 +615,49 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			// plus the `_meta` property we add.
 			rowValues = make([]any, len(row)+1)
 		}
+		for idx, val := range row {
+			var field = result.Fields[idx]
+			var translatedValue, err = translateMySQLValue(val.Value(), field.Type, field.Charset)
+			if err != nil {
+				return fmt.Errorf("error translating column %q value: %w", string(field.Name), err)
+			}
+			rowValues[idx+1] = translatedValue
+		}
+
+		// Extract this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				currentCursorValues[i] = rowValues[j]
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				// Update CursorValues and DocumentCount in lockstep
+				state.CursorValues = prevCursorValues
+				state.DocumentCount = nextRowID
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
+
 		var metadata = &documentMetadata{
 			RowID:  nextRowID,
 			Polled: pollTime,
@@ -628,14 +681,6 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			}
 		}
 		rowValues[0] = metadata
-		for idx, val := range row {
-			var field = result.Fields[idx]
-			var translatedValue, err = translateMySQLValue(val.Value(), field.Type, field.Charset)
-			if err != nil {
-				return fmt.Errorf("error translating column %q value: %w", string(field.Name), err)
-			}
-			rowValues[idx+1] = translatedValue
-		}
 
 		serializedDocument, err = shape.Encode(serializedDocument[:0], rowValues)
 		if err != nil {
@@ -644,34 +689,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			cursorValues[i] = rowValues[j]
-		}
-		state.CursorValues = cursorValues
+		prevCursorValues = currentCursorValues
 		queryResultsCount++
 		nextRowID++
+		documentsSinceLastCheckpoint++
 
-		if queryResultsCount%documentsPerCheckpoint == 0 {
-			// When a full-refresh binding outputs into a collection with key `/_meta/row_id`
-			// we rely on the persisted DocumentCount not being updated until after the whole
-			// update query completes successfully, so that we can infer deletions of any rows
-			// between the last rowID of the latest query and the persisted DocumentCount.
-			//
-			// But when emitting partial-progress updates on a _non_ full-refresh binding, we
-			// need to update the persisted DocumentCount on each partial progress checkpoint
-			// so that the rowID the next poll resumes from will match the persisted cursor.
-			if !isFullRefresh {
-				state.DocumentCount = nextRowID
-			}
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
 		if queryResultsCount%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
@@ -720,10 +742,27 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 
 	state.LastPolled = pollTime
 	state.DocumentCount = nextRowID // Always update persisted count on successful completion
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -508,14 +509,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	var rowValues = make([]any, len(columnNames)+1)
 	var serializedDocument []byte
 
-	// When capturing with ORA_ROWSCN (txid), since this cursor is not unique for rows,
-	// we need to ensure we only emit a checkpoint after we have captured all of the rows
-	// with the same SCN
-	var scnCursor = len(cursorNames) == 1 && cursorNames[0] == "TXID"
-	var lastSCN any
-	if scnCursor && state.CursorValues != nil {
-		lastSCN = state.CursorValues[0]
-	}
+	// Partial-progress checkpoint state. We only checkpoint at boundaries between
+	// distinct cursor values, persisting the previous row's cursor: that guarantees
+	// every row sharing the persisted cursor has been emitted, so the next poll's
+	// `WHERE cursor > @persisted` resume query won't skip rows which happen to
+	// share a cursor value with the checkpoint. This subsumes the previous
+	// special case for ORA_ROWSCN (TXID) cursors, where the same property was
+	// hand-rolled to deal with rows sharing the same SCN.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+	var isFullRefresh = len(cursorNames) == 0
 
 	var count int
 	for rows.Next() {
@@ -531,6 +534,39 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			}
 			rowValues[idx] = translatedVal
 		}
+
+		// Extract this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				currentCursorValues[i] = rowValues[j]
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				state.CursorValues = prevCursorValues
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
+
 		rowValues[len(rowValues)-1] = &documentMetadata{
 			Polled: pollTime,
 			Index:  count,
@@ -549,47 +585,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			cursorValues[i] = rowValues[j]
-		}
-
-		// If ORA_ROWSCN is our cursor, only emit a checkpoint when we have captured all of the rows with the same SCN
-		if scnCursor {
-			if lastSCN == nil {
-				lastSCN = cursorValues[0]
-			} else if lastSCN != cursorValues[0] {
-				state.CursorValues = []any{lastSCN}
-				lastSCN = cursorValues[0]
-			}
-		} else {
-			state.CursorValues = cursorValues
-		}
-
+		prevCursorValues = currentCursorValues
 		count++
-		if count%documentsPerCheckpoint == 0 {
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
+		documentsSinceLastCheckpoint++
+
 		if count%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
 				"count": count,
 			}).Info("processing query results")
 		}
-	}
-
-	if scnCursor && lastSCN != nil {
-		// After having completed a query, emit a final checkpoint with the last seen SCN
-		// Since the query is not paginated (i.e. we query all available results), the SCN
-		// should be the latest available SCN in that table. Any new updates to the table which may
-		// update the data will have a higher SCN
-		state.CursorValues = []any{lastSCN}
 	}
 
 	log.WithFields(log.Fields{
@@ -601,10 +606,27 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		return fmt.Errorf("error processing results iterator: %w", err)
 	}
 	state.LastPolled = pollTime
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -655,6 +656,15 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 	var rowValues = make([]any, len(columnNames)+1)
 	var serializedDocument []byte
 
+	// Partial-progress checkpoint state. For incremental bindings we only checkpoint
+	// at boundaries between distinct cursor values, persisting the previous row's
+	// cursor: that guarantees every row sharing the persisted cursor has been emitted,
+	// so the next poll's `WHERE cursor > @persisted` resume query won't skip rows
+	// which happen to share a cursor value with the checkpoint. Full-refresh bindings
+	// don't have this constraint and just checkpoint every K rows.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+
 	var queryResultsCount int
 	for rows.Next() {
 		if err := rows.Scan(columnPointers...); err != nil {
@@ -669,6 +679,41 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 			}
 			rowValues[idx] = translatedVal
 		}
+
+		// Extract this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				currentCursorValues[i] = rowValues[j]
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				// Update CursorValues and DocumentCount in lockstep
+				state.CursorValues = prevCursorValues
+				state.DocumentCount = nextRowID
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
+
 		var metadata = &documentMetadata{
 			RowID:  nextRowID,
 			Polled: pollTime,
@@ -700,35 +745,11 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			cursorValues[i] = rowValues[j]
-		}
-		state.CursorValues = cursorValues
-
+		prevCursorValues = currentCursorValues
 		queryResultsCount++
 		nextRowID++
+		documentsSinceLastCheckpoint++
 
-		if queryResultsCount%documentsPerCheckpoint == 0 {
-			// When a full-refresh binding outputs into a collection with key `/_meta/row_id`
-			// we rely on the persisted DocumentCount not being updated until after the whole
-			// update query completes successfully, so that we can infer deletions of any rows
-			// between the last rowID of the latest query and the persisted DocumentCount.
-			//
-			// But when emitting partial-progress updates on a _non_ full-refresh binding, we
-			// need to update the persisted DocumentCount on each partial progress checkpoint
-			// so that the rowID the next poll resumes from will match the persisted cursor.
-			if !isFullRefresh {
-				state.DocumentCount = nextRowID
-			}
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
 		if queryResultsCount%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
@@ -775,10 +796,27 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 	}
 
 	state.DocumentCount = nextRowID // Always update persisted count on successful completion
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) pollIncremental(ctx context.Context, binding *bindingInfo) error {

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -518,6 +519,15 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 	var rowValues = make([]any, len(columnNames)+1)
 	var serializedDocument []byte
 
+	// Partial-progress checkpoint state. For incremental bindings we only checkpoint
+	// at boundaries between distinct cursor values, persisting the previous row's
+	// cursor: that guarantees every row sharing the persisted cursor has been emitted,
+	// so the next poll's `WHERE cursor > @persisted` resume query won't skip rows
+	// which happen to share a cursor value with the checkpoint. Full-refresh bindings
+	// don't have this constraint and just checkpoint every K rows.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+
 	var count int
 	for rows.Next() {
 		if err := rows.Scan(columnPointers...); err != nil {
@@ -532,6 +542,41 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 			}
 			rowValues[idx] = translatedVal
 		}
+
+		// Extract this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				currentCursorValues[i] = rowValues[j]
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				// Update CursorValues and DocumentCount in lockstep
+				state.CursorValues = prevCursorValues
+				state.DocumentCount = nextRowID
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
+
 		var metadata = &documentMetadata{
 			RowID:  nextRowID,
 			Polled: pollTime,
@@ -563,34 +608,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			cursorValues[i] = rowValues[j]
-		}
-		state.CursorValues = cursorValues
-
+		prevCursorValues = currentCursorValues
 		count++
 		nextRowID++
-		if count%documentsPerCheckpoint == 0 {
-			// When a full-refresh binding outputs into a collection with key `/_meta/row_id`
-			// we rely on the persisted DocumentCount not being updated until after the whole
-			// update query completes successfully, so that we can infer deletions of any rows
-			// between the last rowID of the latest query and the persisted DocumentCount.
-			//
-			// But when emitting partial-progress updates on a _non_ full-refresh binding, we
-			// need to update the persisted DocumentCount on each partial progress checkpoint
-			// so that the rowID the next poll resumes from will match the persisted cursor.
-			if !isFullRefresh {
-				state.DocumentCount = nextRowID
-			}
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
+		documentsSinceLastCheckpoint++
+
 		if count%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
@@ -638,10 +660,27 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 
 	state.LastPolled = pollTime
 	state.DocumentCount = nextRowID // Always update persisted count on successful completion
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -561,12 +562,59 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 	var rowValues = make([]any, len(columnNames)+1)
 	var serializedDocument []byte
 
+	// Partial-progress checkpoint state. For incremental bindings we only checkpoint
+	// at boundaries between distinct cursor values, persisting the previous row's
+	// cursor: that guarantees every row sharing the persisted cursor has been emitted,
+	// so the next poll's `WHERE cursor > @persisted` resume query won't skip rows
+	// which happen to share a cursor value with the checkpoint. Full-refresh bindings
+	// don't have this constraint and just checkpoint every K rows.
+	var documentsSinceLastCheckpoint int
+	var prevCursorValues []any
+
 	var queryResultsCount int
 	for rows.Next() {
 		if err := rows.Scan(columnPointers...); err != nil {
 			return fmt.Errorf("error scanning result row: %w", err)
 		}
 		watchdog.Reset(pollingWatchdogTimeout) // Reset the no-data watchdog timeout after each row received
+
+		// Translate this row's cursor values into a fresh slice. Done before document
+		// emission so we can use the values for the partial-progress decision below.
+		var currentCursorValues []any
+		if !isFullRefresh {
+			currentCursorValues = make([]any, len(cursorIndices))
+			for i, j := range cursorIndices {
+				var translatedCursor, err = c.TranslateCursor(c.Config, columnValues[j], columnTypes[j].DatabaseTypeName())
+				if err != nil {
+					return fmt.Errorf("error translating cursor column %q value: %w", columnNames[j], err)
+				}
+				currentCursorValues[i] = translatedCursor
+			}
+		}
+
+		// Emit a partial-progress checkpoint *before* this row when enough rows have
+		// accumulated since the last checkpoint, and (for incremental bindings) the
+		// cursor value is about to change. For full-refresh bindings the persisted
+		// cursor is empty and resume semantics don't apply, so the boundary check
+		// reduces to "every K rows".
+		if documentsSinceLastCheckpoint >= documentsPerCheckpoint {
+			var shouldEmit = false
+			if isFullRefresh {
+				shouldEmit = true
+			} else if prevCursorValues != nil && !cursorValuesEqual(prevCursorValues, currentCursorValues) {
+				// Update CursorValues and DocumentCount in lockstep
+				state.CursorValues = prevCursorValues
+				state.DocumentCount = nextRowID
+				shouldEmit = true
+			}
+
+			if shouldEmit {
+				if err := c.streamStateCheckpoint(stateKey, state); err != nil {
+					return err
+				}
+				documentsSinceLastCheckpoint = 0
+			}
+		}
 
 		for idx, val := range columnValues {
 			var translatedVal, err = c.TranslateValue(c.Config, val, columnTypes[idx].DatabaseTypeName())
@@ -606,39 +654,11 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 			return fmt.Errorf("error emitting document: %w", err)
 		}
 
-		if len(cursorValues) != len(cursorNames) {
-			// Allocate a new values list if needed. This is done inside of the loop, so
-			// an empty result set will be a no-op even when the previous state is nil.
-			cursorValues = make([]any, len(cursorNames))
-		}
-		for i, j := range cursorIndices {
-			var translatedCursor, err = c.TranslateCursor(c.Config, columnValues[j], columnTypes[j].DatabaseTypeName())
-			if err != nil {
-				return fmt.Errorf("error translating cursor column %q value: %w", columnNames[j], err)
-			}
-			cursorValues[i] = translatedCursor
-		}
-		state.CursorValues = cursorValues
-
+		prevCursorValues = currentCursorValues
 		queryResultsCount++
 		nextRowID++
+		documentsSinceLastCheckpoint++
 
-		if queryResultsCount%documentsPerCheckpoint == 0 {
-			// When a full-refresh binding outputs into a collection with key `/_meta/row_id`
-			// we rely on the persisted DocumentCount not being updated until after the whole
-			// update query completes successfully, so that we can infer deletions of any rows
-			// between the last rowID of the latest query and the persisted DocumentCount.
-			//
-			// But when emitting partial-progress updates on a _non_ full-refresh binding, we
-			// need to update the persisted DocumentCount on each partial progress checkpoint
-			// so that the rowID the next poll resumes from will match the persisted cursor.
-			if !isFullRefresh {
-				state.DocumentCount = nextRowID
-			}
-			if err := c.streamStateCheckpoint(stateKey, state); err != nil {
-				return err
-			}
-		}
 		if queryResultsCount%100000 == 1 {
 			log.WithFields(log.Fields{
 				"name":  res.Name,
@@ -686,10 +706,27 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 
 	state.LastPolled = pollTime
 	state.DocumentCount = nextRowID // Always update persisted count on successful completion
+	if prevCursorValues != nil {
+		// Advance the persisted cursor to the final emitted row. Within the loop
+		// CursorValues is only updated at distinct-value boundaries to avoid losing
+		// rows on a mid-query restart, so the end-of-poll checkpoint is the one
+		// place where we accept the rest-of-batch-redo cost in exchange for the
+		// cursor advancing past the most recent row.
+		state.CursorValues = prevCursorValues
+	}
 	if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 		return err
 	}
 	return nil
+}
+
+// cursorValuesEqual reports whether two cursor tuples are element-wise equal.
+// Uses reflect.DeepEqual so it handles whatever scan types the driver returns,
+// including []byte and time.Time.
+func cursorValuesEqual(a, b []any) bool {
+	return slices.EqualFunc(a, b, func(x, y any) bool {
+		return reflect.DeepEqual(x, y)
+	})
 }
 
 func (c *capture) streamStateCheckpoint(sk boilerplate.StateKey, state *streamState) error {


### PR DESCRIPTION
**Description:**

Tweaks the polling readout logic in various batch SQL captures to only emit incremental-progress checkpoints in between dissimilar cursor values so that long runs of identical cursors have to be read out in full. This is the same rule we use in a bunch of other places, just applied to the batch SQL polling operations which didn't previously use it.

**Documentation links affected:**

None, our documentation doesn't go into that level of detail regarding cursor update timing and users shouldn't really need to care, this will just work more reliably in certain edge cases.