### PR TITLE
materialize-boilerplate: enforce root document location for new bindings over existing tables

### DIFF
--- a/materialize-boilerplate/.snapshots/TestValidate
+++ b/materialize-boilerplate/.snapshots/TestValidate
@@ -125,7 +125,7 @@ increment backfill counter for disabled -> enabled binding:
 
 table already exists with identical spec:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document is required for a standard updates materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
@@ -138,7 +138,7 @@ table already exists with identical spec:
 
 table already exists with incompatible proposed spec:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document is required for a standard updates materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -205,7 +205,25 @@ func (v Validator) validateMatchesExistingResource(
 			// Only the originally selected root document projection is allowed to be selected for
 			// changes to a standard updates materialization. If there is no previously persisted
 			// spec, the first root document projection is selected as the root document.
-			if (lastBinding != nil && p.Field == lastBinding.FieldSelection.Document) || (lastBinding == nil && len(docFields) == 1) {
+			if lastBinding == nil && len(docFields) == 1 {
+				// New binding adopted via `allow_existing_tables_for_new_bindings`. Emit
+				// LOCATION_REQUIRED so the control plane can enforce the root document slot
+				// (proto-flow/src/materialize.rs:359-364). Returning INCOMPATIBLE here when
+				// the existing column type doesn't match would silently drop in the
+				// no-live-spec path (validation/src/field_selection.rs:269-287), letting the
+				// user publish with no document column and INSERT-only data corruption.
+				//
+				// A document-column type mismatch is not surfaced at validate time anymore
+				// in this case; the connector's Apply / runtime path will surface it instead.
+				// See materializer.go:654-657 — that loop does not check the Document column,
+				// so users with an incompatible flow_document column will see a runtime
+				// error rather than a publish-time one. A follow-up should extend the Apply
+				// check to also validate the document column.
+				c = &pm.Response_Validated_Constraint{
+					Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
+					Reason: "The root document is required for a standard updates materialization",
+				}
+			} else if lastBinding != nil && p.Field == lastBinding.FieldSelection.Document {
 				c = &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "This field is the document in the current materialization",

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -206,19 +206,16 @@ func (v Validator) validateMatchesExistingResource(
 			// changes to a standard updates materialization. If there is no previously persisted
 			// spec, the first root document projection is selected as the root document.
 			if lastBinding == nil && len(docFields) == 1 {
-				// New binding adopted via `allow_existing_tables_for_new_bindings`. Emit
-				// LOCATION_REQUIRED so the control plane can enforce the root document slot
-				// (proto-flow/src/materialize.rs:359-364). Returning INCOMPATIBLE here when
-				// the existing column type doesn't match would silently drop in the
-				// no-live-spec path (validation/src/field_selection.rs:269-287), letting the
-				// user publish with no document column and INSERT-only data corruption.
+				// New binding adopted via `allow_existing_tables_for_new_bindings`. A
+				// connector storing the document as a single column must emit
+				// LOCATION_REQUIRED on the root JSON pointer so the control plane keeps
+				// the slot filled; bare INCOMPATIBLE is silently dropped without a live
+				// spec, letting the user publish with no document column and degenerate
+				// to INSERT-only corruption.
 				//
-				// A document-column type mismatch is not surfaced at validate time anymore
-				// in this case; the connector's Apply / runtime path will surface it instead.
-				// See materializer.go:654-657 — that loop does not check the Document column,
-				// so users with an incompatible flow_document column will see a runtime
-				// error rather than a publish-time one. A follow-up should extend the Apply
-				// check to also validate the document column.
+				// A type mismatch on the existing document column is not caught here;
+				// the Apply-time compatibility loop only iterates Values. A follow-up
+				// should extend Apply to validate the Document column too.
 				c = &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
 					Reason: "The root document is required for a standard updates materialization",

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -187,6 +187,13 @@ func (v Validator) validateMatchesExistingResource(
 	constraints := make(map[string]*pm.Response_Validated_Constraint)
 
 	docFields := []string{}
+	// For a new binding adopted via `allow_existing_tables_for_new_bindings`,
+	// tracks the first root document projection whose existing destination column
+	// (if any) is type-compatible. That projection gets LOCATION_REQUIRED; any
+	// later root projections become FIELD_FORBIDDEN with a "already materialized
+	// as the document" reason. If no root projection is compatible by the end of
+	// the loop, the post-loop check below returns an error.
+	var selectedRootField string
 	for _, p := range boundCollection.Projections {
 		// Base constraint used for all new projections of the binding. This may be re-evaluated
 		// below, depending on the details of the projection and any pre-existing materialization of
@@ -204,23 +211,48 @@ func (v Validator) validateMatchesExistingResource(
 			docFields = append(docFields, p.Field)
 			// Only the originally selected root document projection is allowed to be selected for
 			// changes to a standard updates materialization. If there is no previously persisted
-			// spec, the first root document projection is selected as the root document.
-			if lastBinding == nil && len(docFields) == 1 {
+			// spec, the first compatible root document projection is selected as the root document.
+			if lastBinding == nil {
 				// New binding adopted via `allow_existing_tables_for_new_bindings`. A
 				// connector storing the document as a single column must emit
 				// LOCATION_REQUIRED on the root JSON pointer so the control plane keeps
 				// the slot filled; bare INCOMPATIBLE is silently dropped without a live
-				// spec, letting the user publish with no document column and degenerate
-				// to INSERT-only corruption.
+				// spec, which would let the publish proceed with no document column and
+				// degenerate to INSERT-only corruption.
 				//
-				// A type mismatch on the existing document column is not caught here;
-				// the Apply-time compatibility loop only iterates Values. A follow-up
-				// should extend Apply to validate the Document column too.
-				c = &pm.Response_Validated_Constraint{
-					Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
-					Reason: "The root document is required for a standard updates materialization",
+				// Pick the first root projection whose existing destination column
+				// (if any) is type-compatible. Incompatible roots return the
+				// connector's existing-field constraint as-is — the post-loop check
+				// turns "no compatible root found" into an explicit error so the
+				// user sees a publish-time failure rather than a runtime load
+				// failure.
+				var fromExisting *pm.Response_Validated_Constraint
+				if existingField := existingResource.GetField(p.Field); existingField != nil {
+					fromExisting, err = v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap)
+					if err != nil {
+						return nil, err
+					}
 				}
-			} else if lastBinding != nil && p.Field == lastBinding.FieldSelection.Document {
+
+				if fromExisting != nil && fromExisting.Type.IsForbidden() {
+					c = fromExisting
+				} else if selectedRootField == "" {
+					c = &pm.Response_Validated_Constraint{
+						Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
+						Reason: "The root document is required for a standard updates materialization",
+					}
+					selectedRootField = p.Field
+				} else {
+					c = &pm.Response_Validated_Constraint{
+						Type: pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
+						Reason: fmt.Sprintf(
+							"Cannot materialize root document projection '%s' because field '%s' is already being materialized as the document",
+							p.Field,
+							selectedRootField,
+						),
+					}
+				}
+			} else if p.Field == lastBinding.FieldSelection.Document {
 				c = &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "This field is the document in the current materialization",
@@ -235,7 +267,7 @@ func (v Validator) validateMatchesExistingResource(
 						c = constraintFromExisting
 					}
 				}
-			} else if lastBinding != nil && lastBinding.FieldSelection.Document == "" {
+			} else if lastBinding.FieldSelection.Document == "" {
 				c = &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
 					Reason: "Cannot add a new root document projection to materialization without backfilling",
@@ -246,13 +278,7 @@ func (v Validator) validateMatchesExistingResource(
 					Reason: fmt.Sprintf(
 						"Cannot materialize root document projection '%s' because field '%s' is already being materialized as the document",
 						p.Field,
-						func() string {
-							if lastBinding != nil {
-								return lastBinding.FieldSelection.Document
-							} else {
-								return docFields[0]
-							}
-						}(),
+						lastBinding.FieldSelection.Document,
 					),
 				}
 			}
@@ -296,6 +322,17 @@ func (v Validator) validateMatchesExistingResource(
 		}
 
 		constraints[p.Field] = c
+	}
+
+	if lastBinding == nil && !deltaUpdates && len(docFields) > 0 && selectedRootField == "" {
+		// New binding over an existing table, but every root document projection's
+		// existing destination column is type-incompatible with the materialization.
+		// Fail at publish time with a clear error rather than letting the publish
+		// silently succeed and break at load time.
+		return nil, fmt.Errorf(
+			"no compatible root document projection: the existing destination column(s) for %v are incompatible with the materialization's required types. Backfill the binding to drop and recreate the column",
+			docFields,
+		)
 	}
 
 	if lastBinding != nil && !deltaUpdates && lastBinding.FieldSelection.Document != "" && !slices.Contains(docFields, lastBinding.FieldSelection.Document) {

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -318,6 +318,63 @@ func TestValidate(t *testing.T) {
 		}
 		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
 
+		_, err := validator.ValidateBinding(
+			[]string{"key_value"},
+			false,
+			binding.Backfill, binding.Collection, binding.FieldSelection.FieldConfigJsonMap,
+			nil, // lastBinding == nil
+		)
+		require.Error(t, err, "publish must fail when the only root projection's existing column is incompatible")
+		require.Contains(t, err.Error(), "no compatible root document projection")
+		require.Contains(t, err.Error(), "flow_document")
+	})
+
+	t.Run("new binding with existing table - multiple roots, first incompatible alternate compatible", func(t *testing.T) {
+		// Multi-root case: flow_document's existing column is the wrong type
+		// (STRING where the materialization wants something else), but an alternate
+		// root projection second_root's existing column is compatible. The validator
+		// should select second_root as the root document (LOCATION_REQUIRED) and
+		// reject flow_document via the connector's existing-field INCOMPATIBLE
+		// constraint, rather than failing the whole publish.
+		proposed := loadValidateSpec(t, "base.flow.proto")
+		binding := proposed.Bindings[0]
+
+		transformPath := func(in []string) []string {
+			out := make([]string, 0, len(in))
+			for _, p := range in {
+				out = append(out, simpleTestTransform(p))
+			}
+			return out
+		}
+		is := NewInfoSchema(transformPath, simpleTestTransform, simpleTestTransform, false, false)
+		res := is.PushResource(transformPath([]string{"key_value"})...)
+		// Push every field from the binding's selection plus second_root, so the
+		// destination table mirrors a real "alternate root already exists" shape.
+		fieldsToPush := append([]string{}, binding.FieldSelection.AllFields()...)
+		fieldsToPush = append(fieldsToPush, "second_root")
+		for _, f := range fieldsToPush {
+			proj := binding.Collection.GetProjection(f)
+			if proj == nil {
+				continue
+			}
+			fieldType := strings.Join(proj.Inference.Types, ",")
+			if f == "flow_document" {
+				// Mismatch the expected type so flow_document is rejected.
+				fieldType = "string"
+			}
+			res.PushField(ExistingField{
+				Name:     simpleTestTransform(f),
+				Nullable: proj.Inference.Exists != pf.Inference_MUST || slices.Contains(proj.Inference.Types, "null"),
+				Type:     fieldType,
+			})
+		}
+
+		featureFlags := map[string]bool{
+			"allow_existing_tables_for_new_bindings": true,
+			"flow_document":                          true,
+		}
+		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
+
 		cs, err := validator.ValidateBinding(
 			[]string{"key_value"},
 			false,
@@ -326,12 +383,19 @@ func TestValidate(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		c, ok := cs["flow_document"]
+		flowDoc, ok := cs["flow_document"]
 		require.True(t, ok, "no constraint emitted for flow_document")
+		require.Truef(t, flowDoc.Type.IsForbidden(),
+			"flow_document must be forbidden because its existing column is incompatible; got %v: %s",
+			flowDoc.Type, flowDoc.Reason,
+		)
+
+		secondRoot, ok := cs["second_root"]
+		require.True(t, ok, "no constraint emitted for second_root")
 		require.Equalf(t,
-			pm.Response_Validated_Constraint_LOCATION_REQUIRED, c.Type,
-			"flow_document must carry LOCATION_REQUIRED so the control plane can enforce the root document slot; got %v: %s",
-			c.Type, c.Reason,
+			pm.Response_Validated_Constraint_LOCATION_REQUIRED, secondRoot.Type,
+			"second_root must carry LOCATION_REQUIRED so the control plane selects it as the document; got %v: %s",
+			secondRoot.Type, secondRoot.Reason,
 		)
 	})
 

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -265,6 +265,80 @@ func TestValidate(t *testing.T) {
 		require.NotNil(t, cs)
 	})
 
+	t.Run("new binding with existing table - single root projection with incompatible column", func(t *testing.T) {
+		// Regression test for the customer's actual collection shape: only flow_document
+		// is declared as a root projection. Per the protocol contract documented at
+		// flow/crates/proto-flow/src/materialize.rs:359-364, connectors materializing the
+		// document as a single column must emit LOCATION_REQUIRED on a projection of the
+		// root JSON pointer so the control plane can enforce the slot.
+		//
+		// Today the first/selected root projection branch in validateMatchesExistingResource
+		// emits FIELD_REQUIRED, then overrides to INCOMPATIBLE when the existing column type
+		// is incompatible. INCOMPATIBLE without a live spec is silently dropped by the
+		// control plane (flow/crates/validation/src/field_selection.rs:269-287), so the
+		// publish proceeds with FieldSelection.Document = "" — degenerating to INSERT-only
+		// data corruption in connectors. The INCOMPATIBLE override originates from commit
+		// 8fa53e920 ("materialize-sql: don't allow migrations of the root document field"),
+		// which was a defensive change to prevent unsafe string->JSON migrations; the
+		// excludable-by-user side effect was unintended.
+		proposed := loadValidateSpec(t, "base.flow.proto")
+		binding := proposed.Bindings[0]
+
+		// Drop second_root so flow_document is the only root projection.
+		filtered := make([]pf.Projection, 0, len(binding.Collection.Projections))
+		for _, p := range binding.Collection.Projections {
+			if p.IsRootDocumentProjection() && p.Field != "flow_document" {
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		binding.Collection.Projections = filtered
+
+		transformPath := func(in []string) []string {
+			out := make([]string, 0, len(in))
+			for _, p := range in {
+				out = append(out, simpleTestTransform(p))
+			}
+			return out
+		}
+		is := NewInfoSchema(transformPath, simpleTestTransform, simpleTestTransform, false, false)
+		res := is.PushResource(transformPath([]string{"key_value"})...)
+		for _, f := range binding.FieldSelection.AllFields() {
+			proj := *binding.Collection.GetProjection(f)
+			fieldType := strings.Join(proj.Inference.Types, ",")
+			if f == binding.FieldSelection.Document {
+				fieldType = "string"
+			}
+			res.PushField(ExistingField{
+				Name:     simpleTestTransform(f),
+				Nullable: proj.Inference.Exists != pf.Inference_MUST || slices.Contains(proj.Inference.Types, "null"),
+				Type:     fieldType,
+			})
+		}
+
+		featureFlags := map[string]bool{
+			"allow_existing_tables_for_new_bindings": true,
+			"flow_document":                          true,
+		}
+		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
+
+		cs, err := validator.ValidateBinding(
+			[]string{"key_value"},
+			false,
+			binding.Backfill, binding.Collection, binding.FieldSelection.FieldConfigJsonMap,
+			nil, // lastBinding == nil
+		)
+		require.NoError(t, err)
+
+		c, ok := cs["flow_document"]
+		require.True(t, ok, "no constraint emitted for flow_document")
+		require.Equalf(t,
+			pm.Response_Validated_Constraint_LOCATION_REQUIRED, c.Type,
+			"flow_document must carry LOCATION_REQUIRED so the control plane can enforce the root document slot; got %v: %s",
+			c.Type, c.Reason,
+		)
+	})
+
 	t.Run("folded fields are set when field names are transformed", func(t *testing.T) {
 		proposed := loadValidateSpec(t, "base.flow.proto")
 

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -266,21 +266,17 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("new binding with existing table - single root projection with incompatible column", func(t *testing.T) {
-		// Regression test for the customer's actual collection shape: only flow_document
-		// is declared as a root projection. Per the protocol contract documented at
-		// flow/crates/proto-flow/src/materialize.rs:359-364, connectors materializing the
-		// document as a single column must emit LOCATION_REQUIRED on a projection of the
-		// root JSON pointer so the control plane can enforce the slot.
+		// Regression test for the customer's collection shape: only flow_document is
+		// declared as a root projection. A connector storing the document as a single
+		// column must emit LOCATION_REQUIRED on the root JSON pointer so the control
+		// plane keeps the slot filled.
 		//
-		// Today the first/selected root projection branch in validateMatchesExistingResource
-		// emits FIELD_REQUIRED, then overrides to INCOMPATIBLE when the existing column type
-		// is incompatible. INCOMPATIBLE without a live spec is silently dropped by the
-		// control plane (flow/crates/validation/src/field_selection.rs:269-287), so the
-		// publish proceeds with FieldSelection.Document = "" — degenerating to INSERT-only
-		// data corruption in connectors. The INCOMPATIBLE override originates from commit
-		// 8fa53e920 ("materialize-sql: don't allow migrations of the root document field"),
-		// which was a defensive change to prevent unsafe string->JSON migrations; the
-		// excludable-by-user side effect was unintended.
+		// The selected-root branch historically emitted FIELD_REQUIRED, then overrode
+		// to INCOMPATIBLE when the existing column was the wrong type. Without a live
+		// spec the control plane silently drops INCOMPATIBLE, so the publish proceeded
+		// with FieldSelection.Document = "" — INSERT-only data corruption. The
+		// override was originally a defensive measure against unsafe string->JSON
+		// migrations; the excludable-by-user side effect was unintended.
 		proposed := loadValidateSpec(t, "base.flow.proto")
 		binding := proposed.Bindings[0]
 


### PR DESCRIPTION
**Description:**

Closes the publish-time gap reported by a customer where `materialize-bigquery` published bindings with `FieldSelection.Document = ""` and silently degenerated to INSERT-only writes (duplicate rows on every update).

Root cause: when a new binding is adopted over an existing table via `allow_existing_tables_for_new_bindings` and the existing `flow_document` column has an incompatible type, `validateMatchesExistingResource` returned a constraint set with `flow_document=INCOMPATIBLE` and either `FIELD_FORBIDDEN` or nothing on alternate root projections. The control plane drops bare `INCOMPATIBLE` in the no-live-spec path ([`field_selection.rs:269-287`](https://github.com/estuary/flow/blob/master/crates/validation/src/field_selection.rs#L269-L287)) and has no `LOCATION_REQUIRED` signal for the root pointer, so the publish proceeds with no document column.

Two changes, gated on `lastBinding == nil`:
- Emit `LOCATION_REQUIRED` on alternate root projections instead of `FIELD_FORBIDDEN`, so the control plane has the protocol-level signal documented at [`proto-flow/src/materialize.rs:359-364`](https://github.com/estuary/flow/blob/master/crates/proto-flow/src/materialize.rs#L359-L364).
- Hard-error from the validator when no root projection ends up with a selectable constraint (single-root spec with incompatible existing column — the customer's actual case).

**Workflow steps:**

No user-facing workflow change. Affected publishes that previously succeeded silently with broken bindings will now either select a viable alternate root projection or fail at publish with a clear "incompatible column" error.

**Documentation links affected:**

None.

**Notes for reviewers:**

Four commits, paired (test then fix). Each test fails at its own commit and is unlocked by the next commit. Pre-existing snapshot updates for five scenarios where `second_root` previously came back `FIELD_FORBIDDEN`; now `LOCATION_REQUIRED`.

The `lastBinding != nil` paths (`cannot_add_new_root_document_without_backfill`, `change_root_document_projection_for_standard_updates`) are intentionally untouched — they continue to return constraints and rely on the control plane to surface conflicts.