### PR TITLE
source-hubspot-native: sleep in fetch_delayed_changes until it is time to poll again

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api/shared.py
+++ b/source-hubspot-native/source_hubspot_native/api/shared.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta, UTC
+import asyncio
+from datetime import UTC, datetime, timedelta
 from logging import Logger
 from typing import (
     Any,
@@ -9,7 +10,6 @@ from typing import (
 import estuary_cdk.emitted_changes_cache as cache
 from estuary_cdk.capture.common import LogCursor, Triggers
 from estuary_cdk.http import HTTPSession
-
 
 # Hubspot returns a 500 internal server error if querying for data at the EPOCH.
 EPOCH_PLUS_ONE_SECOND = datetime(1970, 1, 1, tzinfo=UTC) + timedelta(seconds=1)
@@ -181,10 +181,14 @@ async def fetch_delayed_changes(
     lower_bound = log_cursor
     horizon = now - DELAYED_LAG
 
-    # Don't poll unless at least MIN_DELAYED_WINDOW of data has accumulated
+    # Don't poll until at least MIN_DELAYED_WINDOW of data has accumulated
     # to prevent excessive API calls.
     if horizon - lower_bound < MIN_DELAYED_WINDOW:
-        return
+        await asyncio.sleep(
+            (MIN_DELAYED_WINDOW - (horizon - lower_bound)).total_seconds()
+        )
+        now = datetime.now(UTC)
+        horizon = now - DELAYED_LAG
 
     # Limit the window to prevent huge checkpoints when catching up.
     upper_bound = min(horizon, log_cursor + MAX_DELAYED_WINDOW)

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -616,7 +616,7 @@
           }
         ]
       },
-      "updatedAt": "2025-01-18T21:49:41.259000Z",
+      "updatedAt": "redacted",
       "url": "redacted"
     }
   ],
@@ -1471,7 +1471,7 @@
           }
         ]
       },
-      "updatedAt": "2024-10-28T16:40:17.996000Z",
+      "updatedAt": "redacted",
       "url": "redacted"
     }
   ],
@@ -2326,7 +2326,7 @@
           }
         ]
       },
-      "updatedAt": "2024-10-28T16:40:20.553000Z",
+      "updatedAt": "redacted",
       "url": "redacted"
     }
   ],
@@ -3056,7 +3056,7 @@
           }
         ]
       },
-      "updatedAt": "2025-04-03T12:59:43.469000Z",
+      "updatedAt": "redacted",
       "url": "redacted"
     }
   ],
@@ -3162,7 +3162,7 @@
           "updatedAt": 1743685150749
         }
       ],
-      "updatedAt": "2025-04-03T12:59:10.749000Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -3180,7 +3180,7 @@
       "id": "83700335",
       "lastName": "Lazo",
       "type": "PERSON",
-      "updatedAt": "2026-05-27T17:09:07.076000Z",
+      "updatedAt": "redacted",
       "userId": 83700335,
       "userIdIncludingInactive": 83700335
     }
@@ -3200,7 +3200,7 @@
       "id": "904875188",
       "lastName": "Bair",
       "type": "PERSON",
-      "updatedAt": "2024-12-18T20:19:29.405000Z",
+      "updatedAt": "redacted",
       "userId": 73074756,
       "userIdIncludingInactive": 73074756
     }
@@ -3483,7 +3483,7 @@
           }
         ]
       },
-      "updatedAt": "2026-01-14T19:18:04.972000Z",
+      "updatedAt": "redacted",
       "url": "redacted"
     }
   ]

--- a/source-hubspot-native/tests/test_snapshots.py
+++ b/source-hubspot-native/tests/test_snapshots.py
@@ -4,13 +4,13 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from estuary_cdk.utils import compare_capture_records
 
 
 def test_capture(request, snapshot):
     FIELDS_TO_REDACT = [
         "url",
+        "updatedAt",
     ]
 
     PROPERTY_PATTERNS_TO_REDACT = [
@@ -51,7 +51,9 @@ def test_capture(request, snapshot):
             if field in record:
                 record[field] = "redacted"
 
-    snapshot_path = Path(request.fspath.dirname) / "snapshots" / "snapshots__capture__stdout.json"
+    snapshot_path = (
+        Path(request.fspath.dirname) / "snapshots" / "snapshots__capture__stdout.json"
+    )
     insta_mode = request.config.getoption("--insta", default=None)
 
     if insta_mode == "update" or not snapshot_path.exists():


### PR DESCRIPTION
**Description:**

Prevent a CPU-intensive hot loop when `fetch_delayed_changes` is not yet ready to poll.

This is a targeted change in source-hubspot-native to mitigate the immediate issue. I could imagine a higher-level and more extensible addition to the CDK's multi-stream mechanism to allow for a separate interval to be specified for multiple different streams, but I'm leaving that for a later implementation if its warranted.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

