### PR TITLE
source-oracle: Per-thread log file selection for RAC

### DIFF
--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/base64"
@@ -167,6 +168,7 @@ type redoFile struct {
 	DictStart   string
 	DictEnd     string
 	Bytes       int
+	Thread      int
 }
 
 var MaxReplicationLogFilesSize = 2 * 1024 * 1024 * 1024
@@ -214,96 +216,127 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 		"minArchiveSCN": minArchiveSCN,
 	}).Debug("starting SCN for log files based on dictionary starting point")
 
-	var liveLogFiles = `SELECT L.STATUS as STATUS, MIN(LF.MEMBER) as NAME, L.SEQUENCE#, L.FIRST_CHANGE#, CASE WHEN L.STATUS = 'CURRENT' THEN 0 ELSE L.NEXT_CHANGE# END as NEXT_CHANGE#, 'NO' as DICT_START, 'NO' as DICT_END, MAX(L.BYTES) FROM V$LOGFILE LF, V$LOG L
+	var liveLogFiles = `SELECT L.STATUS as STATUS, MIN(LF.MEMBER) as NAME, L.SEQUENCE#, L.FIRST_CHANGE#, CASE WHEN L.STATUS = 'CURRENT' THEN 0 ELSE L.NEXT_CHANGE# END as NEXT_CHANGE#, 'NO' as DICT_START, 'NO' as DICT_END, MAX(L.BYTES), L.THREAD# FROM V$LOGFILE LF, V$LOG L
 		LEFT JOIN V$ARCHIVED_LOG A ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE#
     WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) AND L.GROUP# = LF.GROUP# AND L.STATUS <> 'UNUSED'
 		GROUP BY LF.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD#`
 
-	var archivedLogFiles = `SELECT 'ARCHIVED' as STATUS, A.NAME AS NAME, A.SEQUENCE#, A.FIRST_CHANGE#, A.NEXT_CHANGE#, A.DICTIONARY_BEGIN as DICT_START, A.DICTIONARY_END as DICT_END, A.BLOCKS*A.BLOCK_SIZE as BYTES FROM V$ARCHIVED_LOG A
+	var archivedLogFiles = `SELECT 'ARCHIVED' as STATUS, A.NAME AS NAME, A.SEQUENCE#, A.FIRST_CHANGE#, A.NEXT_CHANGE#, A.DICTIONARY_BEGIN as DICT_START, A.DICTIONARY_END as DICT_END, A.BLOCKS*A.BLOCK_SIZE as BYTES, A.THREAD# FROM V$ARCHIVED_LOG A
     WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' AND A.NEXT_CHANGE# >= :1 AND
     DEST_ID IN (` + strconv.Itoa(localDestID) + `)`
 
-	var fullQuery = liveLogFiles + " UNION " + archivedLogFiles + " ORDER BY SEQUENCE#"
+	var fullQuery = liveLogFiles + " UNION " + archivedLogFiles
 	rows, err := s.conn.QueryContext(ctx, fullQuery, minArchiveSCN)
 	if err != nil {
 		return 0, fmt.Errorf("fetching log file list: %w", err)
 	}
 	defer rows.Close()
 
-	var totalSizeBytes int
-	var endSCN SCN
-	var redoSequence int
-	var redoFiles []redoFile
+	var candidates []redoFile
 	for rows.Next() {
 		var f redoFile
-
-		if err := rows.Scan(&f.Status, &f.Name, &f.Sequence, &f.FirstChange, &f.NextChange, &f.DictStart, &f.DictEnd, &f.Bytes); err != nil {
+		if err := rows.Scan(&f.Status, &f.Name, &f.Sequence, &f.FirstChange, &f.NextChange, &f.DictStart, &f.DictEnd, &f.Bytes, &f.Thread); err != nil {
 			return 0, fmt.Errorf("scanning log file record: %w", err)
 		}
+		candidates = append(candidates, f)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
 
-		// The current log file has the same sequence as the last archived log file
-		// in this case we prefer reading from the current log file. It is also possible for
-		// log files to have an ACTIVE and an ARCHIVED version at the same time, we prefer ACTIVE
-		if f.Sequence == redoSequence {
-			var last = redoFiles[len(redoFiles)-1]
-			logrus.WithFields(logrus.Fields{
-				"this": fmt.Sprintf("%+v", f),
-				"last": fmt.Sprintf("%+v", last),
-			}).Debug("found two log files with the same sequence number, keeping CURRENT or ACTIVE")
-
-			if f.Status == "CURRENT" || f.Status == "ACTIVE" {
-				// Remove the last archived log file from the list
-				redoFiles = redoFiles[:len(redoFiles)-1]
-				totalSizeBytes -= last.Bytes
-			} else if last.Status == "CURRENT" || last.Status == "ACTIVE" {
-				// Skip this file
-				continue
-			} else {
-				return 0, fmt.Errorf("found two log files with the same sequence number, but neither is CURRENT or ACTIVE: %+v, %+v", f, last)
-			}
+	candidates, err = resolveDuplicateSequences(candidates)
+	if err != nil {
+		return 0, err
+	}
+	// Sort by FIRST_CHANGE# so that any prefix of the slice gives each thread a
+	// contiguous chain (within a thread, FIRST_CHANGE# is monotonic and equivalent
+	// to SEQUENCE# order). The Thread and Sequence tiebreakers are just for
+	// deterministic ordering when two threads happen to have files starting at
+	// the same SCN.
+	slices.SortFunc(candidates, func(a, b redoFile) int {
+		if c := cmp.Compare(a.FirstChange, b.FirstChange); c != 0 {
+			return c
 		}
-
-		if f.Sequence > redoSequence {
-			redoSequence = f.Sequence
+		if c := cmp.Compare(a.Thread, b.Thread); c != 0 {
+			return c
 		}
+		return cmp.Compare(a.Sequence, b.Sequence)
+	})
 
+	// Every thread that appears in the candidate set has produced redo in the
+	// SCN range we care about and must contribute to coverage. The cluster-wide
+	// covered SCN is the min across threads of their per-thread tails, but only
+	// once every expected thread has at least one file included; before that, we
+	// have no meaningful global coverage.
+	var expectedThreads = make(map[int]struct{})
+	for _, f := range candidates {
+		expectedThreads[f.Thread] = struct{}{}
+	}
+
+	var totalSizeBytes int
+	var endSCN SCN
+	var redoFiles []redoFile
+	var threadTails = make(map[int]SCN)
+	for _, f := range candidates {
 		redoFiles = append(redoFiles, f)
 		totalSizeBytes += f.Bytes
 
+		// Track this thread's tail. A CURRENT file is open-ended (NextChange == 0
+		// sentinel); represent that as math.MaxInt64 so it doesn't drag min() down.
+		if f.NextChange == 0 {
+			threadTails[f.Thread] = math.MaxInt64
+		} else {
+			threadTails[f.Thread] = f.NextChange
+		}
+
+		// globalCoveredSCN is the highest SCN through which every expected thread
+		// has contiguous coverage. Undefined (0) until every thread has a tail.
+		var globalCoveredSCN SCN
+		if len(threadTails) == len(expectedThreads) {
+			globalCoveredSCN = math.MaxInt64
+			for _, tail := range threadTails {
+				if tail < globalCoveredSCN {
+					globalCoveredSCN = tail
+				}
+			}
+		}
+
 		logrus.WithFields(logrus.Fields{
-			"name":           f.Name,
-			"status":         f.Status,
-			"sequence":       f.Sequence,
-			"firstChange":    f.FirstChange,
-			"nextChange":     f.NextChange,
-			"bytes":          f.Bytes,
-			"dictStart":      f.DictStart,
-			"dictEnd":        f.DictEnd,
-			"totalSizeBytes": totalSizeBytes,
+			"name":             f.Name,
+			"status":           f.Status,
+			"sequence":         f.Sequence,
+			"thread":           f.Thread,
+			"firstChange":      f.FirstChange,
+			"nextChange":       f.NextChange,
+			"bytes":            f.Bytes,
+			"dictStart":        f.DictStart,
+			"dictEnd":          f.DictEnd,
+			"totalSizeBytes":   totalSizeBytes,
+			"globalCoveredSCN": globalCoveredSCN,
 		}).Info("logminer: added redo log file")
 
 		var reachedSizeLimit = totalSizeBytes >= MaxReplicationLogFilesSize
-		var reachedMaxSCN = f.NextChange >= maxSCN
-		// advancesCursor guards against stopping on a file whose events are entirely
-		// at or below startSCN (e.g. an archive with NEXT_CHANGE# == startSCN). Setting
-		// endSCN to such a file's NextChange would make the next poll iteration re-fetch
-		// the same files and spin forever. NextChange == 0 is the CURRENT log open-ended
-		// sentinel and always counts as forward progress.
-		var advancesCursor = f.NextChange == 0 || f.NextChange > startSCN
+		var reachedMaxSCN = globalCoveredSCN >= maxSCN
+		// advancesCursor guards against stopping before global coverage has
+		// progressed past startSCN (e.g. early in iteration before all threads
+		// have contributed, or when included files only cover SCNs at or below
+		// startSCN). Setting endSCN to such a value would make the next poll
+		// iteration re-fetch the same files and spin forever.
+		var advancesCursor = globalCoveredSCN > startSCN
 		if reachedMaxSCN || (reachedSizeLimit && advancesCursor) {
 			// In extract mode we only stop on a file whose DICTIONARY_END is 'YES' to
 			// keep the included files self-contained dictionary-wise. Online mode has
 			// no such constraint.
 			if s.dictionaryMode == DictionaryModeOnline || f.DictEnd == "YES" {
-				endSCN = f.NextChange
+				endSCN = min(globalCoveredSCN, maxSCN)
 				var reason string
 				switch {
 				case reachedSizeLimit && reachedMaxSCN:
-					reason = "size cap reached and last file covers maxSCN"
+					reason = "size cap reached and coverage reaches maxSCN"
 				case reachedSizeLimit:
 					reason = "size cap reached"
 				default:
-					reason = "last file covers maxSCN"
+					reason = "coverage reaches maxSCN"
 				}
 				logrus.WithFields(logrus.Fields{
 					"reason":         reason,
@@ -317,14 +350,10 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 		}
 	}
 
-	if err := rows.Err(); err != nil {
-		return 0, err
-	}
-
-	// We set NextChange to 0 when encountering Oracle's maximum SCN value which
-	// is too large to fit in our int64 type, and 0 also persists from the default
-	// when the loop exhausts all available files without breaking. Resolve to
-	// maxSCN here so coverage validation has the final endSCN to check against.
+	// If the loop exhausted all candidates without breaking, endSCN is still
+	// zero. Default to maxSCN so coverage validation has a concrete value to
+	// check; validation will fail loudly if the included files don't actually
+	// cover that far.
 	if endSCN == 0 {
 		endSCN = maxSCN
 	}
@@ -343,39 +372,91 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 }
 
 // validateLogFileCoverage verifies that the selected redo log files provide
-// continuous SCN coverage of [startSCN, endSCN]. Oracle's redo logs partition
-// SCN space such that adjacent files satisfy prev.NEXT_CHANGE# == next.FIRST_CHANGE#.
-// A gap in available files (most commonly because archive log retention deleted
-// a log we need) would otherwise cause LogMiner to silently return only the
-// events present in the files actually added, dropping events from the missing
-// log(s). Fail loudly so the cause is visible rather than silently losing data.
+// continuous SCN coverage of [startSCN, endSCN] for every thread that appears
+// in the file set. Oracle's redo logs partition SCN space per-thread such that
+// adjacent files within a thread satisfy prev.NEXT_CHANGE# == next.FIRST_CHANGE#.
+// In RAC, each instance writes its own thread of redo, and SCN ranges across
+// threads overlap arbitrarily; the adjacency invariant only holds within a
+// single thread. A gap in available files (most commonly because archive log
+// retention deleted a log we need) would otherwise cause LogMiner to silently
+// return only the events present in the files actually added, dropping events
+// from the missing log(s). Fail loudly so the cause is visible rather than
+// silently losing data.
 func validateLogFileCoverage(redoFiles []redoFile, startSCN, endSCN SCN) error {
 	if len(redoFiles) == 0 {
 		return fmt.Errorf("no redo log files available to cover SCN range [%d, %d]", startSCN, endSCN)
 	}
 
-	if redoFiles[0].FirstChange > startSCN {
-		return fmt.Errorf("redo log gap at start of SCN range: first file %q begins at FIRST_CHANGE#=%d, after startSCN=%d", redoFiles[0].Name, redoFiles[0].FirstChange, startSCN)
+	// Partition by thread and validate each thread's chain independently. We
+	// rely on the caller having sorted by FIRST_CHANGE#, which means within
+	// each thread the files are in SEQUENCE# order.
+	var byThread = make(map[int][]redoFile)
+	for _, f := range redoFiles {
+		byThread[f.Thread] = append(byThread[f.Thread], f)
 	}
 
-	for i := 1; i < len(redoFiles); i++ {
-		var prev, curr = redoFiles[i-1], redoFiles[i]
-		// NextChange=0 is our sentinel for the CURRENT online log, which is open
-		// ended and so must be the final file in the list.
-		if prev.NextChange == 0 {
-			return fmt.Errorf("redo log file %q (FIRST_CHANGE#=%d) follows CURRENT-status file %q which has no NEXT_CHANGE#", curr.Name, curr.FirstChange, prev.Name)
+	for thread, files := range byThread {
+		if files[0].FirstChange > startSCN {
+			return fmt.Errorf("redo log gap at start of SCN range for thread %d: first file %q begins at FIRST_CHANGE#=%d, after startSCN=%d", thread, files[0].Name, files[0].FirstChange, startSCN)
 		}
-		if curr.FirstChange != prev.NextChange {
-			return fmt.Errorf("redo log SCN gap between %q (NEXT_CHANGE#=%d) and %q (FIRST_CHANGE#=%d)", prev.Name, prev.NextChange, curr.Name, curr.FirstChange)
+		for i := 1; i < len(files); i++ {
+			var prev, curr = files[i-1], files[i]
+			// NextChange=0 is our sentinel for the CURRENT online log, which is open
+			// ended and so must be the final file in its thread.
+			if prev.NextChange == 0 {
+				return fmt.Errorf("redo log file %q (FIRST_CHANGE#=%d) follows CURRENT-status file %q in thread %d, which has no NEXT_CHANGE#", curr.Name, curr.FirstChange, prev.Name, thread)
+			}
+			if curr.FirstChange != prev.NextChange {
+				return fmt.Errorf("redo log SCN gap in thread %d between %q (NEXT_CHANGE#=%d) and %q (FIRST_CHANGE#=%d)", thread, prev.Name, prev.NextChange, curr.Name, curr.FirstChange)
+			}
 		}
-	}
-
-	var last = redoFiles[len(redoFiles)-1]
-	if last.NextChange != 0 && last.NextChange < endSCN {
-		return fmt.Errorf("redo log gap at end of SCN range: last file %q ends at NEXT_CHANGE#=%d, before endSCN=%d", last.Name, last.NextChange, endSCN)
+		var last = files[len(files)-1]
+		if last.NextChange != 0 && last.NextChange < endSCN {
+			return fmt.Errorf("redo log gap at end of SCN range for thread %d: last file %q ends at NEXT_CHANGE#=%d, before endSCN=%d", thread, last.Name, last.NextChange, endSCN)
+		}
 	}
 
 	return nil
+}
+
+// resolveDuplicateSequences collapses cases where the same (THREAD#, SEQUENCE#)
+// pair appears as both a live entry (CURRENT or ACTIVE) and an ARCHIVED entry,
+// which happens during the window where an ACTIVE log has been copied to archive
+// but not yet retired. The live entry is preferred. If two entries share a key
+// and neither is live (or both are), we treat that as a structural error. In
+// RAC, SEQUENCE# values are per-thread independent counters, so we must include
+// THREAD# in the key to avoid collapsing unrelated files from different threads.
+func resolveDuplicateSequences(files []redoFile) ([]redoFile, error) {
+	type threadSeq struct{ Thread, Sequence int }
+	var isLive = func(f redoFile) bool { return f.Status == "CURRENT" || f.Status == "ACTIVE" }
+	var byKey = make(map[threadSeq]redoFile)
+	for _, f := range files {
+		var key = threadSeq{f.Thread, f.Sequence}
+		var existing, ok = byKey[key]
+		if !ok {
+			byKey[key] = f
+			continue
+		}
+		var kept, dropped redoFile
+		switch {
+		case isLive(f) && !isLive(existing):
+			kept, dropped = f, existing
+		case isLive(existing) && !isLive(f):
+			kept, dropped = existing, f
+		default:
+			return nil, fmt.Errorf("found two log files for thread %d sequence %d, cannot disambiguate: %+v, %+v", f.Thread, f.Sequence, existing, f)
+		}
+		logrus.WithFields(logrus.Fields{
+			"kept":    fmt.Sprintf("%+v", kept),
+			"dropped": fmt.Sprintf("%+v", dropped),
+		}).Debug("found two log files with the same thread and sequence number, keeping CURRENT or ACTIVE")
+		byKey[key] = kept
+	}
+	var out = make([]redoFile, 0, len(byKey))
+	for _, f := range byKey {
+		out = append(out, f)
+	}
+	return out, nil
 }
 
 func (s *replicationStream) startLogminer(ctx context.Context, startSCN, endSCN SCN) error {


### PR DESCRIPTION
**Description:**

In Oracle RAC, each instance writes its own thread of redo, and SCN ranges across threads overlap arbitrarily while sequence numbers are independent. The previous log selection logic assumed a single thread, and could misbehave in all kinds of interesting ways when that wasn't true.

The new selection logic sorts candidate files by `FIRST_CHANGE#` and tracks `NEXT_CHANGE#` per-thread then takes the minimum across threads to find the global covered SCN upper-bound after adding each file. This logic reduces to the old behavior in single-threaded cases.

I have not tested this against a real RAC deployment but I believe that it should work in theory, and as previously mentioned it reduces to the single-thread logic the rest of the time so I believe it should be safe to try in production.