### PR TITLE
materialize-s3-iceberg: always inject user-supplied AWS access keys

### DIFF
--- a/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
+++ b/materialize-s3-iceberg/iceberg-ctl/iceberg_ctl/__main__.py
@@ -85,16 +85,14 @@ def run(
                     PY_IO_IMPL: "pyiceberg.io.fsspec.FsspecFileIO",  # use S3 file IO instead of Arrow
                 }
 
-                # For local/S3-compatible setups the catalog server cannot vend STS creds,
-                # so we pass the user's access keys directly to pyiceberg and disable
-                # catalog credential vending. We key off `s3_endpoint` —
-                # production AWS users leave it blank and continue to receive
-                # vended credentials from the catalog as before.
-                direct_s3_creds = (
-                    cfg.s3_endpoint
-                    and cfg.credentials is not None
-                    and cfg.credentials.auth_type == "AWSAccessKey"
-                    and cfg.region
+                # Whenever the user supplied AWS access keys, bypass catalog
+                # credential vending and pass the keys straight to pyiceberg's
+                # S3 FileIO. This handles both S3-compatible setups (rustfs,
+                # MinIO) and non-vending REST catalogs (e.g. Nessie) on real
+                # AWS. `AWSIAM` users fall through to the catalog-vended path,
+                # which is the model AWS Lakekeeper / Polaris assume.
+                direct_s3_creds = bool(
+                    cfg.credentials.auth_type == "AWSAccessKey" and cfg.region
                 )
 
                 if direct_s3_creds:
@@ -103,7 +101,8 @@ def run(
                         cfg.credentials.aws_secret_access_key
                     )
                     properties["s3.region"] = cfg.region
-                    properties["s3.endpoint"] = cfg.s3_endpoint
+                    if cfg.s3_endpoint:
+                        properties["s3.endpoint"] = cfg.s3_endpoint
                 catalog = RestCatalog(
                     "default",
                     **{k: v for k, v in properties.items() if v is not None},


### PR DESCRIPTION
**Description:**

Fixes a regression where configurations would not fall back to user-supplied AWS credentials for non-vending REST catalogs.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

