### PR TITLE
source-facebook-marketing-native: bump API version to v25

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-API_VERSION = "v23.0"
+API_VERSION = "v25.0"
 BASE_URL = f"https://graph.facebook.com/{API_VERSION}"
 
 

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
@@ -672,14 +672,20 @@ class FacebookInsightsJobManager:
                     return
 
                 elif status.async_status == AsyncJobStatus.JOB_FAILED:
-                    error_msg = f"{desc}: job failed at {status.async_percent_completion}% (job_id={job_id})"
+                    parts = [f"{desc}: job failed at {status.async_percent_completion}% (job_id={job_id})"]
+                    if status.error_user_title:
+                        parts.append(f"reason: {status.error_user_title}")
+                    if status.error_user_msg:
+                        parts.append(status.error_user_msg)
+                    error_msg = " — ".join(parts)
                     log.error(error_msg)
 
                     raise FacebookAPIError(
                         error=FacebookError(
                             message=error_msg,
                             type=InternalJobErrorType.JOB_FAILURE,
-                            code=100,
+                            code=status.error_code or 100,
+                            error_subcode=status.error_subcode,
                         )
                     )
 

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
@@ -186,6 +186,10 @@ class AsyncJobStatusResponse(BaseModel):
     async_status: AsyncJobStatus
     async_percent_completion: int
     error: FacebookError | None = None
+    error_code: int | None = None
+    error_subcode: int | None = None
+    error_user_title: str | None = None
+    error_user_msg: str | None = None
 
     model_config = ConfigDict(extra="allow")
 

--- a/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__spec__capture.stdout.json
@@ -249,8 +249,8 @@
     "documentationUrl": "https://go.estuary.dev/source-facebook-marketing-native",
     "oauth2": {
       "provider": "facebook",
-      "authUrlTemplate": "https://www.facebook.com/v23.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management&state={{#urlencode}}{{{  state }}}{{/urlencode}}",
-      "accessTokenUrlTemplate": "https://graph.facebook.com/v23.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
+      "authUrlTemplate": "https://www.facebook.com/v25.0/dialog/oauth?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&scope=ads_management,ads_read,read_insights,business_management&state={{#urlencode}}{{{  state }}}{{/urlencode}}",
+      "accessTokenUrlTemplate": "https://graph.facebook.com/v25.0/oauth/access_token?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
       "accessTokenResponseMap": {
         "access_token": "/access_token"
       }


### PR DESCRIPTION
**Description:**

Bumps the connector's API version from v23, which reaches EOL June 9th, to v25.

No breaking changes have been observed:

### v24

Only affects a `destination_spec` field in [website destination optimisations](https://www.facebook.com/business/help/1261275665394096?ref=search_new_1) we do not use.

[Reference](https://developers.facebook.com/blog/post/2025/10/08/introducing-graph-api-v24-and-marketing-api-v24/)

### v25

No breaking changes for GET endpoints. A set of top-level error fields have been added to async report job failures. It is understood that the existing `error` object is preserved for failure scenarios where the requester is at fault.

[Reference](https://developers.facebook.com/documentation/ads-commerce/marketing-api/marketing-api-changelog/version25.0)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

