### PR TITLE
source-mysql: Add skip_prerequisites and skip_table_prerequisites

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -49,6 +49,13 @@ var featureFlagDefaults = map[string]bool{
 	//   - Recommended Collection Names
 	//   - Internal StreamIDs
 	"case_sensitive_table_names": false,
+
+	// When true, all prerequisite checks (both global and per-table) are skipped. This is intended
+	// as an escape hatch for situations where the checks themselves are buggy or do not apply.
+	"skip_prerequisites": false,
+
+	// When true, per-table prerequisite checks are skipped. Implied by `skip_prerequisites`.
+	"skip_table_prerequisites": false,
 }
 
 type sshForwarding struct {

--- a/source-mysql/prerequisites.go
+++ b/source-mysql/prerequisites.go
@@ -15,6 +15,11 @@ import (
 func (db *mysqlDatabase) SetupPrerequisites(ctx context.Context) []error {
 	var errs []error
 
+	if db.featureFlags["skip_prerequisites"] {
+		logrus.Warn("skipping all prerequisite checks because the 'skip_prerequisites' feature flag is set")
+		return nil
+	}
+
 	// Our version checking may have been overly conservative, so let's err in the
 	// other direction for a while and disengage the check entirely.
 	if err := db.prerequisiteVersion(ctx); err != nil {
@@ -124,6 +129,10 @@ func (db *mysqlDatabase) prerequisiteUserPermissions(ctx context.Context) error 
 
 func (db *mysqlDatabase) SetupTablePrerequisites(ctx context.Context, tables []sqlcapture.TableID) map[sqlcapture.TableID]error {
 	var errs = make(map[sqlcapture.TableID]error)
+	if db.featureFlags["skip_prerequisites"] || db.featureFlags["skip_table_prerequisites"] {
+		logrus.Warn("skipping per-table prerequisite checks because the 'skip_prerequisites' or 'skip_table_prerequisites' feature flag is set")
+		return errs
+	}
 	for _, table := range tables {
 		if err := db.setupTablePrerequisite(ctx, table.Schema, table.Table); err != nil {
 			errs[table] = err


### PR DESCRIPTION
**Description:**

Adds two feature flags as escape hatches for cases where the connector's prerequisite checks should be skipped.

**Notes for reviewers:**

I have no reason to believe that we need this right now, but we recently introduced these flags for source-postgres and we have a user doing a POC right now which could plausibly struggle with the per-table validation work, so it seems reasonable to just go ahead and add them for symmetry and do it now just in case we need the escape hatch.

