### PR TITLE
materialize-postgres: add "enum" flag that is enabled by default

### DIFF
--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -53,6 +53,7 @@ var featureFlagDefaults = map[string]bool{
 	"datetime_keys_as_string":          true,
 	"retain_existing_data_on_backfill": false,
 	"native_binary_column_type":        true,
+	"enum":                             true,
 }
 
 func ctxWithQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -49,7 +49,12 @@ func createPgDialect(featureFlags map[string]bool) sql.Dialect {
 			sql.STRING_INTEGER: sql.MapStatic("NUMERIC"),
 			sql.STRING_NUMBER:  sql.MapStatic("DECIMAL", sql.AlsoCompatibleWith("numeric")),
 			sql.STRING: sql.MapString(sql.StringMappings{
-				Fallback: MapEnum(primaryKeyTextType),
+				Fallback: func() sql.MapProjectionFn {
+					if featureFlags["enum"] {
+						return MapEnum(primaryKeyTextType)
+					}
+					return primaryKeyTextType
+				}(),
 				WithFormat: map[string]sql.MapProjectionFn{
 					"date":      dateMapping,
 					"date-time": datetimeMapping,


### PR DESCRIPTION
**Description:**

- We released this change but then realised that `_meta/op` is an enum and all tasks triggered migrations. Now some tasks are stuck because of not having enough disk to do the migration, and some other tasks have views that depend on `_meta/op` and during migration they cannot be dropped.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

