### PR TITLE
source-hubspot-native: use extra="allow" on marketing events stream

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api/marketing_events.py
+++ b/source-hubspot-native/source_hubspot_native/api/marketing_events.py
@@ -1,12 +1,11 @@
 from collections.abc import AsyncGenerator
 from logging import Logger
 
-from estuary_cdk.capture.common import BaseDocument
 from estuary_cdk.http import HTTPSession
 from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 from pydantic import BaseModel, JsonValue
 
-from ..models import PageResult
+from ..models import MarketingEvent, PageResult
 from .shared import (
     HUB,
 )
@@ -21,7 +20,7 @@ class _ResponseRemainder(BaseModel, extra="allow"):
 async def fetch_marketing_events(
     http: HTTPSession,
     log: Logger,
-) -> AsyncGenerator[BaseDocument, None]:
+) -> AsyncGenerator[MarketingEvent, None]:
     url = f"{HUB}/marketing/v3/marketing-events"
     after: str | None = None
 
@@ -37,7 +36,7 @@ async def fetch_marketing_events(
         processor = IncrementalJsonProcessor(
             body(),
             "results.item",
-            BaseDocument,
+            MarketingEvent,
             remainder_cls=_ResponseRemainder,
         )
 

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -875,3 +875,7 @@ class Order(BaseCRMObject):
 class Campaign(BaseDocument, extra="allow"):
     id: str
     updatedAt: AwareDatetime
+
+
+class MarketingEvent(BaseDocument, extra="allow"):
+    pass

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -92,6 +92,7 @@ from .models import (
     Goals,
     LineItem,
     MarketingEmail,
+    MarketingEvent,
     Names,
     Order,
     Owner,
@@ -652,7 +653,7 @@ def forms(http: HTTPSession) -> Resource:
 
 def marketing_events(
     http: HTTPSession,
-) -> SnapshotResource[BaseDocument, ResourceConfig]:
+) -> SnapshotResource[MarketingEvent, ResourceConfig]:
     def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -3206,6 +3206,37 @@
     }
   ],
   [
+    "acmeCo/marketing_events",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "appInfo": null,
+      "attendees": null,
+      "cancellations": null,
+      "createdAt": "2026-05-29T14:27:36.562Z",
+      "customProperties": [],
+      "endDateTime": "2026-05-29T04:00:00Z",
+      "eventCancelled": false,
+      "eventCompleted": false,
+      "eventDescription": "My description",
+      "eventName": "Test Marketing Event",
+      "eventOrganizer": "Nicolas Lazo",
+      "eventStatus": "PAST",
+      "eventStatusV2": "completed",
+      "eventType": "Test Event",
+      "eventUrl": null,
+      "externalEventId": null,
+      "noShows": 0,
+      "objectId": "559722810694",
+      "registrants": null,
+      "startDateTime": "2026-05-29T14:27:26.867Z",
+      "updatedAt": "redacted"
+    }
+  ],
+  [
     "acmeCo/orders",
     {
       "_meta": {


### PR DESCRIPTION
**Description:**

Fixes a bug where marketing event API responses were being parsed into `BaseDocument`s, which default to `extra="ignore"`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested using `flowctl preview`. Snapshot shows the new captured document

