### PR TITLE
source-mongodb: treat transcoder shutdown as cancellation, not failure

### DIFF
--- a/source-mongodb/transcoder.go
+++ b/source-mongodb/transcoder.go
@@ -195,6 +195,14 @@ func (t *Transcoder) transcodeBatch(count int, writeAll func() error) ([]*Transc
 	for i := 0; i < count; i++ {
 		resp, err := t.readResponse()
 		if err != nil {
+			// Pipe reads aren't context-aware, so an EOF here is ambiguous. It's
+			// either a real transcoder failure, or during shutdown the result
+			// of CommandContext killing the subprocess because t.ctx was cancelled.
+			// Propagate the context error in the latter case so a cancellation is
+			// reported as such.
+			if ctxErr := t.ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
 			// Check if write failed first - it may explain the read error
 			select {
 			case werr := <-writeErr:
@@ -209,6 +217,11 @@ func (t *Transcoder) transcodeBatch(count int, writeAll func() error) ([]*Transc
 	}
 
 	if err := <-writeErr; err != nil {
+		// As with the read path propagate the context error so a cancellation
+		// that interrupted the write is reported as such.
+		if ctxErr := t.ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, err
 	}
 	return responses, nil


### PR DESCRIPTION
**Description:**

Capture tests intermittently failed with spurious "transcoding ... reading frame: EOF" errors on shutdown, which I hit running tests locally and in CI.

The transcoder subprocess is tied to the capture's context via `exec.CommandContext`, so when the capture shuts down and cancels its context, the subprocess is killed. A batch that's mid-transcode then fails its pipe read or write with EOF, and `transcodeBatch` returned that as a hard error instead of recognizing the cancellation.

Pipe reads and writes aren't context-aware, so on a read or write error `transcodeBatch` now checks `t.ctx.Err()` first, returning the cancellation when the context is done and falling through to the original error otherwise. The EOF is causally downstream of the cancellation, so the context error is always set by then. A genuine crash while the context is live is still surfaced.

This was a regression from moving to an out-of-process transcoder in 5c28c4aaa; previously transcoding was in-process with no subprocess to kill.