### PR TITLE
go/writer: add variant parquet type

### DIFF
--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -157,9 +157,14 @@ type ParquetWriter struct {
 		columnChunkCount int
 	}
 
-	// buffer contains rows of values that are pending to be written as a row group to the scratch
-	// file when bufferSizeBytes exceeds the threshold.
-	buffer          [][]any
+	// buffer holds column-oriented values pending to be written as a row group to the scratch file
+	// when bufferSizeBytes exceeds the threshold. Each entry is a strongly-typed slice (e.g.
+	// *[]int64, *[]parquet.ByteArray) matching the column's parquet physical type, and contains only
+	// non-null values for that column. defLevels[colIdx] runs parallel to the row order with 0 for
+	// null and 1 for present, so its length always equals bufferRowCount.
+	buffer          []any
+	defLevels       [][]int16
+	bufferRowCount  int
 	bufferSizeBytes int
 }
 
@@ -230,6 +235,14 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 		return nil, fmt.Errorf("initializing parquet sink writer: %w", err)
 	}
 
+	buffer := make([]any, len(sch))
+	defLevels := make([][]int16, len(sch))
+	const initialCap = 1000
+	for i, e := range sch {
+		buffer[i] = makeColumnBuffer(e.DataType, initialCap)
+		defLevels[i] = make([]int16, 0, initialCap)
+	}
+
 	return &ParquetWriter{
 		cfg:        cfg,
 		schema:     sch,
@@ -237,7 +250,58 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 		sinkWriter: sinkWriter,
 		cwc:        cwc,
 		rs:         newRowSizing(sch),
+		buffer:     buffer,
+		defLevels:  defLevels,
 	}, nil
+}
+
+// makeColumnBuffer returns a pointer to an empty strongly-typed slice for the given column type.
+// Storing a pointer (one word) in the []any buffer avoids a heap allocation on every append,
+// since the interface data word holds the pointer directly rather than boxing a 3-word slice header.
+func makeColumnBuffer(dt ParquetDataType, initialCap int) any {
+	switch dt {
+	case PrimitiveTypeInteger, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos:
+		s := make([]int64, 0, initialCap)
+		return &s
+	case PrimitiveTypeNumber:
+		s := make([]float64, 0, initialCap)
+		return &s
+	case PrimitiveTypeBoolean:
+		s := make([]bool, 0, initialCap)
+		return &s
+	case PrimitiveTypeBinary, LogicalTypeJson, LogicalTypeString:
+		s := make([]parquet.ByteArray, 0, initialCap)
+		return &s
+	case LogicalTypeUuid, LogicalTypeDecimal, LogicalTypeInterval:
+		s := make([]parquet.FixedLenByteArray, 0, initialCap)
+		return &s
+	case LogicalTypeDate:
+		s := make([]int32, 0, initialCap)
+		return &s
+	default:
+		panic(fmt.Sprintf("makeColumnBuffer unknown type: %d", dt))
+	}
+}
+
+// resetColumnBuffer truncates the slice pointed to by s to length 0 while preserving its
+// underlying capacity so subsequent buffer cycles can reuse the allocation.
+func resetColumnBuffer(s any) {
+	switch sp := s.(type) {
+	case *[]int64:
+		*sp = (*sp)[:0]
+	case *[]int32:
+		*sp = (*sp)[:0]
+	case *[]float64:
+		*sp = (*sp)[:0]
+	case *[]bool:
+		*sp = (*sp)[:0]
+	case *[]parquet.ByteArray:
+		*sp = (*sp)[:0]
+	case *[]parquet.FixedLenByteArray:
+		*sp = (*sp)[:0]
+	default:
+		panic(fmt.Sprintf("resetColumnBuffer unknown type: %T", s))
+	}
 }
 
 func writerOpts(cfg parquetConfig) []file.WriteOption {
@@ -280,8 +344,91 @@ func (w *ParquetWriter) Write(row []any) error {
 		return fmt.Errorf("write: row length (%d) does not match schema length (%d)", len(row), len(w.schema))
 	}
 
-	w.buffer = append(w.buffer, row)
+	var err error
+	for colIdx, f := range w.schema {
+		v := row[colIdx]
+		if v == nil {
+			w.defLevels[colIdx] = append(w.defLevels[colIdx], 0)
+			continue
+		}
+		w.defLevels[colIdx] = append(w.defLevels[colIdx], 1)
+
+		switch f.DataType {
+		case PrimitiveTypeInteger:
+			var q int64
+			if q, err = getIntVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case PrimitiveTypeNumber:
+			var q float64
+			if q, err = getNumberVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case PrimitiveTypeBoolean:
+			var q bool
+			if q, err = getBooleanVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case PrimitiveTypeBinary:
+			var q parquet.ByteArray
+			if q, err = getBinaryVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeJson:
+			var q parquet.ByteArray
+			if q, err = getJsonVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeString:
+			var q parquet.ByteArray
+			if q, err = getStringVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeUuid:
+			var q parquet.FixedLenByteArray
+			if q, err = getUuidVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeDate:
+			var q int32
+			if q, err = getDateVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeTime:
+			var q int64
+			if q, err = getTimeVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeTimestamp:
+			var q int64
+			if q, err = getTimestampVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeTimestampNanos:
+			var q int64
+			if q, err = getTimestampNanosVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeDecimal:
+			var q parquet.FixedLenByteArray
+			if q, err = getDecimalVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeInterval:
+			var q parquet.FixedLenByteArray
+			if q, err = getIntervalVal(v); err == nil {
+				appendVal(w, colIdx, q)
+			}
+		default:
+			panic(fmt.Sprintf("attempted to write unknown type of column '%s': %d", f.Name, f.DataType))
+		}
+		if err != nil {
+			return fmt.Errorf("converting value for column '%s': %w (type %T)", f.Name, err, v)
+		}
+	}
+
 	w.bufferSizeBytes += w.rs.estSize(row)
+	w.bufferRowCount += 1
 	w.scratch.rowCount += 1
 
 	if w.bufferSizeBytes >= w.cfg.bufferSize {
@@ -311,6 +458,13 @@ func (w *ParquetWriter) Write(row []any) error {
 	}
 
 	return nil
+}
+
+// appendVal appends v to the column's typed buffer slice. The caller is
+// responsible for handling nil values and maintaining defLevels.
+func appendVal[T parquetValue](w *ParquetWriter, colIdx int, v T) {
+	sp := w.buffer[colIdx].(*[]T)
+	*sp = append(*sp, v)
 }
 
 // Written returns the number of bytes written to the output writer. This value increases only as
@@ -394,7 +548,7 @@ func (w *ParquetWriter) flushScratchFile() error {
 
 // flushBuffer writes the current buffered rows as a single row group to the scratch file.
 func (w *ParquetWriter) flushBuffer() error {
-	if len(w.buffer) == 0 {
+	if w.bufferRowCount == 0 {
 		return nil
 	}
 
@@ -424,64 +578,65 @@ func (w *ParquetWriter) flushBuffer() error {
 
 	rgWriter := w.scratch.writer.AppendRowGroup()
 
-	// Transpose the buffered rows into the scratch file row group by writing them column-by-column.
 	for colIdx, f := range w.schema {
 		cw, err := rgWriter.NextColumn()
 		if err != nil {
 			return fmt.Errorf("getting next column: %w", err)
 		}
 
+		defLvls := w.defLevels[colIdx]
+
 		switch f.DataType {
 		case PrimitiveTypeInteger:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getIntVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing integer column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeNumber:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Float64ColumnChunkWriter), getNumberVal); err != nil {
+			if err := writeColumn(cw.(*file.Float64ColumnChunkWriter), *w.buffer[colIdx].(*[]float64), defLvls); err != nil {
 				return fmt.Errorf("writing number column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeBoolean:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.BooleanColumnChunkWriter), getBooleanVal); err != nil {
+			if err := writeColumn(cw.(*file.BooleanColumnChunkWriter), *w.buffer[colIdx].(*[]bool), defLvls); err != nil {
 				return fmt.Errorf("writing boolean column '%s': %w", f.Name, err)
 			}
 		case PrimitiveTypeBinary:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getBinaryVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeJson:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getJsonVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array (json) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeString:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getStringVal); err != nil {
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.ByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing byte array (string) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeUuid:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getUuidVal); err != nil {
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing uuid column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDate:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int32ColumnChunkWriter), getDateVal); err != nil {
+			if err := writeColumn(cw.(*file.Int32ColumnChunkWriter), *w.buffer[colIdx].(*[]int32), defLvls); err != nil {
 				return fmt.Errorf("writing date column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTime:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimeVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing time column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTimestamp:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeTimestampNanos:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampNanosVal); err != nil {
+			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeDecimal:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
-				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
+				return fmt.Errorf("writing decimal column '%s': %w", f.Name, err)
 			}
 		case LogicalTypeInterval:
-			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getIntervalVal); err != nil {
+			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
 			}
 		default:
@@ -499,7 +654,11 @@ func (w *ParquetWriter) flushBuffer() error {
 
 	w.scratch.sizeBytes += int(rgWriter.TotalBytesWritten())
 	w.scratch.columnChunkCount += len(w.schema)
-	w.buffer = w.buffer[:0]
+	for i := range w.buffer {
+		resetColumnBuffer(w.buffer[i])
+		w.defLevels[i] = w.defLevels[i][:0]
+	}
+	w.bufferRowCount = 0
 	w.bufferSizeBytes = 0
 
 	// Sync and drop the scratch file's page cache after each row group, so its resident (and
@@ -541,33 +700,7 @@ type columnBatchWriter[T parquetValue] interface {
 	WriteBatch(vals []T, defLvls []int16, repLvls []int16) (valueOffset int64, err error)
 }
 
-type getValFn[T parquetValue] func(v any) (got T, err error)
-
-func writeColumn[T parquetValue](
-	colIdx int,
-	buf [][]any,
-	w columnBatchWriter[T],
-	getVal getValFn[T],
-) error {
-	var vals []T
-	var defLevels []int16
-
-	for _, row := range buf {
-		v := row[colIdx]
-		switch tv := v.(type) {
-		case nil:
-			defLevels = append(defLevels, 0)
-		default:
-			got, err := getVal(tv)
-			if err != nil {
-				return fmt.Errorf("getting typed value for value: %w (type %T)", err, tv)
-			}
-
-			vals = append(vals, got)
-			defLevels = append(defLevels, 1)
-		}
-	}
-
+func writeColumn[T parquetValue](w columnBatchWriter[T], vals []T, defLevels []int16) error {
 	if valuesWritten, err := w.WriteBatch(vals, defLevels, nil); err != nil {
 		return fmt.Errorf("writing batch of values: %w", err)
 	} else if int(valuesWritten) != len(vals) {

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -20,6 +20,7 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/apache/arrow-go/v18/parquet/variant"
 	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
 	iso8601 "github.com/senseyeio/duration"
@@ -88,6 +89,9 @@ func newRowSizing(sch ParquetSchema) rowSize {
 		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos, LogicalTypeInterval:
 			rs.fixed += 16 // string header
 			rs.calcLen = append(rs.calcLen, idx)
+		case LogicalTypeVariant:
+			rs.fixed += 48 // two slice headers, for the value and metadata byte slices
+			rs.calcLen = append(rs.calcLen, idx)
 		default:
 			panic(fmt.Sprintf("newRowSizing unknown type: %d", e.DataType))
 		}
@@ -107,6 +111,8 @@ func (rs rowSize) estSize(row []any) int {
 			out += len(v)
 		case json.RawMessage:
 			out += len(v)
+		case variant.Value:
+			out += len(v.Bytes()) + len(v.Metadata().Bytes())
 		case nil:
 			// No additional overhead is assumed for nil values.
 		default:
@@ -255,6 +261,10 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 	}, nil
 }
 
+type variantColumnBuffer struct {
+	values, metas []parquet.ByteArray
+}
+
 // makeColumnBuffer returns a pointer to an empty strongly-typed slice for the given column type.
 // Storing a pointer (one word) in the []any buffer avoids a heap allocation on every append,
 // since the interface data word holds the pointer directly rather than boxing a 3-word slice header.
@@ -278,6 +288,12 @@ func makeColumnBuffer(dt ParquetDataType, initialCap int) any {
 	case LogicalTypeDate:
 		s := make([]int32, 0, initialCap)
 		return &s
+	case LogicalTypeVariant:
+		s := variantColumnBuffer{
+			values: make([]parquet.ByteArray, 0, initialCap),
+			metas:  make([]parquet.ByteArray, 0, initialCap),
+		}
+		return &s
 	default:
 		panic(fmt.Sprintf("makeColumnBuffer unknown type: %d", dt))
 	}
@@ -299,6 +315,9 @@ func resetColumnBuffer(s any) {
 		*sp = (*sp)[:0]
 	case *[]parquet.FixedLenByteArray:
 		*sp = (*sp)[:0]
+	case *variantColumnBuffer:
+		sp.values = sp.values[:0]
+		sp.metas = sp.metas[:0]
 	default:
 		panic(fmt.Sprintf("resetColumnBuffer unknown type: %T", s))
 	}
@@ -408,6 +427,14 @@ func (w *ParquetWriter) Write(row []any) error {
 			var q int64
 			if q, err = getTimestampNanosVal(v); err == nil {
 				appendVal(w, colIdx, q)
+			}
+		case LogicalTypeVariant:
+			var vv variant.Value
+			vv, err = getVariantVal(v)
+			if err == nil {
+				sp := w.buffer[colIdx].(*variantColumnBuffer)
+				sp.values = append(sp.values, vv.Bytes())
+				sp.metas = append(sp.metas, vv.Metadata().Bytes())
 			}
 		case LogicalTypeDecimal:
 			var q parquet.FixedLenByteArray
@@ -631,6 +658,21 @@ func (w *ParquetWriter) flushBuffer() error {
 			if err := writeColumn(cw.(*file.Int64ColumnChunkWriter), *w.buffer[colIdx].(*[]int64), defLvls); err != nil {
 				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
 			}
+		case LogicalTypeVariant:
+			// Variant occupies two physical columns.
+			sp := w.buffer[colIdx].(*variantColumnBuffer)
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), sp.values, defLvls); err != nil {
+				return fmt.Errorf("writing variant value column '%s': %w", f.Name, err)
+			}
+			if err := cw.Close(); err != nil {
+				return fmt.Errorf("closing variant value column writer: %w", err)
+			}
+			if cw, err = rgWriter.NextColumn(); err != nil {
+				return fmt.Errorf("getting next column for variant metadata: %w", err)
+			}
+			if err := writeColumn(cw.(*file.ByteArrayColumnChunkWriter), sp.metas, defLvls); err != nil {
+				return fmt.Errorf("writing variant metadata column '%s': %w", f.Name, err)
+			}
 		case LogicalTypeDecimal:
 			if err := writeColumn(cw.(*file.FixedLenByteArrayColumnChunkWriter), *w.buffer[colIdx].(*[]parquet.FixedLenByteArray), defLvls); err != nil {
 				return fmt.Errorf("writing decimal column '%s': %w", f.Name, err)
@@ -653,7 +695,9 @@ func (w *ParquetWriter) flushBuffer() error {
 	}
 
 	w.scratch.sizeBytes += int(rgWriter.TotalBytesWritten())
-	w.scratch.columnChunkCount += len(w.schema)
+	for _, f := range w.schema {
+		w.scratch.columnChunkCount += f.physicalColumnCount()
+	}
 	for i := range w.buffer {
 		resetColumnBuffer(w.buffer[i])
 		w.defLevels[i] = w.defLevels[i][:0]
@@ -1054,4 +1098,27 @@ func getDecimalVal(val any) (got parquet.FixedLenByteArray, err error) {
 	}
 
 	return
+}
+
+func getVariantVal(val any) (variant.Value, error) {
+	switch typed := val.(type) {
+	case variant.Value:
+		return typed, nil
+	case int64:
+		return variant.Of(typed)
+	case float64:
+		return variant.Of(typed)
+	case string:
+		return variant.Of(typed)
+	case bool:
+		return variant.Of(typed)
+	case []byte:
+		return variant.Of(typed)
+	case json.RawMessage:
+		return variant.ParseJSONBytes([]byte(typed), false)
+	case decimal128.Num:
+		return variant.Of(variant.DecimalValue[decimal128.Num]{Value: typed})
+	default:
+		return variant.Value{}, fmt.Errorf("unhandled variant type: %T", typed)
+	}
 }

--- a/go/writer/parquet_schema.go
+++ b/go/writer/parquet_schema.go
@@ -22,6 +22,15 @@ type ParquetSchemaElement struct {
 	Scale    int32 // only applicable to LogicalTypeDecimal
 }
 
+// physicalColumnCount reports the number of leaf parquet columns this element produces. Most
+// types correspond to one leaf column, but LogicalTypeVariant is a group with two children.
+func (e ParquetSchemaElement) physicalColumnCount() int {
+	if e.DataType == LogicalTypeVariant {
+		return 2
+	}
+	return 1
+}
+
 // ParquetDataType provides a mapping for the JSON types we support to an appropriate parquet data
 // type. We make use a both primitive and logical types for this.
 //
@@ -56,20 +65,21 @@ type ParquetSchemaElement struct {
 type ParquetDataType int
 
 const (
-	PrimitiveTypeInteger ParquetDataType = iota // INT64 primitive type
-	PrimitiveTypeNumber                         // DOUBLE primitive type, which is a 64-bit float
-	PrimitiveTypeBoolean                        // BOOLEAN primitive type
-	PrimitiveTypeBinary                         // BYTE_ARRAY primitive type
-	LogicalTypeString                           // Extends BYTE_ARRAY
-	LogicalTypeJson                             // Extends BYTE_ARRAY
-	LogicalTypeDate                             // Extends BYTE_ARRAY
-	LogicalTypeTime                             // Extends INT64
-	LogicalTypeTimestamp                        // Extends INT64, microsecond precision
-	LogicalTypeTimestampNanos                   // Extends INT64, nanosecond precision
-	LogicalTypeUuid                             // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
-	LogicalTypeDecimal                          // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
-	LogicalTypeInterval                         // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
-	LogicalTypeUnknown                          // Must always be nil
+	PrimitiveTypeInteger      ParquetDataType = iota // INT64 primitive type
+	PrimitiveTypeNumber                              // DOUBLE primitive type, which is a 64-bit float
+	PrimitiveTypeBoolean                             // BOOLEAN primitive type
+	PrimitiveTypeBinary                              // BYTE_ARRAY primitive type
+	LogicalTypeString                                // Extends BYTE_ARRAY
+	LogicalTypeJson                                  // Extends BYTE_ARRAY
+	LogicalTypeDate                                  // Extends BYTE_ARRAY
+	LogicalTypeTime                                  // Extends INT64
+	LogicalTypeTimestamp                             // Extends INT64, microsecond precision
+	LogicalTypeTimestampNanos                        // Extends INT64, nanosecond precision
+	LogicalTypeUuid                                  // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeDecimal                               // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeInterval                              // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
+	LogicalTypeUnknown                               // Must always be nil
+	LogicalTypeVariant                               // GROUP of two required BYTE_ARRAY children "value" and "metadata"
 )
 
 // makeNode translates a ParquetSchemaElement into an actual parquet schema node.
@@ -155,6 +165,16 @@ func makeNode(e ParquetSchemaElement) schema.Node {
 			-1,
 			fieldId,
 		))
+	case LogicalTypeVariant:
+		value := schema.NewByteArrayNode("value", parquet.Repetitions.Required, -1)
+		metadata := schema.NewByteArrayNode("metadata", parquet.Repetitions.Required, -1)
+		return schema.MustGroup(schema.NewGroupNodeLogical(
+			e.Name,
+			repetition,
+			schema.FieldList{value, metadata},
+			schema.VariantLogicalType{},
+			fieldId,
+		))
 	case LogicalTypeInterval:
 		return schema.Must(schema.NewPrimitiveNodeLogical(
 			e.Name,
@@ -194,6 +214,8 @@ type parquetSchemaConfig struct {
 	timeAsString     bool
 	uuidAsString     bool
 	timestampAsNanos bool
+	objectAsVariant  bool
+	arrayAsVariant   bool
 }
 
 type ParquetSchemaOption func(*parquetSchemaConfig)
@@ -206,13 +228,37 @@ func WithParquetSchemaDurationAsString() ParquetSchemaOption {
 
 func WithParquetSchemaArrayAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
+		if cfg.arrayAsVariant {
+			panic("cannot both WithParquetSchemaArrayAsString and WithParquetSchemaArrayAsVariant")
+		}
 		cfg.arrayAsString = true
+	}
+}
+
+func WithParquetSchemaArrayAsVariant() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		if cfg.arrayAsString {
+			panic("cannot both WithParquetSchemaArrayAsVariant and WithParquetSchemaArrayAsString")
+		}
+		cfg.arrayAsVariant = true
 	}
 }
 
 func WithParquetSchemaObjectAsString() ParquetSchemaOption {
 	return func(cfg *parquetSchemaConfig) {
+		if cfg.objectAsVariant {
+			panic("cannot both WithParquetSchemaObjectAsString and WithParquetSchemaObjectAsVariant")
+		}
 		cfg.objectAsString = true
+	}
+}
+
+func WithParquetSchemaObjectAsVariant() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		if cfg.objectAsString {
+			panic("cannot both WithParquetSchemaObjectAsVariant and WithParquetSchemaObjectAsString")
+		}
+		cfg.objectAsVariant = true
 	}
 }
 
@@ -267,7 +313,7 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 		}
 
 		if hadType {
-			out.DataType = typeOrString(LogicalTypeJson, cfg.objectAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.objectAsString), cfg.objectAsVariant)
 			break
 		}
 
@@ -275,9 +321,9 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 
 		switch t {
 		case "array":
-			out.DataType = typeOrString(LogicalTypeJson, cfg.arrayAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.arrayAsString), cfg.arrayAsVariant)
 		case "object":
-			out.DataType = typeOrString(LogicalTypeJson, cfg.objectAsString)
+			out.DataType = typeOrVariant(typeOrString(LogicalTypeJson, cfg.objectAsString), cfg.objectAsVariant)
 		case "boolean":
 			out.DataType = PrimitiveTypeBoolean
 		case "integer":
@@ -318,9 +364,16 @@ func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts .
 	return out
 }
 
-func typeOrString[T ParquetDataType](base T, shouldString bool) T {
+func typeOrString(base ParquetDataType, shouldString bool) ParquetDataType {
 	if shouldString {
-		return T(LogicalTypeString)
+		return LogicalTypeString
+	}
+	return base
+}
+
+func typeOrVariant(base ParquetDataType, shouldVariant bool) ParquetDataType {
+	if shouldVariant {
+		return LogicalTypeVariant
 	}
 	return base
 }

--- a/go/writer/parquet_schema_test.go
+++ b/go/writer/parquet_schema_test.go
@@ -213,6 +213,49 @@ func TestMakeNodeNilFieldId(t *testing.T) {
 	}
 }
 
+func TestMakeNodeVariant(t *testing.T) {
+	const fid = int32(7)
+
+	for _, required := range []bool{true, false} {
+		t.Run(fmt.Sprintf("required=%v", required), func(t *testing.T) {
+			node := makeNode(ParquetSchemaElement{
+				Name:     "variantField",
+				DataType: LogicalTypeVariant,
+				Required: required,
+				FieldId:  ptrTo(fid),
+			})
+
+			gn, ok := node.(*schema.GroupNode)
+			require.True(t, ok, "expected *schema.GroupNode, got %T", node)
+
+			require.Equal(t, "variantField", gn.Name())
+			require.EqualValues(t, fid, gn.FieldID())
+			wantRep := parquet.Repetitions.Optional
+			if required {
+				wantRep = parquet.Repetitions.Required
+			}
+			require.Equal(t, wantRep, gn.RepetitionType())
+
+			_, ok = gn.LogicalType().(schema.VariantLogicalType)
+			require.True(t, ok, "expected VariantLogicalType, got %T", gn.LogicalType())
+
+			require.Equal(t, 2, gn.NumFields())
+
+			valueNode, ok := gn.Field(0).(*schema.PrimitiveNode)
+			require.True(t, ok)
+			require.Equal(t, "value", valueNode.Name())
+			require.Equal(t, parquet.Types.ByteArray, valueNode.PhysicalType())
+			require.Equal(t, parquet.Repetitions.Required, valueNode.RepetitionType())
+
+			metadataNode, ok := gn.Field(1).(*schema.PrimitiveNode)
+			require.True(t, ok)
+			require.Equal(t, "metadata", metadataNode.Name())
+			require.Equal(t, parquet.Types.ByteArray, metadataNode.PhysicalType())
+			require.Equal(t, parquet.Repetitions.Required, metadataNode.RepetitionType())
+		})
+	}
+}
+
 func TestMakeNodeUnknownDataTypePanics(t *testing.T) {
 	require.PanicsWithValue(t, "makeNode unknown type: 999", func() {
 		makeNode(ParquetSchemaElement{Name: "f", DataType: ParquetDataType(999)})
@@ -612,6 +655,45 @@ func TestProjectionToParquetSchemaElement(t *testing.T) {
 			wantRequired: true,
 		},
 		{
+			name: "WithParquetSchemaArrayAsVariant flips array to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"array"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaArrayAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetSchemaObjectAsVariant flips object to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"object"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaObjectAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
+			name: "WithParquetSchemaObjectAsVariant flips multi-type fallback to variant",
+			projection: pf.Projection{
+				Field: "f",
+				Inference: pf.Inference{
+					Exists: pf.Inference_MUST,
+					Types:  []string{"integer", "boolean"},
+				},
+			},
+			opts:         []ParquetSchemaOption{WithParquetSchemaObjectAsVariant()},
+			wantType:     LogicalTypeVariant,
+			wantRequired: true,
+		},
+		{
 			name: "WithParquetTimestampAsNanoseconds flips date-time to nanos",
 			projection: pf.Projection{
 				Field: "f",
@@ -633,6 +715,41 @@ func TestProjectionToParquetSchemaElement(t *testing.T) {
 			require.Equal(t, tt.projection.Field, got.Name)
 			require.Equal(t, tt.wantType, got.DataType)
 			require.Equal(t, tt.wantRequired, got.Required)
+		})
+	}
+}
+
+func TestProjectionToParquetSchemaElementConflictingOptionsPanic(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      []ParquetSchemaOption
+		wantPanic string
+	}{
+		{
+			name:      "object as string and as variant",
+			opts:      []ParquetSchemaOption{WithParquetSchemaObjectAsString(), WithParquetSchemaObjectAsVariant()},
+			wantPanic: "cannot both WithParquetSchemaObjectAsVariant and WithParquetSchemaObjectAsString",
+		},
+		{
+			name:      "array as string and as variant",
+			opts:      []ParquetSchemaOption{WithParquetSchemaArrayAsString(), WithParquetSchemaArrayAsVariant()},
+			wantPanic: "cannot both WithParquetSchemaArrayAsVariant and WithParquetSchemaArrayAsString",
+		},
+	}
+
+	proj := pf.Projection{
+		Field: "f",
+		Inference: pf.Inference{
+			Exists: pf.Inference_MUST,
+			Types:  []string{"object"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.PanicsWithValue(t, tt.wantPanic, func() {
+				ProjectionToParquetSchemaElement(proj, false, tt.opts...)
+			})
 		})
 	}
 }

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/apache/arrow-go/v18/parquet/variant"
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -150,6 +153,394 @@ func TestParquetWriterTimestampNanos(t *testing.T) {
 	wantTs1, err := time.Parse(time.RFC3339Nano, rows[1])
 	require.NoError(t, err)
 	require.Equal(t, wantTs1.UnixNano(), vals[1])
+}
+
+func TestParquetWriterVariant(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "variantField", DataType: LogicalTypeVariant, Required: false},
+	}
+
+	v0, err := variant.New([]byte{0x01, 0x00, 0x00}, []byte{0x0a})
+	require.NoError(t, err)
+	v1, err := variant.New([]byte{0x01, 0x00, 0x00}, []byte{0x0b, 0x0c})
+	require.NoError(t, err)
+	rows := []any{v0, v1, nil}
+
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
+	for _, v := range rows {
+		require.NoError(t, w.Write([]any{v}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.Equal(t, 2, f.MetaData().Schema.NumColumns())
+
+	valueCol := f.MetaData().Schema.Column(0)
+	require.Equal(t, "value", valueCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, valueCol.PhysicalType())
+	metaCol := f.MetaData().Schema.Column(1)
+	require.Equal(t, "metadata", metaCol.Name())
+	require.Equal(t, parquet.Types.ByteArray, metaCol.PhysicalType())
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(rows), rg.NumRows())
+
+	readByteArrays := func(col int) ([]parquet.ByteArray, []int16) {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(rows))
+		def := make([]int16, len(rows))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(rows)), vals, def, nil)
+		require.NoError(t, err)
+		return vals, def
+	}
+
+	valueVals, valueDef := readByteArrays(0)
+	metaVals, metaDef := readByteArrays(1)
+
+	require.Equal(t, []int16{1, 1, 0}, valueDef)
+	require.Equal(t, []int16{1, 1, 0}, metaDef)
+	require.Equal(t, v0.Bytes(), []byte(valueVals[0]))
+	require.Equal(t, v1.Bytes(), []byte(valueVals[1]))
+	require.Equal(t, v0.Metadata().Bytes(), []byte(metaVals[0]))
+	require.Equal(t, v1.Metadata().Bytes(), []byte(metaVals[1]))
+}
+
+func TestParquetWriterVariantRequired(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "variantField", DataType: LogicalTypeVariant, Required: true},
+	}
+
+	v0, err := variant.Of("hello")
+	require.NoError(t, err)
+	// Use 1<<40 to exceed int32 range, forcing Int64 encoding.
+	v1, err := variant.Of(int64(1 << 40))
+	require.NoError(t, err)
+	rows := []any{v0, v1}
+
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
+	for _, v := range rows {
+		require.NoError(t, w.Write([]any{v}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.Equal(t, 2, f.MetaData().Schema.NumColumns())
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(rows), rg.NumRows())
+
+	readByteArrays := func(col int) []parquet.ByteArray {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(rows))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(rows)), vals, nil, nil)
+		require.NoError(t, err)
+		return vals
+	}
+
+	valueVals := readByteArrays(0)
+	metaVals := readByteArrays(1)
+
+	got0, err := variant.New(metaVals[0], valueVals[0])
+	require.NoError(t, err)
+	require.Equal(t, variant.String, got0.Type())
+	require.Equal(t, "hello", got0.Value())
+
+	got1, err := variant.New(metaVals[1], valueVals[1])
+	require.NoError(t, err)
+	require.Equal(t, variant.Int64, got1.Type())
+	require.Equal(t, int64(1<<40), got1.Value())
+}
+
+func TestGetVariantVal(t *testing.T) {
+	decNum := decimal128.New(0, 42)
+	// Use 1<<40 to exceed int32 range, forcing Int64 encoding.
+	prebuilt, err := variant.Of(int64(1 << 40))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    any
+		wantType variant.Type
+		wantVal  any
+	}{
+		{
+			name:     "variant.Value passthrough",
+			input:    prebuilt,
+			wantType: variant.Int64,
+			wantVal:  int64(1 << 40),
+		},
+		{
+			name:     "int64",
+			input:    int64(1 << 40),
+			wantType: variant.Int64,
+			wantVal:  int64(1 << 40),
+		},
+		{
+			name:     "float64",
+			input:    float64(2.5),
+			wantType: variant.Double,
+			wantVal:  float64(2.5),
+		},
+		{
+			name:     "string",
+			input:    "hello",
+			wantType: variant.String,
+			wantVal:  "hello",
+		},
+		{
+			name:     "bool true",
+			input:    true,
+			wantType: variant.Bool,
+			wantVal:  true,
+		},
+		{
+			name:     "bool false",
+			input:    false,
+			wantType: variant.Bool,
+			wantVal:  false,
+		},
+		{
+			name:     "[]byte",
+			input:    []byte("bin"),
+			wantType: variant.Binary,
+			wantVal:  []byte("bin"),
+		},
+		{
+			// json.RawMessage is parsed as a Variant value, not stored as opaque bytes.
+			name:     "json.RawMessage",
+			input:    json.RawMessage(`42`),
+			wantType: variant.Int8,
+			wantVal:  int8(42),
+		},
+		{
+			name:     "decimal128.Num",
+			input:    decNum,
+			wantType: variant.Decimal16,
+			wantVal:  variant.DecimalValue[decimal128.Num]{Scale: 0, Value: decNum},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getVariantVal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, got.Type())
+			require.Equal(t, tt.wantVal, got.Value())
+		})
+	}
+}
+
+func TestGetVariantValError(t *testing.T) {
+	_, err := getVariantVal(struct{}{})
+	require.ErrorContains(t, err, "unhandled variant type: struct {}")
+}
+
+func TestParquetWriterVariantTypes(t *testing.T) {
+	decNum := decimal128.New(0, 100)
+	// Use 1<<40 to exceed int32 range, forcing Int64 encoding.
+	prebuilt, err := variant.Of(int64(1 << 40))
+	require.NoError(t, err)
+
+	inputs := []any{
+		int64(1 << 40),
+		float64(1.5),
+		"hello world",
+		true,
+		false,
+		[]byte("binary data"),
+		json.RawMessage(`{"key":"value"}`),
+		decNum,
+		prebuilt,
+		nil,
+	}
+
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "v", DataType: LogicalTypeVariant, Required: false},
+	}
+
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
+	for _, inp := range inputs {
+		require.NoError(t, w.Write([]any{inp}))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(inputs), rg.NumRows())
+
+	readByteArrays := func(col int) ([]parquet.ByteArray, []int16) {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(inputs))
+		def := make([]int16, len(inputs))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(inputs)), vals, def, nil)
+		require.NoError(t, err)
+		return vals, def
+	}
+
+	valueVals, valueDef := readByteArrays(0)
+	metaVals, metaDef := readByteArrays(1)
+
+	n := len(inputs)
+	require.Equal(t, int16(0), valueDef[n-1], "nil row should have def=0")
+	require.Equal(t, int16(0), metaDef[n-1], "nil row should have def=0")
+
+	wantTypes := []variant.Type{
+		variant.Int64,
+		variant.Double,
+		variant.String,
+		variant.Bool,
+		variant.Bool,
+		variant.Binary,
+		variant.Object, // json.RawMessage is parsed as a Variant object
+		variant.Decimal16,
+		variant.Int64, // variant.Value passthrough
+	}
+
+	for i, wantType := range wantTypes {
+		require.Equal(t, int16(1), valueDef[i], "row %d def level", i)
+		v, err := variant.New(metaVals[i], valueVals[i])
+		require.NoError(t, err, "row %d reconstruct", i)
+		require.Equal(t, wantType, v.Type(), "row %d type", i)
+	}
+}
+
+func TestParquetWriterVariantMixedSchema(t *testing.T) {
+	// Variant consumes two NextColumn() calls in flushBuffer. This test verifies that
+	// columns placed after a variant column in the schema are written to the correct
+	// physical column, i.e. the cursor does not desync.
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "s", DataType: LogicalTypeString, Required: true},
+		{Name: "v", DataType: LogicalTypeVariant, Required: false},
+		{Name: "n", DataType: PrimitiveTypeInteger, Required: true},
+	}
+
+	v0, err := variant.Of("hello")
+	require.NoError(t, err)
+	// Use 1<<40 to exceed int32 range, forcing Int64 encoding.
+	v2, err := variant.Of(int64(1 << 40))
+	require.NoError(t, err)
+
+	rows := [][]any{
+		{"foo", v0, int64(1)},
+		{"bar", nil, int64(2)}, // nil variant row tests optional null path
+		{"baz", v2, int64(3)},
+	}
+
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
+	for _, r := range rows {
+		require.NoError(t, w.Write(r))
+	}
+	require.NoError(t, w.Close())
+
+	f, err := file.OpenParquetFile(sink.Name(), false)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// 4 physical columns: s, v.value, v.metadata, n
+	require.Equal(t, 4, f.MetaData().Schema.NumColumns())
+
+	rg := f.RowGroup(0)
+	require.EqualValues(t, len(rows), rg.NumRows())
+
+	readStrings := func(col int) []string {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(rows))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(rows)), vals, nil, nil)
+		require.NoError(t, err)
+		out := make([]string, len(vals))
+		for i, v := range vals {
+			out[i] = string(v)
+		}
+		return out
+	}
+	readByteArrays := func(col int) ([]parquet.ByteArray, []int16) {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]parquet.ByteArray, len(rows))
+		def := make([]int16, len(rows))
+		_, _, err = r.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(len(rows)), vals, def, nil)
+		require.NoError(t, err)
+		return vals, def
+	}
+	readInts := func(col int) []int64 {
+		r, err := rg.Column(col)
+		require.NoError(t, err)
+		vals := make([]int64, len(rows))
+		_, _, err = r.(*file.Int64ColumnChunkReader).ReadBatch(int64(len(rows)), vals, nil, nil)
+		require.NoError(t, err)
+		return vals
+	}
+
+	require.Equal(t, []string{"foo", "bar", "baz"}, readStrings(0))
+
+	valueVals, valueDef := readByteArrays(1)
+	metaVals, metaDef := readByteArrays(2)
+	require.Equal(t, []int16{1, 0, 1}, valueDef)
+	require.Equal(t, []int16{1, 0, 1}, metaDef)
+
+	// ReadBatch packs non-null values densely: row 0 is at index 0, row 2 (the second
+	// non-null row) is at index 1 — there is no slot for the null row 1.
+	got0, err := variant.New(metaVals[0], valueVals[0])
+	require.NoError(t, err)
+	require.Equal(t, variant.String, got0.Type())
+	require.Equal(t, "hello", got0.Value())
+
+	got2, err := variant.New(metaVals[1], valueVals[1])
+	require.NoError(t, err)
+	require.Equal(t, variant.Int64, got2.Type())
+	require.Equal(t, int64(1<<40), got2.Value())
+
+	require.Equal(t, []int64{1, 2, 3}, readInts(3))
+}
+
+func TestParquetWriterVariantNilInRequiredColumn(t *testing.T) {
+	// Writing nil to a required column is a caller contract violation. Verify it surfaces
+	// as an error rather than silently producing a corrupt file.
+	dir := t.TempDir()
+	sink, err := os.CreateTemp(dir, "*.parquet")
+	require.NoError(t, err)
+
+	sch := ParquetSchema{
+		{Name: "v", DataType: LogicalTypeVariant, Required: true},
+	}
+
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
+	require.NoError(t, w.Write([]any{nil}))
+	require.Error(t, w.Close())
 }
 
 // This is a regression test for a bug in arrow-go 18.5.2, added test so we


### PR DESCRIPTION
**Description:**

Adds `LogicalTypeVariant` to the `go/writer` parquet package. Variant is a group of two required `BYTE_ARRAY` children (`value` and `metadata`) per the Parquet Variant spec, enabling connectors to emit JSON objects/arrays as native Variant columns instead of raw strings.

New options `WithParquetSchemaObjectAsVariant()` and `WithParquetSchemaArrayAsVariant()` let connectors opt in. A `getVariantVal` helper converts common Go types to `variant.Value` at write time.

**Notes for reviewers:**

- The first commit (a77f7defb `go/writer: column-oriented parquet write buffer`) has its own PR at https://github.com/estuary/connectors/pull/4485 — please review/merge that first. This PR contains only the top commit.
- `LogicalTypeVariant` maps to two physical parquet columns, so `physicalColumnCount()` was added to `ParquetSchemaElement` and `columnChunkCount` accounting was updated accordingly.
