### PR TITLE
source-hubspot-native: use `/modified/after` endpoint for delayed engagements

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api/engagements.py
+++ b/source-hubspot-native/source_hubspot_native/api/engagements.py
@@ -11,18 +11,53 @@ from estuary_cdk.http import HTTPSession
 
 from ..models import (
     Engagement,
+    EngagementsModifiedAfter,
     Names,
     OldRecentEngagements,
 )
 from .object_with_associations import fetch_changes_with_associations
 from .shared import (
+    dt_to_ms,
     ms_to_dt,
     HUB,
     MustBackfillBinding,
 )
 
 
-async def _fetch_engagements(
+async def _fetch_engagements_modified_after(
+    log: Logger,
+    http: HTTPSession,
+    since: datetime,
+    until: datetime,
+    page: PageCursor,
+    count: int,
+) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    # Unlike the "recent/modified" endpoint used by the realtime stream,
+    # "modified/after" is cursor-paginated with no 10k offset cap and reads
+    # forward from a timestamp. The results aren't ordered, so we fully
+    # enumerate the result set here and return everything at once.
+    url = f"{HUB}/engagements/v1/engagements/modified/after"
+    output: list[tuple[datetime, str]] = []
+    after: int | str = dt_to_ms(since)
+
+    while True:
+        params: dict[str, str | int] = {"after": after, "limit": 250}
+        result = EngagementsModifiedAfter.model_validate_json(
+            await http.request(log, url, params=params)
+        )
+        output.extend(
+            (ts, str(r.engagement.id))
+            for r in result.results
+            if (ts := ms_to_dt(r.engagement.lastUpdated)) <= until
+        )
+        if not result.hasMore or not result.after:
+            break
+        after = result.after
+
+    return output, None
+
+
+async def _fetch_recently_modified_engagements(
     log: Logger, http: HTTPSession, page: PageCursor, count: int
 ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
     if count >= 9_900:
@@ -55,7 +90,7 @@ def fetch_recent_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        functools.partial(_fetch_engagements, log, http),
+        functools.partial(_fetch_recently_modified_engagements, log, http),
         log,
         http,
         with_history,
@@ -67,14 +102,10 @@ def fetch_recent_engagements(
 def fetch_delayed_engagements(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
 ) -> AsyncGenerator[tuple[datetime, str, Engagement], None]:
-    # There is no way to fetch engagements other than starting with the most
-    # recent and reading backward, so this is the same process as fetching
-    # "recent" engagements. It relies on the filtering in
-    # `fetch_changes_with_associations` to ignore the more recent items.
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        functools.partial(_fetch_engagements, log, http),
+        functools.partial(_fetch_engagements_modified_after, log, http, since, until),
         log,
         http,
         with_history,

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -688,6 +688,12 @@ class OldRecentEngagements(BaseModel):
     total: int
 
 
+class EngagementsModifiedAfter(BaseModel):
+    results: list[OldRecentEngagements.Item]
+    hasMore: bool
+    after: str | None = None
+
+
 class OldRecentTicket(BaseModel):
     timestamp: int
     objectId: int


### PR DESCRIPTION
**Description:**

The delayed `engagements` stream used the `/engagements/v1/engagements/recent/modified`, endpoint which returns results most-recent-first, is offset-paginated, and caps at ~10k records. Because the delayed stream trails realtime by an hour and that endpoint has no time filter, it had to page through the entire most-recent hour of modifications before reaching the date window it cares about. On a high-volume account, that trailing hour alone exceeds 9,900 records, so every delayed poll raised `MustBackfillBinding`, which triggered a full-connector restart. The result was a constant re-backfill loop that prevented the engagements binding from making progress.

This PR fixes that by switching the delayed stream to use the [`/engagements/v1/engagements/modified/after` endpoint](https://developers.hubspot.com/docs/api-reference/legacy/crm/activities/engagements/get-engagements-v1-engagements-modified-after), which filters by modification time, is cursor-paginated, and has no 10k offset cap. Because it reads forward from the cursor's timestamp there is no recent-zone to page past. Its results are unordered, so the fetcher fully enumerates the cursor and returns everything at once, letting `fetch_changes_with_associations` apply the `[since, until]` windowing. The endpoint returns the same `/engagements/v1` id space, so the existing batch-read, association, and backfill paths are unchanged.

**Notes for reviewers:**

Tested with `flowctl preview`. Confirmed the delayed stream for `engagements` captures data as expected.