### PR TITLE
sqlcapture: Periodic progress logging

### DIFF
--- a/source-postgres/diagnostics.go
+++ b/source-postgres/diagnostics.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
+	"github.com/estuary/connectors/sqlcapture"
 	"github.com/jackc/pgx/v5/pgxpool"
 	log "github.com/sirupsen/logrus"
 )
@@ -48,7 +50,43 @@ func (db *postgresDatabase) ReplicationDiagnostics(ctx context.Context) error {
 	}
 	query("SELECT * FROM pg_replication_slots;")
 	query("SELECT CASE WHEN pg_is_in_recovery() THEN pg_last_wal_replay_lsn() ELSE pg_current_wal_flush_lsn() END;")
+	db.reportDiscardedEvents()
 	return nil
+}
+
+// reportDiscardedEvents drains the per-stream discard tally accumulated since the
+// previous call and logs the top N streams by discard count.
+func (db *postgresDatabase) reportDiscardedEvents() {
+	const maxReportedDiscardStreams = 20
+
+	type streamDiscards struct {
+		StreamID sqlcapture.StreamID
+		Count    int64
+	}
+
+	// Drain entries by copying them out under the lock and then clearing the map.
+	db.discardCounts.Lock()
+	var entries = make([]streamDiscards, 0, len(db.discardCounts.byStream))
+	for streamID, count := range db.discardCounts.byStream {
+		entries = append(entries, streamDiscards{StreamID: streamID, Count: count})
+	}
+	clear(db.discardCounts.byStream)
+	db.discardCounts.Unlock()
+
+	if len(entries) == 0 {
+		return
+	}
+	slices.SortFunc(entries, func(a, b streamDiscards) int { return int(b.Count - a.Count) })
+
+	var reported = min(len(entries), maxReportedDiscardStreams)
+	var fields = log.Fields{}
+	for _, e := range entries[:reported] {
+		fields[e.StreamID.String()] = e.Count
+	}
+	if len(entries) > reported {
+		fields["(omitted)"] = len(entries) - reported
+	}
+	log.WithFields(fields).Warn("discarded replication events for inactive tables")
 }
 
 func (db *postgresDatabase) PeriodicChecks(ctx context.Context) error {

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -409,6 +410,12 @@ type postgresDatabase struct {
 	tablesPublished map[sqlcapture.StreamID]bool     // Tracks which tables are part of the configured publication
 
 	tableStatistics map[sqlcapture.StreamID]*postgresTableStatistics // Tracks table statistics for the current connector invocation
+
+	// Counts of replication events discarded because the table isn't currently active.
+	discardCounts struct {
+		sync.Mutex
+		byStream map[sqlcapture.StreamID]int64
+	}
 
 	featureFlags          map[string]bool // Parsed feature flag settings with defaults applied
 	initialBackfillCursor string          // When set, this cursor will be used instead of the current WAL end when a backfill resets the cursor

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -898,6 +898,17 @@ func (s *replicationStream) decodeChangeEvent(
 	}
 	// If this change event is on a table we're not capturing, skip doing any further processing on it.
 	if !active {
+		// Tally the discard so that ReplicationDiagnostics can later surface tables that
+		// we're receiving (and throwing away) significant volumes of replication events on.
+		if streamID, ok := s.streamIDFromRelationID(relID); ok {
+			s.db.discardCounts.Lock()
+			if s.db.discardCounts.byStream == nil {
+				s.db.discardCounts.byStream = make(map[sqlcapture.StreamID]int64)
+			}
+			s.db.discardCounts.byStream[streamID]++
+			s.db.discardCounts.Unlock()
+		}
+
 		// Return a KeepaliveEvent to indicate that we're actively receiving and discarding
 		// change data. This avoids situations where a sufficiently large transaction full
 		// of changes on a not-currently-active table causes the fenced streaming watchdog

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/segmentio/encoding/json"
@@ -172,9 +173,9 @@ type Capture struct {
 }
 
 const (
-	automatedDiagnosticsTimeout = 5 * time.Minute  // How long to wait *after the point where the fence was requested* before triggering automated diagnostics.
-	rediscoverInterval          = 5 * time.Minute  // The capture will re-run discovery and reinitialize missing/pending tables this frequently.
-	periodicChecksInterval      = 10 * time.Minute // The capture may run some database-specific sanity checks periodically at this interval.
+	rediscoverInterval        = 5 * time.Minute  // The capture will re-run discovery and reinitialize missing/pending tables this frequently.
+	periodicChecksInterval    = 10 * time.Minute // The capture may run some database-specific sanity checks periodically at this interval.
+	streamingProgressInterval = 5 * time.Minute  // How often to log progress and diagnostics during a long-running streaming cycle.
 )
 
 var (
@@ -543,38 +544,62 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStream, fenceAfter time.Duration, reportFlush bool) error {
 	log.WithField("fenceAfter", fenceAfter.String()).Debug("streaming to fence")
 
-	// Log a warning and perform replication diagnostics if we don't observe the next fence within a few minutes
-	var diagnosticsTimeout = time.AfterFunc(fenceAfter+automatedDiagnosticsTimeout, func() {
-		log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
-		if err := c.Database.ReplicationDiagnostics(ctx); err != nil {
-			log.WithField("err", err).Error("replication diagnostics error")
+	// Counters and an interval-start timestamp shared between the deferred final
+	// log and the periodic ticker. Each log call swaps the counters back to zero
+	// and resets the interval timer, so reported counts and rates always reflect
+	// the slice of time since the previous log. This keeps long-running cycles
+	// observable without inviting double-counting when reading consecutive lines.
+	var intervalStarted = time.Now()
+	var flushCount atomic.Int64
+	var changeCount atomic.Int64
+	var otherCount atomic.Int64
+	var changeBytes atomic.Int64
+	var logProgress = func(msg string) {
+		var intervalTime = time.Since(intervalStarted)
+		intervalStarted = time.Now()
+		var bytes = changeBytes.Swap(0)
+		var throughputMBps = float64(bytes) / (1000000 * intervalTime.Seconds())
+		log.WithFields(log.Fields{
+			"change":   changeCount.Swap(0),
+			"flush":    flushCount.Swap(0),
+			"other":    otherCount.Swap(0),
+			"duration": intervalTime.String(),
+			"rate":     fmt.Sprintf("%.02f MBps", throughputMBps),
+		}).Info(msg)
+	}
+
+	// Periodically log progress so that we retain some observability even when a
+	// streaming cycle takes much longer than expected. The WaitGroup ensures the
+	// ticker goroutine is no longer running before the deferred final log fires,
+	// so the two callers of logProgress never overlap on the shared interval state.
+	var progressDone = make(chan struct{})
+	var progressWG sync.WaitGroup
+	progressWG.Go(func() {
+		var ticker = time.NewTicker(streamingProgressInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-progressDone:
+				return
+			case <-ticker.C:
+				logProgress("processing replication events")
+				log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
+				if err := c.Database.ReplicationDiagnostics(ctx); err != nil {
+					log.WithField("err", err).Error("replication diagnostics error")
+				}
+			}
 		}
 	})
-	defer diagnosticsTimeout.Stop()
-
-	// When streaming completes (because we've either reached the fence or encountered an error),
-	// log the number of events which have been processed and some other statistics.
-	var streamingStarted = time.Now() // Time at which the current streaming cycle began
-	var flushCount int                // Flush events
-	var changeCount int               // Change events
-	var otherCount int                // All other events
-	var changeBytes int               // Count of change document bytes emitted
 	defer func() {
-		var streamingTime = time.Since(streamingStarted)
-		var throughputMBps = float64(changeBytes) / (1000000 * streamingTime.Seconds())
-		log.WithFields(log.Fields{
-			"change":   changeCount,
-			"flush":    flushCount,
-			"other":    otherCount,
-			"duration": streamingTime.String(),
-			"rate":     fmt.Sprintf("%.02f MBps", throughputMBps),
-		}).Info("processed replication events")
+		close(progressDone)
+		progressWG.Wait()
+		logProgress("processed replication events")
 	}()
 
 	if err := replStream.StreamToFence(ctx, fenceAfter, func(event DatabaseEvent) error {
 		// Commit events update the checkpoint cursor and may trigger a state update.
 		if event, ok := event.(CommitEvent); ok {
-			flushCount++
+			flushCount.Add(1)
 			var cursorJSON, err = event.AppendJSON(nil)
 			if err != nil {
 				return fmt.Errorf("error serializing commit cursor: %w", err)
@@ -591,15 +616,15 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 		// The core event dispatch happens in handleReplicationEvent but it's useful to
 		// count changes separately from other stuff here.
 		if _, ok := event.(ChangeEvent); ok {
-			changeCount++
+			changeCount.Add(1)
 		} else {
-			otherCount++
+			otherCount.Add(1)
 		}
 
 		if size, err := c.handleReplicationEvent(event); err != nil {
 			return err
 		} else {
-			changeBytes += size
+			changeBytes.Add(int64(size))
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
**Description:**

During normal operation we log `processed replication events` every 60 seconds or thereabouts as stream-to-fence cycles complete. But if things go wrong and a large WAL backlog starts to accumulate we just sit there silently, potentially for hours. This is not ideal.

This PR adds an every-5-minutes ticker to drive periodic progress reporting during long-running stream-to-fence cycles. I've also gone ahead and moved the replication diagnostics into that same ticker, since AFAIK there was never any principled reason to only run it once and if streaming takes several hours to finish it would be really nice if we could get updated diagnostics periodically as well.

I've also thrown in another diagnostic logging change for source-postgres to keep a tally of ignored streams for which it's receiving change events, and to log that information as part of replication diagnostics. One way that streaming cycles can get bogged down is if the connector is being spammed with a ton of changes on tables we're not capturing and this can help to surface that information.