### PR TITLE
scripts: new "verify-affected" script for checking affected collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+verify-affected-*
 venv
 .claude/scheduled_tasks.lock
 tests/benchmark/materialize/runs/*

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -67,6 +67,58 @@ we got unlucky with task restart timing. The window of concern here is minutes a
 impacts new tasks, so just try to perform the two operations close together and keep an eye
 on whether any new tasks were created during the process.
 
+## Verifying Feature Impact
+
+Before changing a default behavior or rolling out a feature, you usually need to know
+*which* production collections have the characteristic that triggers the new behavior,
+and *which* live materialization tasks read those collections. Historically this was
+done with hand-written SQL against the `live_specs` table, which is dangerously
+error-prone.
+
+The `verify-affected.sh` script minimises error and adds two
+independent reviews to every run. It connects to the control plane via the
+`DATABASE_URL` environment variable (a `postgresql://...` string), and runs a fixed,
+tested query that links collections to the materializations which *actually read them*
+via the `reads_from` dependency array. The connector's variants are resolved automatically,
+the query runs inside a read-only transaction, and the expected `live_specs` columns are verified up front so schema drift fails loudly.
+
+The only thing you supply is the predicate that selects "affected" collections, in one
+of two ways:
+
+ - `--check=<name>`: a curated, snapshot-tested check from the registry in
+   `scripts/verify-affected/checks.go` (run `--list-checks` to see them). These are the
+   trusted path — adding a new one is a PR with a snapshot test.
+ - `--check-sql="<expr>"`: an ad-hoc SQL boolean over the collection row (alias `c`),
+   for one-off investigations.
+
+Every run is gated by **two pairs of eyes**:
+
+ 1. A local **Claude Opus 4.8** review of the rendered query and its results, which
+    validates the logic (does it select the right collections, and only the tasks that
+    read them?). This is a **hard gate**: a `CONCERNS` verdict blocks the run unless you
+    pass `--override-ai-review`.
+ 2. An explicit **human sign-off** — interactive confirmation, or `--approver="<name>"`
+    for a non-interactive record.
+
+Both reviews, the rendered SQL, the resolved variants, and the full affected-task list
+are written to a markdown audit report. Typical usage, as the pre-flight step before the
+bulk-editing workflow below:
+
+```bash
+# Requires DATABASE_URL to point at the control-plane Postgres database.
+$ export DATABASE_URL='postgresql://...'
+# List the curated checks.
+$ ../scripts/verify-affected.sh --list-checks
+# Verify which materialize-postgres tasks read enum-using collections.
+$ ../scripts/verify-affected.sh --connector=materialize-postgres --check=uses-enum
+# ... or an ad-hoc predicate (also reviewed):
+$ ../scripts/verify-affected.sh --connector=materialize-postgres \
+        --check-sql="c.spec::text LIKE '%\"enum\":%'"
+```
+
+Once you have the reviewed, signed-off list of affected tasks, feed the same connector
+into the bulk-editing workflow below.
+
 ## Bulk Editing Process
 
 There are a couple of scripts I've written which make it easier to add a feature flag

--- a/scripts/verify-affected.sh
+++ b/scripts/verify-affected.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+TMP="$(mktemp -d)"
+DIR="$(dirname $0)"
+NAME="$(basename $0 .sh)"
+trap "rm -rf '$TMP'" EXIT
+go build -C "$DIR/$NAME" -o "$TMP/$NAME" .
+# "$@" must be quoted: flag values like --check-sql and --approver contain spaces,
+# and unquoted $@ would word-split them (truncating a predicate at its first space).
+"$TMP/$NAME" "$@"

--- a/scripts/verify-affected/.snapshots/TestRenderQuery-adhoc-explicit-column
+++ b/scripts/verify-affected/.snapshots/TestRenderQuery-adhoc-explicit-column
@@ -1,0 +1,11 @@
+SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (c.spec->'schema' ? 'enum')
+ORDER BY m.catalog_name, c.catalog_name;

--- a/scripts/verify-affected/.snapshots/TestRenderQuery-uses-enum-built
+++ b/scripts/verify-affected/.snapshots/TestRenderQuery-uses-enum-built
@@ -1,0 +1,11 @@
+SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (c.built_spec::text LIKE '%"enum":%')
+ORDER BY m.catalog_name, c.catalog_name;

--- a/scripts/verify-affected/.snapshots/TestRenderQuery-uses-enum-spec
+++ b/scripts/verify-affected/.snapshots/TestRenderQuery-uses-enum-spec
@@ -1,0 +1,11 @@
+SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (c.spec::text LIKE '%"enum":%')
+ORDER BY m.catalog_name, c.catalog_name;

--- a/scripts/verify-affected/.snapshots/TestReportRender
+++ b/scripts/verify-affected/.snapshots/TestReportRender
@@ -1,0 +1,65 @@
+# Feature-impact verification report
+
+- **Status:** APPROVED
+- **Timestamp:** 2026-06-02T00:00:00Z
+- **Connector:** materialize-postgres
+- **Check:** uses-enum
+- **Predicate column:** built_spec
+- **Human reviewer:** Mahdi Dibaiee
+- **AI reviewer:** claude-opus-4-8 — verdict **PASS**
+
+## Intent
+
+Collections whose schema constrains a field with an enum.
+
+## Connector images matched
+
+- `ghcr.io/estuary/materialize-postgres`
+
+## Rendered SQL
+
+```sql
+SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (c.built_spec::text LIKE '%"enum":%')
+ORDER BY m.catalog_name, c.catalog_name;
+```
+
+## AI review (claude-opus-4-8)
+
+- Join uses reads_from; scope looks correct.
+
+<details><summary>Full review output</summary>
+
+```
+PASS
+```
+
+</details>
+
+## Result summary
+
+```
+  affected tasks:       2
+  affected collections: 3
+  matched rows:         3
+  by tenant:
+    acmeCo                         tasks=1 collections=2
+    beta                           tasks=1 collections=1
+```
+
+## Affected tasks and collections
+
+| Task | Collection | Image |
+|------|------------|-------|
+| acmeCo/prod/to-pg | acmeCo/orders | ghcr.io/estuary/materialize-postgres |
+| acmeCo/prod/to-pg | acmeCo/users | ghcr.io/estuary/materialize-postgres |
+| beta/sink | beta/events | ghcr.io/estuary/materialize-postgres |
+

--- a/scripts/verify-affected/.snapshots/TestReportRenderTruncated
+++ b/scripts/verify-affected/.snapshots/TestReportRenderTruncated
@@ -1,0 +1,63 @@
+# Feature-impact verification report
+
+- **Status:** APPROVED
+- **Timestamp:** 2026-06-02T00:00:00Z
+- **Connector:** materialize-postgres
+- **Check:** uses-enum
+- **Predicate column:** built_spec
+- **Human reviewer:** Mahdi Dibaiee
+- **AI reviewer:** claude-opus-4-8 — verdict **PASS**
+
+## Intent
+
+enum collections
+
+## Connector images matched
+
+- `ghcr.io/estuary/materialize-postgres`
+
+## Rendered SQL
+
+```sql
+SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (c.built_spec::text LIKE '%"enum":%')
+ORDER BY m.catalog_name, c.catalog_name;
+```
+
+## AI review (claude-opus-4-8)
+
+<details><summary>Full review output</summary>
+
+```
+PASS
+```
+
+</details>
+
+## Result summary
+
+```
+  affected tasks:       5
+  affected collections: 5
+  matched rows:         5
+  by tenant:
+    tenant                         tasks=5 collections=5
+```
+
+## Affected tasks and collections
+
+| Task | Collection | Image |
+|------|------------|-------|
+| tenant/a/to-pg | tenant/a | ghcr.io/estuary/materialize-postgres |
+| tenant/b/to-pg | tenant/b | ghcr.io/estuary/materialize-postgres |
+
+_Showing 2 of 5 rows; see the full list in the audit report file._
+

--- a/scripts/verify-affected/checks.go
+++ b/scripts/verify-affected/checks.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// A Check describes a class of collection that is affected by some connector
+// feature. The Predicate is a SQL boolean expression evaluated against the
+// collection's `live_specs` row (aliased `c` in the query). Within a predicate
+// the token `{{COL}}` is substituted with the configured column reference
+// (`c.spec` or `c.built_spec`) so a single predicate can target either the
+// user-authored spec or the fully-built/inferred spec. The token is delimited
+// with braces so it cannot collide with the substring of a SQL identifier or
+// string literal (e.g. a LIKE pattern matching "PROTOCOL").
+//
+// Registry checks are the trusted, snapshot-tested path: their predicates are
+// fixed in source and covered by tests, so a developer who selects a registry
+// check cannot introduce the kinds of logic errors that plague hand-written
+// ad-hoc queries.
+type Check struct {
+	Name        string
+	Description string // Human intent; also handed to the AI reviewer as the stated goal.
+	Predicate   string // SQL boolean over alias `c`, using the `{{COL}}` placeholder for the column.
+	Column      string // Default column the predicate inspects: "spec" or "built_spec".
+}
+
+// registry holds the curated, tested checks. New checks are added here in a PR
+// alongside a snapshot test of their rendered SQL.
+var registry = []Check{
+	{
+		Name: "uses-enum",
+		Description: "Collections whose schema constrains one or more fields with a JSON Schema " +
+			"`enum`. Use this when a materialization feature changes how enum-typed fields are " +
+			"handled (column typing, validation, etc.).",
+		// The built spec carries the fully-inferred/validated schema the
+		// materialization actually sees, so enum detection is most reliable there.
+		Predicate: `{{COL}}::text LIKE '%"enum":%'`,
+		Column:    "built_spec",
+	},
+}
+
+func lookupCheck(name string) (Check, bool) {
+	for _, c := range registry {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return Check{}, false
+}
+
+func registryListing() string {
+	var b strings.Builder
+	b.WriteString("Available registry checks:\n\n")
+	for _, c := range registry {
+		fmt.Fprintf(&b, "  %s (column: %s)\n    %s\n    predicate: %s\n\n",
+			c.Name, c.Column, c.Description, c.Predicate)
+	}
+	b.WriteString("Or supply an ad-hoc predicate with --check-sql=\"<expr over alias c>\".\n")
+	return b.String()
+}
+
+// renderQuery produces the complete, fixed verification query. The only varying
+// parts are the predicate and the column it inspects; everything else -- the
+// reads_from join that links collections to the materializations that actually
+// read them, the spec_type filters, and the parameterized connector-image
+// filter -- is constant and snapshot-tested. The connector image names are NOT
+// interpolated here; they are bound as the $1 query parameter.
+func renderQuery(predicate, column string) string {
+	pred := strings.ReplaceAll(predicate, "{{COL}}", "c."+column)
+	return fmt.Sprintf(`SELECT
+    m.catalog_name        AS task,
+    m.connector_image_name AS image,
+    c.catalog_name        AS collection
+FROM live_specs m
+JOIN live_specs c ON c.catalog_name = ANY(m.reads_from)
+WHERE m.spec_type = 'materialization'
+  AND m.connector_image_name = ANY($1)
+  AND c.spec_type = 'collection'
+  AND (%s)
+ORDER BY m.catalog_name, c.catalog_name;`, pred)
+}
+
+// listVariants resolves a connector short name (e.g. "materialize-postgres")
+// into the full set of `ghcr.io/estuary/*` image names that should be matched,
+// including any variants declared in the connector's VARIANTS file. This mirrors
+// the resolution used by scripts/list-tasks so that variant tasks are never
+// silently missed. A short name without a "/" is expanded; a value that already
+// looks like an image URL is used verbatim by the caller.
+func listVariants(connectorName string) ([]string, error) {
+	var variantsURL = fmt.Sprintf("https://raw.githubusercontent.com/estuary/connectors/refs/heads/main/%s/VARIANTS", connectorName)
+	var variants = []string{fmt.Sprintf("ghcr.io/estuary/%s", connectorName)}
+
+	resp, err := http.Get(variantsURL)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching variants list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// The primary image is the only variant when no VARIANTS file exists.
+	if resp.StatusCode == http.StatusNotFound {
+		return variants, nil
+	} else if resp.StatusCode/100 != 2 {
+		// http.Get does not error on 4xx/5xx, so guard explicitly: a 403, 5xx,
+		// or redirect page must not be silently parsed as a list of variants.
+		return nil, fmt.Errorf("error fetching variants list: unexpected status %s", resp.Status)
+	}
+
+	bs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching variants list: %w", err)
+	}
+	for _, v := range strings.Split(string(bs), "\n") {
+		if v = strings.TrimSpace(v); v != "" {
+			variants = append(variants, fmt.Sprintf("ghcr.io/estuary/%s", v))
+		}
+	}
+	return variants, nil
+}
+
+// resolveImages returns the image-name set to filter on. A connector value
+// containing "/" is treated as an explicit image URL; otherwise it is expanded
+// into its variant set.
+func resolveImages(connector string) ([]string, error) {
+	if strings.Contains(connector, "/") {
+		return []string{connector}, nil
+	}
+	return listVariants(connector)
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/scripts/verify-affected/checks_test.go
+++ b/scripts/verify-affected/checks_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRegistryValid guards every curated check: a non-empty predicate, a valid
+// column, and a predicate that actually references the {{COL}} placeholder so the
+// column setting is meaningful and the rendered SQL targets the intended column.
+func TestRegistryValid(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range registry {
+		if c.Name == "" {
+			t.Errorf("check has empty name")
+		}
+		if seen[c.Name] {
+			t.Errorf("duplicate check name %q", c.Name)
+		}
+		seen[c.Name] = true
+		if strings.TrimSpace(c.Predicate) == "" {
+			t.Errorf("check %q has empty predicate", c.Name)
+		}
+		if c.Column != "spec" && c.Column != "built_spec" {
+			t.Errorf("check %q has invalid column %q", c.Name, c.Column)
+		}
+		if strings.TrimSpace(c.Description) == "" {
+			t.Errorf("check %q has empty description (the AI reviewer relies on it)", c.Name)
+		}
+		if !strings.Contains(c.Predicate, "{{COL}}") {
+			t.Errorf("check %q predicate should reference the {{COL}} placeholder, got %q", c.Name, c.Predicate)
+		}
+		if rendered := renderQuery(c.Predicate, c.Column); !strings.Contains(rendered, "c."+c.Column) {
+			t.Errorf("check %q did not render against column %q", c.Name, c.Column)
+		}
+	}
+}
+
+func TestParseVerdict(t *testing.T) {
+	cases := []struct {
+		name    string
+		out     string
+		want    string
+		wantErr bool
+		notes   int
+	}{
+		{
+			name: "clean fenced json",
+			out:  "Looks fine.\n```json\n{\"verdict\": \"PASS\", \"notes\": []}\n```",
+			want: verdictPass,
+		},
+		{
+			name:  "fenced json with notes and concerns",
+			out:   "Analysis...\n```json\n{\"verdict\": \"CONCERNS\", \"notes\": [\"prefix join\", \"wrong column\"]}\n```",
+			want:  verdictConcerns,
+			notes: 2,
+		},
+		{
+			name: "bare object in prose",
+			out:  "My verdict is {\"verdict\":\"PASS\",\"notes\":[\"ok\"]} overall.",
+			want: verdictPass,
+		},
+		{
+			name: "verdict token fallback",
+			out:  "I could not produce JSON but VERDICT: CONCERNS",
+			want: verdictConcerns,
+		},
+		{
+			name:  "lowercase verdict normalized",
+			out:   "```json\n{\"verdict\": \"pass\", \"notes\": []}\n```",
+			want:  verdictPass,
+		},
+		{
+			name:    "unparseable",
+			out:     "I have no opinion.",
+			wantErr: true,
+		},
+		{
+			name: "prefers fenced over stray token",
+			out:  "VERDICT: PASS but really:\n```json\n{\"verdict\":\"CONCERNS\",\"notes\":[\"a\"]}\n```",
+			want: verdictConcerns,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := parseVerdict(tc.out)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got verdict %q", v.Verdict)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v.Verdict != tc.want {
+				t.Errorf("verdict = %q, want %q", v.Verdict, tc.want)
+			}
+			if tc.notes != 0 && len(v.Notes) != tc.notes {
+				t.Errorf("notes = %d, want %d", len(v.Notes), tc.notes)
+			}
+			if v.Raw == "" {
+				t.Errorf("Raw should retain the full output for the audit report")
+			}
+		})
+	}
+}

--- a/scripts/verify-affected/main.go
+++ b/scripts/verify-affected/main.go
@@ -1,0 +1,356 @@
+// The verify-affected script determines which production collections and which
+// live materialization tasks are affected by a new connector feature, in a way
+// that eliminates the most common errors of hand-written ad-hoc queries.
+//
+// It connects to the control-plane Postgres database (via the DATABASE_URL
+// environment variable) and runs a fixed, tested query that links collections to
+// the materializations that actually read them via the `reads_from` dependency
+// array on `live_specs` -- never a tenant-prefix heuristic. The only
+// developer-supplied part is a predicate selecting "affected" collections, which
+// is either a curated, snapshot-tested registry check (--check) or an ad-hoc SQL
+// fragment (--check-sql).
+//
+// Every run is gated by two independent reviews:
+//
+//	1. A local Claude Opus 4.8 review of the rendered query and results. This is
+//	   a hard gate: a CONCERNS verdict blocks the run unless --override-ai-review.
+//	2. An explicit human sign-off (interactive confirmation or --approver).
+//
+// Both reviews, the rendered SQL, and the full affected-task list are written to
+// a markdown audit report.
+//
+// See docs/feature_flags.md for how this fits into the bulk-editing workflow.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	log "github.com/sirupsen/logrus"
+)
+
+var scriptDescription = `
+The verify-affected script finds the production collections and live
+materialization tasks affected by a connector feature, linking collections to
+the tasks that actually read them (via reads_from, not a name-prefix guess).
+Every run is gated by a local Claude Opus 4.8 review and a human sign-off, and
+writes a markdown audit report.
+
+See docs/feature_flags.md for the intended workflow.
+`
+
+var (
+	logLevel = flag.String("log_level", "info", "The log level to print at.")
+
+	connector   = flag.String("connector", "", "Required. Connector short name (e.g. 'materialize-postgres'; variants auto-resolved) or a full 'ghcr.io/estuary/...' image URL.")
+	checkName   = flag.String("check", "", "Name of a curated registry check (see --list-checks). Mutually exclusive with --check-sql.")
+	checkSQL    = flag.String("check-sql", "", "Ad-hoc SQL boolean predicate over the collection row (alias 'c'), e.g. \"c.spec::text LIKE '%\\\"enum\\\":%'\". Triggers mandatory AI + human review.")
+	column      = flag.String("column", "", "Column the predicate inspects: 'spec' or 'built_spec'. Defaults to the registry check's column, or 'built_spec' for ad-hoc predicates.")
+	approver    = flag.String("approver", "", "Human reviewer name. Records explicit, non-interactive sign-off (marks the report APPROVED).")
+	overrideAI  = flag.Bool("override-ai-review", false, "Proceed despite a CONCERNS verdict from the AI review (the override is recorded in the report).")
+	claudeModel = flag.String("claude-model", "claude-opus-4-8", "Model passed to `claude -p --model`.")
+	output      = flag.String("output", "", "Path for the markdown audit report. Defaults to ./verify-affected-<connector>-<timestamp>.md")
+	listChecks  = flag.Bool("list-checks", false, "Print the available registry checks and exit.")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "%s\nusage of %s:\n", scriptDescription, os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if lvl, err := log.ParseLevel(*logLevel); err != nil {
+		log.WithFields(log.Fields{"level": *logLevel, "err": err}).Fatal("invalid log level")
+	} else {
+		log.SetLevel(lvl)
+	}
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true, PadLevelText: true})
+
+	if *listChecks {
+		fmt.Print(registryListing())
+		return
+	}
+
+	if err := run(context.Background()); err != nil {
+		log.WithField("err", err).Fatal("verification failed")
+	}
+}
+
+// resolvedCheck is the validated, ready-to-render verification criteria.
+type resolvedCheck struct {
+	Name        string
+	Description string
+	Predicate   string
+	Column      string
+	AdHoc       bool
+}
+
+type affectedRow struct {
+	Task       string
+	Image      string
+	Collection string
+}
+
+type tenantCount struct {
+	Tenant      string
+	Tasks       int
+	Collections int
+}
+
+type summary struct {
+	Rows            []affectedRow
+	TaskCount       int
+	CollectionCount int
+	ByTenant        []tenantCount
+}
+
+func run(ctx context.Context) error {
+	check, err := resolveCheck()
+	if err != nil {
+		return err
+	}
+
+	images, err := resolveImages(*connector)
+	if err != nil {
+		return fmt.Errorf("resolving connector images: %w", err)
+	}
+	images = sortedStrings(images)
+	log.WithField("images", images).Info("resolved connector images")
+
+	sql := renderQuery(check.Predicate, check.Column)
+
+	// Print the exact query (and its $1 binding) before running it, so the
+	// developer can see precisely what is being executed against the control plane.
+	fmt.Printf("\nExecuting query against DATABASE_URL (read-only):\n\n%s\n\n  $1 = %v\n\n",
+		sql, images)
+
+	rows, err := queryAffected(ctx, images, sql)
+	if err != nil {
+		return err
+	}
+	sum := summarize(rows)
+	log.WithFields(log.Fields{"tasks": sum.TaskCount, "collections": sum.CollectionCount}).Info("query complete")
+
+	// First pair of eyes: the AI review, a hard gate.
+	prompt := buildReviewPrompt(check, images, sql, sum)
+	log.WithField("model", *claudeModel).Info("running AI review (this calls the local claude CLI)")
+	verdict, err := runReview(ctx, *claudeModel, prompt)
+	if err != nil {
+		return fmt.Errorf("AI review error: %w", err)
+	}
+
+	report := reportData{
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Connector:  *connector,
+		Images:     images,
+		Check:      check,
+		SQL:        sql,
+		AI:         verdict,
+		AIModel:    *claudeModel,
+		Overridden: *overrideAI,
+		Summary:    sum,
+	}
+
+	blocked := verdict.Verdict == verdictConcerns && !*overrideAI
+	if blocked {
+		report.Status = "BLOCKED (AI CONCERNS)"
+		if path, werr := writeReport(report); werr == nil {
+			fmt.Printf("\nReport written to %s\n", path)
+		}
+		fmt.Fprintln(os.Stderr, "\nAI review returned CONCERNS:")
+		for _, n := range verdict.Notes {
+			fmt.Fprintf(os.Stderr, "  - %s\n", n)
+		}
+		return fmt.Errorf("blocked by AI review; revise the check or re-run with --override-ai-review")
+	}
+
+	// Show the report (with a sampled task list) before asking for sign-off; the
+	// complete list is preserved in the audit report file.
+	fmt.Println()
+	fmt.Println(renderReport(report, terminalRowSample))
+
+	// Second pair of eyes: the human sign-off.
+	status, name := confirmHuman(*approver, len(rows))
+	report.Status = status
+	report.Approver = name
+
+	path, err := writeReport(report)
+	if err != nil {
+		return fmt.Errorf("writing report: %w", err)
+	}
+	fmt.Printf("\nStatus: %s\nReport written to %s\n", status, path)
+	if status == "PENDING" {
+		fmt.Println("A human reviewer must confirm these results. Re-run with --approver=\"<name>\" or approve interactively.")
+	}
+	return nil
+}
+
+func resolveCheck() (resolvedCheck, error) {
+	if *connector == "" {
+		return resolvedCheck{}, fmt.Errorf("--connector is required")
+	}
+	if (*checkName == "") == (*checkSQL == "") {
+		return resolvedCheck{}, fmt.Errorf("exactly one of --check or --check-sql must be provided (see --list-checks)")
+	}
+
+	if *checkName != "" {
+		c, ok := lookupCheck(*checkName)
+		if !ok {
+			return resolvedCheck{}, fmt.Errorf("unknown check %q; see --list-checks", *checkName)
+		}
+		col := c.Column
+		if *column != "" {
+			col = *column
+		}
+		if err := validateColumn(col); err != nil {
+			return resolvedCheck{}, err
+		}
+		return resolvedCheck{Name: c.Name, Description: c.Description, Predicate: c.Predicate, Column: col}, nil
+	}
+
+	col := "built_spec"
+	if *column != "" {
+		col = *column
+	}
+	if err := validateColumn(col); err != nil {
+		return resolvedCheck{}, err
+	}
+	return resolvedCheck{
+		Name:        "(ad-hoc)",
+		Description: "Ad-hoc predicate supplied on the command line: " + *checkSQL,
+		Predicate:   *checkSQL,
+		Column:      col,
+		AdHoc:       true,
+	}, nil
+}
+
+func validateColumn(col string) error {
+	if col != "spec" && col != "built_spec" {
+		return fmt.Errorf("--column must be 'spec' or 'built_spec', got %q", col)
+	}
+	return nil
+}
+
+// requiredColumns are the live_specs columns the query depends on. They are
+// verified to exist before running so that schema drift fails loudly rather than
+// producing silently-wrong results.
+var requiredColumns = []string{"catalog_name", "spec_type", "spec", "built_spec", "connector_image_name", "reads_from"}
+
+func queryAffected(ctx context.Context, images []string, sql string) ([]affectedRow, error) {
+	dburl := os.Getenv("DATABASE_URL")
+	if dburl == "" {
+		return nil, fmt.Errorf("DATABASE_URL is not set; it must be a postgresql://... connection string for the control plane")
+	}
+
+	conn, err := pgx.Connect(ctx, dburl)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to DATABASE_URL: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	if err := verifySchema(ctx, conn); err != nil {
+		return nil, err
+	}
+
+	// A read-only transaction guarantees the (intentionally free-form) predicate
+	// cannot mutate the control plane, regardless of what SQL it contains.
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, fmt.Errorf("starting read-only transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	rows, err := tx.Query(ctx, sql, images)
+	if err != nil {
+		return nil, annotatePredicateError(err)
+	}
+	defer rows.Close()
+
+	var out []affectedRow
+	for rows.Next() {
+		var r affectedRow
+		if err := rows.Scan(&r.Task, &r.Image, &r.Collection); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, annotatePredicateError(err)
+	}
+	return out, nil
+}
+
+// annotatePredicateError reframes the planner-level errors that a malformed
+// predicate produces (the predicate is the only free-form part of the query)
+// into an actionable message, rather than leaking a bare SQLSTATE.
+func annotatePredicateError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "42804": // datatype_mismatch, e.g. "argument of AND must be type boolean"
+			return fmt.Errorf("the predicate must be a boolean expression over the collection row (alias `c`), "+
+				"e.g. `c.built_spec::text LIKE '%%enum%%'`; a bare value like `c.built_spec::text` is not boolean "+
+				"(postgres: %s)", pgErr.Message)
+		case "42703", "42883", "42601", "42P01": // undefined column/function, syntax, undefined table
+			return fmt.Errorf("the predicate appears invalid (%s: %s); check the --check-sql expression references "+
+				"alias `c` and existing columns", pgErr.Code, pgErr.Message)
+		}
+		return fmt.Errorf("running verification query (postgres %s: %s)", pgErr.Code, pgErr.Message)
+	}
+	return fmt.Errorf("running verification query: %w", err)
+}
+
+func verifySchema(ctx context.Context, conn *pgx.Conn) error {
+	rows, err := conn.Query(ctx,
+		`SELECT column_name FROM information_schema.columns WHERE table_name = 'live_specs'`)
+	if err != nil {
+		return fmt.Errorf("introspecting live_specs schema: %w", err)
+	}
+	defer rows.Close()
+
+	present := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("scanning column name: %w", err)
+		}
+		present[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	var missing []string
+	for _, c := range requiredColumns {
+		if !present[c] {
+			missing = append(missing, c)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("live_specs is missing expected column(s) %s; the control-plane schema may have changed. "+
+			"If reads_from is gone, switch the join to live_spec_flows (source_id=collection, target_id=materialization)",
+			strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func writeReport(r reportData) (string, error) {
+	path := *output
+	if path == "" {
+		stamp := strings.ReplaceAll(r.Timestamp, ":", "")
+		path = fmt.Sprintf("./verify-affected-%s-%s.md", sanitize(*connector), stamp)
+	}
+	return path, os.WriteFile(path, []byte(renderReport(r, 0)), 0644)
+}
+
+func sanitize(s string) string {
+	return strings.NewReplacer("/", "_", ":", "_").Replace(s)
+}

--- a/scripts/verify-affected/main_test.go
+++ b/scripts/verify-affected/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+)
+
+// TestRenderQuery pins the fixed query skeleton. The whole point of this tool is
+// that the join/scope logic never drifts: any change to the reads_from join, the
+// spec_type filters, or the parameter binding must be reviewed as a snapshot
+// diff.
+func TestRenderQuery(t *testing.T) {
+	cases := []struct {
+		name      string
+		predicate string
+		column    string
+	}{
+		{"uses-enum-built", `{{COL}}::text LIKE '%"enum":%'`, "built_spec"},
+		{"uses-enum-spec", `{{COL}}::text LIKE '%"enum":%'`, "spec"},
+		{"adhoc-explicit-column", `c.spec->'schema' ? 'enum'`, "built_spec"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cupaloy.SnapshotT(t, renderQuery(tc.predicate, tc.column))
+		})
+	}
+}
+
+// TestReportRender pins the audit-report format using a fixed fixture so format
+// changes are reviewed deliberately.
+func TestReportRender(t *testing.T) {
+	r := reportData{
+		Timestamp:  "2026-06-02T00:00:00Z",
+		Connector:  "materialize-postgres",
+		Images:     []string{"ghcr.io/estuary/materialize-postgres"},
+		AIModel:    "claude-opus-4-8",
+		Overridden: false,
+		Status:     "APPROVED",
+		Approver:   "Mahdi Dibaiee",
+		Check: resolvedCheck{
+			Name:        "uses-enum",
+			Description: "Collections whose schema constrains a field with an enum.",
+			Predicate:   `{{COL}}::text LIKE '%"enum":%'`,
+			Column:      "built_spec",
+		},
+		SQL: renderQuery(`{{COL}}::text LIKE '%"enum":%'`, "built_spec"),
+		AI:  aiVerdict{Verdict: "PASS", Notes: []string{"Join uses reads_from; scope looks correct."}, Raw: "PASS"},
+		Summary: summarize([]affectedRow{
+			{Task: "acmeCo/prod/to-pg", Image: "ghcr.io/estuary/materialize-postgres", Collection: "acmeCo/orders"},
+			{Task: "acmeCo/prod/to-pg", Image: "ghcr.io/estuary/materialize-postgres", Collection: "acmeCo/users"},
+			{Task: "beta/sink", Image: "ghcr.io/estuary/materialize-postgres", Collection: "beta/events"},
+		}),
+	}
+	cupaloy.SnapshotT(t, renderReport(r, 0))
+}
+
+// TestReportRenderTruncated pins the terminal-sampled rendering: the table is
+// capped and a "showing N of M" note is appended, while the file rendering
+// (rowLimit 0) stays complete.
+func TestReportRenderTruncated(t *testing.T) {
+	var rows []affectedRow
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		rows = append(rows, affectedRow{
+			Task:       "tenant/" + n + "/to-pg",
+			Image:      "ghcr.io/estuary/materialize-postgres",
+			Collection: "tenant/" + n,
+		})
+	}
+	r := reportData{
+		Timestamp: "2026-06-02T00:00:00Z",
+		Connector: "materialize-postgres",
+		Images:    []string{"ghcr.io/estuary/materialize-postgres"},
+		AIModel:   "claude-opus-4-8",
+		Status:    "APPROVED",
+		Approver:  "Mahdi Dibaiee",
+		Check:     resolvedCheck{Name: "uses-enum", Description: "enum collections", Predicate: `{{COL}}::text LIKE '%"enum":%'`, Column: "built_spec"},
+		SQL:       renderQuery(`{{COL}}::text LIKE '%"enum":%'`, "built_spec"),
+		AI:        aiVerdict{Verdict: "PASS", Raw: "PASS"},
+		Summary:   summarize(rows),
+	}
+	cupaloy.SnapshotT(t, renderReport(r, 2))
+}

--- a/scripts/verify-affected/report.go
+++ b/scripts/verify-affected/report.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// text renders a compact, human- and AI-readable summary of the result set.
+func (s summary) text() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  affected tasks:       %d\n", s.TaskCount)
+	fmt.Fprintf(&b, "  affected collections: %d\n", s.CollectionCount)
+	fmt.Fprintf(&b, "  matched rows:         %d\n", len(s.Rows))
+	if len(s.ByTenant) > 0 {
+		b.WriteString("  by tenant:\n")
+		for _, t := range s.ByTenant {
+			fmt.Fprintf(&b, "    %-30s tasks=%d collections=%d\n", t.Tenant, t.Tasks, t.Collections)
+		}
+	}
+	return b.String()
+}
+
+// reportData is the full record of a verification run, written to the audit file.
+type reportData struct {
+	Timestamp  string
+	Connector  string
+	Images     []string
+	Check      resolvedCheck
+	SQL        string
+	AI         aiVerdict
+	AIModel    string
+	Overridden bool
+	Summary    summary
+	Status     string // APPROVED | PENDING | BLOCKED (AI CONCERNS)
+	Approver   string
+}
+
+// terminalRowSample bounds how many affected-task rows are printed to the
+// terminal. The full list always goes to the audit report file.
+const terminalRowSample = 20
+
+// renderReport renders the audit report. rowLimit caps the affected-tasks table;
+// a value <= 0 emits every row (used for the file, which is the complete record).
+func renderReport(r reportData, rowLimit int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Feature-impact verification report\n\n")
+	fmt.Fprintf(&b, "- **Status:** %s\n", r.Status)
+	fmt.Fprintf(&b, "- **Timestamp:** %s\n", r.Timestamp)
+	fmt.Fprintf(&b, "- **Connector:** %s\n", r.Connector)
+	fmt.Fprintf(&b, "- **Check:** %s%s\n", r.Check.Name, ternary(r.Check.AdHoc, " (ad-hoc)", ""))
+	fmt.Fprintf(&b, "- **Predicate column:** %s\n", r.Check.Column)
+	fmt.Fprintf(&b, "- **Human reviewer:** %s\n", orNone(r.Approver))
+	fmt.Fprintf(&b, "- **AI reviewer:** %s — verdict **%s**%s\n\n", r.AIModel, orNone(r.AI.Verdict),
+		ternary(r.Overridden, " (overridden by --override-ai-review)", ""))
+
+	fmt.Fprintf(&b, "## Intent\n\n%s\n\n", r.Check.Description)
+
+	fmt.Fprintf(&b, "## Connector images matched\n\n")
+	for _, img := range r.Images {
+		fmt.Fprintf(&b, "- `%s`\n", img)
+	}
+
+	fmt.Fprintf(&b, "\n## Rendered SQL\n\n```sql\n%s\n```\n\n", r.SQL)
+
+	fmt.Fprintf(&b, "## AI review (%s)\n\n", r.AIModel)
+	if len(r.AI.Notes) > 0 {
+		for _, n := range r.AI.Notes {
+			fmt.Fprintf(&b, "- %s\n", n)
+		}
+		b.WriteString("\n")
+	}
+	if r.AI.Raw != "" {
+		fmt.Fprintf(&b, "<details><summary>Full review output</summary>\n\n```\n%s\n```\n\n</details>\n\n", r.AI.Raw)
+	}
+
+	fmt.Fprintf(&b, "## Result summary\n\n```\n%s```\n\n", r.Summary.text())
+
+	fmt.Fprintf(&b, "## Affected tasks and collections\n\n")
+	rows := r.Summary.Rows
+	if len(rows) == 0 {
+		b.WriteString("_No affected tasks found._\n")
+		return b.String()
+	}
+	shown := rows
+	if rowLimit > 0 && len(rows) > rowLimit {
+		shown = rows[:rowLimit]
+	}
+	b.WriteString("| Task | Collection | Image |\n|------|------------|-------|\n")
+	for _, row := range shown {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", row.Task, row.Collection, row.Image)
+	}
+	if len(shown) < len(rows) {
+		fmt.Fprintf(&b, "\n_Showing %d of %d rows; see the full list in the audit report file._\n", len(shown), len(rows))
+	}
+	return b.String()
+}
+
+// confirmHuman obtains the second pair of eyes. A non-empty approver name is
+// treated as an explicit, non-interactive sign-off. Otherwise, if stdin is a
+// terminal, the user is prompted. With neither, the run stays PENDING so a human
+// must revisit it before acting on the results.
+func confirmHuman(approver string, rowCount int) (status, name string) {
+	if approver != "" {
+		return "APPROVED", approver
+	}
+	if !stdinIsTerminal() {
+		return "PENDING", ""
+	}
+	fmt.Printf("\nReviewed the %d affected task(s) above? Approve this verification? [y/N]: ", rowCount)
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	if strings.EqualFold(strings.TrimSpace(line), "y") || strings.EqualFold(strings.TrimSpace(line), "yes") {
+		fmt.Print("Your name (for the audit record): ")
+		nameLine, _ := reader.ReadString('\n')
+		if n := strings.TrimSpace(nameLine); n != "" {
+			return "APPROVED", n
+		}
+		return "APPROVED", "(interactive)"
+	}
+	return "PENDING", ""
+}
+
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// summarize collapses the raw rows into counts and a per-tenant breakdown,
+// where the tenant is the first path segment of the catalog name.
+func summarize(rows []affectedRow) summary {
+	tasks := map[string]bool{}
+	collections := map[string]bool{}
+	tenantTasks := map[string]map[string]bool{}
+	tenantColls := map[string]map[string]bool{}
+
+	for _, r := range rows {
+		tasks[r.Task] = true
+		collections[r.Collection] = true
+		tt := tenantOf(r.Task)
+		if tenantTasks[tt] == nil {
+			tenantTasks[tt] = map[string]bool{}
+			tenantColls[tt] = map[string]bool{}
+		}
+		tenantTasks[tt][r.Task] = true
+		tenantColls[tt][r.Collection] = true
+	}
+
+	var byTenant []tenantCount
+	for t := range tenantTasks {
+		byTenant = append(byTenant, tenantCount{Tenant: t, Tasks: len(tenantTasks[t]), Collections: len(tenantColls[t])})
+	}
+	sort.Slice(byTenant, func(i, j int) bool { return byTenant[i].Tenant < byTenant[j].Tenant })
+
+	return summary{
+		Rows:            rows,
+		TaskCount:       len(tasks),
+		CollectionCount: len(collections),
+		ByTenant:        byTenant,
+	}
+}
+
+func tenantOf(catalogName string) string {
+	if i := strings.Index(catalogName, "/"); i >= 0 {
+		return catalogName[:i]
+	}
+	return catalogName
+}
+
+func ternary(cond bool, a, b string) string {
+	if cond {
+		return a
+	}
+	return b
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}

--- a/scripts/verify-affected/review.go
+++ b/scripts/verify-affected/review.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// aiVerdict is the structured outcome of the Claude review.
+type aiVerdict struct {
+	Verdict string   `json:"verdict"` // "PASS" or "CONCERNS"
+	Notes   []string `json:"notes"`
+	Raw     string   `json:"-"` // The full model output, for the audit report.
+}
+
+const (
+	verdictPass     = "PASS"
+	verdictConcerns = "CONCERNS"
+)
+
+// buildReviewPrompt assembles the logical-review request. The reviewer is asked
+// to judge the query against the stated intent: the central failure mode we are
+// guarding against is associating a collection with a materialization that does
+// not actually read it (e.g. via a tenant-prefix heuristic instead of the
+// reads_from dependency).
+func buildReviewPrompt(check resolvedCheck, images []string, sql string, sum summary) string {
+	var b strings.Builder
+	b.WriteString(`You are the first reviewer of an automated impact-verification query for the Estuary control plane.
+
+Your job is to validate the LOGIC of the query below and its results, then return a strict verdict. Be skeptical and specific. This review is a hard gate: a CONCERNS verdict blocks the run.
+
+Check whether the query correctly identifies BOTH:
+  (a) the collections that genuinely match the stated intent, and
+  (b) ONLY the materialization tasks that actually read those collections.
+
+Common, serious errors to look for:
+  - Linking collections to tasks by a tenant/name-prefix heuristic instead of the real read dependency (reads_from). This produces false positives and is the primary error this tool exists to prevent.
+  - Predicate false positives/negatives: a substring match that hits unrelated specs, or misses the intended ones.
+  - Inspecting the wrong column (spec vs built_spec) for the characteristic in question.
+  - Wrong spec_type / connector-image scoping.
+  - Result summary that looks implausible given the intent (e.g. zero matches when many were expected, or suspiciously broad matches).
+
+`)
+	fmt.Fprintf(&b, "STATED INTENT (what counts as \"affected\"):\n%s\n\n", check.Description)
+	fmt.Fprintf(&b, "PREDICATE COLUMN: %s\n", check.Column)
+	fmt.Fprintf(&b, "AD-HOC PREDICATE: %v\n\n", check.AdHoc)
+	fmt.Fprintf(&b, "CONNECTOR IMAGES MATCHED (the $1 parameter):\n  %s\n\n", strings.Join(images, "\n  "))
+	fmt.Fprintf(&b, "RENDERED SQL:\n%s\n\n", sql)
+	fmt.Fprintf(&b, "RESULT SUMMARY:\n%s\n", sum.text())
+	b.WriteString(sampleRowsText(sum.Rows, 30))
+	b.WriteString(`
+Respond with a brief analysis, then END your message with a fenced JSON block exactly like:
+` + "```json\n" + `{"verdict": "PASS", "notes": ["..."]}` + "\n```" + `
+Use "PASS" only if the query soundly identifies the affected collections and the tasks that read them. Use "CONCERNS" if anything above is wrong or doubtful, listing each concern as a note.`)
+	return b.String()
+}
+
+func sampleRowsText(rows []affectedRow, limit int) string {
+	if len(rows) == 0 {
+		return "\nSAMPLE ROWS: (none)\n"
+	}
+	var b strings.Builder
+	b.WriteString("\nSAMPLE ROWS (task <- collection):\n")
+	for i, r := range rows {
+		if i >= limit {
+			fmt.Fprintf(&b, "  ... and %d more\n", len(rows)-limit)
+			break
+		}
+		fmt.Fprintf(&b, "  %s  <-  %s\n", r.Task, r.Collection)
+	}
+	return b.String()
+}
+
+// runReview invokes the local Claude CLI in non-interactive print mode and
+// parses its verdict.
+func runReview(ctx context.Context, model, prompt string) (aiVerdict, error) {
+	cmd := exec.CommandContext(ctx, "claude", "-p", prompt, "--model", model)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return aiVerdict{}, fmt.Errorf("claude review failed: %w: %s", err, string(ee.Stderr))
+		}
+		return aiVerdict{}, fmt.Errorf("claude review failed (is the `claude` CLI installed and authenticated?): %w", err)
+	}
+	v, perr := parseVerdict(string(out))
+	if perr != nil {
+		return aiVerdict{Raw: string(out)}, perr
+	}
+	return v, nil
+}
+
+var (
+	jsonFenceRe = regexp.MustCompile("(?s)```json\\s*(\\{.*?\\})\\s*```")
+	anyObjectRe = regexp.MustCompile(`(?s)\{[^{}]*"verdict"[^{}]*\}`)
+	verdictRe   = regexp.MustCompile(`(?i)VERDICT\s*[:=]\s*"?(PASS|CONCERNS)"?`)
+)
+
+// parseVerdict extracts a structured verdict from arbitrary model output. It
+// tries, in order: a fenced ```json block, any bare object containing
+// "verdict", then a loose `VERDICT: X` token. This tolerance keeps the hard
+// gate robust against minor formatting drift in the model's reply.
+func parseVerdict(out string) (aiVerdict, error) {
+	out = strings.TrimSpace(out)
+
+	tryObject := func(s string) (aiVerdict, bool) {
+		var v aiVerdict
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			return aiVerdict{}, false
+		}
+		switch strings.ToUpper(strings.TrimSpace(v.Verdict)) {
+		case verdictPass, verdictConcerns:
+			v.Verdict = strings.ToUpper(strings.TrimSpace(v.Verdict))
+			v.Raw = out
+			return v, true
+		}
+		return aiVerdict{}, false
+	}
+
+	if m := jsonFenceRe.FindStringSubmatch(out); m != nil {
+		if v, ok := tryObject(m[1]); ok {
+			return v, nil
+		}
+	}
+	if m := anyObjectRe.FindString(out); m != "" {
+		if v, ok := tryObject(m); ok {
+			return v, nil
+		}
+	}
+	if m := verdictRe.FindStringSubmatch(out); m != nil {
+		return aiVerdict{Verdict: strings.ToUpper(m[1]), Raw: out}, nil
+	}
+	return aiVerdict{Raw: out}, fmt.Errorf("could not parse a PASS/CONCERNS verdict from the review output")
+}


### PR DESCRIPTION
**Description:**

- This script automates the process of checking existing collections for patterns that tell us whether a new change we are releasing is going to affect production collections and tasks. It adds an Opus 4.8 and a human-level verification step.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

