### PR TITLE
source-mysql: Fix latin-1 transcoding in VARCHAR columns

### DIFF
--- a/source-mysql/.snapshots/TestUnicodeText-latin1_char
+++ b/source-mysql/.snapshots/TestUnicodeText-latin1_char
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/test/unicodetext_latin1_char_78412948_07": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_char_78412948_07","cursor":"backfill:0"}},"data":"Sphinx of black quartz, judge my vow","id":100}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_char_78412948_07","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_char_78412948_07","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnicodeText_latin1_char_78412948_07":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"latin1","maxlen":64,"type":"char"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestUnicodeText-latin1_char
+++ b/source-mysql/.snapshots/TestUnicodeText-latin1_char
@@ -5,7 +5,7 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_char_78412948_07","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_char_78412948_07","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":201}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_char_78412948_07","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestUnicodeText-latin1_swedish_ci
+++ b/source-mysql/.snapshots/TestUnicodeText-latin1_swedish_ci
@@ -5,7 +5,7 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":201}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_swedish_ci_78412948_00","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestUnicodeText-latin1_varchar
+++ b/source-mysql/.snapshots/TestUnicodeText-latin1_varchar
@@ -5,7 +5,7 @@
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_varchar_78412948_06","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_varchar_78412948_06","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
-{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":201}
 {"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
 # ================================
 # Final State Checkpoint

--- a/source-mysql/.snapshots/TestUnicodeText-latin1_varchar
+++ b/source-mysql/.snapshots/TestUnicodeText-latin1_varchar
@@ -1,0 +1,14 @@
+# ================================
+# Collection "acmeCo/test/test/unicodetext_latin1_varchar_78412948_06": 6 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_varchar_78412948_06","cursor":"backfill:0"}},"data":"Sphinx of black quartz, judge my vow","id":100}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_varchar_78412948_06","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_latin1_varchar_78412948_06","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_latin1_varchar_78412948_06","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnicodeText_latin1_varchar_78412948_06":{"backfilled":3,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"latin1","maxlen":255,"type":"varchar"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestUnicodeText-ucs2_varchar
+++ b/source-mysql/.snapshots/TestUnicodeText-ucs2_varchar
@@ -1,0 +1,26 @@
+# ================================
+# Collection "acmeCo/test/test/unicodetext_ucs2_varchar_78412948_08": 18 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:0"}},"data":"Sphinx of black quartz, judge my vow","id":100}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:3"}},"data":"Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο","id":103}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:4"}},"data":"Árvíztűrő tükörfúrógép","id":104}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:5"}},"data":"いろはにほへとちりぬるを","id":105}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:6"}},"data":"ולפתע מצא","id":106}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:7"}},"data":"в чащах юга жил бы цитрус","id":107}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"backfill:8"}},"data":"次常用字","id":108}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο","id":203}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Árvíztűrő tükörfúrógép","id":204}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"いろはにほへとちりぬるを","id":205}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ולפתע מצא","id":206}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"в чащах юга жил бы цитрус","id":207}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_ucs2_varchar_78412948_08","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"次常用字","id":208}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnicodeText_ucs2_varchar_78412948_08":{"backfilled":9,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"ucs2","maxlen":255,"type":"varchar"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/.snapshots/TestUnicodeText-utf8mb4_varchar
+++ b/source-mysql/.snapshots/TestUnicodeText-utf8mb4_varchar
@@ -1,0 +1,26 @@
+# ================================
+# Collection "acmeCo/test/test/unicodetext_utf8mb4_varchar_78412948_09": 18 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:0"}},"data":"Sphinx of black quartz, judge my vow","id":100}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:1"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":101}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:2"}},"data":"Heizölrückstoßabdämpfung","id":102}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:3"}},"data":"Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο","id":103}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:4"}},"data":"Árvíztűrő tükörfúrógép","id":104}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:5"}},"data":"いろはにほへとちりぬるを","id":105}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:6"}},"data":"ולפתע מצא","id":106}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:7"}},"data":"в чащах юга жил бы цитрус","id":107}
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"backfill:8"}},"data":"次常用字","id":108}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Sphinx of black quartz, judge my vow","id":200}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Le cœur déçu mais l'âme plutôt naïve","id":201}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Heizölrückstoßabdämpfung","id":202}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο","id":203}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"Árvíztűrő tükörfúrógép","id":204}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"いろはにほへとちりぬるを","id":205}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"ולפתע מצא","id":206}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"в чащах юга жил бы цитрус","id":207}
+{"_meta":{"op":"c","source":{"ts_ms":1111111111111,"schema":"test","table":"UnicodeText_utf8mb4_varchar_78412948_09","cursor":"binlog.000123:56789:123","txid":"11111111-1111-1111-1111-111111111111:111"}},"data":"次常用字","id":208}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FUnicodeText_utf8mb4_varchar_78412948_09":{"backfilled":9,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data"],"types":{"data":{"charset":"utf8mb4","maxlen":255,"type":"varchar"},"id":{"type":"int"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/capture_test.go
+++ b/source-mysql/capture_test.go
@@ -369,27 +369,34 @@ func TestUnicodeText(t *testing.T) {
 	}
 
 	for idx, tc := range []struct {
-		Name    string
-		Options string
-		Inputs  []string
+		Name   string
+		Column string // The `data` column definition, e.g. "TEXT COLLATE latin1_swedish_ci".
+		Inputs []string
 	}{
-		{"latin1_swedish_ci", "COLLATE latin1_swedish_ci", latinTestStrings},                                    // Default in older MySQL and MariaDB releases
-		{"utf8mb4_0900_ai_ci", "COLLATE utf8mb4_0900_ai_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Default in modern MySQL releases
-		{"utf8mb4_general_ci", "COLLATE utf8mb4_general_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Default in Debian MariaDB
-		{"utf8mb3_general_ci", "COLLATE utf8mb3_general_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Testing 3-byte UTF-8 for completeness
-		{"ucs2_general_ci", "COLLATE ucs2_general_ci", slices.Concat(latinTestStrings, otherTestStrings)},       // Testing UCS-2 for completeness
+		{"latin1_swedish_ci", "TEXT COLLATE latin1_swedish_ci", latinTestStrings},                                    // Default in older MySQL and MariaDB releases
+		{"utf8mb4_0900_ai_ci", "TEXT COLLATE utf8mb4_0900_ai_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Default in modern MySQL releases
+		{"utf8mb4_general_ci", "TEXT COLLATE utf8mb4_general_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Default in Debian MariaDB
+		{"utf8mb3_general_ci", "TEXT COLLATE utf8mb3_general_ci", slices.Concat(latinTestStrings, otherTestStrings)}, // Testing 3-byte UTF-8 for completeness
+		{"ucs2_general_ci", "TEXT COLLATE ucs2_general_ci", slices.Concat(latinTestStrings, otherTestStrings)},       // Testing UCS-2 for completeness
 
 		// Testing binary charset/collation for completeness. Apparently what happens when you declare
 		// a column as `TEXT COLLATE binary` is that MySQL just gives you a `BLOB` column and then the
 		// bytes are the correct UTF-8 representation of the input text for both backfill and replication.
-		{"binary", "COLLATE binary", slices.Concat(latinTestStrings, otherTestStrings)},
+		{"binary", "TEXT COLLATE binary", slices.Concat(latinTestStrings, otherTestStrings)},
+
+		// CHAR/VARCHAR columns arrive via replication as a Go string rather than a byte slice.
+		// These cases exercise that path across UTF-8 and non-UTF-8 charsets.
+		{"latin1_varchar", "VARCHAR(255) COLLATE latin1_swedish_ci", latinTestStrings},
+		{"latin1_char", "CHAR(64) COLLATE latin1_swedish_ci", latinTestStrings},
+		{"ucs2_varchar", "VARCHAR(255) COLLATE ucs2_general_ci", slices.Concat(latinTestStrings, otherTestStrings)},
+		{"utf8mb4_varchar", "VARCHAR(255) COLLATE utf8mb4_general_ci", slices.Concat(latinTestStrings, otherTestStrings)},
 
 		// Default in MariaDB after v11.6.0. Cannot be tested against MySQL 8.4 but we have two other utf8mb4 charsets so that's okay.
-		// {"utf8mb4_uca1400_ai_ci", "COLLATE utf8mb4_uca1400_ai_ci", slices.Concat(latinTestStrings, otherTestStrings)},
+		// {"utf8mb4_uca1400_ai_ci", "TEXT COLLATE utf8mb4_uca1400_ai_ci", slices.Concat(latinTestStrings, otherTestStrings)},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			var uniqueID = fmt.Sprintf("78412948_%02d", idx)
-			var tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(id INTEGER PRIMARY KEY, data TEXT %s)", tc.Options))
+			var tableName = tb.CreateTable(ctx, t, uniqueID, fmt.Sprintf("(id INTEGER PRIMARY KEY, data %s)", tc.Column))
 			var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
 			cs.Validator = &st.OrderedCaptureValidator{}
 

--- a/source-mysql/datatypes.go
+++ b/source-mysql/datatypes.go
@@ -563,18 +563,25 @@ type mysqlTextTranscoderReplication struct {
 }
 
 func (t *mysqlTextTranscoderReplication) TranscodeJSON(buf []byte, val any) ([]byte, error) {
-	if str, ok := val.(string); ok {
-		return json.AppendEscape(buf, str, 0), nil
-	} else if bs, ok := val.([]byte); ok {
-		var str, err = decodeBytesToString(t.Charset, bs)
-		if err != nil {
-			return nil, err
-		}
-		return json.AppendEscape(buf, str, 0), nil
-	} else if val == nil {
+	// CHAR/VARCHAR columns arrive from the binlog as a string while TEXT/BLOB columns
+	// arrive as []byte, but in both cases the bytes are in the column's declared charset
+	// and must be decoded before serialization.
+	var bs []byte
+	switch v := val.(type) {
+	case string:
+		bs = unsafe.Slice(unsafe.StringData(v), len(v))
+	case []byte:
+		bs = v
+	case nil:
 		return append(buf, `null`...), nil
+	default:
+		return nil, fmt.Errorf("internal error: text column value must be bytes or nil: got %v", val)
 	}
-	return nil, fmt.Errorf("internal error: text column value must be bytes or nil: got %v", val)
+	var str, err = decodeBytesToString(t.Charset, bs)
+	if err != nil {
+		return nil, err
+	}
+	return json.AppendEscape(buf, str, 0), nil
 }
 
 type mysqlBinaryTranscoder struct {

--- a/source-mysql/discovery.go
+++ b/source-mysql/discovery.go
@@ -654,7 +654,10 @@ func decodeUTF8(bs []byte) (string, error) {
 }
 
 func decodeLatin1(bs []byte) (string, error) {
-	var decoder = charmap.ISO8859_1.NewDecoder()
+	// MySQL's `latin1` charset is actually Windows-1252, not ISO 8859-1. The two agree
+	// except in the 0x80-0x9F range, where cp1252 has printable characters which ISO 8859-1
+	// leaves as C1 control codes.
+	var decoder = charmap.Windows1252.NewDecoder()
 	var decodedBytes, err = decoder.Bytes(bs)
 	if err != nil {
 		return "", nil


### PR DESCRIPTION
**Description:**

Turns out the value decoding path for VARCHAR columns is subtly different from TEXT and we mostly exercised TEXT in our collation test cases, so there was a path for non-ASCII characters in VARCHAR columns with the latin-1 character set to get plumbed directly into JSON serialization (as strings containing the raw latin1 bytes) which would replace them with U+FFFD. Fixed by improving the test coverage and fixing the transcoding pipeline so those strings get translated according to the latin1 character set as well.

Also fixed another issue while I was here, turns out that MySQL "latin1" is not in fact ISO latin1 but rather the Windows cp1252 character set. Because of course it is. The two are mostly identical except for codepoints 0x80-0x9F which are only defined in cp1252, so we should use that character set when decoding these bytes.

**Workflow steps:**

Backfills may be required in some cases to capture the correctly transcoded data, however this edge case isn't terribly common in practice (the default collation in MySQL is UTF-8 these days) and in most cases where latin1 is usable at all the incorrect transcoding result only produces infrequent U+FFFD replacements where there should be an accented character. I don't believe we need to proactively identify impacted dataflows at this time, backfilling collections as needed if/when users complain should be sufficient.