### PR TITLE
materialize-s3-iceberg: add nanosecond timestamps

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -66,6 +66,7 @@ Estuary collections to your tables.
 | **`/region`**                     | Region                | AWS Region.                                                                                                                                         | string | Required         |
 | **`/namespace`**                  | Namespace             | Namespace for bound collection tables (unless overridden within the binding resource configuration).                                                | string | Required         |
 | `/upload_interval`                | Upload Interval       | Frequency at which files will be uploaded. Must be a valid ISO8601 duration string no greater than 4 hours.                                         | string | PT5M             |
+| `/advanced/nanosecond_timestamps` | Nanosecond Timestamps | Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2).                                    | bool   | false            |
 | **`/catalog/catalog_type`**       | Catalog Type          | Either "Iceberg REST Server" or "AWS Glue".                                                                                                         | string | Required         |
 | `/catalog/glue_id`                | Glue Catalog ID       | Glue Catalog ID to use. If not specified, defaults to the account ID of the configured credentials. This enables cross-account Glue catalog access. | string |                  |
 | **`/catalog/uri`**                | URI                   | URI identifying the REST catalog, in the format of 'https://yourserver.com/catalog'.                                                                | string | Required         |
@@ -129,6 +130,13 @@ Estuary collection fields with `{type: string, format: time}` and `{type: string
 materialized as **string** columns rather than **time** and **uuid** columns for compatibility with
 Apache Spark. **[Nested types](https://iceberg.apache.org/spec/#nested-types)** are not currently
 supported.
+
+With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
+instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
+using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
+Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
+existing materialization requires a backfill of its bindings, because Iceberg has no in-place
+promotion between the two timestamp encodings.
 
 ## Table Maintenance
 

--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -136,9 +136,11 @@ instead materialized as **timestamptz_ns** columns with nanosecond precision, an
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
 Make sure your query engine supports format v3 tables before enabling this option.
 
-Toggling the option on an existing materialization applies to data going forward: Iceberg has no
-in-place conversion between the two timestamp encodings, so each timestamp column is re-created
-under the new type, and existing rows read as **null** for those columns. Prior values remain
+Toggling the option in either direction on an existing materialization applies to data going
+forward: Iceberg has no in-place conversion between the two timestamp encodings, so each timestamp
+column is re-created under the new type, and existing rows read as **null** for those columns.
+Enabling the option on an existing format v2 table also upgrades the table to format v3 in place.
+Prior values remain
 readable in the table's earlier snapshots via time travel. To repopulate history under the new
 type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 

--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -134,9 +134,13 @@ supported.
 With the advanced option `nanosecond_timestamps` enabled, fields with `{format: date-time}` are
 instead materialized as **timestamptz_ns** columns with nanosecond precision, and tables are created
 using [Iceberg format v3](https://iceberg.apache.org/spec/#version-3-extended-types-and-capabilities).
-Make sure your query engine supports format v3 tables before enabling this option. Toggling it on an
-existing materialization requires a backfill of its bindings, because Iceberg has no in-place
-promotion between the two timestamp encodings.
+Make sure your query engine supports format v3 tables before enabling this option.
+
+Toggling the option on an existing materialization applies to data going forward: Iceberg has no
+in-place conversion between the two timestamp encodings, so each timestamp column is re-created
+under the new type, and existing rows read as **null** for those columns. Prior values remain
+readable in the table's earlier snapshots via time travel. To repopulate history under the new
+type, trigger a backfill of the binding, which re-materializes the table from the Flow collection.
 
 ## Table Maintenance
 

--- a/materialize-s3-iceberg/.snapshots/TestIntegration-materialize-ns
+++ b/materialize-s3-iceberg/.snapshots/TestIntegration-materialize-ns
@@ -1,0 +1,118 @@
+Task: acmeCo/tests/materialize-s3-iceberg
+
+Resource: tests.simple_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":"_meta/op","Nullable":false,"Type":"string"}
+{"Name":"canary","Nullable":false,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"id","Nullable":false,"Type":"long"}
+{"Name":"val","Nullable":true,"Type":"long"}
+
+Table Data:
+{"_meta/op":"c","canary":"Kringle's","flow_published_at":"1970-01-01 01:00:04+00","id":5,"val":5}
+{"_meta/op":"c","canary":"amputation's","flow_published_at":"1970-01-01 01:00:00+00","id":1,"val":1}
+{"_meta/op":"c","canary":"armament's","flow_published_at":"1970-01-01 01:00:01+00","id":2,"val":2}
+{"_meta/op":"c","canary":"devilish","flow_published_at":"1970-01-01 03:00:02+00","id":9,"val":9}
+{"_meta/op":"c","canary":"glucose's","flow_published_at":"1970-01-01 03:00:03+00","id":10,"val":10}
+{"_meta/op":"c","canary":"grosbeak's","flow_published_at":"1970-01-01 01:00:05+00","id":6,"val":6}
+{"_meta/op":"c","canary":"penguin","flow_published_at":"1970-01-01 03:00:05+00","id":12,"val":12}
+{"_meta/op":"c","canary":"pieced","flow_published_at":"1970-01-01 03:00:00+00","id":7,"val":7}
+{"_meta/op":"c","canary":"roaches","flow_published_at":"1970-01-01 03:00:01+00","id":8,"val":8}
+{"_meta/op":"c","canary":"splatters","flow_published_at":"1970-01-01 01:00:02+00","id":3,"val":3}
+{"_meta/op":"c","canary":"strengthen","flow_published_at":"1970-01-01 01:00:03+00","id":4,"val":4}
+{"_meta/op":"d","canary":"amputation's","flow_published_at":"1970-01-01 03:00:07+00","id":1,"val":1}
+{"_meta/op":"d","canary":"armament's","flow_published_at":"1970-01-01 03:00:08+00","id":2,"val":2}
+{"_meta/op":"d","canary":"asteroid","flow_published_at":"1970-01-01 03:00:04+00","id":11,"val":11}
+{"_meta/op":"d","canary":"penguin","flow_published_at":"1970-01-01 03:00:06+00","id":12,"val":12}
+{"_meta/op":"u","canary":"splatters","flow_published_at":"1970-01-01 03:00:09+00","id":3,"val":3}
+
+Resource: tests.not_simple_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":" ,;{}().- problematicField � 𐀀 嶲 ","Nullable":true,"Type":"string"}
+{"Name":" ,;{}().- problematicKey � 𐀀 嶲 ","Nullable":false,"Type":"string"}
+{"Name":"$dollar$signs","Nullable":true,"Type":"string"}
+{"Name":"123","Nullable":true,"Type":"string"}
+{"Name":"123startsWithDigits","Nullable":true,"Type":"string"}
+{"Name":"FIELDWITHDIFFERENTCAPS","Nullable":true,"Type":"string"}
+{"Name":"_id","Nullable":false,"Type":"string"}
+{"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"string"}
+{"Name":"binaryKey","Nullable":false,"Type":"binary"}
+{"Name":"field with separated words","Nullable":true,"Type":"string"}
+{"Name":"field-with-separated-words","Nullable":true,"Type":"string"}
+{"Name":"field.with-separated_words","Nullable":true,"Type":"string"}
+{"Name":"field.with.separated.words","Nullable":true,"Type":"string"}
+{"Name":"field_with_separated_words","Nullable":true,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"longString","Nullable":true,"Type":"string"}
+{"Name":"testing (%s)","Nullable":true,"Type":"string"}
+
+Table Data:
+{" ,;{}().- problematicField � 𐀀 嶲 ":""," ,;{}().- problematicKey � 𐀀 嶲 ":"test-key-2","$dollar$signs":"","123":"","123startsWithDigits":"","FIELDWITHDIFFERENTCAPS":"","_id":"doc_002","a\"string`with`quote'characters":null,"binaryKey":"TestData","field with separated words":"","field-with-separated-words":"","field.with-separated_words":"","field.with.separated.words":"","field_with_separated_words":"","flow_published_at":"1970-01-01 01:00:07+00","longString":"","testing (%s)":""}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"special chars in data"," ,;{}().- problematicKey � 𐀀 嶲 ":"\\he \\ ' \" `llo`","$dollar$signs":"dollar signs","123":"only numbers","123startsWithDigits":"starts with numbers","FIELDWITHDIFFERENTCAPS":"UPPERCASE","_id":"doc_001","a\"string`with`quote'characters":null,"binaryKey":"Hello World","field with separated words":"spaces work","field-with-separated-words":"dashes work","field.with-separated_words":"mixed separators","field.with.separated.words":"dots work","field_with_separated_words":"underscores work","flow_published_at":"1970-01-01 01:00:06+00","longString":"This is a very long string that tests how the system handles large text data with various characters and unicode symbols like 你好世界 and emojis 🌟🚀🎉","testing (%s)":"printf format"}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"symbols: !@#$%^\u0026*()_+-=[]{}|;':\",./\u003c\u003e?"," ,;{}().- problematicKey � 𐀀 嶲 ":"very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru.","$dollar$signs":"$100.50$","123":"999","123startsWithDigits":"field starting with 123","FIELDWITHDIFFERENTCAPS":"ALL UPPERCASE VALUE","_id":"doc_003","a\"string`with`quote'characters":null,"binaryKey":"BinaryTestData","field with separated words":"edge case testing","field-with-separated-words":"hyphen-separated-values","field.with-separated_words":"mixed.separator-test_data","field.with.separated.words":"system.test.data","field_with_separated_words":"underscore_separated_values","flow_published_at":"1970-01-01 01:00:08+00","longString":"very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru.","testing (%s)":"printf style format string test"}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"updated special chars"," ,;{}().- problematicKey � 𐀀 嶲 ":"\\he \\ ' \" `llo`","$dollar$signs":"updated dollars","123":"updated 123","123startsWithDigits":"updated numbers","FIELDWITHDIFFERENTCAPS":"UPDATED UPPERCASE","_id":"doc_001","a\"string`with`quote'characters":null,"binaryKey":"Hello World","field with separated words":"updated spaces","field-with-separated-words":"updated dashes","field.with-separated_words":"updated mixed","field.with.separated.words":"updated dots","field_with_separated_words":"updated underscores","flow_published_at":"1970-01-01 03:00:10+00","longString":"Updated long string with more Unicode: 🎭🎨🎪🎯 αβγδε ñáéíóú 中文更新测试 العربية עברית русский 한국어 日本語","testing (%s)":"updated printf"}
+
+Resource: tests.data_types_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":"arrayField","Nullable":true,"Type":"string"}
+{"Name":"boolField","Nullable":true,"Type":"boolean"}
+{"Name":"enumField","Nullable":true,"Type":"string"}
+{"Name":"enumNullableField","Nullable":true,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"id","Nullable":false,"Type":"long"}
+{"Name":"intField","Nullable":true,"Type":"long"}
+{"Name":"multipleField","Nullable":true,"Type":"string"}
+{"Name":"numField","Nullable":true,"Type":"double"}
+{"Name":"stringAndIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringAndNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringDateField","Nullable":true,"Type":"date"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"timestamptz_ns"}
+{"Name":"stringDurationField","Nullable":true,"Type":"string"}
+{"Name":"stringEmailField","Nullable":true,"Type":"string"}
+{"Name":"stringField","Nullable":true,"Type":"string"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"string"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"string"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"string"}
+{"Name":"stringIriField","Nullable":true,"Type":"string"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"string"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"string"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"string"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"string"}
+{"Name":"stringNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringRegexField","Nullable":true,"Type":"string"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"string"}
+{"Name":"stringTimeField","Nullable":true,"Type":"string"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"long"}
+{"Name":"stringUriField","Nullable":true,"Type":"string"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"string"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"string"}
+{"Name":"stringUuidField","Nullable":true,"Type":"string"}
+
+Table Data:
+{"arrayField":"[\"updated\",\"array\",\"values\"]","boolField":false,"enumField":"foo","enumNullableField":"one","flow_published_at":"1970-01-01 03:00:11+00","id":4,"intField":2147483647,"multipleField":"999","numField":12345678900,"stringAndIntegerField":999,"stringAndNumberField":999.999,"stringDateField":"2024-12-25","stringDateTimeField":"2024-12-25 00:00:00+00","stringDurationField":"P1D","stringEmailField":"updated@test.org","stringField":"updated value","stringHostnameField":"api.example.org","stringIntegerField":999,"stringIpv4Field":"8.8.8.8","stringIpv6Field":"2001:4860:4860::8888","stringIriField":"https://テスト.例","stringIriReferenceField":"/テスト/例","stringJsonPointerField":"/data/items/0/name","stringMacAddr8Field":"aa:bb:cc:dd:ee:ff:00:11","stringMacAddrField":"aa:bb:cc:dd:ee:ff","stringNumberField":999.999,"stringRegexField":"^\\d{4}-\\d{2}-\\d{2}$","stringRelativeJsonPointerField":"3/updated","stringTimeField":"12:00:00z","stringUint32Field":1000000000,"stringUriField":"https://api.example.org/v1/resource","stringUriReferenceField":"../parent/resource","stringUriTemplateField":"/api/v{version}/users/{id}","stringUuidField":"123e4567-e89b-12d3-a456-426614174000"}
+{"arrayField":"[1,\"two\",3.0,true,null]","boolField":true,"enumField":"baz","enumNullableField":null,"flow_published_at":"1970-01-01 03:00:12+00","id":1,"intField":42,"multipleField":"string value","numField":3.14159,"stringAndIntegerField":1,"stringAndNumberField":123.456,"stringDateField":"2023-01-15","stringDateTimeField":"2023-01-15 10:30:45+00","stringDurationField":"P1Y2M3DT4H5M6S","stringEmailField":"test@example.com","stringField":"hello world","stringHostnameField":"example.com","stringIntegerField":1,"stringIpv4Field":"192.168.1.1","stringIpv6Field":"2001:db8::1","stringIriField":"https://例え.テスト","stringIriReferenceField":"/例え/テスト","stringJsonPointerField":"/path/to/field","stringMacAddr8Field":"00:14:22:ff:fe:01:23:45","stringMacAddrField":"00:14:22:01:23:45","stringNumberField":123.456,"stringRegexField":"^[a-zA-Z0-9]+$","stringRelativeJsonPointerField":"1/name","stringTimeField":"14:30:00+02:30","stringUint32Field":4294967295,"stringUriField":"https://example.com/path","stringUriReferenceField":"/relative/path","stringUriTemplateField":"https://api.example.com/{id}","stringUuidField":"550e8400-e29b-41d4-a716-446655440000"}
+{"arrayField":"[1,\"two\",3.0,true,null]","boolField":true,"enumField":"foo","enumNullableField":"one","flow_published_at":"1970-01-01 01:00:09+00","id":1,"intField":42,"multipleField":"string value","numField":3.14159,"stringAndIntegerField":789,"stringAndNumberField":123.456,"stringDateField":"2023-01-15","stringDateTimeField":"2023-01-15 10:30:45+00","stringDurationField":"P1Y2M3DT4H5M6S","stringEmailField":"test@example.com","stringField":"hello world","stringHostnameField":"example.com","stringIntegerField":789,"stringIpv4Field":"192.168.1.1","stringIpv6Field":"2001:db8::1","stringIriField":"https://例え.テスト","stringIriReferenceField":"/例え/テスト","stringJsonPointerField":"/path/to/field","stringMacAddr8Field":"00:14:22:ff:fe:01:23:45","stringMacAddrField":"00:14:22:01:23:45","stringNumberField":123.456,"stringRegexField":"^[a-zA-Z0-9]+$","stringRelativeJsonPointerField":"1/name","stringTimeField":"14:30:00z","stringUint32Field":4294967295,"stringUriField":"https://example.com/path","stringUriReferenceField":"/relative/path","stringUriTemplateField":"https://api.example.com/{id}","stringUuidField":"550e8400-e29b-41d4-a716-446655440000"}
+{"arrayField":"[]","boolField":false,"enumField":"bar","enumNullableField":null,"flow_published_at":"1970-01-01 01:00:10+00","id":2,"intField":-999,"multipleField":"42","numField":7,"stringAndIntegerField":1,"stringAndNumberField":-456.789,"stringDateField":"1999-12-31","stringDateTimeField":"1999-12-31 23:59:59.999+00","stringDurationField":"PT30M","stringEmailField":"admin@localhost","stringField":"","stringHostnameField":"localhost","stringIntegerField":1,"stringIpv4Field":"127.0.0.1","stringIpv6Field":"::1","stringIriField":"http://localhost","stringIriReferenceField":"/","stringJsonPointerField":"/0","stringMacAddr8Field":"ff:ff:ff:ff:ff:ff:ff:ff","stringMacAddrField":"ff:ff:ff:ff:ff:ff","stringNumberField":-456.789,"stringRegexField":".*","stringRelativeJsonPointerField":"0","stringTimeField":"00:00:00+00:00","stringUint32Field":0,"stringUriField":"http://localhost:8080","stringUriReferenceField":"#fragment","stringUriTemplateField":"http://example.com/~{username}/","stringUuidField":"00000000-0000-0000-0000-000000000000"}
+{"arrayField":"[]","boolField":false,"enumField":"bar","enumNullableField":null,"flow_published_at":"1970-01-01 03:00:13+00","id":2,"intField":-999,"multipleField":"42","numField":-2.718281828,"stringAndIntegerField":-123,"stringAndNumberField":-456.789,"stringDateField":"1999-12-31","stringDateTimeField":"1999-12-31 23:59:59.123456+00","stringDurationField":"PT30M","stringEmailField":"admin@localhost","stringField":"","stringHostnameField":"localhost","stringIntegerField":-123,"stringIpv4Field":"127.0.0.1","stringIpv6Field":"::1","stringIriField":"http://localhost","stringIriReferenceField":"/","stringJsonPointerField":"/0","stringMacAddr8Field":"ff:ff:ff:ff:ff:ff:ff:ff","stringMacAddrField":"ff:ff:ff:ff:ff:ff","stringNumberField":-456.789,"stringRegexField":".*","stringRelativeJsonPointerField":"0","stringTimeField":"03:55:23.123456789Z","stringUint32Field":0,"stringUriField":"http://localhost:8080","stringUriReferenceField":"#fragment","stringUriTemplateField":"http://example.com/~{username}/","stringUuidField":"00000000-0000-0000-0000-000000000000"}
+{"arrayField":"[{\"obj\":\"in array\"},[1,[2,[3]]],\"mixed types\"]","boolField":true,"enumField":"baz","enumNullableField":"two","flow_published_at":"1970-01-01 01:00:11+00","id":3,"intField":0,"multipleField":"{\"object\":\"value\"}","numField":0,"stringAndIntegerField":2147483647,"stringAndNumberField":0,"stringDateField":"2024-02-29","stringDateTimeField":"2024-02-29 12:00:00+00","stringDurationField":"P0D","stringEmailField":"user+tag@sub.domain.com","stringField":"special chars: !@#$%^\u0026*()[]{}|\\:;\"'\u003c\u003e?/.,","stringHostnameField":"sub.domain.example.org","stringIntegerField":2147483647,"stringIpv4Field":"10.0.0.1","stringIpv6Field":"2001:0db8:0000:0000:0000:ff00:0042:8329","stringIriField":"https://москва.рф/path","stringIriReferenceField":"/москва/путь","stringJsonPointerField":"/nested/array/0/field","stringMacAddr8Field":"01:23:45:67:89:ab:cd:ef","stringMacAddrField":"01:23:45:67:89:ab","stringNumberField":0,"stringRegexField":"[0-9]{3}-[0-9]{2}-[0-9]{4}","stringRelativeJsonPointerField":"2/nested/field","stringTimeField":"23:59:59.999-01:15","stringUint32Field":2147483648,"stringUriField":"ftp://user:pass@host.com:21/path?query=value","stringUriReferenceField":"?query=value\u0026other=param","stringUriTemplateField":"https://{host}{/path*}{?query*}","stringUuidField":"f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+
+

--- a/materialize-s3-iceberg/.snapshots/TestIntegrationGlue-materialize-ns
+++ b/materialize-s3-iceberg/.snapshots/TestIntegrationGlue-materialize-ns
@@ -1,0 +1,118 @@
+Task: acmeCo/tests/materialize-s3-iceberg
+
+Resource: tests.simple_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":"_meta/op","Nullable":false,"Type":"string"}
+{"Name":"canary","Nullable":false,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"id","Nullable":false,"Type":"long"}
+{"Name":"val","Nullable":true,"Type":"long"}
+
+Table Data:
+{"_meta/op":"c","canary":"Kringle's","flow_published_at":"1970-01-01 01:00:04+00","id":5,"val":5}
+{"_meta/op":"c","canary":"amputation's","flow_published_at":"1970-01-01 01:00:00+00","id":1,"val":1}
+{"_meta/op":"c","canary":"armament's","flow_published_at":"1970-01-01 01:00:01+00","id":2,"val":2}
+{"_meta/op":"c","canary":"devilish","flow_published_at":"1970-01-01 03:00:02+00","id":9,"val":9}
+{"_meta/op":"c","canary":"glucose's","flow_published_at":"1970-01-01 03:00:03+00","id":10,"val":10}
+{"_meta/op":"c","canary":"grosbeak's","flow_published_at":"1970-01-01 01:00:05+00","id":6,"val":6}
+{"_meta/op":"c","canary":"penguin","flow_published_at":"1970-01-01 03:00:05+00","id":12,"val":12}
+{"_meta/op":"c","canary":"pieced","flow_published_at":"1970-01-01 03:00:00+00","id":7,"val":7}
+{"_meta/op":"c","canary":"roaches","flow_published_at":"1970-01-01 03:00:01+00","id":8,"val":8}
+{"_meta/op":"c","canary":"splatters","flow_published_at":"1970-01-01 01:00:02+00","id":3,"val":3}
+{"_meta/op":"c","canary":"strengthen","flow_published_at":"1970-01-01 01:00:03+00","id":4,"val":4}
+{"_meta/op":"d","canary":"amputation's","flow_published_at":"1970-01-01 03:00:07+00","id":1,"val":1}
+{"_meta/op":"d","canary":"armament's","flow_published_at":"1970-01-01 03:00:08+00","id":2,"val":2}
+{"_meta/op":"d","canary":"asteroid","flow_published_at":"1970-01-01 03:00:04+00","id":11,"val":11}
+{"_meta/op":"d","canary":"penguin","flow_published_at":"1970-01-01 03:00:06+00","id":12,"val":12}
+{"_meta/op":"u","canary":"splatters","flow_published_at":"1970-01-01 03:00:09+00","id":3,"val":3}
+
+Resource: tests.not_simple_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":" ,;{}().- problematicField � 𐀀 嶲 ","Nullable":true,"Type":"string"}
+{"Name":" ,;{}().- problematicKey � 𐀀 嶲 ","Nullable":false,"Type":"string"}
+{"Name":"$dollar$signs","Nullable":true,"Type":"string"}
+{"Name":"123","Nullable":true,"Type":"string"}
+{"Name":"123startsWithDigits","Nullable":true,"Type":"string"}
+{"Name":"FIELDWITHDIFFERENTCAPS","Nullable":true,"Type":"string"}
+{"Name":"_id","Nullable":false,"Type":"string"}
+{"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"string"}
+{"Name":"binaryKey","Nullable":false,"Type":"binary"}
+{"Name":"field with separated words","Nullable":true,"Type":"string"}
+{"Name":"field-with-separated-words","Nullable":true,"Type":"string"}
+{"Name":"field.with-separated_words","Nullable":true,"Type":"string"}
+{"Name":"field.with.separated.words","Nullable":true,"Type":"string"}
+{"Name":"field_with_separated_words","Nullable":true,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"longString","Nullable":true,"Type":"string"}
+{"Name":"testing (%s)","Nullable":true,"Type":"string"}
+
+Table Data:
+{" ,;{}().- problematicField � 𐀀 嶲 ":""," ,;{}().- problematicKey � 𐀀 嶲 ":"test-key-2","$dollar$signs":"","123":"","123startsWithDigits":"","FIELDWITHDIFFERENTCAPS":"","_id":"doc_002","a\"string`with`quote'characters":null,"binaryKey":"TestData","field with separated words":"","field-with-separated-words":"","field.with-separated_words":"","field.with.separated.words":"","field_with_separated_words":"","flow_published_at":"1970-01-01 01:00:07+00","longString":"","testing (%s)":""}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"special chars in data"," ,;{}().- problematicKey � 𐀀 嶲 ":"\\he \\ ' \" `llo`","$dollar$signs":"dollar signs","123":"only numbers","123startsWithDigits":"starts with numbers","FIELDWITHDIFFERENTCAPS":"UPPERCASE","_id":"doc_001","a\"string`with`quote'characters":null,"binaryKey":"Hello World","field with separated words":"spaces work","field-with-separated-words":"dashes work","field.with-separated_words":"mixed separators","field.with.separated.words":"dots work","field_with_separated_words":"underscores work","flow_published_at":"1970-01-01 01:00:06+00","longString":"This is a very long string that tests how the system handles large text data with various characters and unicode symbols like 你好世界 and emojis 🌟🚀🎉","testing (%s)":"printf format"}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"symbols: !@#$%^\u0026*()_+-=[]{}|;':\",./\u003c\u003e?"," ,;{}().- problematicKey � 𐀀 嶲 ":"very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru.","$dollar$signs":"$100.50$","123":"999","123startsWithDigits":"field starting with 123","FIELDWITHDIFFERENTCAPS":"ALL UPPERCASE VALUE","_id":"doc_003","a\"string`with`quote'characters":null,"binaryKey":"BinaryTestData","field with separated words":"edge case testing","field-with-separated-words":"hyphen-separated-values","field.with-separated_words":"mixed.separator-test_data","field.with.separated.words":"system.test.data","field_with_separated_words":"underscore_separated_values","flow_published_at":"1970-01-01 01:00:08+00","longString":"very long string that exceeds 256 characters to test if dynamic sizing of varchar fields works. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostru.","testing (%s)":"printf style format string test"}
+{" ,;{}().- problematicField � 𐀀 嶲 ":"updated special chars"," ,;{}().- problematicKey � 𐀀 嶲 ":"\\he \\ ' \" `llo`","$dollar$signs":"updated dollars","123":"updated 123","123startsWithDigits":"updated numbers","FIELDWITHDIFFERENTCAPS":"UPDATED UPPERCASE","_id":"doc_001","a\"string`with`quote'characters":null,"binaryKey":"Hello World","field with separated words":"updated spaces","field-with-separated-words":"updated dashes","field.with-separated_words":"updated mixed","field.with.separated.words":"updated dots","field_with_separated_words":"updated underscores","flow_published_at":"1970-01-01 03:00:10+00","longString":"Updated long string with more Unicode: 🎭🎨🎪🎯 αβγδε ñáéíóú 中文更新测试 العربية עברית русский 한국어 日本語","testing (%s)":"updated printf"}
+
+Resource: tests.data_types_delta
+["applied.actionDescription", "create table \"tests.simple_delta\"\ncreate table \"tests.not_simple_delta\"\ncreate table \"tests.data_types_delta\""]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"fileKeys":null},"tests%2Fnot_simple_delta":{"fileKeys":null},"tests%2Fsimple_delta":{"fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fnot_simple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null},"tests%2Fsimple_delta":{"currentCheckpoint":"7a60ee931eb4057c","fileKeys":null}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+["connectorState",{"updated":{"bindingStates":{"tests%2Fdata_types_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/data_types_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fnot_simple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/not_simple_delta_<hash>/data/<uuid>.parquet"]},"tests%2Fsimple_delta":{"previousCheckpoint":"7a60ee931eb4057c","currentCheckpoint":"d075ceace3972e7f","fileKeys":["s3://<bucket>/<prefix>/tests/simple_delta_<hash>/data/<uuid>.parquet"]}}}}]
+
+{"Name":"arrayField","Nullable":true,"Type":"string"}
+{"Name":"boolField","Nullable":true,"Type":"boolean"}
+{"Name":"enumField","Nullable":true,"Type":"string"}
+{"Name":"enumNullableField","Nullable":true,"Type":"string"}
+{"Name":"flow_published_at","Nullable":false,"Type":"timestamptz_ns"}
+{"Name":"id","Nullable":false,"Type":"long"}
+{"Name":"intField","Nullable":true,"Type":"long"}
+{"Name":"multipleField","Nullable":true,"Type":"string"}
+{"Name":"numField","Nullable":true,"Type":"double"}
+{"Name":"stringAndIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringAndNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringDateField","Nullable":true,"Type":"date"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"timestamptz_ns"}
+{"Name":"stringDurationField","Nullable":true,"Type":"string"}
+{"Name":"stringEmailField","Nullable":true,"Type":"string"}
+{"Name":"stringField","Nullable":true,"Type":"string"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"string"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"string"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"string"}
+{"Name":"stringIriField","Nullable":true,"Type":"string"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"string"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"string"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"string"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"string"}
+{"Name":"stringNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringRegexField","Nullable":true,"Type":"string"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"string"}
+{"Name":"stringTimeField","Nullable":true,"Type":"string"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"long"}
+{"Name":"stringUriField","Nullable":true,"Type":"string"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"string"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"string"}
+{"Name":"stringUuidField","Nullable":true,"Type":"string"}
+
+Table Data:
+{"arrayField":"[\"updated\",\"array\",\"values\"]","boolField":false,"enumField":"foo","enumNullableField":"one","flow_published_at":"1970-01-01 03:00:11+00","id":4,"intField":2147483647,"multipleField":"999","numField":12345678900,"stringAndIntegerField":999,"stringAndNumberField":999.999,"stringDateField":"2024-12-25","stringDateTimeField":"2024-12-25 00:00:00+00","stringDurationField":"P1D","stringEmailField":"updated@test.org","stringField":"updated value","stringHostnameField":"api.example.org","stringIntegerField":999,"stringIpv4Field":"8.8.8.8","stringIpv6Field":"2001:4860:4860::8888","stringIriField":"https://テスト.例","stringIriReferenceField":"/テスト/例","stringJsonPointerField":"/data/items/0/name","stringMacAddr8Field":"aa:bb:cc:dd:ee:ff:00:11","stringMacAddrField":"aa:bb:cc:dd:ee:ff","stringNumberField":999.999,"stringRegexField":"^\\d{4}-\\d{2}-\\d{2}$","stringRelativeJsonPointerField":"3/updated","stringTimeField":"12:00:00z","stringUint32Field":1000000000,"stringUriField":"https://api.example.org/v1/resource","stringUriReferenceField":"../parent/resource","stringUriTemplateField":"/api/v{version}/users/{id}","stringUuidField":"123e4567-e89b-12d3-a456-426614174000"}
+{"arrayField":"[1,\"two\",3.0,true,null]","boolField":true,"enumField":"baz","enumNullableField":null,"flow_published_at":"1970-01-01 03:00:12+00","id":1,"intField":42,"multipleField":"string value","numField":3.14159,"stringAndIntegerField":1,"stringAndNumberField":123.456,"stringDateField":"2023-01-15","stringDateTimeField":"2023-01-15 10:30:45+00","stringDurationField":"P1Y2M3DT4H5M6S","stringEmailField":"test@example.com","stringField":"hello world","stringHostnameField":"example.com","stringIntegerField":1,"stringIpv4Field":"192.168.1.1","stringIpv6Field":"2001:db8::1","stringIriField":"https://例え.テスト","stringIriReferenceField":"/例え/テスト","stringJsonPointerField":"/path/to/field","stringMacAddr8Field":"00:14:22:ff:fe:01:23:45","stringMacAddrField":"00:14:22:01:23:45","stringNumberField":123.456,"stringRegexField":"^[a-zA-Z0-9]+$","stringRelativeJsonPointerField":"1/name","stringTimeField":"14:30:00+02:30","stringUint32Field":4294967295,"stringUriField":"https://example.com/path","stringUriReferenceField":"/relative/path","stringUriTemplateField":"https://api.example.com/{id}","stringUuidField":"550e8400-e29b-41d4-a716-446655440000"}
+{"arrayField":"[1,\"two\",3.0,true,null]","boolField":true,"enumField":"foo","enumNullableField":"one","flow_published_at":"1970-01-01 01:00:09+00","id":1,"intField":42,"multipleField":"string value","numField":3.14159,"stringAndIntegerField":789,"stringAndNumberField":123.456,"stringDateField":"2023-01-15","stringDateTimeField":"2023-01-15 10:30:45+00","stringDurationField":"P1Y2M3DT4H5M6S","stringEmailField":"test@example.com","stringField":"hello world","stringHostnameField":"example.com","stringIntegerField":789,"stringIpv4Field":"192.168.1.1","stringIpv6Field":"2001:db8::1","stringIriField":"https://例え.テスト","stringIriReferenceField":"/例え/テスト","stringJsonPointerField":"/path/to/field","stringMacAddr8Field":"00:14:22:ff:fe:01:23:45","stringMacAddrField":"00:14:22:01:23:45","stringNumberField":123.456,"stringRegexField":"^[a-zA-Z0-9]+$","stringRelativeJsonPointerField":"1/name","stringTimeField":"14:30:00z","stringUint32Field":4294967295,"stringUriField":"https://example.com/path","stringUriReferenceField":"/relative/path","stringUriTemplateField":"https://api.example.com/{id}","stringUuidField":"550e8400-e29b-41d4-a716-446655440000"}
+{"arrayField":"[]","boolField":false,"enumField":"bar","enumNullableField":null,"flow_published_at":"1970-01-01 01:00:10+00","id":2,"intField":-999,"multipleField":"42","numField":7,"stringAndIntegerField":1,"stringAndNumberField":-456.789,"stringDateField":"1999-12-31","stringDateTimeField":"1999-12-31 23:59:59.999+00","stringDurationField":"PT30M","stringEmailField":"admin@localhost","stringField":"","stringHostnameField":"localhost","stringIntegerField":1,"stringIpv4Field":"127.0.0.1","stringIpv6Field":"::1","stringIriField":"http://localhost","stringIriReferenceField":"/","stringJsonPointerField":"/0","stringMacAddr8Field":"ff:ff:ff:ff:ff:ff:ff:ff","stringMacAddrField":"ff:ff:ff:ff:ff:ff","stringNumberField":-456.789,"stringRegexField":".*","stringRelativeJsonPointerField":"0","stringTimeField":"00:00:00+00:00","stringUint32Field":0,"stringUriField":"http://localhost:8080","stringUriReferenceField":"#fragment","stringUriTemplateField":"http://example.com/~{username}/","stringUuidField":"00000000-0000-0000-0000-000000000000"}
+{"arrayField":"[]","boolField":false,"enumField":"bar","enumNullableField":null,"flow_published_at":"1970-01-01 03:00:13+00","id":2,"intField":-999,"multipleField":"42","numField":-2.718281828,"stringAndIntegerField":-123,"stringAndNumberField":-456.789,"stringDateField":"1999-12-31","stringDateTimeField":"1999-12-31 23:59:59.123456+00","stringDurationField":"PT30M","stringEmailField":"admin@localhost","stringField":"","stringHostnameField":"localhost","stringIntegerField":-123,"stringIpv4Field":"127.0.0.1","stringIpv6Field":"::1","stringIriField":"http://localhost","stringIriReferenceField":"/","stringJsonPointerField":"/0","stringMacAddr8Field":"ff:ff:ff:ff:ff:ff:ff:ff","stringMacAddrField":"ff:ff:ff:ff:ff:ff","stringNumberField":-456.789,"stringRegexField":".*","stringRelativeJsonPointerField":"0","stringTimeField":"03:55:23.123456789Z","stringUint32Field":0,"stringUriField":"http://localhost:8080","stringUriReferenceField":"#fragment","stringUriTemplateField":"http://example.com/~{username}/","stringUuidField":"00000000-0000-0000-0000-000000000000"}
+{"arrayField":"[{\"obj\":\"in array\"},[1,[2,[3]]],\"mixed types\"]","boolField":true,"enumField":"baz","enumNullableField":"two","flow_published_at":"1970-01-01 01:00:11+00","id":3,"intField":0,"multipleField":"{\"object\":\"value\"}","numField":0,"stringAndIntegerField":2147483647,"stringAndNumberField":0,"stringDateField":"2024-02-29","stringDateTimeField":"2024-02-29 12:00:00+00","stringDurationField":"P0D","stringEmailField":"user+tag@sub.domain.com","stringField":"special chars: !@#$%^\u0026*()[]{}|\\:;\"'\u003c\u003e?/.,","stringHostnameField":"sub.domain.example.org","stringIntegerField":2147483647,"stringIpv4Field":"10.0.0.1","stringIpv6Field":"2001:0db8:0000:0000:0000:ff00:0042:8329","stringIriField":"https://москва.рф/path","stringIriReferenceField":"/москва/путь","stringJsonPointerField":"/nested/array/0/field","stringMacAddr8Field":"01:23:45:67:89:ab:cd:ef","stringMacAddrField":"01:23:45:67:89:ab","stringNumberField":0,"stringRegexField":"[0-9]{3}-[0-9]{2}-[0-9]{4}","stringRelativeJsonPointerField":"2/nested/field","stringTimeField":"23:59:59.999-01:15","stringUint32Field":2147483648,"stringUriField":"ftp://user:pass@host.com:21/path?query=value","stringUriReferenceField":"?query=value\u0026other=param","stringUriTemplateField":"https://{host}{/path*}{?query*}","stringUuidField":"f47ac10b-58cc-4372-a567-0e02b2c3d479"}
+
+

--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -246,7 +246,7 @@
               "nanosecond_timestamps": {
                 "type": "boolean",
                 "title": "Nanosecond Timestamps",
-                "description": "Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization triggers a backfill because Iceberg has no in-place promotion between the two timestamp encodings.",
+                "description": "Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization applies to data going forward: existing rows read as null for converted columns unless the binding is explicitly backfilled.",
                 "default": false
               }
             },

--- a/materialize-s3-iceberg/.snapshots/TestSpec
+++ b/materialize-s3-iceberg/.snapshots/TestSpec
@@ -242,6 +242,12 @@
                   "string",
                   "null"
                 ]
+              },
+              "nanosecond_timestamps": {
+                "type": "boolean",
+                "title": "Nanosecond Timestamps",
+                "description": "Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization triggers a backfill because Iceberg has no in-place promotion between the two timestamp encodings.",
+                "default": false
               }
             },
             "additionalProperties": false,

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 2026-07-15
+
+### Added
+- New advanced option `nanosecond_timestamps` materializes date-time fields as
+  nanosecond-precision `timestamptz_ns` columns (Iceberg format v3) instead of
+  microsecond-precision `timestamptz`. Enabling it on an existing
+  materialization requires a backfill, because Iceberg has no in-place
+  promotion between the two timestamp encodings.
+- With `nanosecond_timestamps` enabled, new tables are created as Iceberg
+  format v3, and an existing format v2 table is upgraded to v3 automatically
+  when its first nanosecond timestamp column is added.

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Changelog
 
-## 2026-07-15
+## 2026-07-20
 
 ### Added
 - New advanced option `nanosecond_timestamps` materializes date-time fields as
   nanosecond-precision `timestamptz_ns` columns (Iceberg format v3) instead of
-  microsecond-precision `timestamptz`. Enabling it on an existing
-  materialization requires a backfill, because Iceberg has no in-place
-  promotion between the two timestamp encodings.
+  microsecond-precision `timestamptz`. Toggling it on an existing
+  materialization applies to data going forward: the timestamp columns are
+  re-created under the new type (Iceberg has no in-place conversion), so
+  existing rows read as null for those columns unless the binding is
+  explicitly backfilled.
 - With `nanosecond_timestamps` enabled, new tables are created as Iceberg
   format v3, and an existing format v2 table is upgraded to v3 automatically
   when its first nanosecond timestamp column is added.
+
+### Fixed
+- Parquet files now embed Iceberg field IDs. Previously, columns added by
+  schema evolution could read as null in query engines that strictly apply the
+  table's name mapping, because the mapping was never updated after table
+  creation.

--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -372,9 +373,18 @@ func (c *catalog) createNamespace(ctx context.Context, namespace string) error {
 func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_Binding, res resource) (string, boilerplate.ActionApplyFn, error) {
 	location := tablePath(c.cfg.Bucket, c.cfg.Prefix, b.ResourcePath[0], b.ResourcePath[1], c.locationStyle)
 
-	parquetSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
+	parquetSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap, c.cfg.nanosecondTimestamps())
 	if err != nil {
 		return "", nil, err
+	}
+
+	// Reject a conflicting user-supplied format version rather than silently
+	// overriding it: timestamptz_ns columns are only valid in format v3.
+	if v, ok := res.AdditionalTableProperties[icebergtable.PropertyFormatVersion]; ok &&
+		c.cfg.nanosecondTimestamps() && v != "3" {
+		return "", nil, fmt.Errorf(
+			"additional table property %s=%q conflicts with the nanosecond_timestamps option, which requires format version 3: remove the property or set it to \"3\"",
+			icebergtable.PropertyFormatVersion, v)
 	}
 
 	fields := make([]iceberg.NestedField, 0, len(parquetSchema))
@@ -397,6 +407,9 @@ func (c *catalog) CreateResource(ctx context.Context, b *pf.MaterializationSpec_
 		}
 		props := iceberg.Properties{
 			icebergtable.DefaultNameMappingKey: string(nameMappingJSON),
+		}
+		if c.cfg.nanosecondTimestamps() {
+			props[icebergtable.PropertyFormatVersion] = "3"
 		}
 		for k, v := range res.AdditionalTableProperties {
 			// Never let a user-supplied key override the name mapping.
@@ -451,7 +464,7 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 			}
 		}
 
-		s, err := projectionToParquetSchemaElement(p.Projection.Projection, fc)
+		s, err := projectionToParquetSchemaElement(p.Projection.Projection, fc, c.cfg.nanosecondTimestamps())
 		if err != nil {
 			return "", nil, err
 		}
@@ -472,6 +485,16 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 		}
 
 		tx := tbl.NewTransaction()
+		// timestamptz_ns columns are only valid in Iceberg format v3. A table
+		// created before nanosecond_timestamps was enabled may still be v2, so
+		// upgrade it as part of the same transaction as the schema change.
+		if tbl.Metadata().Version() < 3 && slices.ContainsFunc(adds, func(a addCol) bool {
+			return a.typ.Equals(iceberg.PrimitiveTypes.TimestampTzNs)
+		}) {
+			if err := tx.UpgradeFormatVersion(3); err != nil {
+				return fmt.Errorf("upgrading table %q to format version 3: %w", fqn, err)
+			}
+		}
 		// caseSensitive=true matches pyiceberg's update_schema() default that
 		// the removed Python tool relied on; the connector's field names are
 		// case-sensitive, so column matches during add/relax must be too.

--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -336,13 +336,37 @@ func (c *catalog) populateInfoSchema(ctx context.Context, is *boilerplate.InfoSc
 // tablePaths returns the registered storage path for each resource path in a
 // list, in the same order as the input.
 func (c *catalog) tablePaths(ctx context.Context, resourcePaths [][]string) ([]string, error) {
+	infos, err := c.tableInfos(ctx, resourcePaths)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(infos))
+	for i, info := range infos {
+		out[i] = info.location
+	}
+	return out, nil
+}
+
+// tableInfo carries the per-table facts the transactor needs at Open: the
+// registered storage location, and the current schema's name→field-ID
+// assignments so written parquet files can embed the table's real field IDs.
+type tableInfo struct {
+	location string
+	fieldIDs map[string]int
+}
+
+func (c *catalog) tableInfos(ctx context.Context, resourcePaths [][]string) ([]tableInfo, error) {
 	idents := make([]icebergtable.Identifier, len(resourcePaths))
 	for i, p := range resourcePaths {
 		idents[i] = p
 	}
-	out := make([]string, len(idents))
+	out := make([]tableInfo, len(idents))
 	if err := c.forEachTable(ctx, idents, func(idx int, tbl *icebergtable.Table) error {
-		out[idx] = tbl.Location()
+		fieldIDs := make(map[string]int)
+		for _, f := range tbl.Schema().Fields() {
+			fieldIDs[f.Name] = f.ID
+		}
+		out[idx] = tableInfo{location: tbl.Location(), fieldIDs: fieldIDs}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -443,9 +467,10 @@ func (c *catalog) DeleteResource(ctx context.Context, path []string) (string, bo
 }
 
 func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.BindingUpdate[config, resource, mappedType]) (string, boilerplate.ActionApplyFn, error) {
-	if len(bindingUpdate.NewProjections) == 0 && len(bindingUpdate.NewlyNullableFields) == 0 {
-		// Nothing to do, since only adding new columns or dropping nullability
-		// constraints is supported currently.
+	if len(bindingUpdate.NewProjections) == 0 && len(bindingUpdate.NewlyNullableFields) == 0 &&
+		len(bindingUpdate.FieldsToMigrate) == 0 {
+		// Nothing to do, since only adding new columns, dropping nullability
+		// constraints, and migrating timestamp precision is supported currently.
 		return "", nil, nil
 	}
 
@@ -454,6 +479,11 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 		typ  iceberg.Type
 	}
 	var adds []addCol
+
+	var migrates []addCol
+	for _, f := range bindingUpdate.FieldsToMigrate {
+		migrates = append(migrates, addCol{name: f.From.Name, typ: f.To.Mapped.icebergType})
+	}
 	for _, p := range bindingUpdate.NewProjections {
 		var fc fieldConfig
 		if rawFieldConfig, ok := bindingUpdate.Binding.FieldSelection.FieldConfigJsonMap[p.Field]; ok {
@@ -488,9 +518,12 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 		// timestamptz_ns columns are only valid in Iceberg format v3. A table
 		// created before nanosecond_timestamps was enabled may still be v2, so
 		// upgrade it as part of the same transaction as the schema change.
-		if tbl.Metadata().Version() < 3 && slices.ContainsFunc(adds, func(a addCol) bool {
-			return a.typ.Equals(iceberg.PrimitiveTypes.TimestampTzNs)
-		}) {
+		hasNs := func(cols []addCol) bool {
+			return slices.ContainsFunc(cols, func(a addCol) bool {
+				return a.typ.Equals(iceberg.PrimitiveTypes.TimestampTzNs)
+			})
+		}
+		if tbl.Metadata().Version() < 3 && (hasNs(adds) || hasNs(migrates)) {
 			if err := tx.UpgradeFormatVersion(3); err != nil {
 				return fmt.Errorf("upgrading table %q to format version 3: %w", fqn, err)
 			}
@@ -507,8 +540,26 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 				Required: iceberg.Optional[bool]{Val: false, Valid: true},
 			})
 		}
+		// Iceberg cannot change a column's type in place. Migrate by dropping
+		// and re-adding the column under a new field ID: data going forward is
+		// written with the new type, while prior rows read as null for this
+		// column (their values remain in old data files under the retired
+		// field ID, reachable via time travel).
+		for _, mig := range migrates {
+			us = us.DeleteColumn([]string{mig.name})
+			us = us.AddColumn([]string{mig.name}, mig.typ, "", false, nil)
+		}
 		if err := us.Commit(); err != nil {
 			return fmt.Errorf("staging schema update for %q: %w", fqn, err)
+		}
+		if len(migrates) > 0 {
+			migratedNames := make([]string, len(migrates))
+			for i, mig := range migrates {
+				migratedNames[i] = mig.name
+			}
+			if err := removeFromNameMapping(tx, tbl.Properties(), migratedNames); err != nil {
+				return fmt.Errorf("updating name mapping of %q: %w", fqn, err)
+			}
 		}
 		if _, err := tx.Commit(ctx); err != nil {
 			return fmt.Errorf("altering table %q: %w", fqn, err)
@@ -516,6 +567,32 @@ func (c *catalog) UpdateResource(_ context.Context, bindingUpdate boilerplate.Bi
 
 		return nil
 	}, nil
+}
+
+// removeFromNameMapping strips migrated column names from the table's default
+// name mapping. Legacy files without embedded field IDs must resolve a
+// re-added column to null rather than misreading their old-encoding values as
+// the new type; files written after the migration embed field IDs and never
+// consult the mapping.
+func removeFromNameMapping(tx *icebergtable.Transaction, props iceberg.Properties, migrated []string) error {
+	raw, ok := props[icebergtable.DefaultNameMappingKey]
+	if !ok {
+		return nil
+	}
+	var mapping iceberg.NameMapping
+	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
+		return fmt.Errorf("parsing name mapping: %w", err)
+	}
+	mapping = slices.DeleteFunc(mapping, func(f iceberg.MappedField) bool {
+		return slices.ContainsFunc(migrated, func(name string) bool {
+			return slices.Contains(f.Names, name)
+		})
+	})
+	mappingJSON, err := json.Marshal(mapping)
+	if err != nil {
+		return fmt.Errorf("marshaling name mapping: %w", err)
+	}
+	return tx.SetProperties(iceberg.Properties{icebergtable.DefaultNameMappingKey: string(mappingJSON)})
 }
 
 func (c *catalog) appendFiles(

--- a/materialize-s3-iceberg/clamp.go
+++ b/materialize-s3-iceberg/clamp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"time"
@@ -46,6 +47,36 @@ func clampTimestamp(v tuple.TupleElement) (any, error) {
 		return time.Date(maxYear, 12, 31, 23, 59, 59, 999999000, time.UTC).Format(time.RFC3339Nano), nil
 	case year < minYear:
 		return time.Date(minYear, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), nil
+	}
+	return canonical, nil
+}
+
+// nsMinTime and nsMaxTime are the bounds of the int64 nanoseconds-since-epoch
+// encoding of an Iceberg timestamptz_ns column (roughly years 1677 to 2262).
+// Beyond them time.Time.UnixNano is undefined and wraps, so out-of-range values
+// are clamped to the boundary instants before they reach the writer.
+var (
+	nsMinTime = time.Unix(0, math.MinInt64).UTC()
+	nsMaxTime = time.Unix(0, math.MaxInt64).UTC()
+)
+
+// clampTimestampNanos is the nanosecond-precision analog of clampTimestamp,
+// bounded by the int64-ns band rather than [minYear, maxYear].
+func clampTimestampNanos(v tuple.TupleElement) (any, error) {
+	s, ok := v.(string)
+	if !ok {
+		return v, nil
+	}
+
+	t, canonical, err := sql.ParseRFC3339Nano(s)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case t.After(nsMaxTime):
+		return nsMaxTime.Format(time.RFC3339Nano), nil
+	case t.Before(nsMinTime):
+		return nsMinTime.Format(time.RFC3339Nano), nil
 	}
 	return canonical, nil
 }

--- a/materialize-s3-iceberg/clamp_test.go
+++ b/materialize-s3-iceberg/clamp_test.go
@@ -63,6 +63,63 @@ func TestClampTimestamp(t *testing.T) {
 	}
 }
 
+func TestClampTimestampNanos(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		{
+			name:  "non-string passthrough",
+			input: 42,
+			want:  42,
+		},
+		{
+			name:    "unparseable returns error",
+			input:   "not-a-timestamp",
+			wantErr: true,
+		},
+		{
+			name:  "beyond int64-ns max clamps to boundary",
+			input: "3000-01-01T00:00:00Z",
+			want:  "2262-04-11T23:47:16.854775807Z",
+		},
+		{
+			name:  "before int64-ns min clamps to boundary",
+			input: "1000-01-01T00:00:00Z",
+			want:  "1677-09-21T00:12:43.145224192Z",
+		},
+		{
+			name:  "in-range value passes through unchanged",
+			input: "2025-06-15T12:00:00.123456789Z",
+			want:  "2025-06-15T12:00:00.123456789Z",
+		},
+		{
+			name:  "space separator normalizes to RFC3339",
+			input: "2025-11-29 01:05:28+00:00",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			name:    "missing offset returns error",
+			input:   "2025-11-29 01:05:28",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := clampTimestampNanos(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestClampDate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -128,7 +128,7 @@ func (catalogConfig) JSONSchema() *jsonschema.Schema {
 
 type advancedConfig struct {
 	FeatureFlags         *string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support.,nullable"`
-	NanosecondTimestamps bool    `json:"nanosecond_timestamps,omitempty" jsonschema:"title=Nanosecond Timestamps,description=Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization triggers a backfill because Iceberg has no in-place promotion between the two timestamp encodings.,default=false"`
+	NanosecondTimestamps bool    `json:"nanosecond_timestamps,omitempty" jsonschema:"title=Nanosecond Timestamps,description=Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization applies to data going forward: existing rows read as null for converted columns unless the binding is explicitly backfilled.,default=false"`
 }
 
 func (c config) s3StoreConfig() filesink.S3StoreConfig {
@@ -581,13 +581,28 @@ func (d *materialization) NewTransactor(
 		})
 	}
 
-	tablePaths, err := d.catalog.tablePaths(ctx, resourcePaths)
+	tableInfos, err := d.catalog.tableInfos(ctx, resourcePaths)
 	if err != nil {
-		return nil, fmt.Errorf("looking up table paths: %w", err)
+		return nil, fmt.Errorf("looking up tables: %w", err)
 	}
 
 	for idx := range bindings {
-		bindings[idx].catalogTablePath = tablePaths[idx]
+		b := &bindings[idx]
+		b.catalogTablePath = tableInfos[idx].location
+
+		// Embed the table's field IDs in written parquet files so they are
+		// self-describing: readers then never consult the table's name mapping
+		// for them, which is what allows a schema-evolved column (new field ID,
+		// same name) to read correctly from new files while old ID-less files
+		// resolve to null.
+		for i := range b.pqSchema {
+			id, ok := tableInfos[idx].fieldIDs[b.pqSchema[i].Name]
+			if !ok {
+				return nil, fmt.Errorf("selected field %q has no column in table %q", b.pqSchema[i].Name, pathToFQN(b.path))
+			}
+			fieldID := int32(id)
+			b.pqSchema[i].FieldId = &fieldID
+		}
 	}
 
 	s3store, err := filesink.NewS3Store(ctx, d.cfg.s3StoreConfig())

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -127,7 +127,8 @@ func (catalogConfig) JSONSchema() *jsonschema.Schema {
 }
 
 type advancedConfig struct {
-	FeatureFlags *string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support.,nullable"`
+	FeatureFlags         *string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support.,nullable"`
+	NanosecondTimestamps bool    `json:"nanosecond_timestamps,omitempty" jsonschema:"title=Nanosecond Timestamps,description=Use nanosecond precision (Iceberg format v3) for date-time columns instead of microsecond precision (format v2). Toggling this on an existing materialization triggers a backfill because Iceberg has no in-place promotion between the two timestamp encodings.,default=false"`
 }
 
 func (c config) s3StoreConfig() filesink.S3StoreConfig {
@@ -251,6 +252,10 @@ func (c config) FeatureFlags() (string, map[string]bool) {
 		return "", featureFlagDefaults
 	}
 	return strVal(c.Advanced.FeatureFlags), featureFlagDefaults
+}
+
+func (c config) nanosecondTimestamps() bool {
+	return c.Advanced != nil && c.Advanced.NanosecondTimestamps
 }
 
 func parse8601(in string) (time.Duration, error) {
@@ -490,22 +495,26 @@ func (d *materialization) NewConstraint(p pf.Projection, deltaUpdates bool, fc f
 }
 
 func (d *materialization) MapType(p boilerplate.Projection, fc fieldConfig) (mappedType, boilerplate.ElementConverter) {
-	s, err := projectionToParquetSchemaElement(p.Projection, fc)
+	s, err := projectionToParquetSchemaElement(p.Projection, fc, d.cfg.nanosecondTimestamps())
 	if err != nil {
 		// The only error here is ignoreStringFormat being set on a non-string
 		// field, where it is a no-op. Map by the field's native type rather
 		// than returning a zero mappedType, whose nil iceberg.Type would panic
 		// in String/Compatible. The misconfiguration still surfaces with a
 		// clear error at table creation (parquetSchema).
-		s, _ = projectionToParquetSchemaElement(p.Projection, fieldConfig{})
+		s, _ = projectionToParquetSchemaElement(p.Projection, fieldConfig{}, d.cfg.nanosecondTimestamps())
 	}
 
-	// Clamp date and timestamp values to years 1-9999 before they reach the
-	// writer. See clampDate/clampTimestamp for the bound's origin.
+	// Clamp date and timestamp values before they reach the writer: microsecond
+	// timestamps and dates to years 1-9999 (see clampDate/clampTimestamp for the
+	// bound's origin), nanosecond timestamps to the int64-ns band. The converters
+	// also normalize near-RFC3339 variants that the writer's strict parse rejects.
 	var elementConverter boilerplate.ElementConverter
 	switch s.DataType {
 	case writer.LogicalTypeTimestamp:
 		elementConverter = clampTimestamp
+	case writer.LogicalTypeTimestampNanos:
+		elementConverter = clampTimestampNanos
 	case writer.LogicalTypeDate:
 		elementConverter = clampDate
 	}
@@ -558,7 +567,7 @@ func (d *materialization) NewTransactor(
 
 	for i := range mappedBindings {
 		b := &mappedBindings[i]
-		pqSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap)
+		pqSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap, d.cfg.nanosecondTimestamps())
 		if err != nil {
 			return nil, err
 		}

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/array"
 	parquetfile "github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/iceberg-go"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
@@ -172,6 +173,10 @@ func TestIntegration(t *testing.T) {
 		runNanosecondCreateResourceTest(t, cfg)
 	})
 
+	t.Run("ns-migrate", func(t *testing.T) {
+		runNanosecondMigrateTest(t, cfg)
+	})
+
 	// Migration test is skipped because Iceberg does not support the type
 	// migrations exercised by the test (e.g. long→string).
 	//t.Run("migrate", func(t *testing.T) {
@@ -241,6 +246,10 @@ func TestIntegrationGlue(t *testing.T) {
 	t.Run("ns-create-v3", func(t *testing.T) {
 		runNanosecondCreateResourceTest(t, cfg)
 	})
+
+	t.Run("ns-migrate", func(t *testing.T) {
+		runNanosecondMigrateTest(t, cfg)
+	})
 }
 
 // TestRestGlueSnapshotParity enforces that the REST and Glue materialize
@@ -266,8 +275,8 @@ func TestRestGlueSnapshotParity(t *testing.T) {
 func runTimestampOverflowRegression(t *testing.T, cfg config) {
 	ctx := context.Background()
 
-	rt := newRegressionTable(t, ctx, cfg, "ts_overflow_regression",
-		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTz, Required: false}, nil)
+	rt := newRegressionTable(t, ctx, cfg, "ts_overflow_regression", nil,
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTz, Required: false})
 
 	clampedTS, err := clampTimestamp("9999-12-31T23:59:59-14:00")
 	require.NoError(t, err)
@@ -284,8 +293,8 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 }
 
 // regressionTable is the shared scaffolding of the append regression tests: a
-// freshly created single-column table plus the machinery to write, upload,
-// and append single-column parquet files to it.
+// freshly created table plus the machinery to write, upload, and append
+// parquet files to it.
 type regressionTable struct {
 	cfg      config
 	cat      *catalog
@@ -294,7 +303,7 @@ type regressionTable struct {
 	s3client *s3.Client
 }
 
-func newRegressionTable(t *testing.T, ctx context.Context, cfg config, table string, field iceberg.NestedField, extraProps iceberg.Properties) *regressionTable {
+func newRegressionTable(t *testing.T, ctx context.Context, cfg config, table string, extraProps iceberg.Properties, fields ...iceberg.NestedField) *regressionTable {
 	t.Helper()
 
 	cat, err := newCatalog(ctx, cfg, NestedLocationStyle)
@@ -309,7 +318,7 @@ func newRegressionTable(t *testing.T, ctx context.Context, cfg config, table str
 	table = fmt.Sprintf("%s_flow_test_%d", table, time.Now().Unix())
 	ident := icebergtable.Identifier{cfg.Namespace, table}
 
-	schema := iceberg.NewSchema(0, field)
+	schema := iceberg.NewSchema(0, fields...)
 	nameMappingJSON, err := json.Marshal(schema.NameMapping())
 	require.NoError(t, err)
 
@@ -352,20 +361,29 @@ func newRegressionTable(t *testing.T, ctx context.Context, cfg config, table str
 	}
 }
 
-// uploadParquet writes rows into a single-column parquet file and uploads it to
-// the table's data prefix, returning the s3 path and the local path for tests
-// that inspect the encoded bytes.
+// uploadParquet is the single-column convenience form of uploadParquetRows,
+// returning the s3 path and the local path for tests that inspect the encoded
+// bytes.
 func (rt *regressionTable) uploadParquet(t *testing.T, ctx context.Context, col writer.ParquetSchemaElement, rows ...any) (string, string) {
+	t.Helper()
+	wide := make([][]any, len(rows))
+	for i, row := range rows {
+		wide[i] = []any{row}
+	}
+	return rt.uploadParquetRows(t, ctx, writer.ParquetSchema{col}, wide...)
+}
+
+func (rt *regressionTable) uploadParquetRows(t *testing.T, ctx context.Context, cols writer.ParquetSchema, rows ...[]any) (string, string) {
 	t.Helper()
 
 	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
 	parquetFile, err := os.Create(parquetPath)
 	require.NoError(t, err)
-	pqw, err := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{col},
+	pqw, err := writer.NewParquetWriter(parquetFile, cols,
 		writer.WithParquetCompression(writer.Snappy))
 	require.NoError(t, err)
 	for _, row := range rows {
-		require.NoError(t, pqw.Write([]any{row}))
+		require.NoError(t, pqw.Write(row))
 	}
 	require.NoError(t, pqw.Close())
 
@@ -390,8 +408,8 @@ func (rt *regressionTable) uploadParquet(t *testing.T, ctx context.Context, col 
 func runDateOverflowRegression(t *testing.T, cfg config) {
 	ctx := context.Background()
 
-	rt := newRegressionTable(t, ctx, cfg, "date_overflow_regression",
-		iceberg.NestedField{ID: 1, Name: "d", Type: iceberg.PrimitiveTypes.Date, Required: false}, nil)
+	rt := newRegressionTable(t, ctx, cfg, "date_overflow_regression", nil,
+		iceberg.NestedField{ID: 1, Name: "d", Type: iceberg.PrimitiveTypes.Date, Required: false})
 
 	clampedDate, err := clampDate("10000-01-01")
 	require.NoError(t, err)
@@ -417,8 +435,8 @@ func runCheckpointFenceRegression(t *testing.T, cfg config) {
 
 	const materialization = "acmeCo/tests/regression"
 
-	rt := newRegressionTable(t, ctx, cfg, "checkpoint_fence_regression",
-		iceberg.NestedField{ID: 1, Name: "v", Type: iceberg.PrimitiveTypes.String, Required: false}, nil)
+	rt := newRegressionTable(t, ctx, cfg, "checkpoint_fence_regression", nil,
+		iceberg.NestedField{ID: 1, Name: "v", Type: iceberg.PrimitiveTypes.String, Required: false})
 
 	vCol := writer.ParquetSchemaElement{Name: "v", DataType: writer.LogicalTypeString, Required: false}
 	first, _ := rt.uploadParquet(t, ctx, vCol, "one")
@@ -641,9 +659,8 @@ func runNanosecondTimestampTest(t *testing.T, cfg config) {
 	}
 	adv.NanosecondTimestamps = true
 	cfg.Advanced = &adv
-	rt := newRegressionTable(t, ctx, cfg, "ns_timestamp",
-		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTzNs, Required: false},
-		iceberg.Properties{icebergtable.PropertyFormatVersion: "3"})
+	rt := newRegressionTable(t, ctx, cfg, "ns_timestamp", iceberg.Properties{icebergtable.PropertyFormatVersion: "3"},
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTzNs, Required: false})
 
 	// Values pass through clampTimestampNanos as they do in production, where
 	// MapType wires it as the binding's ElementConverter.
@@ -711,9 +728,8 @@ func runNanosecondV2UpgradeTest(t *testing.T, cfg config) {
 	}
 	adv.NanosecondTimestamps = true
 	cfg.Advanced = &adv
-	rt := newRegressionTable(t, ctx, cfg, "ns_v2_upgrade",
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: false},
-		iceberg.Properties{icebergtable.PropertyFormatVersion: "2"})
+	rt := newRegressionTable(t, ctx, cfg, "ns_v2_upgrade", iceberg.Properties{icebergtable.PropertyFormatVersion: "2"},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: false})
 	cat := rt.cat
 	tableIdent := rt.ident
 
@@ -816,6 +832,143 @@ func runNanosecondCreateResourceTest(t *testing.T, cfg config) {
 	f, ok := tbl.Schema().FindFieldByName("ts")
 	require.True(t, ok)
 	require.True(t, f.Type.Equals(iceberg.PrimitiveTypes.TimestampTzNs))
+}
+
+// runNanosecondMigrateTest exercises the timestamp-precision migration that
+// UpdateResource performs when nanosecond_timestamps is toggled on an existing
+// table: the column is dropped and re-added under a new field ID (Iceberg has
+// no in-place type change), the table upgrades to format v3, and the column's
+// name-mapping entry is removed. The decisive assertions read the table back
+// through iceberg-go's spec-compliant scanner: pre-migration rows must be null
+// for the migrated column — never a misread of their old-encoding values —
+// while post-migration rows (written with embedded field IDs) carry full
+// nanosecond precision. A second migration back to microseconds proves the
+// reverse direction.
+func runNanosecondMigrateTest(t *testing.T, cfg config) {
+	t.Helper()
+	ctx := context.Background()
+
+	// The table keeps a non-timestamp column alongside ts: iceberg-go's
+	// scanner refuses data files that contribute zero projected columns, so a
+	// realistic multi-column shape is required for reading back the
+	// pre-migration file whose only timestamp column was migrated away.
+	rt := newRegressionTable(t, ctx, cfg, "ns_migrate", nil,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.NestedField{ID: 2, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTz, Required: false})
+
+	// A microsecond row lands before the migration in a file without embedded
+	// field IDs, as the connector wrote before field-ID embedding.
+	oldPath, _ := rt.uploadParquetRows(t, ctx, writer.ParquetSchema{
+		{Name: "id", DataType: writer.LogicalTypeString, Required: false},
+		{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false},
+	}, []any{"old", "2023-01-15T12:34:56.123456Z"})
+	require.NoError(t, rt.cat.appendFiles(ctx, "acmeCo/tests/ns-migrate", rt.ident,
+		[]string{oldPath}, "", "checkpoint-1"))
+
+	migrate := func(fromType string, to iceberg.Type) {
+		t.Helper()
+		update := mboilerplate.BindingUpdate[config, resource, mappedType]{
+			Binding: mboilerplate.MappedBinding[config, resource, mappedType]{
+				MaterializationSpec_Binding: pf.MaterializationSpec_Binding{
+					ResourcePath: rt.ident,
+				},
+			},
+			FieldsToMigrate: []mboilerplate.MigrateField[mappedType]{{
+				From: mboilerplate.ExistingField{Name: "ts", Type: fromType},
+				To: mboilerplate.MappedProjection[mappedType]{
+					Projection: mboilerplate.Projection{Projection: pf.Projection{Field: "ts"}},
+					Mapped:     mappedType{icebergType: to},
+				},
+			}},
+		}
+		_, apply, err := rt.cat.UpdateResource(ctx, update)
+		require.NoError(t, err)
+		require.NoError(t, apply(ctx))
+	}
+
+	migrate("timestamptz", iceberg.PrimitiveTypes.TimestampTzNs)
+
+	tbl, err := rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	require.Equal(t, 3, tbl.Metadata().Version())
+	f, ok := tbl.Schema().FindFieldByName("ts")
+	require.True(t, ok)
+	require.True(t, f.Type.Equals(iceberg.PrimitiveTypes.TimestampTzNs))
+	require.NotEqual(t, 2, f.ID, "migrated column must get a new field ID")
+
+	var mapping iceberg.NameMapping
+	require.NoError(t, json.Unmarshal([]byte(tbl.Properties()[icebergtable.DefaultNameMappingKey]), &mapping))
+	for _, mf := range mapping {
+		require.NotContains(t, mf.Names, "ts", "migrated column must be removed from the name mapping")
+	}
+
+	// The pre-migration row survives the migration with its migrated column
+	// reading null — never a misread of its microsecond value as nanoseconds.
+	require.Equal(t, []any{"old"}, scanColumn(t, ctx, rt, "id"))
+	require.Equal(t, []any{nil}, scanColumn(t, ctx, rt, "ts"))
+
+	// A nanosecond row lands after the migration with the table's field IDs
+	// embedded, as the connector now writes.
+	idID, tsID := int32(1), int32(f.ID)
+	newPath, _ := rt.uploadParquetRows(t, ctx, writer.ParquetSchema{
+		{Name: "id", DataType: writer.LogicalTypeString, Required: false, FieldId: &idID},
+		{Name: "ts", DataType: writer.LogicalTypeTimestampNanos, Required: false, FieldId: &tsID},
+	}, []any{"new", "2025-06-15T12:00:00.123456789Z"})
+	require.NoError(t, rt.cat.appendFiles(ctx, "acmeCo/tests/ns-migrate", rt.ident,
+		[]string{newPath}, "checkpoint-1", "checkpoint-2"))
+
+	require.ElementsMatch(t, []any{"old", "new"}, scanColumn(t, ctx, rt, "id"))
+	require.ElementsMatch(t, []any{nil, int64(1749988800123456789)}, scanColumn(t, ctx, rt, "ts"))
+
+	// Reverse direction: back to microseconds.
+	migrate("timestamptz_ns", iceberg.PrimitiveTypes.TimestampTz)
+
+	tbl, err = rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	f2, ok := tbl.Schema().FindFieldByName("ts")
+	require.True(t, ok)
+	require.True(t, f2.Type.Equals(iceberg.PrimitiveTypes.TimestampTz))
+	require.NotEqual(t, f.ID, f2.ID)
+
+	// Both prior rows are now null: the ns row's file embeds the retired ns
+	// field ID, and the µs row's file remains unmapped.
+	require.ElementsMatch(t, []any{nil, nil}, scanColumn(t, ctx, rt, "ts"))
+}
+
+// scanColumn reads the named column of every row through iceberg-go's scanner,
+// which applies the table's current schema and name mapping the same way
+// external query engines do. Values are returned as int64 epoch offsets in the
+// column's unit, with nil for nulls.
+func scanColumn(t *testing.T, ctx context.Context, rt *regressionTable, name string) []any {
+	t.Helper()
+
+	tbl, err := rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	arrowTbl, err := tbl.Scan().ToArrowTable(ctx)
+	require.NoError(t, err)
+	defer arrowTbl.Release()
+
+	idx := arrowTbl.Schema().FieldIndices(name)
+	require.Len(t, idx, 1)
+
+	var out []any
+	for _, chunk := range arrowTbl.Column(idx[0]).Data().Chunks() {
+		for i := 0; i < chunk.Len(); i++ {
+			if chunk.IsNull(i) {
+				out = append(out, nil)
+				continue
+			}
+			switch arr := chunk.(type) {
+			case *array.Timestamp:
+				out = append(out, int64(arr.Value(i)))
+			case *array.String:
+				out = append(out, arr.Value(i))
+			default:
+				t.Fatalf("column %q has unhandled arrow type %T", name, chunk)
+			}
+		}
+	}
+	return out
 }
 
 func loadTestConfig(t *testing.T) config {
@@ -1088,4 +1241,21 @@ func TestMapTypeNanosecondWiring(t *testing.T) {
 	v, err = conv(probe)
 	require.NoError(t, err)
 	require.Equal(t, "2262-04-11T23:47:16.854775807Z", v)
+}
+
+// TestCanMigrate pins the migratable set to exactly the microsecond↔nanosecond
+// timestamp pair: anything else must remain INCOMPATIBLE (backfill) rather
+// than silently migrating.
+func TestCanMigrate(t *testing.T) {
+	us := mappedType{icebergType: iceberg.PrimitiveTypes.TimestampTz}
+	ns := mappedType{icebergType: iceberg.PrimitiveTypes.TimestampTzNs}
+	str := mappedType{icebergType: iceberg.PrimitiveTypes.String}
+
+	require.True(t, ns.CanMigrate(mboilerplate.ExistingField{Type: "timestamptz"}))
+	require.True(t, us.CanMigrate(mboilerplate.ExistingField{Type: "timestamptz_ns"}))
+	require.False(t, us.CanMigrate(mboilerplate.ExistingField{Type: "timestamptz"}))
+	require.False(t, ns.CanMigrate(mboilerplate.ExistingField{Type: "timestamptz_ns"}))
+	require.False(t, ns.CanMigrate(mboilerplate.ExistingField{Type: "string"}))
+	require.False(t, str.CanMigrate(mboilerplate.ExistingField{Type: "timestamptz"}))
+	require.False(t, str.CanMigrate(mboilerplate.ExistingField{Type: "long"}))
 }

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	parquetfile "github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/iceberg-go"
 	icebergcatalog "github.com/apache/iceberg-go/catalog"
 	icebergio "github.com/apache/iceberg-go/io"
@@ -138,6 +140,10 @@ func TestIntegration(t *testing.T) {
 		boilerplate.RunMaterializationTest(t, newMaterialization, "testdata/materialize.flow.yaml", makeResourceFn, materializeSanitizers())
 	})
 
+	t.Run("materialize-ns", func(t *testing.T) {
+		boilerplate.RunMaterializationTest(t, newMaterialization, "testdata/materialize-ns.flow.yaml", makeResourceFn, materializeSanitizers())
+	})
+
 	t.Run("apply", func(t *testing.T) {
 		boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply.flow.yaml", makeResourceFn)
 	})
@@ -152,6 +158,18 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("checkpoint-fence-regression", func(t *testing.T) {
 		runCheckpointFenceRegression(t, cfg)
+	})
+
+	t.Run("ns-timestamp", func(t *testing.T) {
+		runNanosecondTimestampTest(t, cfg)
+	})
+
+	t.Run("ns-v2-upgrade", func(t *testing.T) {
+		runNanosecondV2UpgradeTest(t, cfg)
+	})
+
+	t.Run("ns-create-v3", func(t *testing.T) {
+		runNanosecondCreateResourceTest(t, cfg)
 	})
 
 	// Migration test is skipped because Iceberg does not support the type
@@ -192,6 +210,10 @@ func TestIntegrationGlue(t *testing.T) {
 		boilerplate.RunMaterializationTest(t, newMaterialization, "testdata/materialize-glue.flow.yaml", makeResourceFn, materializeSanitizers())
 	})
 
+	t.Run("materialize-ns", func(t *testing.T) {
+		boilerplate.RunMaterializationTest(t, newMaterialization, "testdata/materialize-glue-ns.flow.yaml", makeResourceFn, materializeSanitizers())
+	})
+
 	t.Run("apply", func(t *testing.T) {
 		boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply-glue.flow.yaml", makeResourceFn)
 	})
@@ -207,6 +229,18 @@ func TestIntegrationGlue(t *testing.T) {
 	t.Run("checkpoint-fence-regression", func(t *testing.T) {
 		runCheckpointFenceRegression(t, cfg)
 	})
+
+	t.Run("ns-timestamp", func(t *testing.T) {
+		runNanosecondTimestampTest(t, cfg)
+	})
+
+	t.Run("ns-v2-upgrade", func(t *testing.T) {
+		runNanosecondV2UpgradeTest(t, cfg)
+	})
+
+	t.Run("ns-create-v3", func(t *testing.T) {
+		runNanosecondCreateResourceTest(t, cfg)
+	})
 }
 
 // TestRestGlueSnapshotParity enforces that the REST and Glue materialize
@@ -214,12 +248,14 @@ func TestIntegrationGlue(t *testing.T) {
 // catalog code paths produced different results — the drift this coverage
 // exists to catch.
 func TestRestGlueSnapshotParity(t *testing.T) {
-	rest, err := os.ReadFile(".snapshots/TestIntegration-materialize")
-	require.NoError(t, err)
-	glue, err := os.ReadFile(".snapshots/TestIntegrationGlue-materialize")
-	require.NoError(t, err)
-	require.Equal(t, string(rest), string(glue),
-		"REST and Glue materialize snapshots diverged; this indicates catalog-specific drift")
+	for _, name := range []string{"materialize", "materialize-ns"} {
+		rest, err := os.ReadFile(".snapshots/TestIntegration-" + name)
+		require.NoError(t, err)
+		glue, err := os.ReadFile(".snapshots/TestIntegrationGlue-" + name)
+		require.NoError(t, err)
+		require.Equal(t, string(rest), string(glue),
+			"REST and Glue %s snapshots diverged; this indicates catalog-specific drift", name)
+	}
 }
 
 // runTimestampOverflowRegression reproduces a production failure observed at
@@ -235,7 +271,7 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 
 	clampedTS, err := clampTimestamp("9999-12-31T23:59:59-14:00")
 	require.NoError(t, err)
-	s3Path := rt.uploadParquet(t, ctx,
+	s3Path, _ := rt.uploadParquet(t, ctx,
 		writer.ParquetSchemaElement{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false}, clampedTS)
 
 	require.NoError(t, rt.cat.appendFiles(ctx,
@@ -317,8 +353,9 @@ func newRegressionTable(t *testing.T, ctx context.Context, cfg config, table str
 }
 
 // uploadParquet writes rows into a single-column parquet file and uploads it to
-// the table's data prefix, returning its s3 path.
-func (rt *regressionTable) uploadParquet(t *testing.T, ctx context.Context, col writer.ParquetSchemaElement, rows ...any) string {
+// the table's data prefix, returning the s3 path and the local path for tests
+// that inspect the encoded bytes.
+func (rt *regressionTable) uploadParquet(t *testing.T, ctx context.Context, col writer.ParquetSchemaElement, rows ...any) (string, string) {
 	t.Helper()
 
 	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
@@ -344,7 +381,7 @@ func (rt *regressionTable) uploadParquet(t *testing.T, ctx context.Context, col 
 	})
 	require.NoError(t, err)
 
-	return s3Path
+	return s3Path, parquetPath
 }
 
 // runDateOverflowRegression is the date analog of runTimestampOverflowRegression.
@@ -358,7 +395,7 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 
 	clampedDate, err := clampDate("10000-01-01")
 	require.NoError(t, err)
-	s3Path := rt.uploadParquet(t, ctx,
+	s3Path, _ := rt.uploadParquet(t, ctx,
 		writer.ParquetSchemaElement{Name: "d", DataType: writer.LogicalTypeDate, Required: false}, clampedDate)
 
 	require.NoError(t, rt.cat.appendFiles(ctx,
@@ -384,7 +421,7 @@ func runCheckpointFenceRegression(t *testing.T, cfg config) {
 		iceberg.NestedField{ID: 1, Name: "v", Type: iceberg.PrimitiveTypes.String, Required: false}, nil)
 
 	vCol := writer.ParquetSchemaElement{Name: "v", DataType: writer.LogicalTypeString, Required: false}
-	first := rt.uploadParquet(t, ctx, vCol, "one")
+	first, _ := rt.uploadParquet(t, ctx, vCol, "one")
 	require.NoError(t, rt.cat.appendFiles(ctx, materialization, rt.ident,
 		[]string{first}, "", "checkpoint-1"))
 
@@ -393,7 +430,7 @@ func runCheckpointFenceRegression(t *testing.T, cfg config) {
 	require.NoError(t, rt.cat.appendFiles(ctx, materialization, rt.ident,
 		[]string{first}, "", "checkpoint-1"))
 
-	second := rt.uploadParquet(t, ctx, vCol, "two")
+	second, _ := rt.uploadParquet(t, ctx, vCol, "two")
 	require.NoError(t, rt.cat.appendFiles(ctx, materialization, rt.ident,
 		[]string{second}, "checkpoint-1", "checkpoint-2"))
 
@@ -585,6 +622,200 @@ func TestPopulateInfoSchemaSkipsAbsentNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, fake.listTablesCalled)
 	})
+}
+
+// runNanosecondTimestampTest verifies that timestamptz_ns (Iceberg v3 format) columns:
+//   - write nanosecond-precision timestamps correctly
+//   - clamp out-of-range values (before 1677 / after 2262) to int64 min/max rather than overflowing
+//   - encode exact int64 nanosecond values in the produced Parquet file
+//     (asserted against the raw column bytes)
+func runNanosecondTimestampTest(t *testing.T, cfg config) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Advanced is a pointer shared with the caller's cfg: clone it before
+	// mutating so the flag doesn't leak into subtests that run after this one.
+	adv := advancedConfig{}
+	if cfg.Advanced != nil {
+		adv = *cfg.Advanced
+	}
+	adv.NanosecondTimestamps = true
+	cfg.Advanced = &adv
+	rt := newRegressionTable(t, ctx, cfg, "ns_timestamp",
+		iceberg.NestedField{ID: 1, Name: "ts", Type: iceberg.PrimitiveTypes.TimestampTzNs, Required: false},
+		iceberg.Properties{icebergtable.PropertyFormatVersion: "3"})
+
+	// Values pass through clampTimestampNanos as they do in production, where
+	// MapType wires it as the binding's ElementConverter.
+	var rows []any
+	for _, raw := range []string{
+		"2023-01-15T12:34:56.123456789Z", // in-range: sub-microsecond digits (789) must survive the round-trip
+		"1000-01-01T00:00:00Z",           // out-of-range past: clamps to math.MinInt64 rather than overflowing
+		"3000-01-01T00:00:00Z",           // out-of-range future: clamps to math.MaxInt64 rather than overflowing
+	} {
+		v, err := clampTimestampNanos(raw)
+		require.NoError(t, err)
+		rows = append(rows, v)
+	}
+	s3Path, parquetPath := rt.uploadParquet(t, ctx,
+		writer.ParquetSchemaElement{Name: "ts", DataType: writer.LogicalTypeTimestampNanos, Required: false}, rows...)
+
+	require.NoError(t, rt.cat.appendFiles(ctx,
+		"acmeCo/tests/ns-timestamp",
+		rt.ident,
+		[]string{s3Path},
+		"",
+		"deadbeefdeadbeef",
+	))
+
+	// Verify nanosecond precision by reading the raw int64 values from the Parquet file.
+	// DuckDB maps nanosecond Parquet timestamps to TIMESTAMPTZ (microsecond precision),
+	// dropping sub-microsecond digits — so we read the encoded bytes directly instead.
+	pqf, err := os.Open(parquetPath)
+	require.NoError(t, err)
+	defer pqf.Close()
+
+	pqr, err := parquetfile.NewParquetReader(pqf)
+	require.NoError(t, err)
+	defer pqr.Close()
+
+	col, err := pqr.RowGroup(0).Column(0)
+	require.NoError(t, err)
+
+	int64Col := col.(*parquetfile.Int64ColumnChunkReader)
+	vals := make([]int64, 3)
+	defLevels := make([]int16, 3)
+	_, valuesRead, err := int64Col.ReadBatch(3, vals, defLevels, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, valuesRead)
+	// 2023-01-15T12:34:56.123456789Z → unix nanoseconds
+	require.Equal(t, int64(1673786096123456789), vals[0], "in-range: sub-microsecond precision lost")
+	require.Equal(t, int64(math.MinInt64), vals[1], "out-of-range past not clamped to MinInt64")
+	require.Equal(t, int64(math.MaxInt64), vals[2], "out-of-range future not clamped to MaxInt64")
+}
+
+// runNanosecondV2UpgradeTest reproduces adding a timestamptz_ns column to a
+// table that predates nanosecond_timestamps being enabled: the table is still
+// format v2 (and had no date-time columns, so flipping the flag forces no
+// backfill), and UpdateResource must upgrade it to v3 for the AddColumn to be
+// valid.
+func runNanosecondV2UpgradeTest(t *testing.T, cfg config) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Advanced is a pointer shared with the caller's cfg: clone it before
+	// mutating so the flag doesn't leak into subtests that run after this one.
+	adv := advancedConfig{}
+	if cfg.Advanced != nil {
+		adv = *cfg.Advanced
+	}
+	adv.NanosecondTimestamps = true
+	cfg.Advanced = &adv
+	rt := newRegressionTable(t, ctx, cfg, "ns_v2_upgrade",
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: false},
+		iceberg.Properties{icebergtable.PropertyFormatVersion: "2"})
+	cat := rt.cat
+	tableIdent := rt.ident
+
+	tbl, err := cat.cat.LoadTable(ctx, tableIdent)
+	require.NoError(t, err)
+	require.Equal(t, 2, tbl.Metadata().Version())
+
+	update := mboilerplate.BindingUpdate[config, resource, mappedType]{
+		Binding: mboilerplate.MappedBinding[config, resource, mappedType]{
+			MaterializationSpec_Binding: pf.MaterializationSpec_Binding{
+				ResourcePath: tableIdent,
+			},
+		},
+		NewProjections: []mboilerplate.MappedProjection[mappedType]{{
+			Projection: mboilerplate.Projection{
+				Projection: pf.Projection{
+					Field: "ts",
+					Inference: pf.Inference{
+						Types:   []string{"string"},
+						String_: &pf.Inference_String{Format: "date-time"},
+					},
+				},
+			},
+		}},
+	}
+
+	_, apply, err := cat.UpdateResource(ctx, update)
+	require.NoError(t, err)
+	require.NoError(t, apply(ctx))
+
+	tbl, err = cat.cat.LoadTable(ctx, tableIdent)
+	require.NoError(t, err)
+	require.Equal(t, 3, tbl.Metadata().Version())
+	f, ok := tbl.Schema().FindFieldByName("ts")
+	require.True(t, ok)
+	require.True(t, f.Type.Equals(iceberg.PrimitiveTypes.TimestampTzNs))
+}
+
+// runNanosecondCreateResourceTest exercises the connector's own CreateResource
+// path with nanosecond_timestamps enabled: a user-supplied format-version
+// table property that conflicts with the required v3 is rejected with an
+// explicit error, and a clean create yields a format v3 table with a
+// timestamptz_ns column.
+func runNanosecondCreateResourceTest(t *testing.T, cfg config) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Advanced is a pointer shared with the caller's cfg: clone it before
+	// mutating so the flag doesn't leak into subtests that run after this one.
+	adv := advancedConfig{}
+	if cfg.Advanced != nil {
+		adv = *cfg.Advanced
+	}
+	adv.NanosecondTimestamps = true
+	cfg.Advanced = &adv
+
+	cat, err := newCatalog(ctx, cfg, NestedLocationStyle)
+	require.NoError(t, err)
+	ensureNamespace(t, cfg)
+
+	// Same per-run naming convention as newRegressionTable, so concurrent runs
+	// can't collide and leaked tables are swept by the boilerplate cleanup.
+	table := fmt.Sprintf("ns_create_flow_test_%d", time.Now().Unix())
+	ident := icebergtable.Identifier{cfg.Namespace, table}
+
+	binding := &pf.MaterializationSpec_Binding{
+		ResourcePath: ident,
+		Collection: pf.CollectionSpec{
+			Name: "acmeCo/tests/ns-create",
+			Projections: []pf.Projection{{
+				Field: "ts",
+				Inference: pf.Inference{
+					Types:   []string{"string"},
+					String_: &pf.Inference_String{Format: "date-time"},
+				},
+			}},
+		},
+		FieldSelection: pf.FieldSelection{Values: []string{"ts"}},
+	}
+
+	_, _, err = cat.CreateResource(ctx, binding, resource{
+		AdditionalTableProperties: map[string]string{
+			icebergtable.PropertyFormatVersion: "2",
+		},
+	})
+	require.ErrorContains(t, err, "requires format version 3")
+
+	_, apply, err := cat.CreateResource(ctx, binding, resource{})
+	require.NoError(t, err)
+	require.NoError(t, apply(ctx))
+	t.Cleanup(func() {
+		if err := cat.cat.DropTable(ctx, ident); err != nil {
+			t.Log("failed to drop table", ident, err)
+		}
+	})
+
+	tbl, err := cat.cat.LoadTable(ctx, ident)
+	require.NoError(t, err)
+	require.Equal(t, 3, tbl.Metadata().Version())
+	f, ok := tbl.Schema().FindFieldByName("ts")
+	require.True(t, ok)
+	require.True(t, f.Type.Equals(iceberg.PrimitiveTypes.TimestampTzNs))
 }
 
 func loadTestConfig(t *testing.T) config {
@@ -820,4 +1051,41 @@ func TestMapTypeIgnoreStringFormatOnNonStringField(t *testing.T) {
 
 	require.Equal(t, "long", mt.String())
 	require.Nil(t, conv)
+}
+
+// TestMapTypeNanosecondWiring guards the MapType switch arm that installs
+// clampTimestampNanos for date-time fields when nanosecond_timestamps is
+// enabled. The integration tests invoke the clamp directly, so a silent
+// fallback to the microsecond clamp would pass every other test while
+// overflowing int64 nanoseconds in production.
+func TestMapTypeNanosecondWiring(t *testing.T) {
+	proj := mboilerplate.Projection{
+		Projection: pf.Projection{
+			Field: "ts",
+			Inference: pf.Inference{
+				Exists:  pf.Inference_MUST,
+				Types:   []string{"string"},
+				String_: &pf.Inference_String{Format: "date-time"},
+			},
+		},
+	}
+
+	// Year 3000 distinguishes the two clamps: in-range for the microsecond
+	// clamp (years 1-9999), beyond the int64-nanoseconds band for the
+	// nanosecond clamp.
+	const probe = "3000-01-01T00:00:00Z"
+
+	var micro = &materialization{}
+	mt, conv := micro.MapType(proj, fieldConfig{})
+	require.Equal(t, "timestamptz", mt.String())
+	v, err := conv(probe)
+	require.NoError(t, err)
+	require.Equal(t, probe, v)
+
+	var nanos = &materialization{cfg: config{Advanced: &advancedConfig{NanosecondTimestamps: true}}}
+	mt, conv = nanos.MapType(proj, fieldConfig{})
+	require.Equal(t, "timestamptz_ns", mt.String())
+	v, err = conv(probe)
+	require.NoError(t, err)
+	require.Equal(t, "2262-04-11T23:47:16.854775807Z", v)
 }

--- a/materialize-s3-iceberg/testdata/config-glue-ns.yaml
+++ b/materialize-s3-iceberg/testdata/config-glue-ns.yaml
@@ -1,0 +1,36 @@
+# AWS Glue integration-test config.
+#
+# Disabled by default: TestIntegrationGlue only runs with -s3iceberg.test-glue
+# (or S3_ICEBERG_TEST_GLUE set) and needs real AWS credentials with Glue Data
+# Catalog + S3 access. Replace the REPLACE_ME placeholders below and sops-encrypt
+# this file before enabling the test. The connector creates the `namespace`
+# (a Glue database) and its tables; the S3 `bucket` must already exist or be
+# creatable by the supplied credentials.
+# Shared test bucket + Glue account also used by materialize-iceberg. The prefix
+# and namespace are deliberately distinct from that connector's so the two do not
+# clobber each other's tables in the shared Glue catalog.
+bucket: estuary-connector-test-bucket
+region: us-east-2
+prefix: s3-iceberg-test
+namespace: tests
+upload_interval: PT1S
+credentials:
+    auth_type: AWSAccessKey
+    awsAccessKeyId_sops: ENC[AES256_GCM,data:MtlUFvpUs3yZDM+UGBlUU6jRKKo=,iv:WsNfvZvSbwh+esBiDigdVnqxg5o/03PNY+9GZNp37kY=,tag:mx9ncxv1UETmBn7HpQ5J0w==,type:str]
+    awsSecretAccessKey_sops: ENC[AES256_GCM,data:TEBxk8CcDVArTurZkRjf/M9n6iWXJCpcTDssfqnttUIfvuw4a/pAbw==,iv:DJqRhL952DBCAgK9FKAVi4i6jfNe2Z15ADZLWxvJb0c=,tag:naG9wlJTOZHcsvEJnW9f1Q==,type:str]
+catalog:
+    catalog_type: AWS Glue
+    # glue_id is optional; defaults to the account ID of the credentials above.
+    # Set to 076183946664 if the credentials belong to a different account.
+advanced:
+    feature_flags: allow_existing_tables_for_new_bindings
+    nanosecond_timestamps: true
+sops:
+    gcp_kms:
+        - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
+          created_at: "2026-07-17T23:12:34Z"
+          enc: CiUAdmEdwqV0pPxTTaGNVcoC9OWfwhlSJ0eAu+5JAgk0nzt4HnroEkkApbezqgPNJP4KubS8KXEg6K0Cz9dsuJD/A8ntGW7dLX7QXGB8FsRdRPZObtcqwCnIgqQo3bEkCnnGlpu0qeZba59DIvQRCqJ3
+    lastmodified: "2026-07-17T23:12:34Z"
+    mac: ENC[AES256_GCM,data:prhAMeSpQRbpKNOU+eQmtQzO2NdfVjci/jX/um4H+44Mh+obFJXczDJk3tLa9R3utvjcvQNbvGVu1C+WNndg/uDW4ctGuZt9fpq8pps3Ha+LKkpmsXQKrokWx6jJwIISr7/ZYddEFF816Zf2iQPlneG4KWItZEPAUrFxS3YnVgI=,iv:L1P+mq2hJh99lrAYCOh0u6YVBPC/goWiotcuBe2qurc=,tag:i0KFfpyNqtoLtFaUJhXR8w==,type:str]
+    encrypted_suffix: _sops
+    version: 3.12.1

--- a/materialize-s3-iceberg/testdata/config-ns.yaml
+++ b/materialize-s3-iceberg/testdata/config-ns.yaml
@@ -1,0 +1,19 @@
+bucket: test-warehouse
+region: us-east-1
+prefix: warehouse
+namespace: tests
+upload_interval: PT1S
+s3_endpoint: http://localhost:9702
+credentials:
+    auth_type: AWSAccessKey
+    awsAccessKeyId: flow
+    awsSecretAccessKey: flow
+catalog:
+    catalog_type: Iceberg REST Server
+    uri: http://localhost:9700/api/catalog
+    credential: root:s3cr3t
+    warehouse: test_warehouse
+    scope: PRINCIPAL_ROLE:ALL
+advanced:
+    nanosecond_timestamps: true
+    feature_flags: allow_existing_tables_for_new_bindings

--- a/materialize-s3-iceberg/testdata/materialize-glue-ns.flow.yaml
+++ b/materialize-s3-iceberg/testdata/materialize-glue-ns.flow.yaml
@@ -1,0 +1,33 @@
+import:
+  - ../../materialize-boilerplate/testdata/integration/collections.materialize.flow.yaml
+
+materializations:
+  acmeCo/tests/materialize-s3-iceberg:
+    endpoint:
+      local:
+        command: ["go", "run", "."]
+        protobuf: true
+        config: config-glue-ns.yaml
+    bindings:
+    - resource:
+        table: simple_delta
+        delta_updates: true
+      source: tests/simple
+      fields:
+        recommended: true
+    - resource:
+        table: not_simple_delta
+        delta_updates: true
+      source: tests/not-simple
+      fields:
+        recommended: true
+        exclude:
+          - unsignedBigint
+    - resource:
+        table: data_types_delta
+        delta_updates: true
+      source: tests/data-types
+      fields:
+        recommended: true
+        exclude:
+          - stringUint64Field

--- a/materialize-s3-iceberg/testdata/materialize-ns.flow.yaml
+++ b/materialize-s3-iceberg/testdata/materialize-ns.flow.yaml
@@ -1,0 +1,33 @@
+import:
+  - ../../materialize-boilerplate/testdata/integration/collections.materialize.flow.yaml
+
+materializations:
+  acmeCo/tests/materialize-s3-iceberg:
+    endpoint:
+      local:
+        command: ["go", "run", "."]
+        protobuf: true
+        config: config-ns.yaml
+    bindings:
+    - resource:
+        table: simple_delta
+        delta_updates: true
+      source: tests/simple
+      fields:
+        recommended: true
+    - resource:
+        table: not_simple_delta
+        delta_updates: true
+      source: tests/not-simple
+      fields:
+        recommended: true
+        exclude:
+          - unsignedBigint
+    - resource:
+        table: data_types_delta
+        delta_updates: true
+      source: tests/data-types
+      fields:
+        recommended: true
+        exclude:
+          - stringUint64Field

--- a/materialize-s3-iceberg/type_mapping.go
+++ b/materialize-s3-iceberg/type_mapping.go
@@ -120,6 +120,13 @@ func (mt mappedType) Compatible(existing boilerplate.ExistingField) bool {
 	return strings.EqualFold(existing.Type, mt.icebergType.String())
 }
 
+// CanMigrate permits exactly the microsecond↔nanosecond timestamp pair, in
+// both directions. Iceberg forbids changing a column's type in place, so
+// UpdateResource migrates by dropping and re-adding the column under a new
+// field ID: the new type applies to data going forward, and prior rows read
+// as null for the column.
 func (mt mappedType) CanMigrate(existing boilerplate.ExistingField) bool {
-	return false
+	from, to := strings.ToLower(existing.Type), mt.icebergType.String()
+	return (from == "timestamptz" && to == "timestamptz_ns") ||
+		(from == "timestamptz_ns" && to == "timestamptz")
 }

--- a/materialize-s3-iceberg/type_mapping.go
+++ b/materialize-s3-iceberg/type_mapping.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/apache/iceberg-go"
@@ -25,6 +26,11 @@ var schemaOptions = []writer.ParquetSchemaOption{
 	writer.WithParquetUUIDAsString(),
 }
 
+// nsSchemaOptions is precomputed rather than appended per call: appending to
+// schemaOptions at a call site would alias its backing array if it ever gained
+// spare capacity.
+var nsSchemaOptions = append(slices.Clip(schemaOptions), writer.WithParquetTimestampAsNanoseconds())
+
 type fieldConfig struct {
 	// IgnoreStringFormat can be set to true to indicate that the field should
 	// be materialized as a string, disregarding any format annotations.
@@ -39,8 +45,8 @@ func (fc fieldConfig) CastToString() bool {
 	return fc.IgnoreStringFormat
 }
 
-func parquetSchema(fields []string, collection pf.CollectionSpec, fieldConfigJsonMap map[string]json.RawMessage) (writer.ParquetSchema, error) {
-	out := []writer.ParquetSchemaElement{}
+func parquetSchema(fields []string, collection pf.CollectionSpec, fieldConfigJsonMap map[string]json.RawMessage, nanoseconds bool) (writer.ParquetSchema, error) {
+	out := make(writer.ParquetSchema, 0, len(fields))
 
 	for _, f := range fields {
 		var fc fieldConfig
@@ -52,7 +58,7 @@ func parquetSchema(fields []string, collection pf.CollectionSpec, fieldConfigJso
 			}
 		}
 
-		s, err := projectionToParquetSchemaElement(*collection.GetProjection(f), fc)
+		s, err := projectionToParquetSchemaElement(*collection.GetProjection(f), fc, nanoseconds)
 		if err != nil {
 			return nil, err
 		}
@@ -62,7 +68,7 @@ func parquetSchema(fields []string, collection pf.CollectionSpec, fieldConfigJso
 	return out, nil
 }
 
-func projectionToParquetSchemaElement(p pf.Projection, fc fieldConfig) (writer.ParquetSchemaElement, error) {
+func projectionToParquetSchemaElement(p pf.Projection, fc fieldConfig, nanoseconds bool) (writer.ParquetSchemaElement, error) {
 	if fc.IgnoreStringFormat {
 		if p.Inference.String_ == nil {
 			return writer.ParquetSchemaElement{}, fmt.Errorf("cannot set ignoreStringFormat on non-string field %q", p.Field)
@@ -70,7 +76,11 @@ func projectionToParquetSchemaElement(p pf.Projection, fc fieldConfig) (writer.P
 		p.Inference.String_.Format = ""
 	}
 
-	return writer.ProjectionToParquetSchemaElement(p, false, schemaOptions...), nil
+	opts := schemaOptions
+	if nanoseconds {
+		opts = nsSchemaOptions
+	}
+	return writer.ProjectionToParquetSchemaElement(p, false, opts...), nil
 }
 
 func parquetTypeToIcebergType(pqt writer.ParquetDataType) iceberg.Type {
@@ -89,6 +99,8 @@ func parquetTypeToIcebergType(pqt writer.ParquetDataType) iceberg.Type {
 		return iceberg.PrimitiveTypes.Date
 	case writer.LogicalTypeTimestamp:
 		return iceberg.PrimitiveTypes.TimestampTz
+	case writer.LogicalTypeTimestampNanos:
+		return iceberg.PrimitiveTypes.TimestampTzNs
 	case writer.LogicalTypeUuid:
 		return iceberg.PrimitiveTypes.UUID
 	default:


### PR DESCRIPTION
**Description:**

Fixes https://github.com/estuary/connectors/issues/4462

Map timestamps to Iceberg `timestamptz_ns` in `materialize-s3-iceberg`.

Tables are created as format v3 when the option is enabled, and a v2 table that predates the option is upgraded to v3 in the same transaction that adds its first `timestamptz_ns` column. Out-of-range values are clamped to the int64-nanoseconds band (~1677–2262).

**Workflow steps:**

A task-level advanced option (`nanosecond_timestamps`) causes all timestamps to be materialized as `timestamptz_ns` instead of `timestamptz`. Toggling it on an existing materialization requires a backfill: Iceberg has no in-place promotion between the two timestamp encodings.

**Documentation links affected:**

None yet — the new `nanosecond_timestamps` advanced option should be added to the materialize-s3-iceberg docs page.

**Notes for reviewers:**

Two commits: the first adds the regression tests (deliberately does not compile on its own), the second is the implementation that makes them pass. Full suite is green, including the Glue integration run.
