### PR TITLE
materialize-redshift: treat queryid as a reserved word

### DIFF
--- a/materialize-redshift/reserved_words.go
+++ b/materialize-redshift/reserved_words.go
@@ -127,6 +127,7 @@ var REDSHIFT_RESERVED_WORDS = []string{
 	"pivot",
 	"placing",
 	"primary",
+	"queryid",
 	"raw",
 	"readratio",
 	"recover",

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -145,3 +145,23 @@ func TestTruncatedIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentifierer(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier []string
+		expected   string
+	}{
+		{
+			name:       "reserved undocumented",
+			identifier: []string{"queryid"},
+			expected:   `"queryid"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := testDialect.Identifier(tt.identifier...)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
When a query contains `queryid` there is a syntax error:
```
>>> create table howdy(queryid text);
syntax error at or near "queryid" in context "table howdy(queryid"
```

I could not find any documentation indicating that this value is reserved, but when double quoting `queryid` the query succeeds.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

