### PR TITLE
source-oracle: fix deadlock when making recursive queries

### DIFF
--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -719,9 +719,15 @@ func (s *replicationStream) StartReplication(ctx context.Context, discovery map[
 		// Context cancellation typically occurs only in tests, and for test stability
 		// it should be considered a clean shutdown and not necessarily an error.
 		close(s.events)
-		s.transactionsStmt.Close()
-		s.conn.Close()
-		s.innerConn.Close()
+		if cerr := s.transactionsStmt.Close(); cerr != nil {
+			logrus.WithError(cerr).Warn("closing transactions statement")
+		}
+		if cerr := s.conn.Close(); cerr != nil {
+			logrus.WithError(cerr).Warn("closing replication connection")
+		}
+		if cerr := s.innerConn.Close(); cerr != nil {
+			logrus.WithError(cerr).Warn("closing inner replication connection")
+		}
 		s.errCh <- err
 	}()
 
@@ -1108,7 +1114,11 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 	if err != nil {
 		return fmt.Errorf("logminer query: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil {
+			logrus.WithError(cerr).Warn("closing logminer rows")
+		}
+	}()
 
 	var totalMessages = 0
 	var fullMessages = 0
@@ -1360,9 +1370,15 @@ func (s *replicationStream) Acknowledge(ctx context.Context, cursor json.RawMess
 func (s *replicationStream) Close(ctx context.Context) error {
 	logrus.Debug("replication stream close requested")
 	s.cancel()
-	s.transactionsStmt.Close()
-	s.conn.Close()
-	s.innerConn.Close()
+	if cerr := s.transactionsStmt.Close(); cerr != nil {
+		logrus.WithError(cerr).Warn("closing transactions statement")
+	}
+	if cerr := s.conn.Close(); cerr != nil {
+		logrus.WithError(cerr).Warn("closing replication connection")
+	}
+	if cerr := s.innerConn.Close(); cerr != nil {
+		logrus.WithError(cerr).Warn("closing inner replication connection")
+	}
 	return <-s.errCh
 }
 

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -1108,6 +1108,7 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 	if err != nil {
 		return fmt.Errorf("logminer query: %w", err)
 	}
+	defer rows.Close()
 
 	var totalMessages = 0
 	var fullMessages = 0
@@ -1234,8 +1235,6 @@ func (s *replicationStream) receiveMessages(ctx context.Context, startSCN, endSC
 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("rows error: %w", err)
-	} else if err := rows.Close(); err != nil {
-		return fmt.Errorf("rows close: %w", err)
 	}
 
 	var finalSCN SCN

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -147,8 +147,8 @@ func (db *oracleDatabase) ReplicationStream(ctx context.Context, cpJSON json.Raw
 	return stream, nil
 }
 
-func (s *replicationStream) endLogminer(ctx context.Context) error {
-	if _, err := s.conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR.END_LOGMNR; END;"); err != nil {
+func (s *replicationStream) endLogminer(ctx context.Context, conn *sql.Conn) error {
+	if _, err := conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR.END_LOGMNR; END;"); err != nil {
 		// ORA-01307: no LogMiner session is currently active
 		if strings.Contains(err.Error(), "ORA-01307") {
 			return nil
@@ -173,7 +173,7 @@ type redoFile struct {
 
 var MaxReplicationLogFilesSize = 2 * 1024 * 1024 * 1024
 
-func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SCN) (SCN, error) {
+func (s *replicationStream) addLogFiles(ctx context.Context, conn *sql.Conn, startSCN, maxSCN SCN) (SCN, error) {
 	logrus.WithFields(logrus.Fields{
 		"startSCN": startSCN,
 		"maxSCN":   maxSCN,
@@ -182,12 +182,12 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 	// See DBMS_LOGMNR_D.BUILD reference:
 	// https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_LOGMNR_D.html#GUID-20E210F3-A566-46F1-B817-486723069AF4
 	if s.dictionaryMode == DictionaryModeExtract {
-		if _, err := s.conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR_D.BUILD (options => DBMS_LOGMNR_D.STORE_IN_REDO_LOGS); END;"); err != nil {
+		if _, err := conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR_D.BUILD (options => DBMS_LOGMNR_D.STORE_IN_REDO_LOGS); END;"); err != nil {
 			return 0, fmt.Errorf("extracting dictionary from logfile: %w", err)
 		}
 	}
 	// We only add the local version of archived log files to avoid duplicates
-	var row = s.conn.QueryRowContext(ctx, "SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE TYPE='LOCAL' AND STATUS='VALID' AND ROWNUM=1")
+	var row = conn.QueryRowContext(ctx, "SELECT DEST_ID FROM V$ARCHIVE_DEST_STATUS WHERE TYPE='LOCAL' AND STATUS='VALID' AND ROWNUM=1")
 	var localDestID int
 	if err := row.Scan(&localDestID); err != nil {
 		return 0, fmt.Errorf("querying archive log files destination: %w", err)
@@ -200,7 +200,7 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 	if s.dictionaryMode == DictionaryModeExtract {
 		findEarliestLogSCNQuery += " AND DICTIONARY_BEGIN='YES'"
 	}
-	row = s.conn.QueryRowContext(ctx, findEarliestLogSCNQuery, startSCN)
+	row = conn.QueryRowContext(ctx, findEarliestLogSCNQuery, startSCN)
 	var minArchiveSCNScan sql.NullInt64
 	if err := row.Scan(&minArchiveSCNScan); err != nil {
 		return 0, fmt.Errorf("querying latest archive log to contain the dictionary for the SCN range: %w", err)
@@ -226,7 +226,7 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
     DEST_ID IN (` + strconv.Itoa(localDestID) + `)`
 
 	var fullQuery = liveLogFiles + " UNION " + archivedLogFiles
-	rows, err := s.conn.QueryContext(ctx, fullQuery, minArchiveSCN)
+	rows, err := conn.QueryContext(ctx, fullQuery, minArchiveSCN)
 	if err != nil {
 		return 0, fmt.Errorf("fetching log file list: %w", err)
 	}
@@ -363,7 +363,7 @@ func (s *replicationStream) addLogFiles(ctx context.Context, startSCN, maxSCN SC
 	}
 
 	for _, f := range redoFiles {
-		if _, err := s.conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR.ADD_LOGFILE(:filename); END;", f.Name); err != nil {
+		if _, err := conn.ExecContext(ctx, "BEGIN SYS.DBMS_LOGMNR.ADD_LOGFILE(:filename); END;", f.Name); err != nil {
 			return 0, fmt.Errorf("adding logfile %q (%s, %d, %s, %s) to logminer: %w", f.Name, f.Status, f.FirstChange, f.DictStart, f.DictEnd, err)
 		}
 	}
@@ -459,7 +459,7 @@ func resolveDuplicateSequences(files []redoFile) ([]redoFile, error) {
 	return out, nil
 }
 
-func (s *replicationStream) startLogminer(ctx context.Context, startSCN, endSCN SCN) error {
+func (s *replicationStream) startLogminer(ctx context.Context, conn *sql.Conn, startSCN, endSCN SCN) error {
 	var dictionaryOption = ""
 	if s.dictionaryMode == DictionaryModeExtract {
 		dictionaryOption = "DBMS_LOGMNR.DICT_FROM_REDO_LOGS + DBMS_LOGMNR.DDL_DICT_TRACKING"
@@ -472,7 +472,7 @@ func (s *replicationStream) startLogminer(ctx context.Context, startSCN, endSCN 
 		"endSCN":   endSCN,
 	}).Debug("starting logminer")
 	var startQuery = fmt.Sprintf("BEGIN SYS.DBMS_LOGMNR.START_LOGMNR(STARTSCN=>:scn,ENDSCN=>:end,OPTIONS=>%s); END;", dictionaryOption)
-	if _, err := s.conn.ExecContext(ctx, startQuery, startSCN, endSCN); err != nil {
+	if _, err := conn.ExecContext(ctx, startQuery, startSCN, endSCN); err != nil {
 		return fmt.Errorf("starting logminer: %w", err)
 	}
 
@@ -707,7 +707,7 @@ func (s *replicationStream) run(ctx context.Context) error {
 		case <-poll.C:
 		}
 
-		var err = s.poll(ctx, s.lastTxnEndSCN, math.MaxInt64, nil)
+		var err = s.poll(ctx, s.conn, s.lastTxnEndSCN, math.MaxInt64, nil)
 		if err != nil {
 			// ORA-01013: user requested cancel of current operation
 			// this means a cancellation of context happened, which we don't consider an error
@@ -722,7 +722,14 @@ func (s *replicationStream) run(ctx context.Context) error {
 
 // poll logminer for changes in [startSCN, endSCN]
 // if transactions is not empty, only messages for the given transactions are processed
-func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transactions []string) error {
+//
+// The `conn` parameter is the Oracle session used for all LogMiner queries and
+// session-state mutations issued by this poll. Today both the top-level call
+// from `run` and the recursive call from `capturePendingTransaction` pass
+// `s.conn`; a follow-up commit will use a separate connection for the recursive
+// case to avoid driving database/sql into a deadlock when ErrBadConn fires
+// while the outer cursor is mid-iteration.
+func (s *replicationStream) poll(ctx context.Context, conn *sql.Conn, minSCN, maxSCN SCN, transactions []string) error {
 	var startSCN = minSCN
 	logrus.WithFields(logrus.Fields{
 		"minSCN":       minSCN,
@@ -736,7 +743,7 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 		}
 
 		var currentSCN SCN
-		var row = s.conn.QueryRowContext(ctx, "SELECT current_scn FROM V$DATABASE")
+		var row = conn.QueryRowContext(ctx, "SELECT current_scn FROM V$DATABASE")
 		if err := row.Scan(&currentSCN); err != nil {
 			return fmt.Errorf("fetching current SCN: %w", err)
 		}
@@ -748,9 +755,9 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 			iterationMaxSCN = currentSCN
 		}
 
-		if err := s.endLogminer(ctx); err != nil {
+		if err := s.endLogminer(ctx, conn); err != nil {
 			return err
-		} else if endSCN, err = s.addLogFiles(ctx, startSCN, iterationMaxSCN); err != nil {
+		} else if endSCN, err = s.addLogFiles(ctx, conn, startSCN, iterationMaxSCN); err != nil {
 			return err
 		}
 
@@ -764,11 +771,11 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 			"specificXIDs":        len(transactions),
 		}).Info("logminer: starting iteration")
 
-		if err := s.startLogminer(ctx, startSCN, endSCN); err != nil {
+		if err := s.startLogminer(ctx, conn, startSCN, endSCN); err != nil {
 			return err
 		}
 
-		var stmt, debugQuery, err = s.generateLogminerQuery(ctx, transactions)
+		var stmt, debugQuery, err = s.generateLogminerQuery(ctx, conn, transactions)
 		if err != nil {
 			return err
 		}
@@ -803,7 +810,7 @@ func (s *replicationStream) poll(ctx context.Context, minSCN, maxSCN SCN, transa
 			if dictionaryMismatch && s.dictionaryMode == DictionaryModeOnline && s.smartMode {
 				logrus.WithField("error", err).Info("smart mode: encountered dictionary mismatch")
 				s.dictionaryMode = DictionaryModeExtract
-				if lastDDLSCN, err := s.maximumLastDDLSCN(ctx); err != nil {
+				if lastDDLSCN, err := s.maximumLastDDLSCN(ctx, conn); err != nil {
 					return err
 				} else {
 					s.lastDDLSCN = lastDDLSCN
@@ -903,7 +910,7 @@ func (s *replicationStream) capturePendingTransaction(ctx context.Context, tx tr
 		"startSCN": startSCN,
 		"endSCN":   endSCN,
 	}).Info("capturing pending transaction")
-	return s.poll(ctx, startSCN, endSCN, transactions)
+	return s.poll(ctx, s.conn, startSCN, endSCN, transactions)
 }
 
 func (s *replicationStream) emitEvent(ctx context.Context, event sqlcapture.DatabaseEvent) error {
@@ -964,7 +971,7 @@ type transaction struct {
 	StartSCN SCN
 }
 
-func (s *replicationStream) generateLogminerQuery(ctx context.Context, transactions []string) (*sql.Stmt, string, error) {
+func (s *replicationStream) generateLogminerQuery(ctx context.Context, conn *sql.Conn, transactions []string) (*sql.Stmt, string, error) {
 	var tableObjectMapping = s.db.tableObjectMapping
 
 	var conditions []string
@@ -996,7 +1003,7 @@ func (s *replicationStream) generateLogminerQuery(ctx context.Context, transacti
 
 	logrus.Debug("generated logminer query")
 
-	stmt, err := s.conn.PrepareContext(ctx, query)
+	stmt, err := conn.PrepareContext(ctx, query)
 
 	return stmt, query, err
 }
@@ -1237,12 +1244,12 @@ func (s *replicationStream) ActivateTable(ctx context.Context, streamID sqlcaptu
 }
 
 // This function is a no-op if there is no PDB name configured
-func (s *replicationStream) switchToCDB(ctx context.Context) error {
+func (s *replicationStream) switchToCDB(ctx context.Context, conn *sql.Conn) error {
 	if s.db.pdbName == "" {
 		return nil
 	}
 
-	if _, err := s.conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER=CDB$ROOT"); err != nil {
+	if _, err := conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER=CDB$ROOT"); err != nil {
 		return fmt.Errorf("switching to CDB: %w", err)
 	}
 
@@ -1250,12 +1257,12 @@ func (s *replicationStream) switchToCDB(ctx context.Context) error {
 }
 
 // This function is a no-op if there is no PDB name configured
-func (s *replicationStream) switchToPDB(ctx context.Context) error {
+func (s *replicationStream) switchToPDB(ctx context.Context, conn *sql.Conn) error {
 	if s.db.pdbName == "" {
 		return nil
 	}
 
-	if _, err := s.conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET CONTAINER=%s", s.db.pdbName)); err != nil {
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET CONTAINER=%s", s.db.pdbName)); err != nil {
 		return fmt.Errorf("switching to PDB %s: %w", s.db.pdbName, err)
 	}
 
@@ -1266,7 +1273,7 @@ func (s *replicationStream) switchToPDB(ctx context.Context) error {
 // by a DDL statement. This function returns the maximum of all of those times
 // across all tables. When we hit a dictionary mismatch, we stay on Extract mode until
 // we have covered all the latest DDLs on all tables before switching back to online mode
-func (s *replicationStream) maximumLastDDLSCN(ctx context.Context) (SCN, error) {
+func (s *replicationStream) maximumLastDDLSCN(ctx context.Context, conn *sql.Conn) (SCN, error) {
 	var tablesCondition = ""
 	var i = 0
 	for _, mapping := range s.db.tableObjectMapping {
@@ -1278,11 +1285,11 @@ func (s *replicationStream) maximumLastDDLSCN(ctx context.Context) (SCN, error) 
 	}
 	var query = fmt.Sprintf(`SELECT TIMESTAMP_TO_SCN(MAX(LAST_DDL_TIME)) last_ddl FROM ALL_OBJECTS WHERE %s`, tablesCondition)
 
-	if err := s.switchToPDB(ctx); err != nil {
+	if err := s.switchToPDB(ctx, conn); err != nil {
 		return 0, err
 	}
 
-	row := s.conn.QueryRowContext(ctx, query)
+	row := conn.QueryRowContext(ctx, query)
 
 	var maximumDDLSCN SCN
 	if err := row.Scan(&maximumDDLSCN); err != nil {
@@ -1291,7 +1298,7 @@ func (s *replicationStream) maximumLastDDLSCN(ctx context.Context) (SCN, error) 
 		// materialized into a SCN, in these scenarios we use current SCN
 		if strings.Contains(err.Error(), "ORA-08180") {
 			var currentSCN SCN
-			var row = s.conn.QueryRowContext(ctx, "SELECT current_scn FROM V$DATABASE")
+			var row = conn.QueryRowContext(ctx, "SELECT current_scn FROM V$DATABASE")
 			if err := row.Scan(&currentSCN); err != nil {
 				return 0, fmt.Errorf("fetching current SCN: %w", err)
 			}
@@ -1301,7 +1308,7 @@ func (s *replicationStream) maximumLastDDLSCN(ctx context.Context) (SCN, error) 
 		return 0, fmt.Errorf("fetching maximum last DDL SCN: %w", err)
 	}
 
-	if err := s.switchToCDB(ctx); err != nil {
+	if err := s.switchToCDB(ctx, conn); err != nil {
 		return 0, err
 	}
 

--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -34,6 +34,28 @@ const OUT_DATE_FORMAT = "2006-01-02T15:04:05"
 const OUT_TS_FORMAT = "2006-01-02T15:04:05.999999999"
 const OUT_TSTZ_FORMAT = time.RFC3339Nano
 
+// configureReplicationSession applies the Oracle session settings required for
+// LogMiner: predictable NLS date/timestamp formats, and for CDB instances a
+// container switch to CDB$ROOT since LogMiner cannot run from within a PDB.
+func configureReplicationSession(ctx context.Context, conn *sql.Conn, pdbName string) error {
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_DATE_FORMAT = '%s'", ORACLE_DATE_FORMAT)); err != nil {
+		return fmt.Errorf("set NLS_DATE_FORMAT: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_TIMESTAMP_FORMAT = '%s'", ORACLE_TS_FORMAT)); err != nil {
+		return fmt.Errorf("set NLS_TIMESTAMP_FORMAT: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_TIMESTAMP_TZ_FORMAT = '%s'", ORACLE_TSTZ_FORMAT)); err != nil {
+		return fmt.Errorf("set NLS_TIMESTAMP_TZ_FORMAT: %w", err)
+	}
+
+	if pdbName != "" {
+		if _, err := conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER=CDB$ROOT"); err != nil {
+			return fmt.Errorf("switching to CDB: %w", err)
+		}
+	}
+	return nil
+}
+
 func (db *oracleDatabase) ReplicationStream(ctx context.Context, cpJSON json.RawMessage) (sqlcapture.ReplicationStream, error) {
 	var dbConn, err = sql.Open("oracle", db.config.ToURI(db.config.Advanced.IncrementalChunkSize+1))
 	if err != nil {
@@ -43,22 +65,21 @@ func (db *oracleDatabase) ReplicationStream(ctx context.Context, cpJSON json.Raw
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to database: %w", err)
 	}
-
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_DATE_FORMAT = '%s'", ORACLE_DATE_FORMAT)); err != nil {
-		return nil, fmt.Errorf("set NLS_DATE_FORMAT: %w", err)
-	}
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_TIMESTAMP_FORMAT = '%s'", ORACLE_TS_FORMAT)); err != nil {
-		return nil, fmt.Errorf("set NLS_TIMESTAMP_FORMAT: %w", err)
-	}
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER SESSION SET NLS_TIMESTAMP_TZ_FORMAT = '%s'", ORACLE_TSTZ_FORMAT)); err != nil {
-		return nil, fmt.Errorf("set NLS_TIMESTAMP_TZ_FORMAT: %w", err)
+	if err := configureReplicationSession(ctx, conn, db.pdbName); err != nil {
+		return nil, err
 	}
 
-	// Logminer cannot run on PDB instances, so we switch to the CDB
-	if db.pdbName != "" {
-		if _, err := conn.ExecContext(ctx, "ALTER SESSION SET CONTAINER=CDB$ROOT"); err != nil {
-			return nil, fmt.Errorf("switching to CDB: %w", err)
-		}
+	// A second pinned connection used exclusively for capturePendingTransaction's
+	// recursive poll. Keeping it on its own Oracle session means END_LOGMNR /
+	// ADD_LOGFILE / START_LOGMNR inside the recursive call don't disrupt the outer
+	// LogMiner cursor running on `conn`, which would otherwise drive the underlying
+	// driver into ErrBadConn and deadlock database/sql's connection cleanup.
+	innerConn, err := dbConn.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to acquire inner connection: %w", err)
+	}
+	if err := configureReplicationSession(ctx, innerConn, db.pdbName); err != nil {
+		return nil, fmt.Errorf("configuring inner connection: %w", err)
 	}
 
 	// Decode start cursor from a JSON quoted string into its actual string contents
@@ -128,8 +149,9 @@ func (db *oracleDatabase) ReplicationStream(ctx context.Context, cpJSON json.Raw
 		dictionaryMode = DictionaryModeOnline
 	}
 	var stream = &replicationStream{
-		db:   db,
-		conn: conn,
+		db:        db,
+		conn:      conn,
+		innerConn: innerConn,
 
 		lastTxnEndSCN: startSCN,
 
@@ -502,8 +524,19 @@ func (s *oracleSource) Common() sqlcapture.SourceCommon {
 // A replicationStream represents the process of receiving Oracle
 // logminer events, and translating changes into a more friendly representation.
 type replicationStream struct {
-	db   *oracleDatabase
-	conn *sql.Conn // The Oracle connection
+	db *oracleDatabase
+
+	// conn is the Oracle session used by the outer LogMiner cursor driven from
+	// run().
+	//
+	// innerConn is a separate Oracle session used exclusively by
+	// capturePendingTransaction's recursive poll. Keeping the recursive call on
+	// its own session means END_LOGMNR / ADD_LOGFILE / START_LOGMNR don't disrupt
+	// the outer cursor's LogMiner state, and — because each *sql.Conn has its
+	// own closemu RWMutex — an ErrBadConn on one session can't deadlock
+	// database/sql's cleanup of the other.
+	conn      *sql.Conn
+	innerConn *sql.Conn
 
 	cancel context.CancelFunc            // Cancel function for the replication goroutine's context
 	errCh  chan error                    // Error channel for the final exit status of the replication goroutine
@@ -688,6 +721,7 @@ func (s *replicationStream) StartReplication(ctx context.Context, discovery map[
 		close(s.events)
 		s.transactionsStmt.Close()
 		s.conn.Close()
+		s.innerConn.Close()
 		s.errCh <- err
 	}()
 
@@ -723,12 +757,12 @@ func (s *replicationStream) run(ctx context.Context) error {
 // poll logminer for changes in [startSCN, endSCN]
 // if transactions is not empty, only messages for the given transactions are processed
 //
-// The `conn` parameter is the Oracle session used for all LogMiner queries and
-// session-state mutations issued by this poll. Today both the top-level call
-// from `run` and the recursive call from `capturePendingTransaction` pass
-// `s.conn`; a follow-up commit will use a separate connection for the recursive
-// case to avoid driving database/sql into a deadlock when ErrBadConn fires
-// while the outer cursor is mid-iteration.
+// `conn` is the Oracle session used for all LogMiner queries and
+// session-state mutations issued by this poll. The top-level call from `run`
+// passes `s.conn`; the recursive call from `capturePendingTransaction` passes
+// `s.innerConn` so that LogMiner state mutations don't disrupt the outer
+// cursor (which would otherwise drive database/sql into a deadlock when the
+// driver returns ErrBadConn while the outer cursor's Rows is mid-iteration).
 func (s *replicationStream) poll(ctx context.Context, conn *sql.Conn, minSCN, maxSCN SCN, transactions []string) error {
 	var startSCN = minSCN
 	logrus.WithFields(logrus.Fields{
@@ -910,7 +944,10 @@ func (s *replicationStream) capturePendingTransaction(ctx context.Context, tx tr
 		"startSCN": startSCN,
 		"endSCN":   endSCN,
 	}).Info("capturing pending transaction")
-	return s.poll(ctx, s.conn, startSCN, endSCN, transactions)
+	// Run the recursive poll on innerConn so its LogMiner state mutations
+	// (END_LOGMNR / ADD_LOGFILE / START_LOGMNR) don't disturb the outer cursor
+	// currently iterating on s.conn.
+	return s.poll(ctx, s.innerConn, startSCN, endSCN, transactions)
 }
 
 func (s *replicationStream) emitEvent(ctx context.Context, event sqlcapture.DatabaseEvent) error {
@@ -1326,6 +1363,7 @@ func (s *replicationStream) Close(ctx context.Context) error {
 	s.cancel()
 	s.transactionsStmt.Close()
 	s.conn.Close()
+	s.innerConn.Close()
 	return <-s.errCh
 }
 


### PR DESCRIPTION
**Description:**

`source-oracle` has been observed deadlocking when capturing a multi-window transaction. The outer LogMiner cursor and the recursive `capturePendingTransaction` poll share the same pinned `*sql.Conn`, and running `END_LOGMNR` / `ADD_LOGFILE` / `START_LOGMNR` on it while the outer cursor's `Rows` is still streaming eventually trips `driver.ErrBadConn`. `database/sql`'s cleanup of the bad connection then blocks acquiring the writer lock on the connection's `closemu`, which the outer `Rows` still holds as an `RLock`. The single goroutine driving both ends up waiting on itself, stuck in permanent self-deadlock.

This PR's scope includes three commits:
1. Refactor all helper functions to accept an `*sql.Conn` parameter instead of always reading `s.conn` off the receiver. This is a refactor that makes no behavioral changes in order to more clearly illustrate the behavioral changes in the next commit.
2. Use a separate `*sql.Conn` (`innerConn`) for `capturePendingTransaction`'s recursive poll. Each connection has an independent `closemu`, so an `ErrBadConn` on one session doesn't collide with the other session. Independent LogMiner state on the inner session also very likely prevents a cause of `ErrBadConn` entirely since the inner queries no longer mutate the outer cursor's session state.
3. Defer `rows.Close()` in `receiveMessages` to ensure we always call `rows.Close()` even if we encounter an error while iterating through `rows.Next()`.

I recommend reading commit-by-commit. This PR looks like a lot of changes, but a good chunk of them are due to the refactor in the first commit.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

