### PR TITLE
materialize-iceberg: `nullable` in fieldConfig

### DIFF
--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -320,7 +320,9 @@ func (d *materialization) NewConstraint(p pf.Projection, deltaUpdates bool, fc f
 }
 
 func (d *materialization) MapType(p boilerplate.Projection, fc fieldConfig) (mapped, boilerplate.ElementConverter) {
-	return mapProjection(p, d.cfg.Advanced.LowercaseColumnNames)
+	m, converter := mapProjection(p, d.cfg.Advanced.LowercaseColumnNames)
+	m.Nullable = fc.Nullable
+	return m, converter
 }
 
 func (d *materialization) Setup(ctx context.Context, is *boilerplate.InfoSchema) (string, error) {

--- a/materialize-iceberg/sqlgen_test.go
+++ b/materialize-iceberg/sqlgen_test.go
@@ -23,19 +23,19 @@ func TestTemplates(t *testing.T) {
 	}
 
 	keys := []boilerplate.MappedProjection[mapped]{
-		{Projection: makeProjection("first-key"), Mapped: mapped{iceberg.StringType{}, "first-key"}},
-		{Projection: makeProjection("second-key"), Mapped: mapped{iceberg.BinaryType{}, "second-key"}},
-		{Projection: makeProjection("third-key"), Mapped: mapped{iceberg.Int64Type{}, "third-key"}},
+		{Projection: makeProjection("first-key"), Mapped: mapped{type_: iceberg.StringType{}, Name: "first-key"}},
+		{Projection: makeProjection("second-key"), Mapped: mapped{type_: iceberg.BinaryType{}, Name: "second-key"}},
+		{Projection: makeProjection("third-key"), Mapped: mapped{type_: iceberg.Int64Type{}, Name: "third-key"}},
 	}
 
 	values := []boilerplate.MappedProjection[mapped]{
-		{Projection: makeProjection("first-val"), Mapped: mapped{iceberg.StringType{}, "first-val"}},
-		{Projection: makeProjection("second-val"), Mapped: mapped{iceberg.StringType{}, "second-val"}},
-		{Projection: makeProjection("third-val"), Mapped: mapped{iceberg.BinaryType{}, "third-val"}},
-		{Projection: makeProjection("fourth-val"), Mapped: mapped{iceberg.StringType{}, "fourth-val"}},
+		{Projection: makeProjection("first-val"), Mapped: mapped{type_: iceberg.StringType{}, Name: "first-val"}},
+		{Projection: makeProjection("second-val"), Mapped: mapped{type_: iceberg.StringType{}, Name: "second-val"}},
+		{Projection: makeProjection("third-val"), Mapped: mapped{type_: iceberg.BinaryType{}, Name: "third-val"}},
+		{Projection: makeProjection("fourth-val"), Mapped: mapped{type_: iceberg.StringType{}, Name: "fourth-val"}},
 	}
 
-	doc := &boilerplate.MappedProjection[mapped]{Projection: makeProjection("flow_document"), Mapped: mapped{iceberg.StringType{}, "flow_document"}}
+	doc := &boilerplate.MappedProjection[mapped]{Projection: makeProjection("flow_document"), Mapped: mapped{type_: iceberg.StringType{}, Name: "flow_document"}}
 
 	input := templateInput{
 		binding: binding{

--- a/materialize-iceberg/type_mapping.go
+++ b/materialize-iceberg/type_mapping.go
@@ -13,6 +13,7 @@ import (
 
 type fieldConfig struct {
 	CastToString_ bool `json:"castToString"`
+	Nullable      bool `json:"nullable"`
 }
 
 func (fc fieldConfig) Validate() error { return nil }
@@ -25,6 +26,10 @@ type mapped struct {
 	// name, depending on the materialization configuration. This is exported so
 	// it can be used in templates.
 	Name string
+	// Nullable overrides the field's inferred nullability, forcing it to be
+	// nullable even if the collection schema says it's always present and
+	// non-null. Primary key fields are always required regardless of this flag.
+	Nullable bool
 }
 
 func (m mapped) String() string {
@@ -240,7 +245,7 @@ func appendProjectionsAsFields(dst *[]iceberg.NestedField, ps []boilerplate.Mapp
 			ID:       id,
 			Name:     p.Mapped.Name,
 			Type:     p.Mapped.type_,
-			Required: p.MustExist || p.IsPrimaryKey,
+			Required: (p.MustExist && !p.Mapped.Nullable) || p.IsPrimaryKey,
 			Doc:      strings.ReplaceAll(p.Comment, "\n", " - "), // Glue catalogs don't support newlines in field comments
 		})
 		ids = append(ids, id)


### PR DESCRIPTION
**Description:**

- There is a known bug in Iceberg EMR runtime and its parquet writer https://github.com/apache/parquet-java/pull/3575 which causes required fields which are larger than a threshold in size, end up without NullStatistics written on the parquet files. This causes downstream consumers of these parquet files to fail (such as Snowflake). One workaround we have right now is to allow those columns to be explicitly made as nullable in the iceberg table.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

