### PR TITLE
source-hubspot-native: add marketing event participants stream

### DIFF
--- a/source-hubspot-native/acmeCo/flow.yaml
+++ b/source-hubspot-native/acmeCo/flow.yaml
@@ -49,6 +49,10 @@ collections:
     schema: marketing_emails.schema.yaml
     key:
     - /id
+  acmeCo/marketing_event_participants:
+    schema: marketing_event_participants.schema.yaml
+    key:
+    - /_meta/row_id
   acmeCo/marketing_events:
     schema: marketing_events.schema.yaml
     key:

--- a/source-hubspot-native/acmeCo/marketing_event_participants.schema.yaml
+++ b/source-hubspot-native/acmeCo/marketing_event_participants.schema.yaml
@@ -1,0 +1,40 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+    title: Meta
+    type: object
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+title: BaseDocument
+type: object
+x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-hubspot-native/source_hubspot_native/api/__init__.py
+++ b/source-hubspot-native/source_hubspot_native/api/__init__.py
@@ -66,7 +66,10 @@ from .marketing_emails import (
     fetch_marketing_emails_page,
     fetch_recent_marketing_emails,
 )
-from .marketing_events import fetch_marketing_events
+from .marketing_events import (
+    fetch_marketing_event_participants,
+    fetch_marketing_events,
+)
 from .object_with_associations import fetch_page_with_associations
 from .orders import (
     fetch_delayed_orders,
@@ -120,6 +123,7 @@ __all__ = [
     "fetch_form_submissions",
     "fetch_forms",
     "fetch_marketing_emails_page",
+    "fetch_marketing_event_participants",
     "fetch_marketing_events",
     "fetch_owners",
     "fetch_page_with_associations",

--- a/source-hubspot-native/source_hubspot_native/api/marketing_events.py
+++ b/source-hubspot-native/source_hubspot_native/api/marketing_events.py
@@ -5,12 +5,10 @@ from estuary_cdk.http import HTTPSession
 from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 from pydantic import BaseModel, JsonValue
 
-from ..models import MarketingEvent, PageResult
-from .shared import (
-    HUB,
-)
+from ..models import MarketingEvent, MarketingEventParticipant, PageResult
+from .shared import HUB
 
-MARKETING_EVENTS_PAGE_SIZE = 100
+PAGE_SIZE = 100
 
 
 class _ResponseRemainder(BaseModel, extra="allow"):
@@ -24,9 +22,7 @@ async def fetch_marketing_events(
     url = f"{HUB}/marketing/v3/marketing-events"
     after: str | None = None
 
-    input: dict[str, JsonValue] = {
-        "limit": MARKETING_EVENTS_PAGE_SIZE,
-    }
+    input: dict[str, JsonValue] = {"limit": PAGE_SIZE}
 
     while True:
         if after:
@@ -48,3 +44,39 @@ async def fetch_marketing_events(
             return
 
         after = paging.next.after
+
+
+async def fetch_marketing_event_participants(
+    http: HTTPSession,
+    log: Logger,
+) -> AsyncGenerator[MarketingEventParticipant, None]:
+    event_ids = [event.objectId async for event in fetch_marketing_events(http, log)]
+
+    for event_id in event_ids:
+        url = (
+            f"{HUB}/marketing/v3/marketing-events/participations/"
+            f"{event_id}/breakdown"
+        )
+        after: str | None = None
+        input: dict[str, JsonValue] = {"limit": PAGE_SIZE}
+
+        while True:
+            if after:
+                input["after"] = after
+
+            _, body = await http.request_stream(log, url, method="GET", params=input)
+            processor = IncrementalJsonProcessor(
+                body(),
+                "results.item",
+                MarketingEventParticipant,
+                remainder_cls=_ResponseRemainder,
+            )
+
+            async for participant in processor:
+                yield participant
+
+            paging = processor.get_remainder().paging
+            if not paging:
+                break
+
+            after = paging.next.after

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -180,6 +180,7 @@ class Names(StrEnum):
     carts = auto()
     partner_clients = auto()
     marketing_events = auto()
+    marketing_event_participants = auto()
     marketing_emails = auto()
     contact_lists = auto()
     contact_list_memberships = auto()
@@ -884,4 +885,8 @@ class Campaign(BaseDocument, extra="allow"):
 
 
 class MarketingEvent(BaseDocument, extra="allow"):
+    objectId: str
+
+
+class MarketingEventParticipant(BaseDocument, extra="allow"):
     pass

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -50,6 +50,7 @@ from .api import (
     fetch_form_submissions,
     fetch_forms,
     fetch_marketing_emails_page,
+    fetch_marketing_event_participants,
     fetch_marketing_events,
     fetch_owners,
     fetch_page_with_associations,
@@ -93,6 +94,7 @@ from .models import (
     LineItem,
     MarketingEmail,
     MarketingEvent,
+    MarketingEventParticipant,
     Names,
     Order,
     Owner,
@@ -153,6 +155,10 @@ async def _remove_permission_blocked_resources(
         ),
         (Names.forms, fetch_forms(http, log)),
         (Names.marketing_events, fetch_marketing_events(http, log)),
+        (
+            Names.marketing_event_participants,
+            fetch_marketing_event_participants(http, log),
+        ),
         (Names.form_submissions, fetch_form_submissions(http, log, 0)),
         (
             Names.feedback_submissions,
@@ -365,6 +371,7 @@ async def all_resources(
         form_submissions(http),
         marketing_emails(http),
         marketing_events(http),
+        marketing_event_participants(http),
         feedback_submissions(http, with_history),
         contact_lists(http),
         contact_list_memberships(http),
@@ -674,6 +681,33 @@ def marketing_events(
         open=open,
         initial_config=ResourceConfig(
             name=Names.marketing_events, interval=timedelta(minutes=5)
+        ),
+    )
+
+
+def marketing_event_participants(
+    http: HTTPSession,
+) -> SnapshotResource[MarketingEventParticipant, ResourceConfig]:
+    def open(
+        binding: CaptureBinding[ResourceConfig],
+        binding_index: int,
+        state: ResourceState,
+        task: Task,
+        all_bindings,
+    ):
+        open_binding(
+            binding,
+            binding_index,
+            state,
+            task,
+            fetch_snapshot=functools.partial(fetch_marketing_event_participants, http),
+        )
+
+    return SnapshotResource(
+        name=Names.marketing_event_participants,
+        open=open,
+        initial_config=ResourceConfig(
+            name=Names.marketing_event_participants, interval=timedelta(minutes=15)
         ),
     )
 

--- a/source-hubspot-native/test.flow.yaml
+++ b/source-hubspot-native/test.flow.yaml
@@ -70,6 +70,10 @@ captures:
         interval: PT5M
       target: acmeCo/marketing_events
     - resource:
+        name: marketing_event_participants
+        interval: PT5M
+      target: acmeCo/marketing_event_participants
+    - resource:
         name: contact_lists
         interval: PT3H
       target: acmeCo/contact_lists

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -196,6 +196,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": null,
         "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": null,
         "hs_v2_cumulative_time_in_customer": null,
@@ -871,8 +872,10 @@
         "hs_predictivecontactscore_v2": null,
         "hs_predictivecontactscorebucket": null,
         "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": "0",
         "hs_prospecting_agent_enrollment_status": null,
+        "hs_prospecting_agent_enrollment_status_raw": null,
         "hs_prospecting_agent_last_enrolled": null,
         "hs_prospecting_agent_sender": null,
         "hs_prospecting_agent_total_enrolled_count": null,
@@ -927,6 +930,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": null,
         "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": null,
         "hs_v2_cumulative_time_in_customer": null,
@@ -1730,8 +1734,10 @@
         "hs_predictivecontactscore_v2": null,
         "hs_predictivecontactscorebucket": null,
         "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": "0",
         "hs_prospecting_agent_enrollment_status": null,
+        "hs_prospecting_agent_enrollment_status_raw": null,
         "hs_prospecting_agent_last_enrolled": null,
         "hs_prospecting_agent_sender": null,
         "hs_prospecting_agent_total_enrolled_count": null,
@@ -1786,6 +1792,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": null,
         "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": null,
         "hs_v2_cumulative_time_in_customer": null,
@@ -2339,6 +2346,876 @@
     }
   ],
   [
+    "acmeCo/contacts",
+    {
+      "_meta": {
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "archived": false,
+      "createdAt": "2026-06-02T17:19:07.527000Z",
+      "id": 225877317544,
+      "properties": {
+        "address": null,
+        "annualrevenue": null,
+        "associatedcompanyid": null,
+        "associatedcompanylastupdated": null,
+        "city": null,
+        "closedate": null,
+        "company": null,
+        "company_size": null,
+        "country": null,
+        "createdate": "2026-06-02T17:19:07.527Z",
+        "currentlyinworkflow": null,
+        "date_of_birth": null,
+        "days_to_close": null,
+        "degree": null,
+        "email": "test@test.com",
+        "engagements_last_meeting_booked": null,
+        "engagements_last_meeting_booked_campaign": null,
+        "engagements_last_meeting_booked_medium": null,
+        "engagements_last_meeting_booked_source": null,
+        "fax": null,
+        "field_of_study": null,
+        "first_conversion_date": null,
+        "first_conversion_event_name": null,
+        "first_deal_created_date": null,
+        "firstname": "John",
+        "followercount": null,
+        "gender": null,
+        "graduation_date": null,
+        "hs_additional_emails": null,
+        "hs_all_accessible_team_ids": null,
+        "hs_all_assigned_business_unit_ids": null,
+        "hs_all_contact_vids": "225877317544",
+        "hs_all_owner_ids": null,
+        "hs_all_team_ids": null,
+        "hs_analytics_average_page_views": "0",
+        "hs_analytics_first_referrer": null,
+        "hs_analytics_first_timestamp": "2026-06-02T17:19:00Z",
+        "hs_analytics_first_touch_converting_campaign": null,
+        "hs_analytics_first_url": null,
+        "hs_analytics_first_visit_timestamp": null,
+        "hs_analytics_last_referrer": null,
+        "hs_analytics_last_timestamp": null,
+        "hs_analytics_last_touch_converting_campaign": null,
+        "hs_analytics_last_url": null,
+        "hs_analytics_last_visit_timestamp": null,
+        "hs_analytics_num_event_completions": "0",
+        "hs_analytics_num_page_views": "0",
+        "hs_analytics_num_visits": "0",
+        "hs_analytics_revenue": "0.0",
+        "hs_analytics_source": "OFFLINE",
+        "hs_analytics_source_composite_data": null,
+        "hs_analytics_source_data_1": "IMPORT",
+        "hs_analytics_source_data_2": "76185710",
+        "hs_associated_target_accounts": "0",
+        "hs_avatar_filemanager_key": null,
+        "hs_bing_ad_clicked": null,
+        "hs_bing_click_id": null,
+        "hs_buying_role": null,
+        "hs_calculated_form_submissions": null,
+        "hs_calculated_merged_vids": null,
+        "hs_calculated_mobile_number": null,
+        "hs_calculated_phone_number": null,
+        "hs_calculated_phone_number_area_code": null,
+        "hs_calculated_phone_number_country_code": null,
+        "hs_calculated_phone_number_region_code": null,
+        "hs_chat_assistant_iql_date": null,
+        "hs_chat_assistant_source": null,
+        "hs_chat_assistant_summary": null,
+        "hs_clicked_linkedin_ad": null,
+        "hs_contact_creation_legal_basis_source_instance_id": null,
+        "hs_contact_enrichment_opt_out": null,
+        "hs_contact_enrichment_opt_out_timestamp": null,
+        "hs_content_membership_email": null,
+        "hs_content_membership_email_confirmed": null,
+        "hs_content_membership_follow_up_enqueued_at": null,
+        "hs_content_membership_notes": null,
+        "hs_content_membership_registered_at": null,
+        "hs_content_membership_registration_domain_sent_to": null,
+        "hs_content_membership_registration_email_sent_at": null,
+        "hs_content_membership_status": null,
+        "hs_conversations_visitor_email": null,
+        "hs_count_is_unworked": null,
+        "hs_count_is_worked": null,
+        "hs_country_region_code": null,
+        "hs_created_by_conversations": null,
+        "hs_created_by_user_id": "73074756",
+        "hs_createdate": null,
+        "hs_cross_account_note": null,
+        "hs_cross_sell_opportunity": null,
+        "hs_current_customer": null,
+        "hs_currently_enrolled_in_prospecting_agent": "false",
+        "hs_customer_agent_lead_status": null,
+        "hs_data_privacy_ads_consent": null,
+        "hs_document_last_revisited": null,
+        "hs_email_bad_address": null,
+        "hs_email_bounce": null,
+        "hs_email_click": null,
+        "hs_email_communication_subscriptions_opted_in": null,
+        "hs_email_communication_subscriptions_opted_out": null,
+        "hs_email_customer_quarantined_reason": null,
+        "hs_email_delivered": null,
+        "hs_email_domain": "test.com",
+        "hs_email_first_click_date": null,
+        "hs_email_first_open_date": null,
+        "hs_email_first_reply_date": null,
+        "hs_email_first_send_date": null,
+        "hs_email_hard_bounce_reason": null,
+        "hs_email_hard_bounce_reason_enum": null,
+        "hs_email_is_ineligible": null,
+        "hs_email_last_click_date": null,
+        "hs_email_last_email_name": null,
+        "hs_email_last_open_date": null,
+        "hs_email_last_reply_date": null,
+        "hs_email_last_send_date": null,
+        "hs_email_live_sourcing_restricted": null,
+        "hs_email_open": null,
+        "hs_email_optimal_send_day_of_week": null,
+        "hs_email_optimal_send_time_of_day": null,
+        "hs_email_optout": null,
+        "hs_email_optout_453651751": null,
+        "hs_email_optout_453651753": null,
+        "hs_email_quarantined": null,
+        "hs_email_quarantined_reason": null,
+        "hs_email_recipient_fatigue_recovery_time": null,
+        "hs_email_replied": null,
+        "hs_email_sends_since_last_engagement": null,
+        "hs_email_type": null,
+        "hs_emailconfirmationstatus": null,
+        "hs_employment_change_detected_date": null,
+        "hs_enforce_double_opt_in": null,
+        "hs_enriched_email_bounce_detected": null,
+        "hs_excluded_from_cross_account_data_mirroring": null,
+        "hs_facebook_ad_clicked": null,
+        "hs_facebook_click_id": null,
+        "hs_facebookid": null,
+        "hs_feedback_last_ces_survey_date": null,
+        "hs_feedback_last_ces_survey_follow_up": null,
+        "hs_feedback_last_ces_survey_rating": null,
+        "hs_feedback_last_csat_survey_date": null,
+        "hs_feedback_last_csat_survey_follow_up": null,
+        "hs_feedback_last_csat_survey_rating": null,
+        "hs_feedback_last_nps_follow_up": null,
+        "hs_feedback_last_nps_rating": null,
+        "hs_feedback_last_nps_rating_number": null,
+        "hs_feedback_last_survey_date": null,
+        "hs_feedback_show_nps_web_survey": null,
+        "hs_first_closed_order_id": null,
+        "hs_first_engagement_object_id": null,
+        "hs_first_order_closed_date": null,
+        "hs_first_outreach_date": null,
+        "hs_first_subscription_create_date": null,
+        "hs_full_name_or_email": "John Doe",
+        "hs_geohash_1": null,
+        "hs_geohash_2": null,
+        "hs_geohash_3": null,
+        "hs_geohash_4": null,
+        "hs_geohash_5": null,
+        "hs_geohash_6": null,
+        "hs_google_click_id": null,
+        "hs_googleplusid": null,
+        "hs_gps_error": null,
+        "hs_gps_latitude": null,
+        "hs_gps_longitude": null,
+        "hs_has_active_subscription": null,
+        "hs_inferred_language_codes": null,
+        "hs_intent_paid_up_to_date": null,
+        "hs_intent_signals_enabled": null,
+        "hs_ip_timezone": null,
+        "hs_is_contact": "true",
+        "hs_is_enriched": null,
+        "hs_is_mass_marketing_activation_disallowed": null,
+        "hs_is_merge_revertible": null,
+        "hs_is_unworked": "true",
+        "hs_job_change_detected_date": null,
+        "hs_journey_stage": null,
+        "hs_language": null,
+        "hs_last_metered_enrichment_timestamp": null,
+        "hs_last_sales_activity_date": null,
+        "hs_last_sales_activity_timestamp": null,
+        "hs_last_sales_activity_type": null,
+        "hs_last_sms_send_date": null,
+        "hs_last_sms_send_name": null,
+        "hs_lastmodifieddate": null,
+        "hs_latest_disqualified_lead_date": null,
+        "hs_latest_meeting_activity": null,
+        "hs_latest_open_lead_date": null,
+        "hs_latest_qualified_lead_date": null,
+        "hs_latest_sequence_ended_date": null,
+        "hs_latest_sequence_enrolled": null,
+        "hs_latest_sequence_enrolled_date": null,
+        "hs_latest_sequence_finished_date": null,
+        "hs_latest_sequence_unenrolled_date": null,
+        "hs_latest_source": "OFFLINE",
+        "hs_latest_source_composite_data": null,
+        "hs_latest_source_data_1": "IMPORT",
+        "hs_latest_source_data_2": "76185710",
+        "hs_latest_source_timestamp": "2026-06-02T17:19:00Z",
+        "hs_latest_subscription_create_date": null,
+        "hs_latitude": null,
+        "hs_lead_status": null,
+        "hs_legal_basis": null,
+        "hs_linkedin_ad_clicked": null,
+        "hs_linkedin_click_id": null,
+        "hs_linkedin_url": null,
+        "hs_linkedinid": null,
+        "hs_live_enrichment_deadline": null,
+        "hs_longitude": null,
+        "hs_manual_campaign_ids": null,
+        "hs_marketable_reason_id": null,
+        "hs_marketable_reason_type": null,
+        "hs_marketable_status": null,
+        "hs_marketable_until_renewal": null,
+        "hs_membership_has_accessed_private_content": "0",
+        "hs_membership_last_private_content_access_date": null,
+        "hs_merged_object_ids": null,
+        "hs_messaging_engagement_score": null,
+        "hs_mobile_sdk_push_tokens": null,
+        "hs_notes_last_activity": null,
+        "hs_notes_next_activity": null,
+        "hs_notes_next_activity_type": null,
+        "hs_num_associated_open_deals": "0",
+        "hs_object_id": "225877317544",
+        "hs_object_source": "IMPORT",
+        "hs_object_source_detail_1": "Marketing Events Attendance Test Data",
+        "hs_object_source_detail_2": null,
+        "hs_object_source_detail_3": null,
+        "hs_object_source_id": "76185710",
+        "hs_object_source_label": "IMPORT",
+        "hs_object_source_user_id": "73074756",
+        "hs_owning_teams": null,
+        "hs_persona": null,
+        "hs_pinned_engagement_id": null,
+        "hs_pipeline": "contacts-lifecycle-pipeline",
+        "hs_predictivecontactscore": null,
+        "hs_predictivecontactscore_v2": null,
+        "hs_predictivecontactscorebucket": null,
+        "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_status": null,
+        "hs_prospecting_agent_actively_enrolled_count": "0",
+        "hs_prospecting_agent_enrollment_status": null,
+        "hs_prospecting_agent_enrollment_status_raw": null,
+        "hs_prospecting_agent_last_enrolled": null,
+        "hs_prospecting_agent_sender": null,
+        "hs_prospecting_agent_total_enrolled_count": "0",
+        "hs_quarantined_emails": null,
+        "hs_read_only": null,
+        "hs_recent_closed_order_date": null,
+        "hs_registered_member": "0",
+        "hs_registration_method": null,
+        "hs_returning_to_office_detected_date": null,
+        "hs_role": null,
+        "hs_sa_first_engagement_date": null,
+        "hs_sa_first_engagement_descr": null,
+        "hs_sa_first_engagement_object_type": null,
+        "hs_sales_email_last_clicked": null,
+        "hs_sales_email_last_opened": null,
+        "hs_sales_email_last_replied": null,
+        "hs_searchable_calculated_international_mobile_number": null,
+        "hs_searchable_calculated_international_phone_number": null,
+        "hs_searchable_calculated_mobile_number": null,
+        "hs_searchable_calculated_phone_number": null,
+        "hs_seniority": null,
+        "hs_sequences_actively_enrolled_count": "0",
+        "hs_sequences_enrolled_count": null,
+        "hs_sequences_is_enrolled": null,
+        "hs_shared_team_ids": null,
+        "hs_shared_user_ids": null,
+        "hs_social_facebook_clicks": "0",
+        "hs_social_google_plus_clicks": "0",
+        "hs_social_last_engagement": null,
+        "hs_social_linkedin_clicks": "0",
+        "hs_social_num_broadcast_clicks": "0",
+        "hs_social_twitter_clicks": "0",
+        "hs_source_object_id": null,
+        "hs_source_portal_id": null,
+        "hs_sourced_contact_origin": null,
+        "hs_state_code": null,
+        "hs_sub_role": null,
+        "hs_testpurge": null,
+        "hs_testrollback": null,
+        "hs_tiktok_ad_clicked": null,
+        "hs_tiktok_click_id": null,
+        "hs_time_between_contact_creation_and_deal_close": null,
+        "hs_time_between_contact_creation_and_deal_creation": null,
+        "hs_time_to_first_engagement": null,
+        "hs_time_to_move_from_lead_to_customer": null,
+        "hs_time_to_move_from_marketingqualifiedlead_to_customer": null,
+        "hs_time_to_move_from_opportunity_to_customer": null,
+        "hs_time_to_move_from_salesqualifiedlead_to_customer": null,
+        "hs_time_to_move_from_subscriber_to_customer": null,
+        "hs_timezone": null,
+        "hs_twitterid": null,
+        "hs_unique_creation_key": null,
+        "hs_updated_by_user_id": "73074756",
+        "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
+        "hs_user_ids_of_all_notification_unfollowers": null,
+        "hs_user_ids_of_all_owners": null,
+        "hs_v2_cumulative_time_in_customer": null,
+        "hs_v2_cumulative_time_in_evangelist": null,
+        "hs_v2_cumulative_time_in_lead": null,
+        "hs_v2_cumulative_time_in_marketingqualifiedlead": null,
+        "hs_v2_cumulative_time_in_opportunity": null,
+        "hs_v2_cumulative_time_in_other": null,
+        "hs_v2_cumulative_time_in_salesqualifiedlead": null,
+        "hs_v2_cumulative_time_in_subscriber": null,
+        "hs_v2_date_entered_current_stage": "2026-06-02T17:19:07.527Z",
+        "hs_v2_date_entered_customer": null,
+        "hs_v2_date_entered_evangelist": null,
+        "hs_v2_date_entered_lead": "2026-06-02T17:19:07.527Z",
+        "hs_v2_date_entered_marketingqualifiedlead": null,
+        "hs_v2_date_entered_opportunity": null,
+        "hs_v2_date_entered_other": null,
+        "hs_v2_date_entered_salesqualifiedlead": null,
+        "hs_v2_date_entered_subscriber": null,
+        "hs_v2_date_exited_customer": null,
+        "hs_v2_date_exited_evangelist": null,
+        "hs_v2_date_exited_lead": null,
+        "hs_v2_date_exited_marketingqualifiedlead": null,
+        "hs_v2_date_exited_opportunity": null,
+        "hs_v2_date_exited_other": null,
+        "hs_v2_date_exited_salesqualifiedlead": null,
+        "hs_v2_date_exited_subscriber": null,
+        "hs_v2_latest_time_in_customer": null,
+        "hs_v2_latest_time_in_evangelist": null,
+        "hs_v2_latest_time_in_lead": null,
+        "hs_v2_latest_time_in_marketingqualifiedlead": null,
+        "hs_v2_latest_time_in_opportunity": null,
+        "hs_v2_latest_time_in_other": null,
+        "hs_v2_latest_time_in_salesqualifiedlead": null,
+        "hs_v2_latest_time_in_subscriber": null,
+        "hs_v2_time_in_current_stage": "2026-06-02T17:19:07.527Z",
+        "hs_was_imported": "true",
+        "hs_whatsapp_bsuids": null,
+        "hs_whatsapp_phone_number": null,
+        "hs_why_this_contact": null,
+        "hubspot_owner_assigneddate": null,
+        "hubspot_owner_id": null,
+        "hubspot_team_id": null,
+        "hubspotscore": null,
+        "industry": null,
+        "ip_city": null,
+        "ip_country": null,
+        "ip_country_code": null,
+        "ip_latlon": null,
+        "ip_state": null,
+        "ip_state_code": null,
+        "ip_zipcode": null,
+        "job_function": null,
+        "jobtitle": null,
+        "kloutscoregeneral": null,
+        "lastmodifieddate": "2026-06-02T17:19:18.431Z",
+        "lastname": "Doe",
+        "lifecyclestage": "lead",
+        "linkedinbio": null,
+        "linkedinconnections": null,
+        "marital_status": null,
+        "message": null,
+        "military_status": null,
+        "mobilephone": null,
+        "notes_last_contacted": null,
+        "notes_last_updated": null,
+        "notes_next_activity_date": null,
+        "num_associated_deals": null,
+        "num_contacted_notes": null,
+        "num_conversion_events": "0",
+        "num_notes": "0",
+        "num_unique_conversion_events": "0",
+        "numemployees": null,
+        "owneremail": null,
+        "ownername": null,
+        "phone": null,
+        "photo": null,
+        "recent_conversion_date": null,
+        "recent_conversion_event_name": null,
+        "recent_deal_amount": null,
+        "recent_deal_close_date": null,
+        "relationship_status": null,
+        "salutation": null,
+        "school": null,
+        "seniority": null,
+        "start_date": null,
+        "state": null,
+        "surveymonkeyeventlastupdated": null,
+        "total_revenue": null,
+        "twitterbio": null,
+        "twitterhandle": null,
+        "twitterprofilephoto": null,
+        "webinareventlastupdated": null,
+        "website": null,
+        "work_email": null,
+        "zip": null
+      },
+      "propertiesWithHistory": {
+        "createdate": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "2026-06-02T17:19:07.527Z"
+          }
+        ],
+        "email": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "test@test.com"
+          }
+        ],
+        "firstname": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "John"
+          }
+        ],
+        "hs_all_contact_vids": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "225877317544"
+          }
+        ],
+        "hs_analytics_average_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_first_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "2026-06-02T17:19:00Z"
+          }
+        ],
+        "hs_analytics_num_event_completions": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_page_views": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_num_visits": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_analytics_revenue": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0.0"
+          }
+        ],
+        "hs_analytics_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_analytics_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "IMPORT"
+          }
+        ],
+        "hs_analytics_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "76185710"
+          }
+        ],
+        "hs_associated_target_accounts": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_created_by_user_id": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "73074756"
+          }
+        ],
+        "hs_currently_enrolled_in_prospecting_agent": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "false"
+          }
+        ],
+        "hs_email_domain": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "test.com"
+          }
+        ],
+        "hs_full_name_or_email": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "John Doe"
+          }
+        ],
+        "hs_is_contact": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "value": "true"
+          }
+        ],
+        "hs_is_unworked": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "true"
+          }
+        ],
+        "hs_latest_source": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "OFFLINE"
+          }
+        ],
+        "hs_latest_source_data_1": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "IMPORT"
+          }
+        ],
+        "hs_latest_source_data_2": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "76185710"
+          }
+        ],
+        "hs_latest_source_timestamp": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "2026-06-02T17:19:00Z"
+          }
+        ],
+        "hs_membership_has_accessed_private_content": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_num_associated_open_deals": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_object_id": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "225877317544"
+          }
+        ],
+        "hs_object_source": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "IMPORT"
+          }
+        ],
+        "hs_object_source_detail_1": [
+          {
+            "sourceId": "RecordSourceDetailsWriterWorker",
+            "sourceType": "INTERNAL_PROCESSING",
+            "timestamp": "2026-06-02T17:19:08.187000Z",
+            "value": "Marketing Events Attendance Test Data"
+          }
+        ],
+        "hs_object_source_id": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "76185710"
+          }
+        ],
+        "hs_object_source_label": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "IMPORT"
+          }
+        ],
+        "hs_object_source_user_id": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "73074756"
+          }
+        ],
+        "hs_pipeline": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "contacts-lifecycle-pipeline"
+          }
+        ],
+        "hs_prospecting_agent_actively_enrolled_count": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_prospecting_agent_total_enrolled_count": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_registered_member": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_sequences_actively_enrolled_count": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "hs_social_facebook_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_google_plus_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_linkedin_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_num_broadcast_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_social_twitter_clicks": [
+          {
+            "sourceId": "WebAnalyticsPropertyCalculation",
+            "sourceType": "ANALYTICS",
+            "timestamp": "2026-06-02T17:19:19.528000Z",
+            "value": "0"
+          }
+        ],
+        "hs_updated_by_user_id": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "73074756"
+          }
+        ],
+        "hs_v2_date_entered_current_stage": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "2026-06-02T17:19:07.527Z"
+          }
+        ],
+        "hs_v2_date_entered_lead": [
+          {
+            "sourceId": "StageCalculatedPropertiesRollup",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "value": "2026-06-02T17:19:07.527Z"
+          }
+        ],
+        "hs_v2_time_in_current_stage": [
+          {
+            "sourceId": "CalculatedPropertyComputer",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "2026-06-02T17:19:07.527Z"
+          }
+        ],
+        "hs_was_imported": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "true"
+          }
+        ],
+        "lastmodifieddate": [
+          {
+            "sourceType": "API",
+            "timestamp": "2026-06-02T17:19:18.431000Z",
+            "value": "2026-06-02T17:19:18.431Z"
+          },
+          {
+            "sourceId": "RecordSourceDetailsWriterWorker",
+            "sourceType": "INTERNAL_PROCESSING",
+            "timestamp": "2026-06-02T17:19:08.187000Z",
+            "value": "2026-06-02T17:19:08.187Z"
+          },
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "2026-06-02T17:19:07.527Z"
+          }
+        ],
+        "lastname": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "Doe"
+          }
+        ],
+        "lifecyclestage": [
+          {
+            "sourceId": "76185710",
+            "sourceType": "IMPORT",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "lead"
+          }
+        ],
+        "num_conversion_events": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:08.481000Z",
+            "value": "0"
+          }
+        ],
+        "num_notes": [
+          {
+            "sourceId": "InitialRollupProperties",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:07.527000Z",
+            "updatedByUserId": 73074756,
+            "value": "0"
+          }
+        ],
+        "num_unique_conversion_events": [
+          {
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-06-02T17:19:08.481000Z",
+            "value": "0"
+          }
+        ]
+      },
+      "updatedAt": "redacted",
+      "url": "redacted"
+    }
+  ],
+  [
     "acmeCo/deals",
     {
       "_meta": {
@@ -2509,6 +3386,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": "73074756",
         "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": "73074756",
         "hs_v2_cumulative_time_in_appointmentscheduled": null,
@@ -3222,11 +4100,11 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "appInfo": null,
-      "attendees": null,
+      "attendees": 1,
       "cancellations": null,
       "createdAt": "2026-05-29T14:27:36.562Z",
       "customProperties": [],
-      "endDateTime": "2026-05-29T04:00:00Z",
+      "endDateTime": "2026-06-02T16:00:00Z",
       "eventCancelled": false,
       "eventCompleted": false,
       "eventDescription": "My description",
@@ -3237,11 +4115,43 @@
       "eventType": "Test Event",
       "eventUrl": null,
       "externalEventId": null,
-      "noShows": 0,
+      "noShows": -1,
       "objectId": "559722810694",
       "registrants": null,
       "startDateTime": "2026-05-29T14:27:26.867Z",
       "updatedAt": "redacted"
+    }
+  ],
+  [
+    "acmeCo/marketing_event_participants",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "associations": {
+        "contact": {
+          "contactId": "225877317544",
+          "email": "test@test.com",
+          "firstname": "John",
+          "lastname": "Doe"
+        },
+        "marketingEvent": {
+          "externalAccountId": null,
+          "externalEventId": null,
+          "marketingEventId": "559722810694",
+          "name": "Test Marketing Event"
+        }
+      },
+      "createdAt": "2026-06-02T17:29:25.619Z",
+      "id": "560628475813",
+      "properties": {
+        "attendanceDurationSeconds": 2422800,
+        "attendancePercentage": null,
+        "attendanceState": "ATTENDED",
+        "occurredAt": 1780282800000
+      }
     }
   ],
   [
@@ -3352,6 +4262,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": "73074756",
         "hs_user_ids_of_all_notification_followers": null,
+        "hs_user_ids_of_all_notification_recipients": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": null,
         "hs_was_imported": null,

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -2430,6 +2430,75 @@
     ]
   },
   {
+    "recommendedName": "marketing_event_participants",
+    "resourceConfig": {
+      "name": "marketing_event_participants",
+      "interval": "PT15M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "BaseDocument",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/_meta/row_id"
+    ]
+  },
+  {
     "recommendedName": "contact_lists",
     "resourceConfig": {
       "name": "contact_lists",


### PR DESCRIPTION
**Description:**

Adds a new stream for the [Retrieve participant breakdown by HubSpot ID](https://developers.hubspot.com/docs/api-reference/legacy/marketing/marketing-events/participant-state/get-breakdown) endpoint.

**Notes for reviewers:**

- Tested using `flowctl preview`
- `MarketingEvent.objectId` has been made a mandatory field. It is used to construct event participation URLs
- Filtering events by `updatedAt` has been considered, but adding new participants has not caused a timestamp refresh. All events will have to be iterated through unconditionally.

