### PR TITLE
source-http-ingest: add HMAC SHA-256 signature verifications

### DIFF
--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "models",
  "p256",
  "proto-flow",
+ "regex",
  "reqwest",
  "schemars",
  "serde",

--- a/source-http-ingest/Cargo.lock
+++ b/source-http-ingest/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +399,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -411,6 +441,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -454,7 +502,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -486,10 +534,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -521,7 +581,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "time",
@@ -544,7 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -565,7 +625,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -840,12 +900,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -929,6 +1004,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1481,7 +1565,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1932,7 +2016,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -1996,7 +2080,7 @@ version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2163,8 +2247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2197,7 +2292,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -2263,6 +2358,8 @@ dependencies = [
  "chrono",
  "doc",
  "futures",
+ "hex",
+ "hmac 0.13.0",
  "http 1.4.0",
  "insta",
  "itertools 0.13.0",
@@ -2276,6 +2373,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "time",
  "tokio",
  "tower 0.4.13",
@@ -2675,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -45,6 +45,7 @@ tower = "0.4"
 p256 = { version = "0.13.2", features = ["pem"] }
 base64 = "0.22.1"
 chrono = "0.4.43"
+regex = "1"
 
 [dev-dependencies]
 insta = { version = "1.28", features = ["json", "serde"] }

--- a/source-http-ingest/Cargo.toml
+++ b/source-http-ingest/Cargo.toml
@@ -46,6 +46,13 @@ p256 = { version = "0.13.2", features = ["pem"] }
 base64 = "0.22.1"
 chrono = "0.4.43"
 regex = "1"
+hex = "0.4"
+hmac = "0.13.0"
+
+# FIXME: I'm manually adding this duplicate dependency because p256 requires 0.10
+# but hmac needs 0.11.
+# Please remove this line when p256 upgrades its dependencies
+sha2 = "0.11"
 
 [dev-dependencies]
 insta = { version = "1.28", features = ["json", "serde"] }

--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -204,6 +204,34 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                 "required": ["provider", "publicKey"]
             },
             {
+                "title": "Knock",
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "const": "knock",
+                        "default": "knock",
+                        "order": 0
+                    },
+                    "publicKey": {
+                        "type": "string",
+                        "title": "Signing Key",
+                        "description": "Knock webhook signing key used as the HMAC-SHA256 secret.",
+                        "secret": true,
+                        "order": 1
+                    },
+                    "maxSignatureAge": {
+                        "type": "integer",
+                        "title": "Max Signature Age",
+                        "description": "Maximum age of a signed request in seconds before it is rejected. Defaults to 300 (5 minutes).",
+                        "default": 300,
+                        "minimum": 1,
+                        "maximum": 259200,
+                        "order": 2
+                    }
+                },
+                "required": ["provider", "publicKey"]
+            },
+            {
                 "title": "Custom",
                 "properties": {
                     "provider": {

--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -205,11 +205,17 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                         "description": "HTTP header containing the base64-encoded signature.",
                         "order": 3
                     },
+                    "signingStringTemplate": {
+                        "type": "string",
+                        "title": "Signing String Template",
+                        "description": "Template used to construct the string that is signed. Must include {PAYLOAD}, may include {TIMESTAMP}. Example: \"{TIMESTAMP}:{PAYLOAD}\".",
+                        "order": 4
+                    },
                     "timestampHeader": {
                         "type": "string",
                         "title": "Timestamp Header",
                         "description": "Optional HTTP header containing the timestamp.",
-                        "order": 4
+                        "order": 5
                     },
                     "maxSignatureAge": {
                         "type": "integer",
@@ -218,10 +224,10 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                         "default": 300,
                         "minimum": 1,
                         "maximum": 259200,
-                        "order": 5
+                        "order": 6
                     }
                 },
-                "required": ["provider", "algorithm", "publicKey", "signatureHeader"]
+                "required": ["provider", "algorithm", "publicKey", "signatureHeader", "signingStringTemplate"]
             }
         ]
     }))

--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -187,14 +187,14 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                     "algorithm": {
                         "type": "string",
                         "title": "Algorithm",
-                        "enum": ["ecdsa"],
-                        "default": "ecdsa",
+                        "enum": ["hmac_sha256", "ecdsa"],
+                        "default": "hmac_sha256",
                         "order": 1
                     },
                     "publicKey": {
                         "type": "string",
                         "title": "Public Key",
-                        "description": "PEM-encoded public key.",
+                        "description": "PEM-encoded public key for ECDSA, or shared secret for HMAC.",
                         "secret": true,
                         "multiline": true,
                         "order": 2
@@ -202,20 +202,28 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                     "signatureHeader": {
                         "type": "string",
                         "title": "Signature Header",
-                        "description": "HTTP header containing the base64-encoded signature.",
+                        "description": "HTTP header containing the signature.",
                         "order": 3
+                    },
+                    "signatureEncoding": {
+                        "type": "string",
+                        "title": "Signature Encoding",
+                        "description": "Encoding of the signature value in the header. Defaults to hex.",
+                        "enum": ["hex", "base64"],
+                        "default": "hex",
+                        "order": 4
                     },
                     "signingStringTemplate": {
                         "type": "string",
                         "title": "Signing String Template",
                         "description": "Template used to construct the string that is signed. Must include {PAYLOAD}, may include {TIMESTAMP}. Example: \"{TIMESTAMP}:{PAYLOAD}\".",
-                        "order": 4
+                        "order": 5
                     },
                     "timestampHeader": {
                         "type": "string",
                         "title": "Timestamp Header",
                         "description": "Optional HTTP header containing the timestamp.",
-                        "order": 5
+                        "order": 6
                     },
                     "maxSignatureAge": {
                         "type": "integer",
@@ -224,7 +232,7 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                         "default": 300,
                         "minimum": 1,
                         "maximum": 259200,
-                        "order": 6
+                        "order": 7
                     }
                 },
                 "required": ["provider", "algorithm", "publicKey", "signatureHeader", "signingStringTemplate"]

--- a/source-http-ingest/src/lib.rs
+++ b/source-http-ingest/src/lib.rs
@@ -176,6 +176,34 @@ fn webhook_signature_schema(_gen: &mut generate::SchemaGenerator) -> Schema {
                 "required": ["provider", "publicKey"]
             },
             {
+                "title": "Zoom",
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "const": "zoom",
+                        "default": "zoom",
+                        "order": 0
+                    },
+                    "publicKey": {
+                        "type": "string",
+                        "title": "Secret Token",
+                        "description": "Zoom webhook secret token used as the HMAC-SHA256 key.",
+                        "secret": true,
+                        "order": 1
+                    },
+                    "maxSignatureAge": {
+                        "type": "integer",
+                        "title": "Max Signature Age",
+                        "description": "Maximum age of a signed request in seconds before it is rejected. Defaults to 300 (5 minutes).",
+                        "default": 300,
+                        "minimum": 1,
+                        "maximum": 259200,
+                        "order": 2
+                    }
+                },
+                "required": ["provider", "publicKey"]
+            },
+            {
                 "title": "Custom",
                 "properties": {
                     "provider": {

--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -430,7 +430,7 @@ impl Handler {
             }
         }
 
-        let body = match self.signature_verifier.verify(&request_headers, body) {
+        let body = match self.signature_verifier.verify_request(&request_headers, body) {
             Ok(b) => b,
             Err(err) => {
                 return Ok(err_response(StatusCode::UNAUTHORIZED, err, matched_path));

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use chrono::{DateTime, TimeDelta, Utc};
 use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
 use p256::pkcs8::DecodePublicKey;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
@@ -16,15 +17,85 @@ pub enum SignatureAlgorithm {
     Ecdsa,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct EcdsaProviderSettings<'a> {
-    pub signature_header: &'a str,
-    pub timestamp_header: Option<&'a str>,
+#[derive(Debug, Clone)]
+enum TemplateSegment {
+    Literal(String),
+    Timestamp,
+    Payload,
 }
 
-const TWILIO_SETTINGS: EcdsaProviderSettings = EcdsaProviderSettings {
+#[derive(Debug, Clone)]
+struct SigningStringTemplate(Vec<TemplateSegment>);
+
+impl SigningStringTemplate {
+    fn render(&self, request_body: &[u8], timestamp: Option<&[u8]>) -> Result<Vec<u8>> {
+        let mut out = Vec::with_capacity(request_body.len() + 32);
+        for seg in &self.0 {
+            match seg {
+                TemplateSegment::Literal(b) => out.extend_from_slice(b.as_bytes()),
+                TemplateSegment::Payload => out.extend_from_slice(request_body),
+                TemplateSegment::Timestamp => out.extend_from_slice(
+                    timestamp.context("template requires timestamp but none provided")?,
+                ),
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl TryFrom<&str> for SigningStringTemplate {
+    type Error = anyhow::Error;
+
+    fn try_from(input: &str) -> Result<Self> {
+        let regex = Regex::new(r"\{(PAYLOAD|TIMESTAMP)\}").unwrap();
+        let mut segments = Vec::new();
+        let mut cursor = 0;
+
+        for cap in regex.captures_iter(input) {
+            let m = cap.get(0).unwrap();
+            if m.start() > cursor {
+                segments.push(TemplateSegment::Literal(
+                    input[cursor..m.start()].to_string(),
+                ));
+            }
+            segments.push(match &cap[1] {
+                "PAYLOAD" => TemplateSegment::Payload,
+                "TIMESTAMP" => TemplateSegment::Timestamp,
+                _ => unreachable!(),
+            });
+            cursor = m.end();
+        }
+        if cursor < input.len() {
+            segments.push(TemplateSegment::Literal(input[cursor..].to_string()));
+        }
+
+        if !segments
+            .iter()
+            .any(|s| matches!(s, TemplateSegment::Payload))
+        {
+            bail!(
+                "Hash message format must include at least {{PAYLOAD}}. \
+                Supported placeholders: {{PAYLOAD}}, {{TIMESTAMP}}. \
+                Ex: \"{{TIMESTAMP}}:{{PAYLOAD}}\""
+            );
+        }
+
+        Ok(SigningStringTemplate(segments))
+    }
+}
+
+/// Platform-specific settings. These are invariant across all users of the same source.
+#[derive(Debug, Clone)]
+pub struct SignatureProviderSettings {
+    pub signature_header: &'static str,
+    pub timestamp_header: Option<&'static str>,
+    pub template: &'static str,
+}
+
+const TWILIO_SETTINGS: SignatureProviderSettings = SignatureProviderSettings {
     signature_header: "X-Twilio-Email-Event-Webhook-Signature",
     timestamp_header: Some("X-Twilio-Email-Event-Webhook-Timestamp"),
+    template: "{TIMESTAMP}{PAYLOAD}",
 };
 
 fn default_max_signature_age() -> u64 {
@@ -56,6 +127,8 @@ pub enum WebhookSignatureConfig {
         timestamp_header: Option<String>,
         #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
         max_signature_age: u64,
+        #[serde(rename = "signingStringTemplate")]
+        template: String,
     },
 }
 
@@ -66,24 +139,25 @@ impl Default for WebhookSignatureConfig {
 }
 
 pub trait WebhookSignatureVerifier: Send + Sync {
-    fn verify(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes>;
+    fn verify_request(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes>;
 }
 
 struct NoopVerifier;
 
 impl WebhookSignatureVerifier for NoopVerifier {
-    fn verify(&self, _: &HeaderMap, body: Bytes) -> Result<Bytes> {
+    fn verify_request(&self, _: &HeaderMap, body: Bytes) -> Result<Bytes> {
         Ok(body)
     }
 }
 
+/// Utility to protect against replay attacks.
 #[derive(Debug)]
-struct TimestampParser {
+struct TimestampVerifier {
     header: String,
     max_age: TimeDelta,
 }
 
-impl TimestampParser {
+impl TimestampVerifier {
     fn new(header: String, max_age_seconds: u64) -> Result<Self> {
         if header.trim().is_empty() {
             anyhow::bail!("Timestamp header name was provided but was empty");
@@ -136,22 +210,38 @@ impl TimestampParser {
 struct EcdsaVerifier {
     verifying_key: VerifyingKey,
     signature_header: String,
-    timestamp_parser: Option<TimestampParser>,
+    timestamp_verifier: Option<TimestampVerifier>,
+    template: SigningStringTemplate,
 }
 
 impl EcdsaVerifier {
     pub fn new(
         public_key: &str,
         signature_header: String,
-        timestamp_parser: Option<TimestampParser>,
+        timestamp_verifier: Option<TimestampVerifier>,
+        template: &str,
     ) -> anyhow::Result<Self> {
+        let public_key = public_key.trim();
+        if public_key.is_empty() {
+            anyhow::bail!("Public key is required but was empty");
+        }
+
         if signature_header.trim().is_empty() {
             anyhow::bail!("Signature header name is required but was empty");
         }
 
-        let public_key = public_key.trim();
-        if public_key.is_empty() {
-            anyhow::bail!("Public key is required but was empty");
+        let template = SigningStringTemplate::try_from(template)?;
+
+        if timestamp_verifier.is_none()
+            && template
+                .0
+                .iter()
+                .any(|s| matches!(s, TemplateSegment::Timestamp))
+        {
+            anyhow::bail!(
+                "{{TIMESTAMP}} placeholder was defined in hashed message format \
+                but no timestamp parsing details were included"
+            )
         }
 
         let verifying_key = {
@@ -178,13 +268,14 @@ impl EcdsaVerifier {
         Ok(Self {
             verifying_key,
             signature_header,
-            timestamp_parser,
+            timestamp_verifier,
+            template,
         })
     }
 }
 
 impl WebhookSignatureVerifier for EcdsaVerifier {
-    fn verify(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
+    fn verify_request(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
         let signature = {
             let b64 = headers.get(&self.signature_header).with_context(|| {
                 format!(
@@ -207,15 +298,15 @@ impl WebhookSignatureVerifier for EcdsaVerifier {
         };
 
         let payload = {
-            let mut value = Vec::new();
+            let timestamp = self
+                .timestamp_verifier
+                .as_ref()
+                .map(|tv| tv.as_bytes(headers))
+                .transpose()?;
 
-            if let Some(v) = &self.timestamp_parser {
-                value.extend(v.as_bytes(headers)?);
-            }
-            value.extend(&body);
-
-            value
-        };
+            self.template.render(&body, timestamp)
+        }
+        .with_context(|| "Failed to build the hash value")?;
 
         self.verifying_key.verify(&payload, &signature).context(
             "Signature verification failed. Check that the public key matches your webhook provider's key",
@@ -224,7 +315,7 @@ impl WebhookSignatureVerifier for EcdsaVerifier {
         // Verify timestamp freshness after the cryptographic signature check.
         // This prevents unauthenticated callers from probing the server's
         // max-age window via crafted timestamp headers.
-        if let Some(v) = &self.timestamp_parser {
+        if let Some(v) = &self.timestamp_verifier {
             v.verify(headers)?;
         }
 
@@ -243,7 +334,7 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 public_key,
                 max_signature_age,
             } => {
-                let timestamp_parser = TimestampParser::new(
+                let timestamp_verifier = TimestampVerifier::new(
                     // .unwrap() call is operating on a constant
                     TWILIO_SETTINGS.timestamp_header.unwrap().to_string(),
                     max_signature_age,
@@ -252,7 +343,8 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 Ok(Box::new(EcdsaVerifier::new(
                     &public_key,
                     TWILIO_SETTINGS.signature_header.to_string(),
-                    Some(timestamp_parser),
+                    Some(timestamp_verifier),
+                    TWILIO_SETTINGS.template,
                 )?))
             }
 
@@ -262,15 +354,17 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 signature_header,
                 timestamp_header,
                 max_signature_age,
+                template,
             } => match algorithm {
                 SignatureAlgorithm::Ecdsa => {
                     let tv = timestamp_header
-                        .map(|h| TimestampParser::new(h, max_signature_age))
+                        .map(|h| TimestampVerifier::new(h, max_signature_age))
                         .transpose()?;
                     Ok(Box::new(EcdsaVerifier::new(
                         &public_key,
                         signature_header,
                         tv,
+                        &template,
                     )?))
                 }
             },
@@ -314,13 +408,25 @@ mod test {
     }
 
     fn make_ecdsa_verifier(with_timestamp: bool) -> Box<dyn WebhookSignatureVerifier> {
-        let tv = if with_timestamp {
-            Some(TimestampParser::new("X-Timestamp".into(), default_max_signature_age()).unwrap())
+        let (tv, template) = if with_timestamp {
+            (
+                Some(
+                    TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age())
+                        .unwrap(),
+                ),
+                "{TIMESTAMP}{PAYLOAD}",
+            )
         } else {
-            None
+            (None, "{PAYLOAD}")
         };
         Box::new(
-            EcdsaVerifier::new(&test_verifying_key_pem(), "X-Signature".to_string(), tv).unwrap(),
+            EcdsaVerifier::new(
+                &test_verifying_key_pem(),
+                "X-Signature".to_string(),
+                tv,
+                template,
+            )
+            .unwrap(),
         )
     }
 
@@ -328,9 +434,20 @@ mod test {
         max_age_seconds: Option<u64>,
     ) -> Box<dyn WebhookSignatureVerifier> {
         let tv =
-            max_age_seconds.map(|age| TimestampParser::new("X-Timestamp".into(), age).unwrap());
+            max_age_seconds.map(|age| TimestampVerifier::new("X-Timestamp".into(), age).unwrap());
+        let template = if tv.is_some() {
+            "{TIMESTAMP}{PAYLOAD}"
+        } else {
+            "{PAYLOAD}"
+        };
         Box::new(
-            EcdsaVerifier::new(&test_verifying_key_pem(), "X-Signature".to_string(), tv).unwrap(),
+            EcdsaVerifier::new(
+                &test_verifying_key_pem(),
+                "X-Signature".to_string(),
+                tv,
+                template,
+            )
+            .unwrap(),
         )
     }
 
@@ -342,13 +459,25 @@ mod test {
     }
 
     fn make_ecdsa_verifier_b64(with_timestamp: bool) -> Box<dyn WebhookSignatureVerifier> {
-        let tv = if with_timestamp {
-            Some(TimestampParser::new("X-Timestamp".into(), default_max_signature_age()).unwrap())
+        let (tv, template) = if with_timestamp {
+            (
+                Some(
+                    TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age())
+                        .unwrap(),
+                ),
+                "{TIMESTAMP}{PAYLOAD}",
+            )
         } else {
-            None
+            (None, "{PAYLOAD}")
         };
         Box::new(
-            EcdsaVerifier::new(&test_verifying_key_b64(), "X-Signature".to_string(), tv).unwrap(),
+            EcdsaVerifier::new(
+                &test_verifying_key_b64(),
+                "X-Signature".to_string(),
+                tv,
+                template,
+            )
+            .unwrap(),
         )
     }
 
@@ -372,7 +501,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(true);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_ref(), body);
@@ -391,7 +520,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_ref(), body);
@@ -412,7 +541,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_err());
         assert_snapshot!(
@@ -427,7 +556,7 @@ mod test {
         let headers = axum::http::HeaderMap::new();
 
         let verifier = make_ecdsa_verifier(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_err());
         assert_snapshot!(
@@ -449,7 +578,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(true);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_err());
         assert_snapshot!(
@@ -470,7 +599,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_err());
         assert_snapshot!(
@@ -494,7 +623,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_err());
         assert_snapshot!(
@@ -523,6 +652,7 @@ mod test {
             signature_header: "X-Custom-Sig".to_string(),
             timestamp_header: Some("X-Custom-Ts".to_string()),
             max_signature_age: default_max_signature_age(),
+            template: "{TIMESTAMP}{PAYLOAD}".to_string(),
         };
         let verifier: Result<Box<dyn WebhookSignatureVerifier>, _> = config.try_into();
         assert!(verifier.is_ok());
@@ -548,7 +678,8 @@ mod test {
                 "algorithm": "ecdsa",
                 "publicKey": {},
                 "signatureHeader": "X-Sig",
-                "timestampHeader": "X-Ts"
+                "timestampHeader": "X-Ts",
+                "signingStringTemplate": "{{TIMESTAMP}}.{{PAYLOAD}}"
             }}"#,
             serde_json::to_string(&pem_key).unwrap()
         );
@@ -576,7 +707,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier_with_age(Some(3600));
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
     }
 
@@ -604,7 +735,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier_with_age(Some(1));
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
@@ -621,7 +752,8 @@ mod test {
                 "algorithm": "ecdsa",
                 "publicKey": {},
                 "signatureHeader": "X-Sig",
-                "maxSignatureAge": 3600
+                "maxSignatureAge": 3600,
+                "signingStringTemplate": "{{PAYLOAD}}"
             }}"#,
             serde_json::to_string(&pem_key).unwrap()
         );
@@ -638,7 +770,12 @@ mod test {
 
     #[test]
     fn test_ecdsa_raw_b64_key_parses() {
-        let result = EcdsaVerifier::new(&test_verifying_key_b64(), "X-Signature".to_string(), None);
+        let result = EcdsaVerifier::new(
+            &test_verifying_key_b64(),
+            "X-Signature".to_string(),
+            None,
+            "{PAYLOAD}",
+        );
         assert!(result.is_ok());
     }
 
@@ -654,7 +791,7 @@ mod test {
         };
 
         let verifier = make_ecdsa_verifier_b64(false);
-        let result = verifier.verify(&headers, Bytes::from_static(body));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_ref(), body);
@@ -662,7 +799,12 @@ mod test {
 
     #[test]
     fn test_ecdsa_raw_b64_key_invalid_base64() {
-        let result = EcdsaVerifier::new("not-valid-base64", "X-Signature".to_string(), None);
+        let result = EcdsaVerifier::new(
+            "not-valid-base64",
+            "X-Signature".to_string(),
+            None,
+            "{PAYLOAD}",
+        );
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
@@ -673,11 +815,130 @@ mod test {
     #[test]
     fn test_ecdsa_raw_b64_key_invalid_der() {
         let garbage_der = BASE64_STANDARD.encode(b"this is not valid DER");
-        let result = EcdsaVerifier::new(&garbage_der, "X-Signature".to_string(), None);
+        let result = EcdsaVerifier::new(&garbage_der, "X-Signature".to_string(), None, "{PAYLOAD}");
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
             @"Failed to parse base64-decoded bytes as a P-256 ECDSA public key in SPKI DER format"
         );
+    }
+
+    #[test]
+    fn test_template_rejects_missing_payload() {
+        let result = SigningStringTemplate::try_from("{TIMESTAMP}-only");
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @r#"Hash message format must include at least {PAYLOAD}. Supported placeholders: {PAYLOAD}, {TIMESTAMP}. Ex: "{TIMESTAMP}:{PAYLOAD}""#
+        );
+    }
+
+    #[test]
+    fn test_template_rejects_empty() {
+        let result = SigningStringTemplate::try_from("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_template_rejects_literal_only() {
+        let result = SigningStringTemplate::try_from("no placeholders here");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_template_accepts_payload_only() {
+        let template = SigningStringTemplate::try_from("{PAYLOAD}").unwrap();
+        let built = template.render(b"hello", None).unwrap();
+        assert_eq!(built, b"hello");
+    }
+
+    #[test]
+    fn test_template_interleaves_literals() {
+        let template = SigningStringTemplate::try_from("v1:{TIMESTAMP}.{PAYLOAD}").unwrap();
+        let built = template.render(b"body", Some(b"12345")).unwrap();
+        assert_eq!(built, b"v1:12345.body");
+    }
+
+    #[test]
+    fn test_template_payload_before_timestamp() {
+        let template = SigningStringTemplate::try_from("{PAYLOAD}|{TIMESTAMP}").unwrap();
+        let built = template.render(b"body", Some(b"99")).unwrap();
+        assert_eq!(built, b"body|99");
+    }
+
+    #[test]
+    fn test_template_build_fails_when_timestamp_missing() {
+        let template = SigningStringTemplate::try_from("{TIMESTAMP}{PAYLOAD}").unwrap();
+        let result = template.render(b"body", None);
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"template requires timestamp but none provided"
+        );
+    }
+
+    #[test]
+    fn test_ecdsa_rejects_timestamp_placeholder_without_verifier() {
+        let result = EcdsaVerifier::new(
+            &test_verifying_key_pem(),
+            "X-Signature".to_string(),
+            None,
+            "{TIMESTAMP}{PAYLOAD}",
+        );
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"{TIMESTAMP} placeholder was defined in hashed message format but no timestamp parsing details were included"
+        );
+    }
+
+    #[test]
+    fn test_ecdsa_rejects_template_without_payload() {
+        let tv = TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age()).unwrap();
+        let result = EcdsaVerifier::new(
+            &test_verifying_key_pem(),
+            "X-Signature".to_string(),
+            Some(tv),
+            "{TIMESTAMP}-no-payload",
+        );
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @r#"Hash message format must include at least {PAYLOAD}. Supported placeholders: {PAYLOAD}, {TIMESTAMP}. Ex: "{TIMESTAMP}:{PAYLOAD}""#
+        );
+    }
+
+    #[test]
+    fn test_ecdsa_verifies_with_custom_template() {
+        let body = b"webhook payload";
+        let timestamp = Utc::now().timestamp().to_string();
+
+        let signature = {
+            let mut payload = Vec::new();
+            payload.extend_from_slice(b"v1:");
+            payload.extend_from_slice(timestamp.as_bytes());
+            payload.extend_from_slice(b".");
+            payload.extend_from_slice(body);
+            sign_payload(&payload)
+        };
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", timestamp.parse().unwrap());
+            val
+        };
+
+        let tv = TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age()).unwrap();
+        let verifier = EcdsaVerifier::new(
+            &test_verifying_key_pem(),
+            "X-Signature".to_string(),
+            Some(tv),
+            "v1:{TIMESTAMP}.{PAYLOAD}",
+        )
+        .unwrap();
+
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
     }
 }

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -52,6 +52,15 @@ fn parser_encoded(encoding: SignatureEncoding) -> SignatureParser {
     Box::new(move |raw| encoding.decode(raw))
 }
 
+fn parser_prefixed(prefix: &'static str, encoding: SignatureEncoding) -> SignatureParser {
+    Box::new(move |raw| {
+        let stripped = raw.trim().strip_prefix(prefix).with_context(|| {
+            format!("Signature did not start with expected prefix '{}'", prefix)
+        })?;
+        encoding.decode(stripped)
+    })
+}
+
 #[derive(Debug, Clone)]
 enum TemplateSegment {
     Literal(String),
@@ -119,20 +128,6 @@ impl TryFrom<&str> for SigningStringTemplate {
     }
 }
 
-/// Platform-specific settings. These are invariant across all users of the same source.
-#[derive(Debug, Clone)]
-pub struct SignatureProviderSettings {
-    pub signature_header: &'static str,
-    pub timestamp_header: Option<&'static str>,
-    pub template: &'static str,
-}
-
-const TWILIO_SETTINGS: SignatureProviderSettings = SignatureProviderSettings {
-    signature_header: "X-Twilio-Email-Event-Webhook-Signature",
-    timestamp_header: Some("X-Twilio-Email-Event-Webhook-Timestamp"),
-    template: "{TIMESTAMP}{PAYLOAD}",
-};
-
 fn default_max_signature_age() -> u64 {
     300
 }
@@ -142,6 +137,14 @@ fn default_max_signature_age() -> u64 {
 pub enum WebhookSignatureConfig {
     #[serde(rename = "none")]
     None {},
+
+    #[serde(rename = "zoom")]
+    Zoom {
+        #[serde(rename = "publicKey")]
+        public_key: String,
+        #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
+        max_signature_age: u64,
+    },
 
     #[serde(rename = "twilio")]
     Twilio {
@@ -475,21 +478,38 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
         match config {
             WebhookSignatureConfig::None {} => Ok(Box::new(NoopVerifier {})),
 
+            WebhookSignatureConfig::Zoom {
+                public_key,
+                max_signature_age,
+            } => {
+                let timestamp_verifier = TimestampVerifier::new(
+                    "x-zm-request-timestamp".to_string(),
+                    max_signature_age,
+                )?;
+
+                Ok(Box::new(HmacSha256Verifier::new(
+                    &public_key,
+                    "x-zm-signature".to_string(),
+                    parser_prefixed("v0=", SignatureEncoding::Hex),
+                    Some(timestamp_verifier),
+                    "v0:{TIMESTAMP}:{PAYLOAD}",
+                )?))
+            }
+
             WebhookSignatureConfig::Twilio {
                 public_key,
                 max_signature_age,
             } => {
                 let timestamp_verifier = TimestampVerifier::new(
-                    // .unwrap() call is operating on a constant
-                    TWILIO_SETTINGS.timestamp_header.unwrap().to_string(),
+                    "X-Twilio-Email-Event-Webhook-Timestamp".to_string(),
                     max_signature_age,
                 )?;
 
                 Ok(Box::new(EcdsaVerifier::new(
                     &public_key,
-                    TWILIO_SETTINGS.signature_header.to_string(),
+                    "X-Twilio-Email-Event-Webhook-Signature".to_string(),
                     Some(timestamp_verifier),
-                    TWILIO_SETTINGS.template,
+                    "{TIMESTAMP}{PAYLOAD}",
                 )?))
             }
 
@@ -1193,6 +1213,42 @@ mod test {
     }
 
     #[test]
+    fn test_hmac_signature_valid_with_prefix() {
+        let body = b"test body content";
+        let signature = format!("v0={}", hex::encode(hmac_sign(body)));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_prefixed("v0=", SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_hmac_signature_prefix_missing() {
+        let body = b"test body content";
+        let signature = hex::encode(hmac_sign(body));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_prefixed("v0=", SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature did not start with expected prefix 'v0='"
+        );
+    }
+
+    #[test]
     fn test_hmac_signature_invalid() {
         let body = b"test body content";
         let wrong_body = b"different content";
@@ -1376,6 +1432,30 @@ mod test {
             result.unwrap_err(),
             @r#"Hash message format must include at least {PAYLOAD}. Supported placeholders: {PAYLOAD}, {TIMESTAMP}. Ex: "{TIMESTAMP}:{PAYLOAD}""#
         );
+    }
+
+    #[test]
+    fn test_zoom_config_conversion_and_verifies() {
+        let now = Utc::now().timestamp().to_string();
+        let body = b"zoom event body";
+
+        let signed = format!("v0:{}:{}", now, str::from_utf8(body).unwrap());
+        let signature = format!("v0={}", hex::encode(hmac_sign(signed.as_bytes())));
+
+        let config = WebhookSignatureConfig::Zoom {
+            public_key: str::from_utf8(HMAC_SECRET).unwrap().to_string(),
+            max_signature_age: default_max_signature_age(),
+        };
+        let verifier: Box<dyn WebhookSignatureVerifier> = config.try_into().unwrap();
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("x-zm-signature", signature.parse().unwrap());
+            val.insert("x-zm-request-timestamp", now.parse().unwrap());
+            val
+        };
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -309,6 +309,7 @@ impl TimestampVerifier {
 struct EcdsaVerifier {
     verifying_key: VerifyingKey,
     signature_header: String,
+    signature_encoding: SignatureEncoding,
     timestamp_verifier: Option<TimestampVerifier>,
     template: SigningStringTemplate,
 }
@@ -317,6 +318,7 @@ impl EcdsaVerifier {
     pub fn new(
         public_key: &str,
         signature_header: String,
+        signature_encoding: SignatureEncoding,
         timestamp_verifier: Option<TimestampVerifier>,
         template: &str,
     ) -> anyhow::Result<Self> {
@@ -367,6 +369,7 @@ impl EcdsaVerifier {
         Ok(Self {
             verifying_key,
             signature_header,
+            signature_encoding,
             timestamp_verifier,
             template,
         })
@@ -375,19 +378,27 @@ impl EcdsaVerifier {
 
 impl WebhookSignatureVerifier for EcdsaVerifier {
     fn verify_request(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
+        if body.is_empty() {
+            bail!("Refusing to verify signature over an empty request body");
+        }
+
         let signature = {
-            let b64 = headers.get(&self.signature_header).with_context(|| {
-                format!(
-                    "A signature value was expected at header {} but was not found",
-                    self.signature_header,
-                )
-            })?;
-            let bytes = BASE64_STANDARD.decode(b64).with_context(|| {
-                format!(
-                    "Failed to decode base64 signature from header '{}'",
-                    self.signature_header
-                )
-            })?;
+            let raw = headers
+                .get(&self.signature_header)
+                .with_context(|| {
+                    format!(
+                        "A signature value was expected at header {} but was not found",
+                        self.signature_header,
+                    )
+                })?
+                .to_str()
+                .with_context(|| {
+                    format!(
+                        "Signature header '{}' is not valid UTF-8",
+                        self.signature_header
+                    )
+                })?;
+            let bytes = self.signature_encoding.decode(raw)?;
             Signature::from_der(&bytes).with_context(|| {
                 format!(
                     "Failed to parse DER-encoded ECDSA signature from header '{}'",
@@ -472,7 +483,8 @@ impl HmacSha256Verifier {
             )
         }
 
-        let mac: Hmac<Sha256> = Hmac::new_from_slice(key.as_bytes())?;
+        let mac: Hmac<Sha256> = Hmac::new_from_slice(key.as_bytes())
+            .context("Failed to initialize HMAC with the provided secret")?;
 
         Ok(Self {
             mac,
@@ -487,6 +499,10 @@ impl HmacSha256Verifier {
 
 impl WebhookSignatureVerifier for HmacSha256Verifier {
     fn verify_request(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
+        if body.is_empty() {
+            bail!("Refusing to verify signature over an empty request body");
+        }
+
         let raw = headers
             .get(&self.signature_header)
             .with_context(|| {
@@ -592,6 +608,7 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 Ok(Box::new(EcdsaVerifier::new(
                     &public_key,
                     "X-Twilio-Email-Event-Webhook-Signature".to_string(),
+                    SignatureEncoding::Base64,
                     Some(timestamp_verifier),
                     "{TIMESTAMP}{PAYLOAD}",
                 )?))
@@ -613,6 +630,7 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                     Ok(Box::new(EcdsaVerifier::new(
                         &public_key,
                         signature_header,
+                        signature_encoding,
                         tv,
                         &template,
                     )?))
@@ -640,7 +658,8 @@ mod test {
     use super::*;
     use chrono::TimeZone;
     use insta::assert_snapshot;
-    use p256::pkcs8::EncodePublicKey;
+    use p256::ecdsa::signature::Signer;
+    use p256::pkcs8::{EncodePublicKey, LineEnding};
 
     const TEST_PRIVATE_KEY_B64: &str = "eis1jT5PECEyQ1RldoeYqa7L3O3+DxEiM0RVZneImao=";
 
@@ -657,14 +676,11 @@ mod test {
 
     /// Helper to create a signed payload for testing
     fn sign_payload(payload: &[u8]) -> String {
-        use p256::ecdsa::signature::Signer;
-
         let signature: Signature = test_signing_key().sign(payload);
         BASE64_STANDARD.encode(signature.to_der())
     }
 
     fn test_verifying_key_pem() -> String {
-        use p256::pkcs8::LineEnding;
         test_verifying_key()
             .to_public_key_pem(LineEnding::LF)
             .expect("failed to encode public key as PEM")
@@ -686,6 +702,7 @@ mod test {
             EcdsaVerifier::new(
                 &test_verifying_key_pem(),
                 "X-Signature".to_string(),
+                SignatureEncoding::Base64,
                 tv,
                 template,
             )
@@ -707,6 +724,7 @@ mod test {
             EcdsaVerifier::new(
                 &test_verifying_key_pem(),
                 "X-Signature".to_string(),
+                SignatureEncoding::Base64,
                 tv,
                 template,
             )
@@ -737,6 +755,7 @@ mod test {
             EcdsaVerifier::new(
                 &test_verifying_key_b64(),
                 "X-Signature".to_string(),
+                SignatureEncoding::Base64,
                 tv,
                 template,
             )
@@ -867,7 +886,7 @@ mod test {
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
-            @"Failed to decode base64 signature from header 'X-Signature'"
+            @"Failed to base64-decode signature"
         )
     }
 
@@ -1037,6 +1056,7 @@ mod test {
         let result = EcdsaVerifier::new(
             &test_verifying_key_b64(),
             "X-Signature".to_string(),
+            SignatureEncoding::Base64,
             None,
             "{PAYLOAD}",
         );
@@ -1066,6 +1086,7 @@ mod test {
         let result = EcdsaVerifier::new(
             "not-valid-base64",
             "X-Signature".to_string(),
+            SignatureEncoding::Base64,
             None,
             "{PAYLOAD}",
         );
@@ -1079,7 +1100,13 @@ mod test {
     #[test]
     fn test_ecdsa_raw_b64_key_invalid_der() {
         let garbage_der = BASE64_STANDARD.encode(b"this is not valid DER");
-        let result = EcdsaVerifier::new(&garbage_der, "X-Signature".to_string(), None, "{PAYLOAD}");
+        let result = EcdsaVerifier::new(
+            &garbage_der,
+            "X-Signature".to_string(),
+            SignatureEncoding::Base64,
+            None,
+            "{PAYLOAD}",
+        );
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
@@ -1146,6 +1173,7 @@ mod test {
         let result = EcdsaVerifier::new(
             &test_verifying_key_pem(),
             "X-Signature".to_string(),
+            SignatureEncoding::Base64,
             None,
             "{TIMESTAMP}{PAYLOAD}",
         );
@@ -1162,6 +1190,7 @@ mod test {
         let result = EcdsaVerifier::new(
             &test_verifying_key_pem(),
             "X-Signature".to_string(),
+            SignatureEncoding::Base64,
             Some(tv),
             "{TIMESTAMP}-no-payload",
         );
@@ -1197,6 +1226,7 @@ mod test {
         let verifier = EcdsaVerifier::new(
             &test_verifying_key_pem(),
             "X-Signature".to_string(),
+            SignatureEncoding::Base64,
             Some(tv),
             "v1:{TIMESTAMP}.{PAYLOAD}",
         )
@@ -1633,5 +1663,86 @@ mod test {
             }
             _ => panic!("expected Custom variant"),
         }
+    }
+
+    #[test]
+    fn test_hmac_rejects_empty_body() {
+        let now = Utc::now().timestamp().to_string();
+
+        let mut signed = Vec::new();
+        signed.extend(now.as_bytes());
+        let signature = hex::encode(hmac_sign(&signed));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", now.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(true, extract_identity(), SignatureEncoding::Hex);
+        let result = verifier.verify_request(&headers, Bytes::new());
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Refusing to verify signature over an empty request body"
+        );
+    }
+
+    #[test]
+    fn test_ecdsa_rejects_empty_body() {
+        let signature = sign_payload(b"");
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_ecdsa_verifier(false);
+        let result = verifier.verify_request(&headers, Bytes::new());
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Refusing to verify signature over an empty request body"
+        );
+    }
+
+    #[test]
+    fn test_noop_accepts_empty_body() {
+        let config = WebhookSignatureConfig::None {};
+        let verifier: Box<dyn WebhookSignatureVerifier> = config.try_into().unwrap();
+        let result = verifier.verify_request(&axum::http::HeaderMap::new(), Bytes::new());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_ecdsa_custom_hex_encoding() {
+        let body = b"webhook payload";
+        let signature_hex = {
+            let sig: Signature = test_signing_key().sign(body);
+            hex::encode(sig.to_der())
+        };
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature_hex.parse().unwrap());
+            val
+        };
+
+        let config = WebhookSignatureConfig::Custom {
+            algorithm: SignatureAlgorithm::Ecdsa,
+            public_key: test_verifying_key_pem(),
+            signature_header: "X-Signature".to_string(),
+            signature_encoding: SignatureEncoding::Hex,
+            timestamp_header: None,
+            max_signature_age: default_max_signature_age(),
+            template: "{PAYLOAD}".to_string(),
+        };
+        let verifier: Box<dyn WebhookSignatureVerifier> = config.try_into().unwrap();
+
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
     }
 }

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -46,19 +46,41 @@ impl SignatureEncoding {
     }
 }
 
-type SignatureParser = Box<dyn Fn(&str) -> Result<Vec<u8>> + Send + Sync>;
+type HeaderExtractor = Box<dyn Fn(&str) -> Result<String> + Send + Sync>;
 
-fn parser_encoded(encoding: SignatureEncoding) -> SignatureParser {
-    Box::new(move |raw| encoding.decode(raw))
+fn extract_identity() -> HeaderExtractor {
+    Box::new(|raw| Ok(raw.to_string()))
 }
 
-fn parser_prefixed(prefix: &'static str, encoding: SignatureEncoding) -> SignatureParser {
+fn extract_prefixed(prefix: &'static str) -> HeaderExtractor {
     Box::new(move |raw| {
-        let stripped = raw.trim().strip_prefix(prefix).with_context(|| {
-            format!("Signature did not start with expected prefix '{}'", prefix)
-        })?;
-        encoding.decode(stripped)
+        raw.trim()
+            .strip_prefix(prefix)
+            .map(str::to_string)
+            .with_context(|| {
+                format!(
+                    "Header value did not start with expected prefix '{}'",
+                    prefix
+                )
+            })
     })
+}
+
+fn extract_regex(pattern: &'static str) -> HeaderExtractor {
+    let re = Regex::new(pattern).expect("invalid regex pattern");
+    Box::new(move |raw| {
+        let cap = re
+            .captures(raw)
+            .context("Regex did not match header value")?;
+        let val = cap.get(1).context("Regex must contain a capture group")?;
+        Ok(val.as_str().to_string())
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TimestampUnit {
+    Seconds,
+    Milliseconds,
 }
 
 #[derive(Debug, Clone)]
@@ -146,6 +168,14 @@ pub enum WebhookSignatureConfig {
         max_signature_age: u64,
     },
 
+    #[serde(rename = "knock")]
+    Knock {
+        #[serde(rename = "publicKey")]
+        public_key: String,
+        #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
+        max_signature_age: u64,
+    },
+
     #[serde(rename = "twilio")]
     Twilio {
         #[serde(rename = "publicKey")]
@@ -191,25 +221,52 @@ impl WebhookSignatureVerifier for NoopVerifier {
 }
 
 /// Utility to protect against replay attacks.
-#[derive(Debug)]
 struct TimestampVerifier {
     header: String,
+    extract: HeaderExtractor,
+    unit: TimestampUnit,
     max_age: TimeDelta,
+}
+
+impl std::fmt::Debug for TimestampVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimestampVerifier")
+            .field("header", &self.header)
+            .field("unit", &self.unit)
+            .field("max_age", &self.max_age)
+            .finish_non_exhaustive()
+    }
 }
 
 impl TimestampVerifier {
     fn new(header: String, max_age_seconds: u64) -> Result<Self> {
+        Self::with_options(
+            header,
+            max_age_seconds,
+            extract_identity(),
+            TimestampUnit::Seconds,
+        )
+    }
+
+    fn with_options(
+        header: String,
+        max_age_seconds: u64,
+        extract: HeaderExtractor,
+        unit: TimestampUnit,
+    ) -> Result<Self> {
         if header.trim().is_empty() {
             anyhow::bail!("Timestamp header name was provided but was empty");
         }
         Ok(Self {
             header,
+            extract,
+            unit,
             max_age: TimeDelta::seconds(max_age_seconds as i64),
         })
     }
 
-    fn as_bytes<'a>(&self, header_map: &'a HeaderMap) -> Result<&'a [u8]> {
-        let val = header_map
+    fn value(&self, header_map: &HeaderMap) -> Result<String> {
+        let raw = header_map
             .get(&self.header)
             .with_context(|| {
                 format!(
@@ -217,22 +274,24 @@ impl TimestampVerifier {
                     &self.header
                 )
             })?
-            .as_bytes();
-
-        Ok(val)
+            .to_str()
+            .context("Timestamp header is not valid UTF-8")?;
+        (self.extract)(raw)
     }
 
     fn verify(&self, header_map: &HeaderMap) -> Result<()> {
-        let ts_bytes = self.as_bytes(header_map)?;
-        let ts_str = str::from_utf8(ts_bytes).context("Timestamp header is not valid UTF-8")?;
+        let ts_str = self.value(header_map)?;
         let ts_unix: i64 = ts_str.parse().with_context(|| {
             format!(
                 "Failed to parse timestamp header as integer: \"{}\"",
                 ts_str
             )
         })?;
-        let ts = DateTime::from_timestamp(ts_unix, 0)
-            .with_context(|| format!("Invalid Unix timestamp: \"{}\"", ts_unix))?;
+        let ts = match self.unit {
+            TimestampUnit::Seconds => DateTime::from_timestamp(ts_unix, 0),
+            TimestampUnit::Milliseconds => DateTime::from_timestamp_millis(ts_unix),
+        }
+        .with_context(|| format!("Invalid Unix timestamp: \"{}\"", ts_unix))?;
         let age = Utc::now().signed_duration_since(ts);
 
         if age > self.max_age {
@@ -337,16 +396,15 @@ impl WebhookSignatureVerifier for EcdsaVerifier {
             })?
         };
 
-        let payload = {
-            let timestamp = self
-                .timestamp_verifier
-                .as_ref()
-                .map(|tv| tv.as_bytes(headers))
-                .transpose()?;
-
-            self.template.render(&body, timestamp)
-        }
-        .with_context(|| "Failed to build the hash value")?;
+        let ts_str = self
+            .timestamp_verifier
+            .as_ref()
+            .map(|tv| tv.value(headers))
+            .transpose()?;
+        let payload = self
+            .template
+            .render(&body, ts_str.as_deref().map(str::as_bytes))
+            .with_context(|| "Failed to build the hash value")?;
 
         self.verifying_key.verify(&payload, &signature).context(
             "Signature verification failed. Check that the public key matches your webhook provider's key",
@@ -366,7 +424,8 @@ impl WebhookSignatureVerifier for EcdsaVerifier {
 struct HmacSha256Verifier {
     mac: Hmac<Sha256>,
     signature_header: String,
-    parse_signature: SignatureParser,
+    signature_extractor: HeaderExtractor,
+    signature_encoding: SignatureEncoding,
     timestamp_verifier: Option<TimestampVerifier>,
     template: SigningStringTemplate,
 }
@@ -385,7 +444,8 @@ impl HmacSha256Verifier {
     pub fn new(
         key: &str,
         signature_header: String,
-        parse_signature: SignatureParser,
+        signature_extractor: HeaderExtractor,
+        signature_encoding: SignatureEncoding,
         timestamp_verifier: Option<TimestampVerifier>,
         template: &str,
     ) -> anyhow::Result<Self> {
@@ -417,7 +477,8 @@ impl HmacSha256Verifier {
         Ok(Self {
             mac,
             signature_header,
-            parse_signature,
+            signature_extractor,
+            signature_encoding,
             timestamp_verifier,
             template,
         })
@@ -442,17 +503,18 @@ impl WebhookSignatureVerifier for HmacSha256Verifier {
                 )
             })?;
 
-        let sig_bytes = (self.parse_signature)(raw)?;
+        let extracted = (self.signature_extractor)(raw)?;
+        let sig_bytes = self.signature_encoding.decode(&extracted)?;
 
-        let signed = {
-            let timestamp = self
-                .timestamp_verifier
-                .as_ref()
-                .map(|tv| tv.as_bytes(headers))
-                .transpose()?;
-            self.template.render(&body, timestamp)
-        }
-        .with_context(|| "Failed to build the hash value")?;
+        let ts_str = self
+            .timestamp_verifier
+            .as_ref()
+            .map(|tv| tv.value(headers))
+            .transpose()?;
+        let signed = self
+            .template
+            .render(&body, ts_str.as_deref().map(str::as_bytes))
+            .with_context(|| "Failed to build the hash value")?;
 
         let mut mac = self.mac.clone();
         mac.update(&signed);
@@ -490,9 +552,31 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 Ok(Box::new(HmacSha256Verifier::new(
                     &public_key,
                     "x-zm-signature".to_string(),
-                    parser_prefixed("v0=", SignatureEncoding::Hex),
+                    extract_prefixed("v0="),
+                    SignatureEncoding::Hex,
                     Some(timestamp_verifier),
                     "v0:{TIMESTAMP}:{PAYLOAD}",
+                )?))
+            }
+
+            WebhookSignatureConfig::Knock {
+                public_key,
+                max_signature_age,
+            } => {
+                let timestamp_verifier = TimestampVerifier::with_options(
+                    "x-knock-signature".to_string(),
+                    max_signature_age,
+                    extract_regex(r"(?:^|,)t=([^,]+)"),
+                    TimestampUnit::Milliseconds,
+                )?;
+
+                Ok(Box::new(HmacSha256Verifier::new(
+                    &public_key,
+                    "x-knock-signature".to_string(),
+                    extract_regex(r"(?:^|,)s=([^,]+)"),
+                    SignatureEncoding::Base64,
+                    Some(timestamp_verifier),
+                    "{TIMESTAMP}.{PAYLOAD}",
                 )?))
             }
 
@@ -540,7 +624,8 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                     Ok(Box::new(HmacSha256Verifier::new(
                         &public_key,
                         signature_header,
-                        parser_encoded(signature_encoding),
+                        extract_identity(),
+                        signature_encoding,
                         tv,
                         &template,
                     )?))
@@ -1131,7 +1216,8 @@ mod test {
 
     fn make_hmac_verifier(
         with_timestamp: bool,
-        parser: SignatureParser,
+        extractor: HeaderExtractor,
+        encoding: SignatureEncoding,
     ) -> Box<dyn WebhookSignatureVerifier> {
         let (tv, template) = if with_timestamp {
             (
@@ -1148,7 +1234,8 @@ mod test {
             HmacSha256Verifier::new(
                 str::from_utf8(HMAC_SECRET).unwrap(),
                 "X-Signature".to_string(),
-                parser,
+                extractor,
+                encoding,
                 tv,
                 template,
             )
@@ -1173,7 +1260,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(true, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_ref(), body);
@@ -1190,7 +1277,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
         assert_eq!(result.unwrap().as_ref(), body);
@@ -1207,7 +1294,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Base64));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Base64);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
     }
@@ -1223,7 +1310,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_prefixed("v0=", SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_prefixed("v0="), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
     }
@@ -1239,12 +1326,12 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_prefixed("v0=", SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_prefixed("v0="), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
             result.unwrap_err(),
-            @"Signature did not start with expected prefix 'v0='"
+            @"Header value did not start with expected prefix 'v0='"
         );
     }
 
@@ -1260,7 +1347,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1274,7 +1361,7 @@ mod test {
         let body = b"test body content";
         let headers = axum::http::HeaderMap::new();
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1294,7 +1381,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(true, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1313,7 +1400,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1332,7 +1419,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Base64));
+        let verifier = make_hmac_verifier(false, extract_identity(), SignatureEncoding::Base64);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1362,7 +1449,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(true, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1392,7 +1479,7 @@ mod test {
             val
         };
 
-        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let verifier = make_hmac_verifier(true, extract_identity(), SignatureEncoding::Hex);
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_err());
         assert_snapshot!(
@@ -1406,7 +1493,8 @@ mod test {
         let result = HmacSha256Verifier::new(
             str::from_utf8(HMAC_SECRET).unwrap(),
             "X-Signature".to_string(),
-            parser_encoded(SignatureEncoding::Hex),
+            extract_identity(),
+            SignatureEncoding::Hex,
             None,
             "{TIMESTAMP}{PAYLOAD}",
         );
@@ -1423,7 +1511,8 @@ mod test {
         let result = HmacSha256Verifier::new(
             str::from_utf8(HMAC_SECRET).unwrap(),
             "X-Signature".to_string(),
-            parser_encoded(SignatureEncoding::Hex),
+            extract_identity(),
+            SignatureEncoding::Hex,
             Some(tv),
             "{TIMESTAMP}-no-payload",
         );
@@ -1456,6 +1545,73 @@ mod test {
         };
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
+    }
+
+    fn knock_signed_payload(ts: &str, body: &[u8]) -> String {
+        format!("{}.{}", ts, str::from_utf8(body).unwrap())
+    }
+
+    #[test]
+    fn test_knock_config_conversion_and_verifies() {
+        let ts = Utc::now().timestamp_millis().to_string();
+        let body = br#"{"event":"x"}"#;
+        let sig = BASE64_STANDARD.encode(hmac_sign(knock_signed_payload(&ts, body).as_bytes()));
+        let composite = format!("t={},s={}", ts, sig);
+
+        let config = WebhookSignatureConfig::Knock {
+            public_key: str::from_utf8(HMAC_SECRET).unwrap().to_string(),
+            max_signature_age: default_max_signature_age(),
+        };
+        let verifier: Box<dyn WebhookSignatureVerifier> = config.try_into().unwrap();
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("x-knock-signature", composite.parse().unwrap());
+            val
+        };
+        let result = verifier.verify_request(&headers, Bytes::copy_from_slice(body));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_knock_signature_expired_timestamp() {
+        let ts = Utc
+            .with_ymd_and_hms(2000, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp_millis()
+            .to_string();
+        let body = br#"{"event":"x"}"#;
+        let sig = BASE64_STANDARD.encode(hmac_sign(knock_signed_payload(&ts, body).as_bytes()));
+        let composite = format!("t={},s={}", ts, sig);
+
+        let config = WebhookSignatureConfig::Knock {
+            public_key: str::from_utf8(HMAC_SECRET).unwrap().to_string(),
+            max_signature_age: default_max_signature_age(),
+        };
+        let verifier: Box<dyn WebhookSignatureVerifier> = config.try_into().unwrap();
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("x-knock-signature", composite.parse().unwrap());
+            val
+        };
+        let result = verifier.verify_request(&headers, Bytes::copy_from_slice(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature expired. Signed at: 2000-01-01 00:00:00 UTC"
+        );
+    }
+
+    #[test]
+    fn test_extract_regex_no_match() {
+        let extractor = extract_regex(r"(?:^|,)t=([^,]+)");
+        let result = (extractor)("s=abc,other=stuff");
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Regex did not match header value"
+        );
     }
 
     #[test]

--- a/source-http-ingest/src/signature.rs
+++ b/source-http-ingest/src/signature.rs
@@ -5,16 +5,51 @@ use axum::http::HeaderMap;
 use base64::prelude::*;
 use bytes::Bytes;
 use chrono::{DateTime, TimeDelta, Utc};
+use hmac::{Hmac, KeyInit, Mac};
 use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
 use p256::pkcs8::DecodePublicKey;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum SignatureAlgorithm {
     #[serde(rename = "ecdsa")]
     Ecdsa,
+    #[serde(rename = "hmac_sha256")]
+    HmacSha256,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SignatureEncoding {
+    Hex,
+    Base64,
+}
+
+impl Default for SignatureEncoding {
+    fn default() -> Self {
+        Self::Hex
+    }
+}
+
+impl SignatureEncoding {
+    fn decode(&self, s: &str) -> Result<Vec<u8>> {
+        let s = s.trim();
+        match self {
+            Self::Hex => hex::decode(s).context("Failed to hex-decode signature"),
+            Self::Base64 => BASE64_STANDARD
+                .decode(s)
+                .context("Failed to base64-decode signature"),
+        }
+    }
+}
+
+type SignatureParser = Box<dyn Fn(&str) -> Result<Vec<u8>> + Send + Sync>;
+
+fn parser_encoded(encoding: SignatureEncoding) -> SignatureParser {
+    Box::new(move |raw| encoding.decode(raw))
 }
 
 #[derive(Debug, Clone)]
@@ -123,6 +158,8 @@ pub enum WebhookSignatureConfig {
         public_key: String,
         #[serde(rename = "signatureHeader")]
         signature_header: String,
+        #[serde(default, rename = "signatureEncoding")]
+        signature_encoding: SignatureEncoding,
         #[serde(default, rename = "timestampHeader")]
         timestamp_header: Option<String>,
         #[serde(default = "default_max_signature_age", rename = "maxSignatureAge")]
@@ -323,6 +360,114 @@ impl WebhookSignatureVerifier for EcdsaVerifier {
     }
 }
 
+struct HmacSha256Verifier {
+    mac: Hmac<Sha256>,
+    signature_header: String,
+    parse_signature: SignatureParser,
+    timestamp_verifier: Option<TimestampVerifier>,
+    template: SigningStringTemplate,
+}
+
+impl std::fmt::Debug for HmacSha256Verifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HmacSha256Verifier")
+            .field("signature_header", &self.signature_header)
+            .field("timestamp_verifier", &self.timestamp_verifier)
+            .field("template", &self.template)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HmacSha256Verifier {
+    pub fn new(
+        key: &str,
+        signature_header: String,
+        parse_signature: SignatureParser,
+        timestamp_verifier: Option<TimestampVerifier>,
+        template: &str,
+    ) -> anyhow::Result<Self> {
+        if signature_header.trim().is_empty() {
+            anyhow::bail!("Signature header name is required but was empty");
+        }
+
+        let key = key.trim();
+        if key.is_empty() {
+            anyhow::bail!("Secret key is required but was empty");
+        }
+
+        let template: SigningStringTemplate = template.try_into()?;
+
+        if timestamp_verifier.is_none()
+            && template
+                .0
+                .iter()
+                .any(|s| matches!(s, TemplateSegment::Timestamp))
+        {
+            anyhow::bail!(
+                "{{TIMESTAMP}} placeholder was defined in hashed message format \
+                but no timestamp parsing details were included"
+            )
+        }
+
+        let mac: Hmac<Sha256> = Hmac::new_from_slice(key.as_bytes())?;
+
+        Ok(Self {
+            mac,
+            signature_header,
+            parse_signature,
+            timestamp_verifier,
+            template,
+        })
+    }
+}
+
+impl WebhookSignatureVerifier for HmacSha256Verifier {
+    fn verify_request(&self, headers: &HeaderMap, body: Bytes) -> Result<Bytes> {
+        let raw = headers
+            .get(&self.signature_header)
+            .with_context(|| {
+                format!(
+                    "A signature value was expected at header {} but was not found",
+                    self.signature_header,
+                )
+            })?
+            .to_str()
+            .with_context(|| {
+                format!(
+                    "Signature header '{}' is not valid UTF-8",
+                    self.signature_header
+                )
+            })?;
+
+        let sig_bytes = (self.parse_signature)(raw)?;
+
+        let signed = {
+            let timestamp = self
+                .timestamp_verifier
+                .as_ref()
+                .map(|tv| tv.as_bytes(headers))
+                .transpose()?;
+            self.template.render(&body, timestamp)
+        }
+        .with_context(|| "Failed to build the hash value")?;
+
+        let mut mac = self.mac.clone();
+        mac.update(&signed);
+        mac.verify_slice(&sig_bytes).context(
+            "Signature verification failed. Check that the secret key matches your webhook provider's key",
+        )?;
+
+        // Verify timestamp freshness after the cryptographic signature check.
+        // This prevents unauthenticated callers from probing the server's
+        // max-age window via crafted timestamp headers.
+        if let Some(v) = &self.timestamp_verifier {
+            v.verify(headers)?;
+        }
+
+        Ok(body)
+    }
+}
+
 impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
     type Error = anyhow::Error;
 
@@ -352,6 +497,7 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                 algorithm,
                 public_key,
                 signature_header,
+                signature_encoding,
                 timestamp_header,
                 max_signature_age,
                 template,
@@ -363,6 +509,18 @@ impl TryFrom<WebhookSignatureConfig> for Box<dyn WebhookSignatureVerifier> {
                     Ok(Box::new(EcdsaVerifier::new(
                         &public_key,
                         signature_header,
+                        tv,
+                        &template,
+                    )?))
+                }
+                SignatureAlgorithm::HmacSha256 => {
+                    let tv = timestamp_header
+                        .map(|h| TimestampVerifier::new(h, max_signature_age))
+                        .transpose()?;
+                    Ok(Box::new(HmacSha256Verifier::new(
+                        &public_key,
+                        signature_header,
+                        parser_encoded(signature_encoding),
                         tv,
                         &template,
                     )?))
@@ -650,6 +808,7 @@ mod test {
             algorithm: SignatureAlgorithm::Ecdsa,
             public_key: pem_key,
             signature_header: "X-Custom-Sig".to_string(),
+            signature_encoding: SignatureEncoding::default(),
             timestamp_header: Some("X-Custom-Ts".to_string()),
             max_signature_age: default_max_signature_age(),
             template: "{TIMESTAMP}{PAYLOAD}".to_string(),
@@ -940,5 +1099,303 @@ mod test {
 
         let result = verifier.verify_request(&headers, Bytes::from_static(body));
         assert!(result.is_ok());
+    }
+
+    const HMAC_SECRET: &[u8] = b"super-secret-key";
+
+    fn hmac_sign(payload: &[u8]) -> Vec<u8> {
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(HMAC_SECRET).unwrap();
+        mac.update(payload);
+        mac.finalize().into_bytes().to_vec()
+    }
+
+    fn make_hmac_verifier(
+        with_timestamp: bool,
+        parser: SignatureParser,
+    ) -> Box<dyn WebhookSignatureVerifier> {
+        let (tv, template) = if with_timestamp {
+            (
+                Some(
+                    TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age())
+                        .unwrap(),
+                ),
+                "{TIMESTAMP}{PAYLOAD}",
+            )
+        } else {
+            (None, "{PAYLOAD}")
+        };
+        Box::new(
+            HmacSha256Verifier::new(
+                str::from_utf8(HMAC_SECRET).unwrap(),
+                "X-Signature".to_string(),
+                parser,
+                tv,
+                template,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_hmac_signature_valid() {
+        let now = Utc::now().timestamp().to_string();
+        let body = b"test body content";
+
+        let mut signed = Vec::new();
+        signed.extend(now.as_bytes());
+        signed.extend(body);
+        let signature = hex::encode(hmac_sign(&signed));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", now.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_ref(), body);
+    }
+
+    #[test]
+    fn test_hmac_signature_valid_no_timestamp() {
+        let body = b"test body content";
+        let signature = hex::encode(hmac_sign(body));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_ref(), body);
+    }
+
+    #[test]
+    fn test_hmac_signature_valid_base64_encoding() {
+        let body = b"test body content";
+        let signature = BASE64_STANDARD.encode(hmac_sign(body));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Base64));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_hmac_signature_invalid() {
+        let body = b"test body content";
+        let wrong_body = b"different content";
+        let signature = hex::encode(hmac_sign(wrong_body));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature verification failed. Check that the secret key matches your webhook provider's key"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_missing_header() {
+        let body = b"test body content";
+        let headers = axum::http::HeaderMap::new();
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"A signature value was expected at header X-Signature but was not found"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_missing_timestamp() {
+        let body = b"test body content";
+        let signature = hex::encode(hmac_sign(body));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err().to_string(),
+            @"A timestamp was expected at header X-Timestamp but was not found"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_invalid_hex() {
+        let body = b"test body content";
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", "zz-not-hex".parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Failed to hex-decode signature"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_invalid_base64() {
+        let body = b"test body content";
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", "not-valid-base64!!!".parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(false, parser_encoded(SignatureEncoding::Base64));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Failed to base64-decode signature"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_expired_timestamp() {
+        let old_ts = Utc
+            .with_ymd_and_hms(2000, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp()
+            .to_string();
+        let body = b"test body content";
+
+        let mut signed = Vec::new();
+        signed.extend(old_ts.as_bytes());
+        signed.extend(body);
+        let signature = hex::encode(hmac_sign(&signed));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", old_ts.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature expired. Signed at: 2000-01-01 00:00:00 UTC"
+        );
+    }
+
+    #[test]
+    fn test_hmac_signature_future_timestamp() {
+        let future_ts = Utc
+            .with_ymd_and_hms(2099, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp()
+            .to_string();
+        let body = b"test body content";
+
+        let mut signed = Vec::new();
+        signed.extend(future_ts.as_bytes());
+        signed.extend(body);
+        let signature = hex::encode(hmac_sign(&signed));
+
+        let headers = {
+            let mut val = axum::http::HeaderMap::new();
+            val.insert("X-Signature", signature.parse().unwrap());
+            val.insert("X-Timestamp", future_ts.parse().unwrap());
+            val
+        };
+
+        let verifier = make_hmac_verifier(true, parser_encoded(SignatureEncoding::Hex));
+        let result = verifier.verify_request(&headers, Bytes::from_static(body));
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"Signature is in the future. Signed at: 2099-01-01 00:00:00 UTC"
+        );
+    }
+
+    #[test]
+    fn test_hmac_rejects_timestamp_placeholder_without_verifier() {
+        let result = HmacSha256Verifier::new(
+            str::from_utf8(HMAC_SECRET).unwrap(),
+            "X-Signature".to_string(),
+            parser_encoded(SignatureEncoding::Hex),
+            None,
+            "{TIMESTAMP}{PAYLOAD}",
+        );
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @"{TIMESTAMP} placeholder was defined in hashed message format but no timestamp parsing details were included"
+        );
+    }
+
+    #[test]
+    fn test_hmac_rejects_template_without_payload() {
+        let tv = TimestampVerifier::new("X-Timestamp".into(), default_max_signature_age()).unwrap();
+        let result = HmacSha256Verifier::new(
+            str::from_utf8(HMAC_SECRET).unwrap(),
+            "X-Signature".to_string(),
+            parser_encoded(SignatureEncoding::Hex),
+            Some(tv),
+            "{TIMESTAMP}-no-payload",
+        );
+        assert!(result.is_err());
+        assert_snapshot!(
+            result.unwrap_err(),
+            @r#"Hash message format must include at least {PAYLOAD}. Supported placeholders: {PAYLOAD}, {TIMESTAMP}. Ex: "{TIMESTAMP}:{PAYLOAD}""#
+        );
+    }
+
+    #[test]
+    fn test_custom_hmac_config_json_deserialization_base64() {
+        let json = r#"{
+            "provider": "custom",
+            "algorithm": "hmac_sha256",
+            "publicKey": "shhh",
+            "signatureHeader": "X-Sig",
+            "signatureEncoding": "base64",
+            "signingStringTemplate": "{PAYLOAD}"
+        }"#;
+        let config: WebhookSignatureConfig = serde_json::from_str(json).unwrap();
+        match config {
+            WebhookSignatureConfig::Custom {
+                signature_encoding, ..
+            } => {
+                assert_eq!(signature_encoding, SignatureEncoding::Base64);
+            }
+            _ => panic!("expected Custom variant"),
+        }
     }
 }

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -101,6 +101,37 @@ expression: schema
           ]
         },
         {
+          "title": "Zoom",
+          "properties": {
+            "maxSignatureAge": {
+              "title": "Max Signature Age",
+              "description": "Maximum age of a signed request in seconds before it is rejected. Defaults to 300 (5 minutes).",
+              "type": "integer",
+              "default": 300,
+              "maximum": 259200,
+              "minimum": 1,
+              "order": 2
+            },
+            "provider": {
+              "type": "string",
+              "const": "zoom",
+              "default": "zoom",
+              "order": 0
+            },
+            "publicKey": {
+              "title": "Secret Token",
+              "description": "Zoom webhook secret token used as the HMAC-SHA256 key.",
+              "type": "string",
+              "order": 1,
+              "secret": true
+            }
+          },
+          "required": [
+            "provider",
+            "publicKey"
+          ]
+        },
+        {
           "title": "Custom",
           "properties": {
             "algorithm": {

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -132,6 +132,37 @@ expression: schema
           ]
         },
         {
+          "title": "Knock",
+          "properties": {
+            "maxSignatureAge": {
+              "title": "Max Signature Age",
+              "description": "Maximum age of a signed request in seconds before it is rejected. Defaults to 300 (5 minutes).",
+              "type": "integer",
+              "default": 300,
+              "maximum": 259200,
+              "minimum": 1,
+              "order": 2
+            },
+            "provider": {
+              "type": "string",
+              "const": "knock",
+              "default": "knock",
+              "order": 0
+            },
+            "publicKey": {
+              "title": "Signing Key",
+              "description": "Knock webhook signing key used as the HMAC-SHA256 secret.",
+              "type": "string",
+              "order": 1,
+              "secret": true
+            }
+          },
+          "required": [
+            "provider",
+            "publicKey"
+          ]
+        },
+        {
           "title": "Custom",
           "properties": {
             "algorithm": {

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -106,8 +106,9 @@ expression: schema
             "algorithm": {
               "title": "Algorithm",
               "type": "string",
-              "default": "ecdsa",
+              "default": "hmac_sha256",
               "enum": [
+                "hmac_sha256",
                 "ecdsa"
               ],
               "order": 1
@@ -119,7 +120,7 @@ expression: schema
               "default": 300,
               "maximum": 259200,
               "minimum": 1,
-              "order": 6
+              "order": 7
             },
             "provider": {
               "type": "string",
@@ -129,15 +130,26 @@ expression: schema
             },
             "publicKey": {
               "title": "Public Key",
-              "description": "PEM-encoded public key.",
+              "description": "PEM-encoded public key for ECDSA, or shared secret for HMAC.",
               "type": "string",
               "multiline": true,
               "order": 2,
               "secret": true
             },
+            "signatureEncoding": {
+              "title": "Signature Encoding",
+              "description": "Encoding of the signature value in the header. Defaults to hex.",
+              "type": "string",
+              "default": "hex",
+              "enum": [
+                "hex",
+                "base64"
+              ],
+              "order": 4
+            },
             "signatureHeader": {
               "title": "Signature Header",
-              "description": "HTTP header containing the base64-encoded signature.",
+              "description": "HTTP header containing the signature.",
               "type": "string",
               "order": 3
             },
@@ -145,13 +157,13 @@ expression: schema
               "title": "Signing String Template",
               "description": "Template used to construct the string that is signed. Must include {PAYLOAD}, may include {TIMESTAMP}. Example: \"{TIMESTAMP}:{PAYLOAD}\".",
               "type": "string",
-              "order": 4
+              "order": 5
             },
             "timestampHeader": {
               "title": "Timestamp Header",
               "description": "Optional HTTP header containing the timestamp.",
               "type": "string",
-              "order": 5
+              "order": 6
             }
           },
           "required": [

--- a/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
+++ b/source-http-ingest/src/snapshots/source_http_ingest__test__endpoint_config_schema.snap
@@ -119,7 +119,7 @@ expression: schema
               "default": 300,
               "maximum": 259200,
               "minimum": 1,
-              "order": 5
+              "order": 6
             },
             "provider": {
               "type": "string",
@@ -141,18 +141,25 @@ expression: schema
               "type": "string",
               "order": 3
             },
+            "signingStringTemplate": {
+              "title": "Signing String Template",
+              "description": "Template used to construct the string that is signed. Must include {PAYLOAD}, may include {TIMESTAMP}. Example: \"{TIMESTAMP}:{PAYLOAD}\".",
+              "type": "string",
+              "order": 4
+            },
             "timestampHeader": {
               "title": "Timestamp Header",
               "description": "Optional HTTP header containing the timestamp.",
               "type": "string",
-              "order": 4
+              "order": 5
             }
           },
           "required": [
             "provider",
             "algorithm",
             "publicKey",
-            "signatureHeader"
+            "signatureHeader",
+            "signingStringTemplate"
           ]
         }
       ],


### PR DESCRIPTION
**Description:**

Adds support for HMAC SHA-256 signature verifications. This involved implementing several new parameters, like header encodings, signing message templates, and timestamp units.

Parsing signatures for the new Zoom and Knock vendor variants is not as simple as a plain header lookup. The former appends `v0=` to its already encoded values, while the latter packs signatures and timestamps into the same header with parameter. A system of chainable transforms has been put in place to handle such cases, but there are no plans of exposing it to users through endpoint configs for the time being.

Closes #4009

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested using a local stack and a couple of helper scripts:

```bash
#!/usr/bin/env bash
# Exercise the Zoom HMAC-SHA256 signature variant against a running capture.
#
# Usage:
#   SECRET=zoom-test-secret-d4f7a9c2b1e8 URL=http://localhost:8080/webhook-data \
#       ./test_zoom_signatures.sh
#
# Expects an HTTP 200 only on the correctly-signed case. Every other case
# (missing header, wrong secret, tampered body, expired timestamp, bad prefix)
# must be rejected by the connector.
set -uo pipefail

SECRET="${SECRET:-zoom-test-secret-d4f7a9c2b1e8}"

# Flow assigns the connector a fresh ephemeral host port on every restart.
# Discover the current one from docker (via lima) unless URL is set explicitly.
if [[ -z "${URL:-}" ]]; then
    PORT=$(limactl shell tiger -- docker ps \
        --filter "ancestor=ghcr.io/estuary/source-http-ingest:local" \
        --format '{{.Ports}}' \
        | grep -oE '0\.0\.0\.0:[0-9]+->8080/tcp' \
        | head -1 \
        | sed -E 's|.*:([0-9]+)->.*|\1|')
    if [[ -z "$PORT" ]]; then
        echo "Could not discover http-ingest container port. Is the capture running?" >&2
        exit 2
    fi
    URL="http://localhost:$PORT/webhook-data"
    echo "Discovered capture at $URL"
fi

PASS=0
FAIL=0

sign() {
    local ts="$1" body="$2"
    printf "v0:%s:%s" "$ts" "$body" \
        | openssl dgst -sha256 -hmac "$SECRET" -hex \
        | awk '{print $NF}'
}

send() {
    local name="$1" expect="$2" body="$3"
    shift 3
    local -a hdrs=()
    for h in "$@"; do hdrs+=(-H "$h"); done

    local status
    status=$(curl -s -o /dev/null -w "%{http_code}" \
        -X POST -H "Content-Type: application/json" \
        "${hdrs[@]}" -d "$body" "$URL")

    if [[ "$status" == "$expect" ]]; then
        echo "[PASS] $name — got HTTP $status (expected $expect)"
        PASS=$((PASS+1))
    else
        echo "[FAIL] $name — got HTTP $status (expected $expect)"
        FAIL=$((FAIL+1))
    fi
}

TS=$(date +%s)
BODY='{"event":"zoom-test","id":"z1"}'
GOOD_SIG=$(sign "$TS" "$BODY")

# 1. Correctly signed: should be accepted.
send "signed (happy path)" 200 "$BODY" \
    "x-zm-signature: v0=$GOOD_SIG" \
    "x-zm-request-timestamp: $TS"

# 2. No signature header at all.
send "unsigned (no headers)" 401 "$BODY"

# 3. Signature header present, timestamp header missing.
send "missing timestamp header" 401 "$BODY" \
    "x-zm-signature: v0=$GOOD_SIG"

# 4. Wrong secret used to sign.
WRONG_SIG=$(printf "v0:%s:%s" "$TS" "$BODY" \
    | openssl dgst -sha256 -hmac "not-the-real-secret" -hex \
    | awk '{print $NF}')
send "wrong secret" 401 "$BODY" \
    "x-zm-signature: v0=$WRONG_SIG" \
    "x-zm-request-timestamp: $TS"

# 5. Body tampered after signing.
send "tampered body" 401 '{"event":"zoom-test","id":"z1","injected":true}' \
    "x-zm-signature: v0=$GOOD_SIG" \
    "x-zm-request-timestamp: $TS"

# 6. Expired timestamp (well outside default 300s window).
OLD_TS=$(( $(date +%s) - 3600 ))
OLD_SIG=$(sign "$OLD_TS" "$BODY")
send "expired timestamp" 401 "$BODY" \
    "x-zm-signature: v0=$OLD_SIG" \
    "x-zm-request-timestamp: $OLD_TS"

# 7. Missing the "v0=" prefix on the signature.
send "signature missing v0= prefix" 401 "$BODY" \
    "x-zm-signature: $GOOD_SIG" \
    "x-zm-request-timestamp: $TS"

echo
echo "=== $PASS passed, $FAIL failed ==="
exit $FAIL
```

```bash
#!/usr/bin/env bash
# Exercise the Knock HMAC-SHA256 signature variant against a running capture.
#
# Knock signs "<ts_ms>.<body>" with HMAC-SHA256, base64-encodes the result, and
# bundles it with the timestamp in a single header:
#     x-knock-signature: t=<ts_ms>,s=<base64_sig>
#
# Usage:
#   SECRET=knock-test-secret-8b2e6f4a9d31 URL=http://localhost:32788/webhook-data \
#       ./test_knock_signatures.sh
set -uo pipefail

SECRET="${SECRET:-knock-test-secret-8b2e6f4a9d31}"

# Flow assigns the connector a fresh ephemeral host port on every restart.
# Discover the current one from docker (via lima) unless URL is set explicitly.
if [[ -z "${URL:-}" ]]; then
    PORT=$(limactl shell tiger -- docker ps \
        --filter "ancestor=ghcr.io/estuary/source-http-ingest:local" \
        --format '{{.Ports}}' \
        | grep -oE '0\.0\.0\.0:[0-9]+->8080/tcp' \
        | head -1 \
        | sed -E 's|.*:([0-9]+)->.*|\1|')
    if [[ -z "$PORT" ]]; then
        echo "Could not discover http-ingest container port. Is the capture running?" >&2
        exit 2
    fi
    URL="http://localhost:$PORT/webhook-data"
    echo "Discovered capture at $URL"
fi

PASS=0
FAIL=0

sign() {
    local ts_ms="$1" body="$2"
    printf "%s.%s" "$ts_ms" "$body" \
        | openssl dgst -sha256 -hmac "$SECRET" -binary \
        | base64 | tr -d '\n'
}

send() {
    local name="$1" expect="$2" body="$3"
    shift 3
    local -a hdrs=()
    for h in "$@"; do hdrs+=(-H "$h"); done

    local status
    status=$(curl -s -o /dev/null -w "%{http_code}" \
        -X POST -H "Content-Type: application/json" \
        "${hdrs[@]}" -d "$body" "$URL")

    if [[ "$status" == "$expect" ]]; then
        echo "[PASS] $name — got HTTP $status (expected $expect)"
        PASS=$((PASS+1))
    else
        echo "[FAIL] $name — got HTTP $status (expected $expect)"
        FAIL=$((FAIL+1))
    fi
}

TS_MS=$(($(date +%s%N) / 1000000))
BODY='{"event":"knock-test","id":"k1"}'
GOOD_SIG=$(sign "$TS_MS" "$BODY")

# 1. Correctly signed: should be accepted.
send "signed (happy path)" 200 "$BODY" \
    "x-knock-signature: t=$TS_MS,s=$GOOD_SIG"

# 2. No signature header at all.
send "unsigned (no headers)" 401 "$BODY"

# 3. Header present but missing the t= component.
send "missing timestamp component" 401 "$BODY" \
    "x-knock-signature: s=$GOOD_SIG"

# 4. Header present but missing the s= component.
send "missing signature component" 401 "$BODY" \
    "x-knock-signature: t=$TS_MS"

# 5. Wrong secret used to sign.
WRONG_SIG=$(printf "%s.%s" "$TS_MS" "$BODY" \
    | openssl dgst -sha256 -hmac "not-the-real-secret" -binary \
    | base64 | tr -d '\n')
send "wrong secret" 401 "$BODY" \
    "x-knock-signature: t=$TS_MS,s=$WRONG_SIG"

# 6. Body tampered after signing.
send "tampered body" 401 '{"event":"knock-test","id":"k1","injected":true}' \
    "x-knock-signature: t=$TS_MS,s=$GOOD_SIG"

# 7. Expired timestamp (well outside default 300s window).
OLD_TS_MS=$(( $(date +%s%N) / 1000000 - 3600000 ))
OLD_SIG=$(sign "$OLD_TS_MS" "$BODY")
send "expired timestamp" 401 "$BODY" \
    "x-knock-signature: t=$OLD_TS_MS,s=$OLD_SIG"

# 8. Timestamp in seconds instead of milliseconds (still recent, but wrong unit).
TS_SEC=$(date +%s)
SEC_SIG=$(sign "$TS_SEC" "$BODY")
send "timestamp in seconds (wrong unit)" 401 "$BODY" \
    "x-knock-signature: t=$TS_SEC,s=$SEC_SIG"

echo
echo "=== $PASS passed, $FAIL failed ==="
exit $FAIL
```

Best reviewed commit by commit.