### PR TITLE
source-oracle: tolerate redo log SCN gaps from database restarts

### DIFF
--- a/source-oracle/replication.go
+++ b/source-oracle/replication.go
@@ -191,6 +191,11 @@ type redoFile struct {
 	DictEnd     string
 	Bytes       int
 	Thread      int
+	// ResetlogsID identifies the database incarnation this log belongs to. It
+	// changes when the database is opened with RESETLOGS, which discards redo
+	// and forks a new timeline. Used by validateLogFileCoverage to distinguish
+	// a benign restart gap from a data-losing incarnation change.
+	ResetlogsID int
 }
 
 var MaxReplicationLogFilesSize = 2 * 1024 * 1024 * 1024
@@ -238,12 +243,15 @@ func (s *replicationStream) addLogFiles(ctx context.Context, conn *sql.Conn, sta
 		"minArchiveSCN": minArchiveSCN,
 	}).Debug("starting SCN for log files based on dictionary starting point")
 
-	var liveLogFiles = `SELECT L.STATUS as STATUS, MIN(LF.MEMBER) as NAME, L.SEQUENCE#, L.FIRST_CHANGE#, CASE WHEN L.STATUS = 'CURRENT' THEN 0 ELSE L.NEXT_CHANGE# END as NEXT_CHANGE#, 'NO' as DICT_START, 'NO' as DICT_END, MAX(L.BYTES), L.THREAD# FROM V$LOGFILE LF, V$LOG L
+	// Live logs always belong to the current database incarnation, so
+	// their RESETLOGS_ID is taken from V$DATABASE_INCARNATION rather than the log
+	// view itself (V$LOG does not expose it).
+	var liveLogFiles = `SELECT L.STATUS as STATUS, MIN(LF.MEMBER) as NAME, L.SEQUENCE#, L.FIRST_CHANGE#, CASE WHEN L.STATUS = 'CURRENT' THEN 0 ELSE L.NEXT_CHANGE# END as NEXT_CHANGE#, 'NO' as DICT_START, 'NO' as DICT_END, MAX(L.BYTES), L.THREAD#, (SELECT MAX(DI.RESETLOGS_ID) FROM V$DATABASE_INCARNATION DI WHERE DI.STATUS = 'CURRENT') as RESETLOGS_ID FROM V$LOGFILE LF, V$LOG L
 		LEFT JOIN V$ARCHIVED_LOG A ON A.FIRST_CHANGE# = L.FIRST_CHANGE# AND A.NEXT_CHANGE# = L.NEXT_CHANGE#
     WHERE (A.STATUS <> 'A' OR A.FIRST_CHANGE# IS NULL) AND L.GROUP# = LF.GROUP# AND L.STATUS <> 'UNUSED'
 		GROUP BY LF.GROUP#, L.FIRST_CHANGE#, L.NEXT_CHANGE#, L.STATUS, L.ARCHIVED, L.SEQUENCE#, L.THREAD#`
 
-	var archivedLogFiles = `SELECT 'ARCHIVED' as STATUS, A.NAME AS NAME, A.SEQUENCE#, A.FIRST_CHANGE#, A.NEXT_CHANGE#, A.DICTIONARY_BEGIN as DICT_START, A.DICTIONARY_END as DICT_END, A.BLOCKS*A.BLOCK_SIZE as BYTES, A.THREAD# FROM V$ARCHIVED_LOG A
+	var archivedLogFiles = `SELECT 'ARCHIVED' as STATUS, A.NAME AS NAME, A.SEQUENCE#, A.FIRST_CHANGE#, A.NEXT_CHANGE#, A.DICTIONARY_BEGIN as DICT_START, A.DICTIONARY_END as DICT_END, A.BLOCKS*A.BLOCK_SIZE as BYTES, A.THREAD#, A.RESETLOGS_ID FROM V$ARCHIVED_LOG A
     WHERE A.NAME IS NOT NULL AND A.ARCHIVED = 'YES' AND A.STATUS = 'A' AND A.NEXT_CHANGE# >= :1 AND
     DEST_ID IN (` + strconv.Itoa(localDestID) + `)`
 
@@ -257,7 +265,7 @@ func (s *replicationStream) addLogFiles(ctx context.Context, conn *sql.Conn, sta
 	var candidates []redoFile
 	for rows.Next() {
 		var f redoFile
-		if err := rows.Scan(&f.Status, &f.Name, &f.Sequence, &f.FirstChange, &f.NextChange, &f.DictStart, &f.DictEnd, &f.Bytes, &f.Thread); err != nil {
+		if err := rows.Scan(&f.Status, &f.Name, &f.Sequence, &f.FirstChange, &f.NextChange, &f.DictStart, &f.DictEnd, &f.Bytes, &f.Thread, &f.ResetlogsID); err != nil {
 			return 0, fmt.Errorf("scanning log file record: %w", err)
 		}
 		candidates = append(candidates, f)
@@ -429,6 +437,25 @@ func validateLogFileCoverage(redoFiles []redoFile, startSCN, endSCN SCN) error {
 				return fmt.Errorf("redo log file %q (FIRST_CHANGE#=%d) follows CURRENT-status file %q in thread %d, which has no NEXT_CHANGE#", curr.Name, curr.FirstChange, prev.Name, thread)
 			}
 			if curr.FirstChange != prev.NextChange {
+				// A forward SCN gap between two logs that are consecutive in
+				// SEQUENCE# and share an incarnation should be benign; it's the signature
+				// of a database restart. An unbroken SEQUENCE# chain means no log is
+				// missing, and matching RESETLOGS_ID rules out an OPEN RESETLOGS that
+				// would discard redos. So unlike a true gap, nothing was lost here.
+				var benignRestartGap = curr.Sequence == prev.Sequence+1 &&
+					curr.FirstChange > prev.NextChange &&
+					curr.ResetlogsID == prev.ResetlogsID
+				if benignRestartGap {
+					logrus.WithFields(logrus.Fields{
+						"thread":          thread,
+						"prevName":        prev.Name,
+						"prevNextChange":  prev.NextChange,
+						"currName":        curr.Name,
+						"currFirstChange": curr.FirstChange,
+						"resetlogsID":     curr.ResetlogsID,
+					}).Warn("tolerating benign redo log SCN gap across consecutive sequences (likely a database restart)")
+					continue
+				}
 				return fmt.Errorf("redo log SCN gap in thread %d between %q (NEXT_CHANGE#=%d) and %q (FIRST_CHANGE#=%d)", thread, prev.Name, prev.NextChange, curr.Name, curr.FirstChange)
 			}
 		}

--- a/source-oracle/replication_test.go
+++ b/source-oracle/replication_test.go
@@ -20,3 +20,107 @@ func TestDecodeUnistr(t *testing.T) {
 		require.Equal(t, c[1], out)
 	}
 }
+
+func TestValidateLogFileCoverage(t *testing.T) {
+	// rf is a terse constructor for a redo log file. All test files share a
+	// dictionary state ("NO"/"NO") and a non-zero size, which are irrelevant to
+	// coverage validation.
+	var rf = func(thread, sequence int, firstChange, nextChange SCN, resetlogsID int) redoFile {
+		return redoFile{
+			Status: "ARCHIVED", Name: "log", Thread: thread, Sequence: sequence,
+			FirstChange: firstChange, NextChange: nextChange, ResetlogsID: resetlogsID, Bytes: 1,
+		}
+	}
+
+	var cases = []struct {
+		name        string
+		files       []redoFile
+		startSCN    SCN
+		endSCN      SCN
+		errContains string // empty means no error expected
+	}{
+		{
+			name:     "contiguous chain is valid",
+			files:    []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 200, 300, 1)},
+			startSCN: 100, endSCN: 300,
+		},
+		{
+			// Server restart leaves an SCN gap between two
+			// consecutively-numbered archive logs of the same incarnation.
+			name:     "restart gap across consecutive sequences is tolerated",
+			files:    []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 250, 300, 1)},
+			startSCN: 100, endSCN: 300,
+		},
+		{
+			name:        "missing log (non-consecutive sequence) fails",
+			files:       []redoFile{rf(1, 1, 100, 200, 1), rf(1, 3, 250, 300, 1)},
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "redo log SCN gap in thread 1",
+		},
+		{
+			// Same consecutive-sequence forward gap, but a RESETLOGS forked the
+			// timeline between the two files: real data loss, must fail.
+			name:        "incarnation change (RESETLOGS) is not tolerated",
+			files:       []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 250, 300, 2)},
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "redo log SCN gap in thread 1",
+		},
+		{
+			// A backward discontinuity (overlap) is not the restart signature and
+			// must still fail even with consecutive sequences.
+			name:        "backward overlap is not tolerated",
+			files:       []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 150, 300, 1)},
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "redo log SCN gap in thread 1",
+		},
+		{
+			name:        "gap at start of range fails",
+			files:       []redoFile{rf(1, 1, 150, 300, 1)},
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "gap at start",
+		},
+		{
+			name:        "gap at end of range fails",
+			files:       []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 200, 300, 1)},
+			startSCN:    100,
+			endSCN:      400,
+			errContains: "gap at end",
+		},
+		{
+			name:        "empty file set fails",
+			files:       nil,
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "no redo log files available",
+		},
+		{
+			name:        "file following a CURRENT log fails",
+			files:       []redoFile{rf(1, 1, 100, 0, 1), rf(1, 2, 200, 300, 1)},
+			startSCN:    100,
+			endSCN:      300,
+			errContains: "has no NEXT_CHANGE#",
+		},
+		{
+			// RAC: each thread is validated independently. A benign restart gap in
+			// thread 1 is tolerated while thread 2 stays contiguous.
+			name:     "per-thread validation tolerates a benign gap in one thread",
+			files:    []redoFile{rf(1, 1, 100, 200, 1), rf(1, 2, 250, 300, 1), rf(2, 1, 100, 300, 1)},
+			startSCN: 100, endSCN: 300,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var err = validateLogFileCoverage(c.files, c.startSCN, c.endSCN)
+			if c.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, c.errContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:**

`validateLogFileCoverage` required each redo log to be exactly adjacent to the previous one (`curr.FIRST_CHANGE# == prev.NEXT_CHANGE#`), which catches when archive logs are deleted before we can mine them. But it also causes the connector to fail when an Oracle restart leaves behind an SCN gap after routine maintenance, with errors like:
```
redo log SCN gap in thread 1 between "..._seq_357345..." (NEXT_CHANGE#=91403872085) and "..._seq_357346..." (FIRST_CHANGE#=91403893034)
```

Within a thread, an unbroken `SEQUENCE#` chain is what guarantees no redo was lost. This PR relaxes the check to tolerate a gap only when it carries the restart signature: consecutive `SEQUENCE#`s, a forward SCN jump, and an unchanged incarnation (`RESETLOGS_ID`, ruling out an `OPEN RESETLOGS` rewind that discards redo).

**Notes for reviewers:**

I confirmed with a dockerized Oracle instance that restarts keep `SEQUENCE#` consecutive and `RESETLOGS_ID` unchanged while the SCN jumps forward across a range that contained no changes to user tables.

