### PR TITLE
materialize-iceberg: don't add required columns to existing tables

### DIFF
--- a/materialize-iceberg/.snapshots/TestComputeSchemas
+++ b/materialize-iceberg/.snapshots/TestComputeSchemas
@@ -24,7 +24,7 @@ table {
 	13: new: optional string
 	14: dateToStr_flow_tmp: optional string
 	15: intToDecimal_flow_tmp: optional decimal(38, 0)
-	16: decimalToFloat_flow_tmp: required double
+	16: decimalToFloat_flow_tmp: optional double
 	17: timestampToStr_flow_tmp: optional string
 }
 
@@ -37,6 +37,6 @@ table {
 	13: new: optional string
 	14: dateToStr: optional string
 	15: intToDecimal: optional decimal(38, 0)
-	16: decimalToFloat: required double
+	16: decimalToFloat: optional double
 	17: timestampToStr: optional string
 }

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/writer"
-	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	boilertest "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	"github.com/estuary/connectors/materialize-iceberg/catalog"
 	"github.com/estuary/connectors/materialize-iceberg/python"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/assert"
@@ -169,15 +171,15 @@ func TestIntegration(t *testing.T) {
 	}
 
 	t.Run("materialize", func(t *testing.T) {
-		boilerplate.RunMaterializationTestParallel(t, newMaterialization, materializeSpec, makeResourceFn, actionDescSanitizers)
+		boilertest.RunMaterializationTestParallel(t, newMaterialization, materializeSpec, makeResourceFn, actionDescSanitizers)
 	})
 
 	t.Run("apply", func(t *testing.T) {
-		boilerplate.RunApplyTestParallel(t, &Driver{}, newMaterialization, applySpec, makeResourceFn)
+		boilertest.RunApplyTestParallel(t, &Driver{}, newMaterialization, applySpec, makeResourceFn)
 	})
 
 	t.Run("migrate", func(t *testing.T) {
-		boilerplate.RunMigrationTestParallel(t, newMaterialization, migrateSpec, makeResourceFn, nil)
+		boilertest.RunMigrationTestParallel(t, newMaterialization, migrateSpec, makeResourceFn, nil)
 	})
 
 	t.Run("ts-overflow-regression", func(t *testing.T) {
@@ -478,17 +480,30 @@ func runAddRequiredColumnRegression(t *testing.T) {
 	require.NoError(t, json.Unmarshal(respBody, &result))
 	require.Truef(t, result.Success, "initial merge failed: %s", result.Error)
 
-	// Evolve the schema: add `payload` as required. Mirror the connector's
-	// UpdateResource path - AddSchemaUpdate + SetCurrentSchemaUpdate on the
-	// catalog with an AssertCurrentSchemaID requirement (see driver.go's
-	// UpdateResource and type_mapping.go's computeSchemaForUpdatedTable).
+	// Evolve the schema through the connector's own code path. The
+	// boilerplate hands UpdateResource a BindingUpdate with NewProjections;
+	// the connector calls computeSchemaForUpdatedTable to derive the next
+	// schema and submits it via cat.UpdateTable. Exercising that function
+	// here means the test reflects exactly what the connector emits.
 	tbl, err := cat.GetTable(ctx, ns, tblName)
 	require.NoError(t, err)
 	current := tbl.Metadata.CurrentSchema()
-	schemaV1 := iceberg.NewSchemaWithIdentifiers(current.ID+1, []int{1},
-		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: true},
-		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.PrimitiveTypes.String, Required: true},
-	)
+
+	newPayload := boilerplate.MappedProjection[mapped]{
+		Projection: boilerplate.Projection{
+			Projection: pf.Projection{Field: "payload"},
+			// MustExist=true is the production trigger - the source
+			// collection's required array includes the new field, and its
+			// types doesn't include "null", so MustExist comes back true.
+			MustExist: true,
+		},
+		Mapped: mapped{type_: iceberg.PrimitiveTypes.String, Name: "payload"},
+	}
+	bindingUpdate := boilerplate.BindingUpdate[config, resource, mapped]{
+		NewProjections: []boilerplate.MappedProjection[mapped]{newPayload},
+	}
+	schemaV1 := computeSchemaForUpdatedTable(current.Fields()[len(current.Fields())-1].ID, current, bindingUpdate)
+
 	require.NoError(t, cat.UpdateTable(ctx, ns, tblName,
 		[]catalog.TableRequirement{catalog.AssertCurrentSchemaID(current.ID)},
 		[]catalog.TableUpdate{
@@ -497,9 +512,19 @@ func runAddRequiredColumnRegression(t *testing.T) {
 		},
 	))
 
-	// payloadFieldID is the iceberg field id assigned to the `payload`
-	// column above. Manifest metric maps key off this id.
-	const payloadFieldID = 2
+	// Locate the `payload` field in the schema the connector produced -
+	// the field id is whatever computeSchemaForUpdatedTable assigned, not
+	// a hard-coded 2.
+	var payloadField *iceberg.NestedField
+	for _, f := range schemaV1.Fields() {
+		if f.Name == "payload" {
+			f := f
+			payloadField = &f
+			break
+		}
+	}
+	require.NotNil(t, payloadField, "computeSchemaForUpdatedTable did not produce a payload field")
+	payloadFieldID := payloadField.ID
 
 	// Walk the current snapshot's manifests via the iceberg-go avro
 	// readers, fed directly from the same MinIO that holds the data files.
@@ -552,13 +577,21 @@ func runAddRequiredColumnRegression(t *testing.T) {
 	}
 	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
 
-	t.Logf("manifest metric maps for required payload column added after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
+	t.Logf("computeSchemaForUpdatedTable produced payload: Required=%v (fieldID=%d)", payloadField.Required, payloadFieldID)
+	t.Logf("manifest metric maps for payload column added after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
 		hasValueCount, hasNullCount, hasLowerBound, hasUpperBound)
 
-	// The decisive assertion: a required column with a missing
-	// null_value_counts entry is exactly what Snowflake refuses with errno
-	// 100478. The other maps are logged for diagnostic context.
-	assert.True(t, hasNullCount, "manifest should have null_value_counts for required `payload` column added after data")
+	// Snowflake's errno 100478 fires when a `required` column lacks
+	// null_value_counts in the manifest. If the connector emits the new
+	// field as Optional - the post-fix state - Snowflake doesn't care that
+	// the metric maps are empty for pre-existing data files, because the
+	// column is allowed to be null. The test passes either way provided
+	// the connector never produces the (Required, no-null_value_counts)
+	// combination.
+	if payloadField.Required {
+		assert.True(t, hasNullCount,
+			"a Required column added to an existing table requires null_value_counts in the manifest; the connector should have emitted Optional instead")
+	}
 }
 
 // runDemoteRequiredColumnRegression covers the inverse direction of

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -526,60 +526,8 @@ func runAddRequiredColumnRegression(t *testing.T) {
 	require.NotNil(t, payloadField, "computeSchemaForUpdatedTable did not produce a payload field")
 	payloadFieldID := payloadField.ID
 
-	// Walk the current snapshot's manifests via the iceberg-go avro
-	// readers, fed directly from the same MinIO that holds the data files.
-	tblAfter, err := cat.GetTable(ctx, ns, tblName)
-	require.NoError(t, err)
-	snap := tblAfter.Metadata.CurrentSnapshot()
-	require.NotNilf(t, snap, "no current snapshot for %s.%s", ns, tblName)
-
-	openS3 := func(s3URI string) io.ReadCloser {
-		require.True(t, strings.HasPrefix(s3URI, "s3://warehouse/"),
-			"unexpected s3 uri: %s", s3URI)
-		key := strings.TrimPrefix(s3URI, "s3://warehouse/")
-		out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
-			Bucket: aws.String("warehouse"),
-			Key:    aws.String(key),
-		})
-		require.NoError(t, err)
-		return out.Body
-	}
-
-	mlBody := openS3(snap.ManifestList)
-	defer mlBody.Close()
-	manifests, err := iceberg.ReadManifestList(mlBody)
-	require.NoError(t, err)
-	require.NotEmptyf(t, manifests, "no manifests for %s.%s", ns, tblName)
-
-	hasValueCount, hasNullCount, hasLowerBound, hasUpperBound := true, true, true, true
-	entriesSeen := 0
-	for _, mf := range manifests {
-		mfBody := openS3(mf.FilePath())
-		entries, err := iceberg.ReadManifest(mf, mfBody, true)
-		mfBody.Close()
-		require.NoError(t, err)
-		for _, e := range entries {
-			df := e.DataFile()
-			if _, ok := df.ValueCounts()[payloadFieldID]; !ok {
-				hasValueCount = false
-			}
-			if _, ok := df.NullValueCounts()[payloadFieldID]; !ok {
-				hasNullCount = false
-			}
-			if _, ok := df.LowerBoundValues()[payloadFieldID]; !ok {
-				hasLowerBound = false
-			}
-			if _, ok := df.UpperBoundValues()[payloadFieldID]; !ok {
-				hasUpperBound = false
-			}
-			entriesSeen++
-		}
-	}
-	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
-
 	t.Logf("computeSchemaForUpdatedTable produced payload: Required=%v (fieldID=%d)", payloadField.Required, payloadFieldID)
-	t.Logf("manifest metric maps for payload column added after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
-		hasValueCount, hasNullCount, hasLowerBound, hasUpperBound)
+	maps := inspectIcebergManifest(t, ctx, cat, s3client, ns, tblName, payloadFieldID)
 
 	// Snowflake's errno 100478 fires when a `required` column lacks
 	// null_value_counts in the manifest. If the connector emits the new
@@ -589,7 +537,7 @@ func runAddRequiredColumnRegression(t *testing.T) {
 	// the connector never produces the (Required, no-null_value_counts)
 	// combination.
 	if payloadField.Required {
-		assert.True(t, hasNullCount,
+		assert.True(t, maps.hasNullCount,
 			"a Required column added to an existing table requires null_value_counts in the manifest; the connector should have emitted Optional instead")
 	}
 }
@@ -707,11 +655,89 @@ func runDemoteRequiredColumnRegression(t *testing.T) {
 	))
 
 	const payloadFieldID = 2
+	maps := inspectIcebergManifest(t, ctx, cat, s3client, ns, tblName, payloadFieldID)
 
-	tblAfter, err := cat.GetTable(ctx, ns, tblName)
+	// Demotion mustn't strip per-column metric maps for pre-existing data
+	// files - those data files actually have the values, so the manifest
+	// entries should retain every metric map. If any of these go missing
+	// it implies the demotion path is mutating manifest metadata in
+	// addition to the schema, which would be a regression in its own
+	// right.
+	assert.True(t, maps.hasColumnSize, "manifest should retain column_sizes for payload after demotion to optional")
+	assert.True(t, maps.hasValueCount, "manifest should retain value_counts for payload after demotion to optional")
+	assert.True(t, maps.hasNullCount, "manifest should retain null_value_counts for payload after demotion to optional")
+	assert.True(t, maps.hasLowerBound, "manifest should retain lower_bounds for payload after demotion to optional")
+	assert.True(t, maps.hasUpperBound, "manifest should retain upper_bounds for payload after demotion to optional")
+}
+
+// payloadMetricMaps records which of the five iceberg manifest per-column
+// metric maps carry an entry for a given field id, across every
+// ManifestEntry of the current snapshot.
+type payloadMetricMaps struct {
+	hasColumnSize bool
+	hasValueCount bool
+	hasNullCount  bool
+	hasLowerBound bool
+	hasUpperBound bool
+}
+
+// inspectIcebergManifest walks the table's current snapshot via the
+// iceberg-go avro readers, logs enough table-metadata state to debug a
+// downstream-reader complaint (schemas list, format-version, snapshot's
+// schema_id, all fields' required state), and reports whether each per-column
+// metric map in the manifest's DataFile entries carries an entry for the
+// supplied field id. Snowflake's errno 100478 fires on (current schema says
+// required) + (manifest entry lacks null_value_counts for that field id), so
+// inspecting the iceberg manifest - not the parquet column-chunk Statistics -
+// is the right layer for this regression's assertions.
+func inspectIcebergManifest(
+	t *testing.T,
+	ctx context.Context,
+	cat *catalog.Catalog,
+	s3client *s3.Client,
+	ns, tblName string,
+	fieldID int,
+) payloadMetricMaps {
+	t.Helper()
+
+	tbl, err := cat.GetTable(ctx, ns, tblName)
 	require.NoError(t, err)
-	snap := tblAfter.Metadata.CurrentSnapshot()
+	snap := tbl.Metadata.CurrentSnapshot()
 	require.NotNilf(t, snap, "no current snapshot for %s.%s", ns, tblName)
+
+	// The V2-spec multi-schema mechanism is supposed to mean old data
+	// files survive a schema add: the prior schema stays in
+	// metadata.schemas, and the snapshot keeps its original schema_id -
+	// pointing at the schema its data files were actually written under,
+	// not the current one. On read, a spec-compliant projector resolves
+	// fields by id against the current schema and treats any field id
+	// missing from the data file as null (or default in V3). Pin those
+	// invariants so a regression in the catalog wrapper that drops prior
+	// schemas (or that mutates the snapshot's schema_id on schema add)
+	// would be loud here.
+	require.GreaterOrEqualf(t, len(tbl.Metadata.Schemas()), 2,
+		"schema evolution should retain the previous schema; got %d schemas", len(tbl.Metadata.Schemas()))
+	require.NotNilf(t, snap.SchemaID, "current snapshot should reference a schema id")
+	schemaIDs := make([]int, 0, len(tbl.Metadata.Schemas()))
+	for _, s := range tbl.Metadata.Schemas() {
+		schemaIDs = append(schemaIDs, s.ID)
+	}
+	require.Containsf(t, schemaIDs, *snap.SchemaID,
+		"snapshot's schema_id %d should reference one of the table's schemas %v", *snap.SchemaID, schemaIDs)
+
+	t.Logf("iceberg metadata: format-version=%d schemas=%v current-schema-id=%d last-column-id=%d snapshot-id=%d snapshot-schema-id=%d",
+		tbl.Metadata.Version(),
+		schemaIDs,
+		tbl.Metadata.CurrentSchema().ID,
+		tbl.Metadata.LastColumnID(),
+		snap.SnapshotID,
+		*snap.SchemaID)
+	for _, s := range tbl.Metadata.Schemas() {
+		for _, f := range s.Fields() {
+			t.Logf("  schema %d field %d: name=%s required=%v type=%s",
+				s.ID, f.ID, f.Name, f.Required, f.Type.String())
+		}
+	}
 
 	openS3 := func(s3URI string) io.ReadCloser {
 		require.True(t, strings.HasPrefix(s3URI, "s3://warehouse/"),
@@ -731,7 +757,13 @@ func runDemoteRequiredColumnRegression(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmptyf(t, manifests, "no manifests for %s.%s", ns, tblName)
 
-	hasValueCount, hasNullCount, hasLowerBound, hasUpperBound := true, true, true, true
+	maps := payloadMetricMaps{
+		hasColumnSize: true,
+		hasValueCount: true,
+		hasNullCount:  true,
+		hasLowerBound: true,
+		hasUpperBound: true,
+	}
 	entriesSeen := 0
 	for _, mf := range manifests {
 		mfBody := openS3(mf.FilePath())
@@ -740,34 +772,28 @@ func runDemoteRequiredColumnRegression(t *testing.T) {
 		require.NoError(t, err)
 		for _, e := range entries {
 			df := e.DataFile()
-			if _, ok := df.ValueCounts()[payloadFieldID]; !ok {
-				hasValueCount = false
+			if _, ok := df.ColumnSizes()[fieldID]; !ok {
+				maps.hasColumnSize = false
 			}
-			if _, ok := df.NullValueCounts()[payloadFieldID]; !ok {
-				hasNullCount = false
+			if _, ok := df.ValueCounts()[fieldID]; !ok {
+				maps.hasValueCount = false
 			}
-			if _, ok := df.LowerBoundValues()[payloadFieldID]; !ok {
-				hasLowerBound = false
+			if _, ok := df.NullValueCounts()[fieldID]; !ok {
+				maps.hasNullCount = false
 			}
-			if _, ok := df.UpperBoundValues()[payloadFieldID]; !ok {
-				hasUpperBound = false
+			if _, ok := df.LowerBoundValues()[fieldID]; !ok {
+				maps.hasLowerBound = false
+			}
+			if _, ok := df.UpperBoundValues()[fieldID]; !ok {
+				maps.hasUpperBound = false
 			}
 			entriesSeen++
 		}
 	}
 	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
 
-	t.Logf("manifest metric maps for payload column demoted to optional after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
-		hasValueCount, hasNullCount, hasLowerBound, hasUpperBound)
+	t.Logf("manifest metric maps for field id %d: ColumnSizes=%v ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
+		fieldID, maps.hasColumnSize, maps.hasValueCount, maps.hasNullCount, maps.hasLowerBound, maps.hasUpperBound)
 
-	// Demotion mustn't strip per-column metric maps for pre-existing data
-	// files - those data files actually have the values, so the manifest
-	// entries should retain every metric map. If any of these go missing
-	// it implies the demotion path is mutating manifest metadata in
-	// addition to the schema, which would be a regression in its own
-	// right.
-	assert.True(t, hasValueCount, "manifest should retain value_counts for payload after demotion to optional")
-	assert.True(t, hasNullCount, "manifest should retain null_value_counts for payload after demotion to optional")
-	assert.True(t, hasLowerBound, "manifest should retain lower_bounds for payload after demotion to optional")
-	assert.True(t, hasUpperBound, "manifest should retain upper_bounds for payload after demotion to optional")
+	return maps
 }

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -21,11 +21,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/writer"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	"github.com/estuary/connectors/materialize-iceberg/catalog"
 	"github.com/estuary/connectors/materialize-iceberg/python"
-	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -186,6 +187,10 @@ func TestIntegration(t *testing.T) {
 	t.Run("date-overflow-regression", func(t *testing.T) {
 		runDateOverflowRegression(t)
 	})
+
+	t.Run("add-required-column-regression", func(t *testing.T) {
+		runAddRequiredColumnRegression(t)
+	})
 }
 
 // runTimestampOverflowRegression checks whether a year-10000 timestamp - the
@@ -259,7 +264,7 @@ func runTimestampOverflowRegression(t *testing.T) {
 		}},
 	}
 	body, err := json.Marshal(struct {
-		Action string             `json:"action"`
+		Action string            `json:"action"`
 		Input  python.MergeInput `json:"input"`
 	}{Action: "merge", Input: mergeInput})
 	require.NoError(t, err)
@@ -365,4 +370,189 @@ func runDateOverflowRegression(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(respBody, &result))
 	require.Truef(t, result.Success, "merge failed: %s", result.Error)
+}
+
+// runAddRequiredColumnRegression reproduces the Snowflake-rejection failure
+// mode reported for the `html_body` column: errno 100478, "Invalid parquet
+// file: non-nullable column without default missing data".
+//
+// The trigger is schema evolution, not value size. When the connector adds a
+// projection whose inference says MUST-exist (or it becomes a primary key) to
+// a table that already has data files, `appendProjectionsAsFields` in
+// type_mapping.go writes the new field with `required: true`. Pre-existing
+// data files have no data for the new field id, and the resulting manifest
+// entries have no `null_value_counts` entry for it. Snowflake (and any other
+// reader that refuses to assume "absent ⇒ 0" for a required column) then
+// rejects the table.
+//
+// The test creates a table with `id` only, inserts a row, then evolves the
+// schema by adding `payload` as a required column - the same kind of update
+// `UpdateResource` issues via `catalog.AddSchemaUpdate` + `SetCurrentSchemaUpdate`
+// - and asserts that the manifest entry carries `null_value_counts` for the
+// new field id. Pre-fix the assertion fails because the metric maps for the
+// pre-existing data file have no entry for field id 2.
+func runAddRequiredColumnRegression(t *testing.T) {
+	ctx := context.Background()
+
+	creds, err := readPolarisCreds()
+	require.NoError(t, err)
+	credential := creds.ClientID + ":" + creds.ClientSecret
+	scope := "PRINCIPAL_ROLE:flow_user_role"
+
+	cat, err := catalog.New(ctx, "http://localhost:9802/api/catalog", "quickstart_catalog",
+		catalog.WithClientCredential(credential, "v1/oauth/tokens", &scope))
+	require.NoError(t, err)
+
+	s3client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("flow", "flow", ""),
+		BaseEndpoint: aws.String("http://localhost:9800"),
+		UsePathStyle: true,
+	})
+
+	const (
+		ns      = "add_required_column_regression"
+		tblName = "payload"
+	)
+
+	// Start with id only.
+	schemaV0 := iceberg.NewSchemaWithIdentifiers(0, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	_ = cat.DeleteTable(ctx, ns, tblName)
+	// CreateNamespace is idempotent for our purposes - an "already exists"
+	// just means leftover state from a prior run.
+	_ = cat.CreateNamespace(ctx, ns)
+	require.NoError(t, cat.CreateTable(ctx, ns, tblName, schemaV0, nil, nil, nil))
+	t.Cleanup(func() { _ = cat.DeleteTable(context.Background(), ns, tblName) })
+
+	// Insert a row through the production CSV → Spark merge daemon path, so
+	// the table has a real data file written by Spark (matching what
+	// happens in production before the schema evolves).
+	csvPath := filepath.Join(t.TempDir(), "data.csv.gz")
+	csvFile, err := os.Create(csvPath)
+	require.NoError(t, err)
+	csvw := writer.NewCsvWriter(csvFile, []string{"id"},
+		writer.WithCsvSkipHeaders(), writer.WithCsvQuoteChar('`'))
+	require.NoError(t, csvw.Write([]any{"row1"}))
+	require.NoError(t, csvw.Close())
+	csvBody, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+	csvKey := "staging/add-required-col-" + uuid.New().String() + ".csv.gz"
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("warehouse"),
+		Key:    aws.String(csvKey),
+		Body:   bytes.NewReader(csvBody),
+	})
+	require.NoError(t, err)
+
+	mergeInput := python.MergeInput{
+		Bindings: []python.MergeBinding{{
+			Binding: 0,
+			Query:   fmt.Sprintf("INSERT INTO estuary.%s.%s SELECT id FROM merge_view_0", ns, tblName),
+			Columns: []python.NestedField{{Name: "id", Type: "string"}},
+			Files:   []string{"s3://warehouse/" + csvKey},
+		}},
+	}
+	body, err := json.Marshal(struct {
+		Action string            `json:"action"`
+		Input  python.MergeInput `json:"input"`
+	}{Action: "merge", Input: mergeInput})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://localhost:9806/run", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "daemon response: %s", respBody)
+
+	var result struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	require.Truef(t, result.Success, "initial merge failed: %s", result.Error)
+
+	// Evolve the schema: add `payload` as required. Mirror the connector's
+	// UpdateResource path - AddSchemaUpdate + SetCurrentSchemaUpdate on the
+	// catalog with an AssertCurrentSchemaID requirement (see driver.go's
+	// UpdateResource and type_mapping.go's computeSchemaForUpdatedTable).
+	tbl, err := cat.GetTable(ctx, ns, tblName)
+	require.NoError(t, err)
+	current := tbl.Metadata.CurrentSchema()
+	schemaV1 := iceberg.NewSchemaWithIdentifiers(current.ID+1, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	require.NoError(t, cat.UpdateTable(ctx, ns, tblName,
+		[]catalog.TableRequirement{catalog.AssertCurrentSchemaID(current.ID)},
+		[]catalog.TableUpdate{
+			catalog.AddSchemaUpdate(schemaV1),
+			catalog.SetCurrentSchemaUpdate(schemaV1.ID),
+		},
+	))
+
+	// payloadFieldID is the iceberg field id assigned to the `payload`
+	// column above. Manifest metric maps key off this id.
+	const payloadFieldID = 2
+
+	// Walk the current snapshot's manifests via the iceberg-go avro
+	// readers, fed directly from the same MinIO that holds the data files.
+	tblAfter, err := cat.GetTable(ctx, ns, tblName)
+	require.NoError(t, err)
+	snap := tblAfter.Metadata.CurrentSnapshot()
+	require.NotNilf(t, snap, "no current snapshot for %s.%s", ns, tblName)
+
+	openS3 := func(s3URI string) io.ReadCloser {
+		require.True(t, strings.HasPrefix(s3URI, "s3://warehouse/"),
+			"unexpected s3 uri: %s", s3URI)
+		key := strings.TrimPrefix(s3URI, "s3://warehouse/")
+		out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String("warehouse"),
+			Key:    aws.String(key),
+		})
+		require.NoError(t, err)
+		return out.Body
+	}
+
+	mlBody := openS3(snap.ManifestList)
+	defer mlBody.Close()
+	manifests, err := iceberg.ReadManifestList(mlBody)
+	require.NoError(t, err)
+	require.NotEmptyf(t, manifests, "no manifests for %s.%s", ns, tblName)
+
+	hasValueCount, hasNullCount, hasLowerBound, hasUpperBound := true, true, true, true
+	entriesSeen := 0
+	for _, mf := range manifests {
+		mfBody := openS3(mf.FilePath())
+		entries, err := iceberg.ReadManifest(mf, mfBody, true)
+		mfBody.Close()
+		require.NoError(t, err)
+		for _, e := range entries {
+			df := e.DataFile()
+			if _, ok := df.ValueCounts()[payloadFieldID]; !ok {
+				hasValueCount = false
+			}
+			if _, ok := df.NullValueCounts()[payloadFieldID]; !ok {
+				hasNullCount = false
+			}
+			if _, ok := df.LowerBoundValues()[payloadFieldID]; !ok {
+				hasLowerBound = false
+			}
+			if _, ok := df.UpperBoundValues()[payloadFieldID]; !ok {
+				hasUpperBound = false
+			}
+			entriesSeen++
+		}
+	}
+	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
+
+	t.Logf("manifest metric maps for required payload column added after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
+		hasValueCount, hasNullCount, hasLowerBound, hasUpperBound)
+
+	// The decisive assertion: a required column with a missing
+	// null_value_counts entry is exactly what Snowflake refuses with errno
+	// 100478. The other maps are logged for diagnostic context.
+	assert.True(t, hasNullCount, "manifest should have null_value_counts for required `payload` column added after data")
 }

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -191,6 +191,10 @@ func TestIntegration(t *testing.T) {
 	t.Run("add-required-column-regression", func(t *testing.T) {
 		runAddRequiredColumnRegression(t)
 	})
+
+	t.Run("demote-required-column-regression", func(t *testing.T) {
+		runDemoteRequiredColumnRegression(t)
+	})
 }
 
 // runTimestampOverflowRegression checks whether a year-10000 timestamp - the
@@ -555,4 +559,182 @@ func runAddRequiredColumnRegression(t *testing.T) {
 	// null_value_counts entry is exactly what Snowflake refuses with errno
 	// 100478. The other maps are logged for diagnostic context.
 	assert.True(t, hasNullCount, "manifest should have null_value_counts for required `payload` column added after data")
+}
+
+// runDemoteRequiredColumnRegression covers the inverse direction of
+// runAddRequiredColumnRegression: a column that was MUST-exist when the table
+// was created later has its inference relax (a document arrives without it,
+// or the inferred-schema engine demotes it). This flows through the
+// boilerplate's `NewlyNullableFields` path, and `computeSchemaForUpdatedTable`
+// in type_mapping.go flips the existing field's `required` to false before
+// issuing `AddSchemaUpdate` + `SetCurrentSchemaUpdate`. The expected outcome
+// is benign: the parquet for the pre-demotion data file is unchanged, so its
+// manifest entry still carries every metric map for `payload`. This test
+// pins that expectation so a future change to the demotion path can't
+// regress the per-column metric maps for pre-existing data.
+func runDemoteRequiredColumnRegression(t *testing.T) {
+	ctx := context.Background()
+
+	creds, err := readPolarisCreds()
+	require.NoError(t, err)
+	credential := creds.ClientID + ":" + creds.ClientSecret
+	scope := "PRINCIPAL_ROLE:flow_user_role"
+
+	cat, err := catalog.New(ctx, "http://localhost:9802/api/catalog", "quickstart_catalog",
+		catalog.WithClientCredential(credential, "v1/oauth/tokens", &scope))
+	require.NoError(t, err)
+
+	s3client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("flow", "flow", ""),
+		BaseEndpoint: aws.String("http://localhost:9800"),
+		UsePathStyle: true,
+	})
+
+	const (
+		ns      = "demote_required_column_regression"
+		tblName = "payload"
+	)
+
+	// Start with `payload` required - mirrors a table created when
+	// inference said the field is MUST-exist.
+	schemaV0 := iceberg.NewSchemaWithIdentifiers(0, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.PrimitiveTypes.String, Required: true},
+	)
+	_ = cat.DeleteTable(ctx, ns, tblName)
+	_ = cat.CreateNamespace(ctx, ns)
+	require.NoError(t, cat.CreateTable(ctx, ns, tblName, schemaV0, nil, nil, nil))
+	t.Cleanup(func() { _ = cat.DeleteTable(context.Background(), ns, tblName) })
+
+	// Insert one row with both columns populated through the production
+	// CSV → Spark merge daemon path.
+	csvPath := filepath.Join(t.TempDir(), "data.csv.gz")
+	csvFile, err := os.Create(csvPath)
+	require.NoError(t, err)
+	csvw := writer.NewCsvWriter(csvFile, []string{"id", "payload"},
+		writer.WithCsvSkipHeaders(), writer.WithCsvQuoteChar('`'))
+	require.NoError(t, csvw.Write([]any{"row1", "hello"}))
+	require.NoError(t, csvw.Close())
+	csvBody, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+	csvKey := "staging/demote-required-col-" + uuid.New().String() + ".csv.gz"
+	_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("warehouse"),
+		Key:    aws.String(csvKey),
+		Body:   bytes.NewReader(csvBody),
+	})
+	require.NoError(t, err)
+
+	mergeInput := python.MergeInput{
+		Bindings: []python.MergeBinding{{
+			Binding: 0,
+			Query:   fmt.Sprintf("INSERT INTO estuary.%s.%s SELECT id, payload FROM merge_view_0", ns, tblName),
+			Columns: []python.NestedField{{Name: "id", Type: "string"}, {Name: "payload", Type: "string"}},
+			Files:   []string{"s3://warehouse/" + csvKey},
+		}},
+	}
+	body, err := json.Marshal(struct {
+		Action string            `json:"action"`
+		Input  python.MergeInput `json:"input"`
+	}{Action: "merge", Input: mergeInput})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://localhost:9806/run", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "daemon response: %s", respBody)
+
+	var result struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	require.Truef(t, result.Success, "initial merge failed: %s", result.Error)
+
+	// Evolve the schema by demoting `payload` to optional. Mirrors what
+	// `computeSchemaForUpdatedTable` does when boilerplate hands it a
+	// `NewlyNullableFields` entry: keep every existing field as-is but flip
+	// the matching field's `required` to false.
+	tbl, err := cat.GetTable(ctx, ns, tblName)
+	require.NoError(t, err)
+	current := tbl.Metadata.CurrentSchema()
+	schemaV1 := iceberg.NewSchemaWithIdentifiers(current.ID+1, []int{1},
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.String, Required: true},
+		iceberg.NestedField{ID: 2, Name: "payload", Type: iceberg.PrimitiveTypes.String, Required: false},
+	)
+	require.NoError(t, cat.UpdateTable(ctx, ns, tblName,
+		[]catalog.TableRequirement{catalog.AssertCurrentSchemaID(current.ID)},
+		[]catalog.TableUpdate{
+			catalog.AddSchemaUpdate(schemaV1),
+			catalog.SetCurrentSchemaUpdate(schemaV1.ID),
+		},
+	))
+
+	const payloadFieldID = 2
+
+	tblAfter, err := cat.GetTable(ctx, ns, tblName)
+	require.NoError(t, err)
+	snap := tblAfter.Metadata.CurrentSnapshot()
+	require.NotNilf(t, snap, "no current snapshot for %s.%s", ns, tblName)
+
+	openS3 := func(s3URI string) io.ReadCloser {
+		require.True(t, strings.HasPrefix(s3URI, "s3://warehouse/"),
+			"unexpected s3 uri: %s", s3URI)
+		key := strings.TrimPrefix(s3URI, "s3://warehouse/")
+		out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String("warehouse"),
+			Key:    aws.String(key),
+		})
+		require.NoError(t, err)
+		return out.Body
+	}
+
+	mlBody := openS3(snap.ManifestList)
+	defer mlBody.Close()
+	manifests, err := iceberg.ReadManifestList(mlBody)
+	require.NoError(t, err)
+	require.NotEmptyf(t, manifests, "no manifests for %s.%s", ns, tblName)
+
+	hasValueCount, hasNullCount, hasLowerBound, hasUpperBound := true, true, true, true
+	entriesSeen := 0
+	for _, mf := range manifests {
+		mfBody := openS3(mf.FilePath())
+		entries, err := iceberg.ReadManifest(mf, mfBody, true)
+		mfBody.Close()
+		require.NoError(t, err)
+		for _, e := range entries {
+			df := e.DataFile()
+			if _, ok := df.ValueCounts()[payloadFieldID]; !ok {
+				hasValueCount = false
+			}
+			if _, ok := df.NullValueCounts()[payloadFieldID]; !ok {
+				hasNullCount = false
+			}
+			if _, ok := df.LowerBoundValues()[payloadFieldID]; !ok {
+				hasLowerBound = false
+			}
+			if _, ok := df.UpperBoundValues()[payloadFieldID]; !ok {
+				hasUpperBound = false
+			}
+			entriesSeen++
+		}
+	}
+	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
+
+	t.Logf("manifest metric maps for payload column demoted to optional after data: ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
+		hasValueCount, hasNullCount, hasLowerBound, hasUpperBound)
+
+	// Demotion mustn't strip per-column metric maps for pre-existing data
+	// files - those data files actually have the values, so the manifest
+	// entries should retain every metric map. If any of these go missing
+	// it implies the demotion path is mutating manifest metadata in
+	// addition to the schema, which would be a regression in its own
+	// right.
+	assert.True(t, hasValueCount, "manifest should retain value_counts for payload after demotion to optional")
+	assert.True(t, hasNullCount, "manifest should retain null_value_counts for payload after demotion to optional")
+	assert.True(t, hasLowerBound, "manifest should retain lower_bounds for payload after demotion to optional")
+	assert.True(t, hasUpperBound, "manifest should retain upper_bounds for payload after demotion to optional")
 }

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/iceberg-go"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -668,17 +669,45 @@ func runDemoteRequiredColumnRegression(t *testing.T) {
 	assert.True(t, maps.hasNullCount, "manifest should retain null_value_counts for payload after demotion to optional")
 	assert.True(t, maps.hasLowerBound, "manifest should retain lower_bounds for payload after demotion to optional")
 	assert.True(t, maps.hasUpperBound, "manifest should retain upper_bounds for payload after demotion to optional")
+
+	// Parquet layer: the data file was written with payload populated, so
+	// every row group's column chunk should carry both null_count and
+	// min/max statistics. Demoting the iceberg field's required flag
+	// mustn't touch the parquet metadata at all.
+	require.Positivef(t, maps.parquetRowGroups, "no parquet row groups inspected for %s.%s", ns, tblName)
+	assert.Equal(t, maps.parquetRowGroups, maps.parquetRowGroupsWithColumn,
+		"every row group should contain the payload column in parquet")
+	assert.Equal(t, maps.parquetRowGroups, maps.parquetRowGroupsWithNullCount,
+		"every row group's payload column chunk should record null_count in parquet")
+	assert.Equal(t, maps.parquetRowGroups, maps.parquetRowGroupsWithMinMax,
+		"every row group's payload column chunk should record min/max in parquet")
 }
 
-// payloadMetricMaps records which of the five iceberg manifest per-column
-// metric maps carry an entry for a given field id, across every
-// ManifestEntry of the current snapshot.
+// payloadMetricMaps records two distinct layers of "did the writer record
+// stats for this column?" state. Snowflake's errno 100478 has historically
+// been described as a manifest-level check, but the parquet column chunk
+// statistics live in their own structure - the parquet footer - and can in
+// principle diverge from the iceberg manifest (iceberg's metrics-mode and
+// metrics-column-cap properties can drop manifest entries even when parquet
+// kept them; in the reverse direction, parquet truncating its Statistics on
+// wide values can drop parquet entries while iceberg's manifest separately
+// carries null_value_counts). Track both so a regression in either layer is
+// visible.
 type payloadMetricMaps struct {
+	// Iceberg manifest layer: presence flags for the DataFile per-column
+	// metric maps, keyed by iceberg field id, across every ManifestEntry.
 	hasColumnSize bool
 	hasValueCount bool
 	hasNullCount  bool
 	hasLowerBound bool
 	hasUpperBound bool
+
+	// Parquet layer: aggregated across every row group of every data file
+	// the manifest references.
+	parquetRowGroups              int
+	parquetRowGroupsWithColumn    int
+	parquetRowGroupsWithNullCount int
+	parquetRowGroupsWithMinMax    int
 }
 
 // inspectIcebergManifest walks the table's current snapshot via the
@@ -751,6 +780,16 @@ func inspectIcebergManifest(
 		return out.Body
 	}
 
+	// Look up the iceberg field name so we can match by name against
+	// parquet schema columns. (Parquet field-id metadata exists too, but
+	// the connector writes column names matching the iceberg field name,
+	// and name lookup keeps the test independent of iceberg-go's parquet
+	// schema-id annotation behavior.)
+	var fieldName string
+	if f, ok := tbl.Metadata.CurrentSchema().FindFieldByID(fieldID); ok {
+		fieldName = f.Name
+	}
+
 	mlBody := openS3(snap.ManifestList)
 	defer mlBody.Close()
 	manifests, err := iceberg.ReadManifestList(mlBody)
@@ -772,6 +811,8 @@ func inspectIcebergManifest(
 		require.NoError(t, err)
 		for _, e := range entries {
 			df := e.DataFile()
+
+			// Iceberg manifest layer.
 			if _, ok := df.ColumnSizes()[fieldID]; !ok {
 				maps.hasColumnSize = false
 			}
@@ -788,12 +829,79 @@ func inspectIcebergManifest(
 				maps.hasUpperBound = false
 			}
 			entriesSeen++
+
+			// Parquet layer.
+			inspectParquetColumn(t, ctx, s3client, df.FilePath(), fieldName, &maps)
 		}
 	}
 	require.NotZerof(t, entriesSeen, "no manifest entries for %s.%s", ns, tblName)
 
-	t.Logf("manifest metric maps for field id %d: ColumnSizes=%v ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
-		fieldID, maps.hasColumnSize, maps.hasValueCount, maps.hasNullCount, maps.hasLowerBound, maps.hasUpperBound)
+	t.Logf("manifest metric maps for field id %d (%q): ColumnSizes=%v ValueCounts=%v NullValueCounts=%v LowerBounds=%v UpperBounds=%v",
+		fieldID, fieldName, maps.hasColumnSize, maps.hasValueCount, maps.hasNullCount, maps.hasLowerBound, maps.hasUpperBound)
+	t.Logf("parquet column %q stats across all data files: row_groups=%d with_column=%d with_null_count=%d with_min_max=%d",
+		fieldName, maps.parquetRowGroups, maps.parquetRowGroupsWithColumn, maps.parquetRowGroupsWithNullCount, maps.parquetRowGroupsWithMinMax)
 
 	return maps
+}
+
+// inspectParquetColumn downloads a single data file from S3 and tallies, per
+// row group, whether the named column appears and whether its column-chunk
+// Statistics record HasMinMax and HasNullCount. Counters accumulate into the
+// caller's maps so a multi-data-file walk can summarize the whole snapshot.
+func inspectParquetColumn(
+	t *testing.T,
+	ctx context.Context,
+	s3client *s3.Client,
+	s3URI, columnName string,
+	maps *payloadMetricMaps,
+) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(s3URI, "s3://warehouse/"),
+		"unexpected s3 uri: %s", s3URI)
+	key := strings.TrimPrefix(s3URI, "s3://warehouse/")
+	out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String("warehouse"),
+		Key:    aws.String(key),
+	})
+	require.NoError(t, err)
+	defer out.Body.Close()
+
+	local := filepath.Join(t.TempDir(), filepath.Base(key))
+	f, err := os.Create(local)
+	require.NoError(t, err)
+	if _, err := io.Copy(f, out.Body); err != nil {
+		f.Close()
+		require.NoError(t, err)
+	}
+	f.Close()
+
+	pf, err := file.OpenParquetFile(local, false)
+	require.NoError(t, err)
+	defer pf.Close()
+
+	colIdx := -1
+	for i := 0; i < pf.MetaData().Schema.NumColumns(); i++ {
+		if pf.MetaData().Schema.Column(i).Name() == columnName {
+			colIdx = i
+			break
+		}
+	}
+
+	for rg := 0; rg < pf.NumRowGroups(); rg++ {
+		maps.parquetRowGroups++
+		if colIdx == -1 {
+			continue
+		}
+		maps.parquetRowGroupsWithColumn++
+		cc, err := pf.MetaData().RowGroup(rg).ColumnChunk(colIdx)
+		require.NoError(t, err)
+		stats, err := cc.Statistics()
+		require.NoError(t, err)
+		if stats != nil && stats.HasNullCount() {
+			maps.parquetRowGroupsWithNullCount++
+		}
+		if stats != nil && stats.HasMinMax() {
+			maps.parquetRowGroupsWithMinMax++
+		}
+	}
 }

--- a/materialize-iceberg/type_mapping.go
+++ b/materialize-iceberg/type_mapping.go
@@ -183,8 +183,22 @@ func computeSchemaForUpdatedTable(
 		tempMigrateProjections = append(tempMigrateProjections, temp)
 	}
 
+	firstNewFieldIdx := len(nextFields)
 	_, lastId := appendProjectionsAsFields(&nextFields, update.NewProjections, currentHighestID)
 	appendProjectionsAsFields(&nextFields, tempMigrateProjections, lastId)
+
+	// Iceberg's spec requires an `initial-default` for a `required` column
+	// added to an existing table, and the connector doesn't supply one. A
+	// strict reader (Snowflake errno 100478 - "non-nullable column without
+	// default missing data") refuses such tables because the manifest
+	// entries for pre-existing data files carry no value_counts /
+	// null_value_counts for the new field id. Force every newly-appended
+	// field to optional regardless of `MustExist`. The same applies to the
+	// migration dance's temporary columns - they are added against
+	// existing data files that have nothing for them.
+	for i := firstNewFieldIdx; i < len(nextFields); i++ {
+		nextFields[i].Required = false
+	}
 
 	return iceberg.NewSchemaWithIdentifiers(current.ID+1, current.IdentifierFieldIDs, nextFields...)
 }


### PR DESCRIPTION
**Description:**

Fixes Snowflake's `errno=100478, "non-nullable column without default missing data"` on iceberg materializations whose source collection inferred a new MUST-exist field (e.g. `html_body`) after the destination already had data.

`computeSchemaForUpdatedTable` writes new fields with `Required: p.MustExist || p.IsPrimaryKey`. Pre-existing data files have no data for the new field id, so their manifest entries have no `null_value_counts` for it. Spark/pyiceberg fill the missing id with null on read; Snowflake refuses. The fix forces `Required: false` on every field appended by `computeSchemaForUpdatedTable` (both `NewProjections` and `tempMigrateProjections`).

**Workflow steps:**

No user-visible change. Inferred-MUST fields added by schema evolution now land as `optional`. Fields added at table-creation time still take `required` from `MustExist`. Bump the binding's `backfill` counter to recreate the table if `required` is desired post-evolution.

**Documentation links affected:**

None.

**Notes for reviewers:**

Test-before-fix per the TDD convention:
- `2d05b953f` - failing regression for the add-required-column case
- `c5c9355a9` - demote direction passes, confirming `NewlyNullableFields` is safe
- `39e0fd441` - refactors the add-test to drive `computeSchemaForUpdatedTable` directly
- `434daf0ca` - fix + `TestComputeSchemas` snapshot update (migration temp columns now optional too)

Reproducer: `TestIntegration/add-required-column-regression`. Asserts conditionally - if the connector emits the field as `required`, the manifest must carry `null_value_counts` for it; post-fix the field is `optional` and the assertion is vacuously satisfied.