### PR TITLE
source-jira-native: support scheduled backfills

### DIFF
--- a/source-jira-native/source_jira_native/__init__.py
+++ b/source-jira-native/source_jira_native/__init__.py
@@ -17,35 +17,35 @@ from .resources import all_resources, validate_credentials, validate_projects
 from .models import (
     ConnectorState,
     EndpointConfig,
-    ResourceConfig,
+    ResourceConfigWithSchedule,
 )
 
 
 class Connector(
-    BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
+    BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
 ):
     def request_class(self):
-        return Request[EndpointConfig, ResourceConfig, ConnectorState]
+        return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]
 
     async def spec(self, log: Logger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=None,
             documentationUrl="https://go.estuary.dev/source-jira-native",
-            resourceConfigSchema=ResourceConfig.model_json_schema(),
-            resourcePathPointers=ResourceConfig.PATH_POINTERS,
+            resourceConfigSchema=ResourceConfigWithSchedule.model_json_schema(),
+            resourcePathPointers=ResourceConfigWithSchedule.PATH_POINTERS,
         )
 
     async def discover(
         self, log: Logger, discover: request.Discover[EndpointConfig]
-    ) -> response.Discovered[ResourceConfig]:
+    ) -> response.Discovered[ResourceConfigWithSchedule]:
         resources = await all_resources(log, self, discover.config, should_fetch_timezone=False, should_check_permissions=True)
         return common.discovered(resources)
 
     async def validate(
         self,
         log: Logger,
-        validate: request.Validate[EndpointConfig, ResourceConfig],
+        validate: request.Validate[EndpointConfig, ResourceConfigWithSchedule],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
         await validate_projects(log, self, validate.config)
@@ -56,7 +56,7 @@ class Connector(
     async def open(
         self,
         log: Logger,
-        open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
+        open: request.Open[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
         resources = await all_resources(log, self, open.capture.config)
         resolved = common.resolve_bindings(open.capture.bindings, resources)

--- a/source-jira-native/source_jira_native/models.py
+++ b/source-jira-native/source_jira_native/models.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Literal, Optional
 from estuary_cdk.capture.common import (
     BasicAuth,
     BaseDocument,
-    ResourceConfig,
+    ResourceConfigWithSchedule,
     ResourceState,
 )
 from estuary_cdk.capture.common import (

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -33,7 +33,7 @@ from .models import (
     MyPermissionsResponse,
     ProjectChildStream,
     Projects,
-    ResourceConfig,
+    ResourceConfigWithSchedule,
     ResourceState,
     ScreenTabFields,
     SprintIssues,
@@ -298,7 +298,7 @@ def full_refresh_resources(
 
     def open(
             stream: type[FullRefreshStream],
-            binding: CaptureBinding[ResourceConfig],
+            binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
             state: ResourceState,
             task: Task,
@@ -323,7 +323,7 @@ def full_refresh_resources(
                 model=FullRefreshResource,
                 open=functools.partial(open, stream),
                 initial_state=ResourceState(),
-                initial_config=ResourceConfig(
+                initial_config=ResourceConfigWithSchedule(
                     name=stream.name, interval=timedelta(minutes=60)
                 ),
                 schema_inference=True,
@@ -339,7 +339,7 @@ def issues(
 ) -> common.Resource:
 
     async def open(
-        binding: CaptureBinding[ResourceConfig],
+        binding: CaptureBinding[ResourceConfigWithSchedule],
         binding_index: int,
         state: ResourceState,
         task: Task,
@@ -388,7 +388,7 @@ def issues(
             },
             backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
         ),
-        initial_config=ResourceConfig(
+        initial_config=ResourceConfigWithSchedule(
             name="issues", interval=timedelta(minutes=5)
         ),
         schema_inference=True,
@@ -402,7 +402,7 @@ def issue_child_resources(
 
     async def open(
         stream: type[IssueChildStream],
-        binding: CaptureBinding[ResourceConfig],
+        binding: CaptureBinding[ResourceConfigWithSchedule],
         binding_index: int,
         state: ResourceState,
         task: Task,
@@ -456,7 +456,7 @@ def issue_child_resources(
                     },
                     backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
                 ),
-                initial_config=ResourceConfig(
+                initial_config=ResourceConfigWithSchedule(
                     name=stream.name, interval=timedelta(minutes=5)
                 ),
                 schema_inference=True,

--- a/source-jira-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-jira-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -94,7 +94,6 @@
     },
     "resourceConfigSchema": {
       "additionalProperties": false,
-      "description": "ResourceConfig is a common resource configuration shape.",
       "properties": {
         "_meta": {
           "anyOf": [
@@ -120,12 +119,19 @@
           "format": "duration",
           "title": "Interval",
           "type": "string"
+        },
+        "schedule": {
+          "default": "",
+          "description": "Schedule to automatically rebackfill this binding. Accepts a cron expression.",
+          "pattern": "^((?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?)(?:,(?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?))*)\\s+((?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?)(?:,(?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?))*)\\s+((?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?)(?:,(?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?))*)\\s+((?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?)(?:,(?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?))*)\\s+((?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?)(?:,(?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?))*)$|^$",
+          "title": "Schedule",
+          "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "title": "ResourceConfig",
+      "title": "ResourceConfigWithSchedule",
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-jira-native",


### PR DESCRIPTION
**Description:**

Some users have expressed interest in scheduling backfills for various resources for `source-jira-native`, mostly for the streams that the connector isn't inferring/capturing deletions for (ex: `issues`, `issue_coments`, etc.). The idea is that the user will be able to infer that any documents _not_ captured since the most recent backfill have been deleted & can be manually marked with `_meta/op = "d"` in their destination.

This commit updates the connector to use `ResourceConfigWithSchedule` to support these uses cases. In the (possibly near?) future, our platform plans on suporting this type of deletion inference & schedule backfills automatically, and using `ResourceConfigWithSchedule` is directionally correct to support that longer term goal.

**Documentation links affected:**

The connector's documentation should be updated to reflect the new `schedule` field on resource configs.