### PR TITLE
source-salesforce-native: add My Domain login host support

### DIFF
--- a/source-salesforce-native/source_salesforce_native/auth.py
+++ b/source-salesforce-native/source_salesforce_native/auth.py
@@ -21,22 +21,27 @@ from simple_salesforce.login import SalesforceLogin
 from .shared import VERSION
 
 
+# _OAUTH_LOGIN_ORIGIN is a mustache fragment rendered by the control plane that selects the OAuth login origin.
+# The org's My Domain host is used when provided, otherwise the standard login/test host is used.
+_OAUTH_LOGIN_ORIGIN = (
+    "https://"
+    r"{{#config.my_domain}}{{{config.my_domain}}}{{/config.my_domain}}"
+    r"{{^config.my_domain}}{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}.salesforce.com{{/config.my_domain}}"
+)
+
+
 OAUTH2_SPEC = OAuth2Spec(
     provider="salesforce",
     authUrlTemplate=(
-        "https://"
-        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
-        ".salesforce.com/services/oauth2/authorize?"
-        r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
-        r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
-        r"&response_type=code"
-        r"&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
+        _OAUTH_LOGIN_ORIGIN + (
+            "/services/oauth2/authorize?"
+            r"client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}"
+            r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
+            r"&response_type=code"
+            r"&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
+        )
     ),
-    accessTokenUrlTemplate=(
-        "https://"
-        r"{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}"
-        ".salesforce.com/services/oauth2/token"
-    ),
+    accessTokenUrlTemplate=_OAUTH_LOGIN_ORIGIN + "/services/oauth2/token",
     accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
     accessTokenBody=(
         "grant_type=authorization_code"
@@ -52,8 +57,19 @@ OAUTH2_SPEC = OAuth2Spec(
 )
 
 # Mustache templates in accessTokenUrlTemplate are not interpolated within the connector, so update_oauth_spec reassigns it for use within the connector.
-def update_oauth_spec(is_sandbox: bool):
-    OAUTH2_SPEC.accessTokenUrlTemplate = f"https://{'test' if is_sandbox else 'login'}.salesforce.com/services/oauth2/token"
+def update_oauth_spec(is_sandbox: bool, my_domain: str):
+    # Refresh-token requests must hit the same host the tokens were issued from. When a My Domain
+    # is configured it's already a full host (e.g. mycompany.my.salesforce.com); otherwise use the
+    # standard login/test host.
+    host = my_domain or f"{'test' if is_sandbox else 'login'}.salesforce.com"
+    OAUTH2_SPEC.accessTokenUrlTemplate = f"https://{host}/services/oauth2/token"
+
+
+def _login_domain_from_my_domain(my_domain: str) -> str:
+    # simple_salesforce builds the SOAP login URL as https://{domain}.salesforce.com/..., so it
+    # wants just the subdomain. my_domain is validated by the EndpointConfig model as a full host ending in
+    # ".my.salesforce.com", so here we strip the ".salesforce.com" it re-appends.
+    return my_domain.removesuffix(".salesforce.com")
 
 
 class UserPass(BaseModel):
@@ -74,12 +90,15 @@ class UserPass(BaseModel):
         json_schema_extra={"secret": True, "order": 3},
     )
 
-    def fetch_access_token_and_instance_url(self, is_sandbox: bool) -> tuple[str, str]:
+    def fetch_access_token_and_instance_url(self, is_sandbox: bool, my_domain: str) -> tuple[str, str]:
+        # Log in through the org's My Domain when configured, otherwise use the standard login/test host.
+        domain = _login_domain_from_my_domain(my_domain) or ("test" if is_sandbox else "login")
+
         access_token, instance_url = SalesforceLogin(
             username=self.username,
             password=self.password,
             security_token=self.security_token,
-            domain="test" if is_sandbox else "login",
+            domain=domain,
             sf_version=VERSION,
         )
 
@@ -135,6 +154,7 @@ class SalesforceTokenSource(TokenSource):
     # unless the new fields are marked as keyword-only using dataclasses.field(kw_only=True).
     credentials: UserPass | OAuth2Credentials = dataclasses.field(kw_only=True)
     is_sandbox: bool = dataclasses.field(kw_only=True)
+    my_domain: str = dataclasses.field(kw_only=True)
 
     async def fetch_token(self, log: Logger, session: HTTPSession) -> tuple[str, str]:
         if isinstance(self.credentials, UserPass):
@@ -149,7 +169,7 @@ class SalesforceTokenSource(TokenSource):
                     return (self.authorization_token_type, self._access_token.access_token)
 
             self._fetched_at = int(current_time)
-            access_token, _ = self.credentials.fetch_access_token_and_instance_url(is_sandbox=self.is_sandbox)
+            access_token, _ = self.credentials.fetch_access_token_and_instance_url(is_sandbox=self.is_sandbox, my_domain=self.my_domain)
             self._access_token = SalesforceTokenSource.AccessTokenResponse(
                 access_token=access_token,
                 token_type=self.authorization_token_type,

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -54,6 +54,21 @@ class EndpointConfig(BaseModel):
         description="Toggle if you're using a Salesforce Sandbox.",
         default=False,
     )
+    my_domain: str = Field(
+        default="",
+        title="My Domain",
+        description=(
+            "Your Salesforce My Domain login host. Enter the full host ending in "
+            ".my.salesforce.com to login with your My Domain host. e.g. mycompany.my.salesforce.com, "
+            "acme--uat.sandbox.my.salesforce.com. Leave blank to log in via the "
+            "standard login/test endpoint."
+        ),
+        # The control plane interpolates this verbatim into the OAuth authorize/token URLs,
+        # so we require a clean host with no scheme or path. Both production (mycompany.my.salesforce.com)
+        # and sandbox (...sandbox.my.salesforce.com) My Domains end in ".my.salesforce.com".
+        # An empty string is allowed to keep the field optional.
+        pattern=r"^$|^[A-Za-z0-9][A-Za-z0-9.-]*\.my\.salesforce\.com$",
+    )
     credentials: OAuth2Credentials | UserPass = Field(
         discriminator="credentials_title",
         title="Authentication",

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -291,7 +291,7 @@ async def _object_to_resource(
 
 def _fetch_instance_url(log: Logger, config: EndpointConfig) -> str:
     if isinstance(config.credentials, UserPass):
-        _, instance_url = config.credentials.fetch_access_token_and_instance_url(config.is_sandbox)
+        _, instance_url = config.credentials.fetch_access_token_and_instance_url(config.is_sandbox, config.my_domain)
     else:
         instance_url = config.credentials.instance_url
 
@@ -302,8 +302,8 @@ def _fetch_instance_url(log: Logger, config: EndpointConfig) -> str:
 async def enabled_resources(
     log: Logger, http: HTTPMixin, config: EndpointConfig, bindings: list[common._ResolvableBinding]
 ) -> list[common.Resource]:
-    update_oauth_spec(config.is_sandbox)
-    http.token_source = SalesforceTokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials, is_sandbox=config.is_sandbox)
+    update_oauth_spec(config.is_sandbox, config.my_domain)
+    http.token_source = SalesforceTokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials, is_sandbox=config.is_sandbox, my_domain=config.my_domain)
     instance_url = _fetch_instance_url(log, config)
 
     enabled_binding_names: list[str] = []
@@ -343,8 +343,8 @@ async def enabled_resources(
 async def all_resources(
     log: Logger, http: HTTPMixin, config: EndpointConfig
 ) -> list[common.Resource]:
-    update_oauth_spec(config.is_sandbox)
-    http.token_source = SalesforceTokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials, is_sandbox=config.is_sandbox)
+    update_oauth_spec(config.is_sandbox, config.my_domain)
+    http.token_source = SalesforceTokenSource(oauth_spec=OAUTH2_SPEC, credentials=config.credentials, is_sandbox=config.is_sandbox, my_domain=config.my_domain)
     instance_url = _fetch_instance_url(log, config)
 
     queryable_object_names = await _fetch_queryable_objects(log, http, instance_url)

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -103,6 +103,13 @@
           "title": "Sandbox",
           "type": "boolean"
         },
+        "my_domain": {
+          "default": "",
+          "description": "Your Salesforce My Domain login host. Enter the full host ending in .my.salesforce.com to login with your My Domain host. e.g. mycompany.my.salesforce.com, acme--uat.sandbox.my.salesforce.com. Leave blank to log in via the standard login/test endpoint.",
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9.-]*\\.my\\.salesforce\\.com$",
+          "title": "My Domain",
+          "type": "string"
+        },
         "credentials": {
           "discriminator": {
             "mapping": {
@@ -178,8 +185,8 @@
     "documentationUrl": "https://go.estuary.dev/source-salesforce-native",
     "oauth2": {
       "provider": "salesforce",
-      "authUrlTemplate": "https://{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}.salesforce.com/services/oauth2/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
-      "accessTokenUrlTemplate": "https://{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}.salesforce.com/services/oauth2/token",
+      "authUrlTemplate": "https://{{#config.my_domain}}{{{config.my_domain}}}{{/config.my_domain}}{{^config.my_domain}}{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}.salesforce.com{{/config.my_domain}}/services/oauth2/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
+      "accessTokenUrlTemplate": "https://{{#config.my_domain}}{{{config.my_domain}}}{{/config.my_domain}}{{^config.my_domain}}{{#config.is_sandbox}}test{{/config.is_sandbox}}{{^config.is_sandbox}}login{{/config.is_sandbox}}.salesforce.com{{/config.my_domain}}/services/oauth2/token",
       "accessTokenBody": "grant_type=authorization_code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}",
       "accessTokenHeaders": {
         "content-type": "application/x-www-form-urlencoded"

--- a/source-salesforce-native/tests/test_auth.py
+++ b/source-salesforce-native/tests/test_auth.py
@@ -1,0 +1,61 @@
+import pytest
+from pydantic import ValidationError
+
+from source_salesforce_native.auth import _login_domain_from_my_domain
+from source_salesforce_native.models import EndpointConfig
+
+
+def _config_with_my_domain(my_domain: str) -> dict:
+    # Minimal valid endpoint config; the OAuth/My Domain template only cares about my_domain.
+    return {
+        "my_domain": my_domain,
+        "credentials": {
+            "credentials_title": "Username, Password, & Security Token",
+            "username": "svc@example.com",
+            "password": "pw",
+            "security_token": "tok",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "my_domain, expected",
+    [
+        # A validated My Domain host is reduced to the subdomain that
+        # simple_salesforce re-appends ".salesforce.com" to.
+        ("mycompany.my.salesforce.com", "mycompany.my"),
+        ("acme--uat.sandbox.my.salesforce.com", "acme--uat.sandbox.my"),
+    ],
+)
+def test_login_domain_from_my_domain(my_domain: str, expected: str) -> None:
+    assert _login_domain_from_my_domain(my_domain) == expected
+
+
+@pytest.mark.parametrize(
+    "my_domain",
+    [
+        "",  # optional — empty is the default and must validate
+        "mycompany.my.salesforce.com",
+        "acme--uat.sandbox.my.salesforce.com",
+    ],
+)
+def test_endpoint_config_accepts_valid_my_domain(my_domain: str) -> None:
+    # The control plane interpolates this value verbatim into the OAuth URLs, so it must be a
+    # clean host; these forms are safe.
+    assert EndpointConfig.model_validate(_config_with_my_domain(my_domain)).my_domain == my_domain
+
+
+@pytest.mark.parametrize(
+    "my_domain",
+    [
+        "https://mycompany.my.salesforce.com",  # scheme would double up in the URL
+        "mycompany.my.salesforce.com/",  # trailing path
+        "mycompany",  # bare My Domain name -> https://mycompany/... (broken)
+        "mycompany.my",  # missing .salesforce.com
+        "na123.salesforce.com",  # instanced URL, not a My Domain
+        "login.salesforce.com",  # standard host, not a My Domain
+    ],
+)
+def test_endpoint_config_rejects_malformed_my_domain(my_domain: str) -> None:
+    with pytest.raises(ValidationError):
+        EndpointConfig.model_validate(_config_with_my_domain(my_domain))


### PR DESCRIPTION
**Description:**

Organizations that require their My Domain login URL and block `login.salesforce.com` could not authenticate with either method since all authentication methods were hardcoded to use the standard `login.salesforce.com` or `test.salesforce.com` URLs.

This PR fixes this by adding an optional top-level `my_domain` field to the endpoint config that is used as the login host for both auth methods when set and falls back to the existing login/test behavior when blank:

- OAuth: the authorize and access-token URL mustache templates select the My Domain host when present, and the runtime refresh-token URL is built from it as well.
- Username/Password: the SOAP login is reduced to the subdomain `simple_salesforce` expects (e.g. mycompany.my.salesforce.com -> mycompany.my).

The field is strictly validated as a full `*.my.salesforce.com` host because the control plane interpolates it verbatim into the OAuth URLs & does not normalize it. An empty or absent value takes the `login`/`test` fallback.

Spec snapshot changes are expected due to the addition of the `my_domain` field to the endpoint config as well as the changes to the mustache templates in the OAuth URLs.

**Documentation links affected:**

The connector's documentation should be updated to include the new `my_domain` endpoint config field. It'd be worthwhile to update the connector's documentation to indicate when users would want to fill out the new `my_domain` field.

**Notes for reviewers:**

Tested on a dev stack. Confirmed:
- Both authentication methods plus the OAuth flow still work without filling out the `my_domain` field.
- Both authentication methods plus the OAuth flow work when the `my_domain` field is filled out.

Relevant Salesforce documentation:
[Customize Your Login Process with My Domain](https://trailhead.salesforce.com/content/learn/modules/identity_login/identity_login_my_domain)
[Log In To Salesforce with Code](https://help.salesforce.com/s/articleView?id=xcloud.domain_name_login_code.htm&type=5)
[Set the My Domain Login Policy](https://help.salesforce.com/s/articleView?id=xcloud.domain_name_setting_login_policy.htm&type=5)