### PR TITLE
materialize-opensearch: new variant of elasticsearch

### DIFF
--- a/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-apply
+++ b/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-apply
@@ -1,0 +1,347 @@
+Task: acmeCo/tests/materialize-elasticsearch
+
+Big Schema Initial Constraints:
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+
+Big Schema Re-validated Constraints:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+
+Big Schema Changed Types Constraints:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
+{"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'intField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
+{"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'FLAT_OBJECT' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringDateField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringDateTimeField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'TEXT' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringIpv4Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv4Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringIpv6Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv6Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringUint64Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+
+Big Schema Materialized Resource Schema With All Fields Required:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"arrayField","Nullable":true,"Type":"flat_object"}
+{"Name":"boolField","Nullable":true,"Type":"boolean"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"intField","Nullable":true,"Type":"long"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"multipleField","Nullable":true,"Type":"flat_object"}
+{"Name":"numField","Nullable":true,"Type":"double"}
+{"Name":"objField","Nullable":true,"Type":"flat_object"}
+{"Name":"stringDateField","Nullable":true,"Type":"date"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"date"}
+{"Name":"stringDurationField","Nullable":true,"Type":"text"}
+{"Name":"stringEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringField","Nullable":true,"Type":"text"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIriField","Nullable":true,"Type":"text"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"text"}
+{"Name":"stringNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringRegexField","Nullable":true,"Type":"text"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringTimeField","Nullable":true,"Type":"text"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"long"}
+{"Name":"stringUint64Field","Nullable":true,"Type":"long"}
+{"Name":"stringUriField","Nullable":true,"Type":"text"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"text"}
+{"Name":"stringUuidField","Nullable":true,"Type":"text"}
+
+Big Schema Materialized Resource Schema With No Fields Required:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"arrayField","Nullable":true,"Type":"flat_object"}
+{"Name":"boolField","Nullable":true,"Type":"boolean"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"intField","Nullable":true,"Type":"long"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"multipleField","Nullable":true,"Type":"flat_object"}
+{"Name":"numField","Nullable":true,"Type":"double"}
+{"Name":"objField","Nullable":true,"Type":"flat_object"}
+{"Name":"stringDateField","Nullable":true,"Type":"date"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"date"}
+{"Name":"stringDurationField","Nullable":true,"Type":"text"}
+{"Name":"stringEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringField","Nullable":true,"Type":"text"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIriField","Nullable":true,"Type":"text"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"text"}
+{"Name":"stringNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringRegexField","Nullable":true,"Type":"text"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringTimeField","Nullable":true,"Type":"text"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"long"}
+{"Name":"stringUint64Field","Nullable":true,"Type":"long"}
+{"Name":"stringUriField","Nullable":true,"Type":"text"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"text"}
+{"Name":"stringUuidField","Nullable":true,"Type":"text"}
+
+Big Schema Changed Types With Backfill Constraints:
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"All Locations that are part of the collections key are required"}
+{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
+{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+
+Big Schema Materialized Resource Schema Changed Types With Backfill:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"arrayField","Nullable":true,"Type":"flat_object"}
+{"Name":"boolField","Nullable":true,"Type":"long"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"intField","Nullable":true,"Type":"text"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"multipleField","Nullable":true,"Type":"flat_object"}
+{"Name":"nullField","Nullable":true,"Type":"flat_object"}
+{"Name":"numField","Nullable":true,"Type":"boolean"}
+{"Name":"objField","Nullable":true,"Type":"text"}
+{"Name":"stringDateField","Nullable":true,"Type":"text"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"text"}
+{"Name":"stringDurationField","Nullable":true,"Type":"text"}
+{"Name":"stringEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringField","Nullable":true,"Type":"long"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringIdnHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"text"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"text"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"text"}
+{"Name":"stringIriField","Nullable":true,"Type":"text"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"text"}
+{"Name":"stringNumberField","Nullable":true,"Type":"text"}
+{"Name":"stringRegexField","Nullable":true,"Type":"text"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringTimeField","Nullable":true,"Type":"text"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"text"}
+{"Name":"stringUint64Field","Nullable":true,"Type":"text"}
+{"Name":"stringUriField","Nullable":true,"Type":"text"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"text"}
+{"Name":"stringUuidField","Nullable":true,"Type":"text"}
+
+add a single field:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"addedOptionalString","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"optionalBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"optionalInteger","Nullable":true,"Type":"long"}
+{"Name":"optionalObject","Nullable":true,"Type":"flat_object"}
+{"Name":"optionalString","Nullable":true,"Type":"text"}
+{"Name":"requiredBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"requiredInteger","Nullable":true,"Type":"long"}
+{"Name":"requiredObject","Nullable":true,"Type":"flat_object"}
+{"Name":"requiredString","Nullable":true,"Type":"text"}
+
+remove a single optional field:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"optionalBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"optionalInteger","Nullable":true,"Type":"long"}
+{"Name":"optionalObject","Nullable":true,"Type":"flat_object"}
+{"Name":"optionalString","Nullable":true,"Type":"text"}
+{"Name":"requiredBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"requiredInteger","Nullable":true,"Type":"long"}
+{"Name":"requiredObject","Nullable":true,"Type":"flat_object"}
+{"Name":"requiredString","Nullable":true,"Type":"text"}
+
+remove a single required field:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"optionalBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"optionalInteger","Nullable":true,"Type":"long"}
+{"Name":"optionalObject","Nullable":true,"Type":"flat_object"}
+{"Name":"optionalString","Nullable":true,"Type":"text"}
+{"Name":"requiredBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"requiredInteger","Nullable":true,"Type":"long"}
+{"Name":"requiredObject","Nullable":true,"Type":"flat_object"}
+{"Name":"requiredString","Nullable":true,"Type":"text"}
+
+add and remove many fields:
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
+{"Name":"addedOptionalString","Nullable":true,"Type":"text"}
+{"Name":"addedRequiredString","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"key","Nullable":true,"Type":"keyword"}
+{"Name":"optionalBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"optionalInteger","Nullable":true,"Type":"long"}
+{"Name":"optionalObject","Nullable":true,"Type":"flat_object"}
+{"Name":"optionalString","Nullable":true,"Type":"text"}
+{"Name":"requiredBoolean","Nullable":true,"Type":"boolean"}
+{"Name":"requiredInteger","Nullable":true,"Type":"long"}
+{"Name":"requiredObject","Nullable":true,"Type":"flat_object"}
+{"Name":"requiredString","Nullable":true,"Type":"text"}
+
+Challenging Field Names Materialized Columns:
+{"Name":" ,;{}()_- problematicKey � 𐀀 嶲 ","Nullable":true,"Type":"keyword"}
+{"Name":" ,;{}()_- problematicValue � 𐀀 嶲 ","Nullable":true,"Type":"text"}
+{"Name":"$dollar$signs","Nullable":true,"Type":"text"}
+{"Name":"123","Nullable":true,"Type":"text"}
+{"Name":"123startsWithDigits","Nullable":true,"Type":"text"}
+{"Name":"_id_flow","Nullable":true,"Type":"keyword"}
+{"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"value with separated words","Nullable":true,"Type":"text"}
+{"Name":"value-with-separated-words","Nullable":true,"Type":"text"}
+{"Name":"value_with-separated_words","Nullable":true,"Type":"text"}
+{"Name":"value_with_separated_words","Nullable":true,"Type":"text"}
+

--- a/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-materialize
+++ b/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-materialize
@@ -1,0 +1,114 @@
+Task: acmeCo/tests/materialize-elasticsearch
+
+Resource: simple_standard
+["applied.actionDescription", "create index \"simple_standard\"\ncreate index \"simple_delta\"\ncreate index \"not_simple\"\ncreate index \"data_types\""]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{"updated":{}}]
+
+{"Name":"_meta/op","Nullable":true,"Type":"text"}
+{"Name":"canary","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"id","Nullable":true,"Type":"long"}
+{"Name":"val","Nullable":true,"Type":"long"}
+
+Table Data:
+
+Resource: simple_delta
+["applied.actionDescription", "create index \"simple_standard\"\ncreate index \"simple_delta\"\ncreate index \"not_simple\"\ncreate index \"data_types\""]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{"updated":{}}]
+
+{"Name":"_meta/op","Nullable":true,"Type":"text"}
+{"Name":"canary","Nullable":true,"Type":"text"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"id","Nullable":true,"Type":"long"}
+{"Name":"val","Nullable":true,"Type":"long"}
+
+Table Data:
+
+Resource: not_simple
+["applied.actionDescription", "create index \"simple_standard\"\ncreate index \"simple_delta\"\ncreate index \"not_simple\"\ncreate index \"data_types\""]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{"updated":{}}]
+
+{"Name":" ,;{}()_- problematicField � 𐀀 嶲 ","Nullable":true,"Type":"text"}
+{"Name":" ,;{}()_- problematicKey � 𐀀 嶲 ","Nullable":true,"Type":"keyword"}
+{"Name":"$dollar$signs","Nullable":true,"Type":"text"}
+{"Name":"123","Nullable":true,"Type":"text"}
+{"Name":"123startsWithDigits","Nullable":true,"Type":"text"}
+{"Name":"FIELDWITHDIFFERENTCAPS","Nullable":true,"Type":"text"}
+{"Name":"_id_flow","Nullable":true,"Type":"keyword"}
+{"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"text"}
+{"Name":"binaryKey","Nullable":true,"Type":"binary"}
+{"Name":"field with separated words","Nullable":true,"Type":"text"}
+{"Name":"field-with-separated-words","Nullable":true,"Type":"text"}
+{"Name":"fieldWithDifferentCaps","Nullable":true,"Type":"text"}
+{"Name":"field_with-separated_words","Nullable":true,"Type":"text"}
+{"Name":"field_with_separated_words","Nullable":true,"Type":"text"}
+{"Name":"fieldwithdifferentcaps","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"longString","Nullable":true,"Type":"text"}
+{"Name":"testing (%s)","Nullable":true,"Type":"text"}
+{"Name":"unsignedBigint","Nullable":true,"Type":"unsigned_long"}
+
+Table Data:
+
+Resource: data_types
+["applied.actionDescription", "create index \"simple_standard\"\ncreate index \"simple_delta\"\ncreate index \"not_simple\"\ncreate index \"data_types\""]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{}]
+["connectorState",{"updated":{}}]
+
+{"Name":"arrayField","Nullable":true,"Type":"flat_object"}
+{"Name":"boolField","Nullable":true,"Type":"boolean"}
+{"Name":"enumField","Nullable":true,"Type":"text"}
+{"Name":"enumNullableField","Nullable":true,"Type":"text"}
+{"Name":"flow_document","Nullable":true,"Type":"flat_object"}
+{"Name":"flow_published_at","Nullable":true,"Type":"date"}
+{"Name":"id","Nullable":true,"Type":"long"}
+{"Name":"intField","Nullable":true,"Type":"long"}
+{"Name":"multipleField","Nullable":true,"Type":"flat_object"}
+{"Name":"numField","Nullable":true,"Type":"double"}
+{"Name":"stringAndIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringAndNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringDateField","Nullable":true,"Type":"date"}
+{"Name":"stringDateTimeField","Nullable":true,"Type":"date"}
+{"Name":"stringDurationField","Nullable":true,"Type":"text"}
+{"Name":"stringEmailField","Nullable":true,"Type":"text"}
+{"Name":"stringField","Nullable":true,"Type":"text"}
+{"Name":"stringHostnameField","Nullable":true,"Type":"text"}
+{"Name":"stringIntegerField","Nullable":true,"Type":"long"}
+{"Name":"stringIpv4Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIpv6Field","Nullable":true,"Type":"ip"}
+{"Name":"stringIriField","Nullable":true,"Type":"text"}
+{"Name":"stringIriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddr8Field","Nullable":true,"Type":"text"}
+{"Name":"stringMacAddrField","Nullable":true,"Type":"text"}
+{"Name":"stringNumberField","Nullable":true,"Type":"double"}
+{"Name":"stringRegexField","Nullable":true,"Type":"text"}
+{"Name":"stringRelativeJsonPointerField","Nullable":true,"Type":"text"}
+{"Name":"stringTimeField","Nullable":true,"Type":"text"}
+{"Name":"stringUint32Field","Nullable":true,"Type":"long"}
+{"Name":"stringUint64Field","Nullable":true,"Type":"unsigned_long"}
+{"Name":"stringUriField","Nullable":true,"Type":"text"}
+{"Name":"stringUriReferenceField","Nullable":true,"Type":"text"}
+{"Name":"stringUriTemplateField","Nullable":true,"Type":"text"}
+{"Name":"stringUuidField","Nullable":true,"Type":"text"}
+
+Table Data:
+
+

--- a/materialize-elasticsearch/VARIANTS
+++ b/materialize-elasticsearch/VARIANTS
@@ -1,0 +1,1 @@
+materialize-opensearch

--- a/materialize-elasticsearch/client.go
+++ b/materialize-elasticsearch/client.go
@@ -148,26 +148,50 @@ func (c *client) populateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 	return nil
 }
 
-func (c *client) isServerless(ctx context.Context) (bool, error) {
+// serverInfo describes the cluster on the other end of the connection, as
+// reported by the root info endpoint. It is used to distinguish Elasticsearch
+// from OpenSearch (an API-compatible fork), and Elastic Cloud serverless from
+// self-managed clusters.
+type serverInfo struct {
+	// Distribution is "opensearch" for OpenSearch clusters and empty (the field
+	// is absent) for Elasticsearch.
+	Distribution string
+	// BuildFlavor is "serverless" for Elastic Cloud serverless clusters.
+	BuildFlavor string
+}
+
+func (i serverInfo) isOpenSearch() bool {
+	return strings.EqualFold(i.Distribution, "opensearch")
+}
+
+func (i serverInfo) isServerless() bool {
+	return strings.EqualFold(i.BuildFlavor, "serverless")
+}
+
+func (c *client) info(ctx context.Context) (serverInfo, error) {
 	res, err := c.es.Info(c.es.Info.WithContext(ctx))
 	if err != nil {
-		return false, fmt.Errorf("getting serverless status: %w", err)
+		return serverInfo{}, fmt.Errorf("getting server info: %w", err)
 	}
 	defer res.Body.Close()
 	if res.IsError() {
-		return false, fmt.Errorf("getting serverless status error response [%s] %s", res.Status(), res.String())
+		return serverInfo{}, fmt.Errorf("getting server info error response [%s] %s", res.Status(), res.String())
 	}
 
 	type infoResponse struct {
 		Version struct {
-			BuildFlavor string `json:"build_flavor"`
+			Distribution string `json:"distribution"`
+			BuildFlavor  string `json:"build_flavor"`
 		} `json:"version"`
 	}
 
 	var info infoResponse
 	if err := json.NewDecoder(res.Body).Decode(&info); err != nil {
-		return false, fmt.Errorf("decoding serverless status response: %w", err)
+		return serverInfo{}, fmt.Errorf("decoding server info response: %w", err)
 	}
 
-	return strings.EqualFold(info.Version.BuildFlavor, "serverless"), nil
+	return serverInfo{
+		Distribution: info.Version.Distribution,
+		BuildFlavor:  info.Version.BuildFlavor,
+	}, nil
 }

--- a/materialize-elasticsearch/docker-compose.yaml
+++ b/materialize-elasticsearch/docker-compose.yaml
@@ -28,6 +28,32 @@ services:
     networks:
       - flow-test
 
+  # OpenSearch is an API-compatible fork of Elasticsearch. The same connector
+  # supports both (it auto-detects OpenSearch and adapts a few field mapping
+  # types), and the integration test exercises both side by side.
+  opensearch:
+    image: "opensearchproject/opensearch:2.13.0"
+    environment:
+      - "discovery.type=single-node"
+      # Disable the security plugin for ease of testing, matching the
+      # elasticsearch service which disables TLS and uses simple auth.
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - "cluster.routing.allocation.disk.threshold_enabled=false"
+      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+    healthcheck:
+      test: curl -s http://localhost:9200 >/dev/null || exit 1
+      interval: 1s
+      timeout: 1s
+      retries: 60
+    ports:
+      - "9201:9200"
+    networks:
+      - flow-test
+
 networks:
   flow-test:
     name: flow-test

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -278,6 +279,14 @@ func (c config) toClient(disableRetry bool) (*client, error) {
 			Username:            c.Credentials.Username,
 			Password:            c.Credentials.Password,
 			APIKey:              c.Credentials.ApiKey,
+			// OpenSearch is an API-compatible fork of Elasticsearch, but the
+			// go-elasticsearch v8 client refuses to talk to it: it requires the
+			// 'X-Elastic-Product: Elasticsearch' response header on the first
+			// successful response, which OpenSearch does not send. We inject the
+			// header when it is absent so the product check passes. Genuine
+			// Elasticsearch always sends this header, so its responses are never
+			// modified and the check still validates against it.
+			Transport: productHeaderInjector{inner: http.DefaultTransport},
 			RetryOnStatus:       []int{429, 502, 503, 504},
 			RetryBackoff: func(i int) time.Duration {
 				d := min(time.Duration(1<<i)*time.Second, 5*time.Second)
@@ -296,6 +305,24 @@ func (c config) toClient(disableRetry bool) (*client, error) {
 	}
 
 	return &client{es: es}, nil
+}
+
+// productHeaderInjector forces the 'X-Elastic-Product: Elasticsearch' response
+// header when it is missing, which allows the go-elasticsearch v8 product check
+// to pass against OpenSearch. See the comment where it is installed in toClient.
+type productHeaderInjector struct {
+	inner http.RoundTripper
+}
+
+func (p productHeaderInjector) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := p.inner.RoundTrip(req)
+	if err != nil {
+		return res, err
+	}
+	if res.Header.Get("X-Elastic-Product") == "" {
+		res.Header.Set("X-Elastic-Product", "Elasticsearch")
+	}
+	return res, nil
 }
 
 type resource struct {
@@ -388,7 +415,15 @@ func (driver) Spec(ctx context.Context, req *pm.Request_Spec) (*pm.Response_Spec
 		return nil, fmt.Errorf("generating resource schema: %w", err)
 	}
 
-	return boilerplate.RunSpec(ctx, req, "https://go.estuary.dev/materialize-elasticsearch", configSchema(), resourceSchema)
+	// Variants (e.g. materialize-opensearch) supply an alternate documentation
+	// URL via the DOCS_URL environment variable; fall back to the Elasticsearch
+	// default when it is not set.
+	docsURL := "https://go.estuary.dev/materialize-elasticsearch"
+	if fromEnv := os.Getenv("DOCS_URL"); fromEnv != "" {
+		docsURL = fromEnv
+	}
+
+	return boilerplate.RunSpec(ctx, req, docsURL, configSchema(), resourceSchema)
 }
 
 func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Response_Validated, error) {
@@ -434,6 +469,11 @@ type materialization struct {
 	metaClient   *client
 	dataClient   *client
 	featureFlags map[string]bool
+
+	// isOpenSearch is true when connected to an OpenSearch cluster rather than
+	// Elasticsearch. OpenSearch is API-compatible except for a handful of field
+	// mapping types (notably it uses 'flat_object' in place of 'flattened').
+	isOpenSearch bool
 }
 
 var _ boilerplate.Materializer[config, fieldConfig, resource, property] = &materialization{}
@@ -449,11 +489,23 @@ func newMaterialization(ctx context.Context, materializationName string, cfg con
 		return nil, fmt.Errorf("creating data client: %w", err)
 	}
 
+	// Detect whether we're talking to OpenSearch so that type mapping can adapt.
+	// This is best-effort: if the cluster is unreachable we default to
+	// Elasticsearch behavior and let CheckPrerequisites surface the connection
+	// error with a friendlier message.
+	var isOpenSearch bool
+	if info, err := metaClient.info(ctx); err != nil {
+		log.WithError(err).Debug("could not determine server distribution; assuming Elasticsearch")
+	} else {
+		isOpenSearch = info.isOpenSearch()
+	}
+
 	return &materialization{
 		cfg:          cfg,
 		metaClient:   metaClient,
 		dataClient:   dataClient,
 		featureFlags: featureFlags,
+		isOpenSearch: isOpenSearch,
 	}, nil
 }
 
@@ -539,6 +591,9 @@ func (d *materialization) NewConstraint(p pf.Projection, deltaUpdates bool, fc f
 func (d *materialization) MapType(p boilerplate.Projection, fc fieldConfig) (property, boilerplate.ElementConverter) {
 	prop := propForProjection(&p.Projection, p.Inference.Types, fc)
 	prop.IgnoreFormat = d.featureFlags["ignore_mapping_format_changes"]
+	if d.isOpenSearch {
+		prop = adaptForOpenSearch(prop)
+	}
 	return prop, nil
 }
 
@@ -552,7 +607,7 @@ func (d *materialization) CreateNamespace(ctx context.Context, ns string) (strin
 
 func (d *materialization) CreateResource(ctx context.Context, res boilerplate.MappedBinding[config, resource, property]) (string, boilerplate.ActionApplyFn, error) {
 	indexName := res.ResourcePath[0]
-	props := buildIndexProperties(res.Keys, res.Values, res.Document)
+	props := buildIndexProperties(res.Keys, res.Values, res.Document, d.isOpenSearch)
 
 	return fmt.Sprintf("create index %q", indexName), func(ctx context.Context) error {
 		return d.metaClient.createIndex(ctx, indexName, res.Config.Shards, d.cfg.Advanced.Replicas, props)
@@ -615,10 +670,11 @@ func (d *materialization) NewTransactor(
 	mappedBindings []boilerplate.MappedBinding[config, resource, property],
 	be *m.BindingEvents,
 ) (m.Transactor, error) {
-	isServerless, err := d.dataClient.isServerless(ctx)
+	info, err := d.dataClient.info(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting serverless status: %w", err)
+		return nil, fmt.Errorf("getting server info: %w", err)
 	}
+	isServerless := info.isServerless()
 	if isServerless {
 		log.Info("connected to a serverless elasticsearch cluster")
 	}

--- a/materialize-elasticsearch/driver_test.go
+++ b/materialize-elasticsearch/driver_test.go
@@ -30,6 +30,21 @@ func TestIntegration(t *testing.T) {
 		boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply.flow.yaml", makeResourceFn)
 	})
 
+	// OpenSearch is an API-compatible fork of Elasticsearch. The same connector
+	// supports both, auto-detecting OpenSearch and adapting a few field mapping
+	// types (notably 'flat_object' in place of 'flattened'). These run against
+	// the opensearch service in the compose file and have their own snapshots,
+	// which differ from the Elasticsearch ones in the affected mapping types.
+	t.Run("opensearch", func(t *testing.T) {
+		t.Run("materialize", func(t *testing.T) {
+			boilerplate.RunMaterializationTest(t, newMaterialization, "testdata/materialize.opensearch.flow.yaml", makeResourceFn, nil)
+		})
+
+		t.Run("apply", func(t *testing.T) {
+			boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply.opensearch.flow.yaml", makeResourceFn)
+		})
+	})
+
 	// Elasticsearch does not support migrations since index mappings are
 	// immutable, so the migration test is not applicable.
 }

--- a/materialize-elasticsearch/testdata/apply.opensearch.flow.yaml
+++ b/materialize-elasticsearch/testdata/apply.opensearch.flow.yaml
@@ -1,0 +1,8 @@
+materializations:
+  acmeCo/tests/materialize-elasticsearch:
+    endpoint:
+      local:
+        command: ["go", "run", "."]
+        protobuf: true
+        config: config.opensearch.local.yaml
+    bindings: []

--- a/materialize-elasticsearch/testdata/config.opensearch.local.yaml
+++ b/materialize-elasticsearch/testdata/config.opensearch.local.yaml
@@ -1,0 +1,8 @@
+endpoint: "http://localhost:9201"
+credentials:
+  username: "admin"
+  password: "admin"
+hardDelete: true
+advanced:
+  number_of_replicas: 0
+  feature_flags: allow_existing_tables_for_new_bindings

--- a/materialize-elasticsearch/testdata/materialize.opensearch.flow.yaml
+++ b/materialize-elasticsearch/testdata/materialize.opensearch.flow.yaml
@@ -1,0 +1,32 @@
+import:
+  - ../../materialize-boilerplate/testdata/integration/collections.materialize.flow.yaml
+
+materializations:
+  acmeCo/tests/materialize-elasticsearch:
+    endpoint:
+      local:
+        command: ["go", "run", "."]
+        protobuf: true
+        config: config.opensearch.local.yaml
+    bindings:
+    - resource:
+        index: simple_standard
+      source: tests/simple
+      fields:
+        recommended: true
+    - resource:
+        index: simple_delta
+        delta_updates: true
+      source: tests/simple
+      fields:
+        recommended: true
+    - resource:
+        index: not_simple
+      source: tests/not-simple
+      fields:
+        recommended: true
+    - resource:
+        index: data_types
+      source: tests/data-types
+      fields:
+        recommended: true

--- a/materialize-elasticsearch/type_mapping.go
+++ b/materialize-elasticsearch/type_mapping.go
@@ -23,7 +23,23 @@ const (
 	elasticTypeIp           elasticPropertyType = "ip"
 	elasticTypeUnsignedLong elasticPropertyType = "unsigned_long"
 	elasticTypeFlattened    elasticPropertyType = "flattened"
+	// elasticTypeFlatObject is OpenSearch's equivalent of Elasticsearch's
+	// "flattened" type. OpenSearch does not support "flattened".
+	elasticTypeFlatObject elasticPropertyType = "flat_object"
 )
+
+// adaptForOpenSearch rewrites a property produced for Elasticsearch into its
+// OpenSearch equivalent. OpenSearch uses "flat_object" in place of "flattened",
+// and unlike "flattened" it does not accept the "ignore_above" or "index"
+// mapping parameters.
+func adaptForOpenSearch(p property) property {
+	if p.Type == elasticTypeFlattened {
+		p.Type = elasticTypeFlatObject
+		p.IgnoreAbove = 0
+		p.Index = nil
+	}
+	return p
+}
 
 type property struct {
 	Type         elasticPropertyType `json:"type"`
@@ -147,7 +163,7 @@ func propForProjection(p *pf.Projection, types []string, fc fieldConfig) propert
 	}
 }
 
-func buildIndexProperties(keys, values []boilerplate.MappedProjection[property], document *boilerplate.MappedProjection[property]) map[string]property {
+func buildIndexProperties(keys, values []boilerplate.MappedProjection[property], document *boilerplate.MappedProjection[property], isOpenSearch bool) map[string]property {
 	props := make(map[string]property)
 
 	for _, v := range append(keys, values...) {
@@ -157,12 +173,15 @@ func buildIndexProperties(keys, values []boilerplate.MappedProjection[property],
 	if document != nil {
 		// Do not index the root document projection, since this would be less useful than other
 		// selected fields and potentially costly.
-		props[translateField(document.Field)] = property{
+		docProp := property{
 			Type: elasticTypeFlattened,
 			// See above for comment on pf.JsonTypeObject.
 			IgnoreAbove: 32766 / 4,
 			Index:       boolPtr(false)}
-
+		if isOpenSearch {
+			docProp = adaptForOpenSearch(docProp)
+		}
+		props[translateField(document.Field)] = docProp
 	}
 
 	return props


### PR DESCRIPTION
**Description:**

- Add OpenSearch as a variant of Elasticsearch
- Integration test results are the same, bar the `flattened` -> `flat_object` difference

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

