### PR TITLE
source-sqlserver{,-batch}: send real server name when tunneling

### DIFF
--- a/source-sqlserver-batch/main.go
+++ b/source-sqlserver-batch/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"text/template"
@@ -107,14 +108,11 @@ func (c *Config) SetDefaults() {
 }
 
 // ToURI converts the Config to a DSN string.
+//
+// The DSN host is always the real server address, even when tunneling. We dial localhost (the
+// tunnel) via tunnelDialer, but advertise the real server address as the LOGIN7 ServerName and
+// TLS SNI for SQL Server instances that rely on those being accurate.
 func (c *Config) ToURI() string {
-	// If SSH Tunnel is configured, we are going to create a tunnel from localhost
-	// to the target via the bastion server, so we use the tunnel's address.
-	var address = c.Address
-	if c.NetworkTunnel != nil && c.NetworkTunnel.SSHForwarding != nil && c.NetworkTunnel.SSHForwarding.SSHEndpoint != "" {
-		address = "localhost:1433"
-	}
-
 	var params = make(url.Values)
 	params.Add("app name", "Flow Batch Connector")
 	params.Add("encrypt", "true")
@@ -123,10 +121,33 @@ func (c *Config) ToURI() string {
 	var connectURL = &url.URL{
 		Scheme:   "sqlserver",
 		User:     url.UserPassword(c.User, c.Password),
-		Host:     address,
+		Host:     c.Address,
 		RawQuery: params.Encode(),
 	}
 	return connectURL.String()
+}
+
+// tunnelDialer redirects connections to the local end of the SSH tunnel while the driver keeps
+// the original hostname for its TLS SNI and TDS LOGIN7 ServerName fields, so that SQL Server
+// instances which route on the server name they receive see the real host, not "localhost".
+type tunnelDialer struct {
+	localAddr string // address of the tunnel's local listener, to which all dials are redirected
+	address   string // the server address being tunneled to
+}
+
+func (d *tunnelDialer) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, d.localAddr)
+}
+
+// HostName marks this as a mssqldb.HostDialer so the driver dials the configured host through
+// this dialer instead of resolving it locally, which keeps the real hostname in the LOGIN7
+// ServerName and TLS SNI.
+func (d *tunnelDialer) HostName() string {
+	if host, _, err := net.SplitHostPort(d.address); err == nil {
+		return host
+	}
+	return d.address
 }
 
 func connectSQLServer(ctx context.Context, cfg *Config) (*sql.DB, error) {
@@ -136,17 +157,22 @@ func connectSQLServer(ctx context.Context, cfg *Config) (*sql.DB, error) {
 		"database": cfg.Database,
 	}).Info("connecting to database")
 
-	// If a network tunnel is configured, then try to start it before establishing connections.
+	connector, err := mssqldb.NewConnector(cfg.ToURI())
+	if err != nil {
+		return nil, fmt.Errorf("error creating connector: %w", err)
+	}
+
+	// If a network tunnel is configured, then try to start it before establishing connections,
+	// and redirect the driver's TCP dial to the tunnel's local listener.
 	if cfg.NetworkTunnel.InUse() {
 		if _, err := cfg.NetworkTunnel.Start(ctx, cfg.Address, "1433"); err != nil {
 			return nil, err
 		}
+		connector.Dialer = &tunnelDialer{localAddr: "localhost:1433", address: cfg.Address}
 	}
 
-	var db, err = sql.Open("sqlserver", cfg.ToURI())
-	if err != nil {
-		return nil, fmt.Errorf("error opening database connection: %w", err)
-	} else if err := db.PingContext(ctx); err != nil {
+	var db = sql.OpenDB(connector)
+	if err := db.PingContext(ctx); err != nil {
 		var mssqlErr mssqldb.Error
 		if errors.As(err, &mssqlErr) {
 			switch mssqlErr.Number {

--- a/source-sqlserver-ct/main.go
+++ b/source-sqlserver-ct/main.go
@@ -140,14 +140,11 @@ func (c *Config) SetDefaults() {
 }
 
 // ToURI converts the Config to a DSN string.
+//
+// The DSN host is always the real server address, even when tunneling. We dial localhost (the
+// tunnel) via tunnelDialer, but advertise the real server address as the LOGIN7 ServerName and
+// TLS SNI for SQL Server instances that rely on those being accurate.
 func (c *Config) ToURI() string {
-	// If SSH Tunnel is configured, we are going to create a tunnel from localhost
-	// to the target via the bastion server, so we use the tunnel's address.
-	var address = c.Address
-	if c.NetworkTunnel != nil && c.NetworkTunnel.SSHForwarding != nil && c.NetworkTunnel.SSHForwarding.SSHEndpoint != "" {
-		address = "localhost:" + defaultPort
-	}
-
 	var params = make(url.Values)
 	params.Add("app name", "Estuary Change Tracking Connector")
 	params.Add("encrypt", "true")
@@ -156,10 +153,33 @@ func (c *Config) ToURI() string {
 	var connectURL = &url.URL{
 		Scheme:   "sqlserver",
 		User:     url.UserPassword(c.User, c.Password),
-		Host:     address,
+		Host:     c.Address,
 		RawQuery: params.Encode(),
 	}
 	return connectURL.String()
+}
+
+// tunnelDialer redirects connections to the local end of the SSH tunnel while the driver keeps
+// the original hostname for its TLS SNI and TDS LOGIN7 ServerName fields, so that SQL Server
+// instances which route on the server name they receive see the real host, not "localhost".
+type tunnelDialer struct {
+	localAddr string // address of the tunnel's local listener, to which all dials are redirected
+	address   string // the server address being tunneled to
+}
+
+func (d *tunnelDialer) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, d.localAddr)
+}
+
+// HostName marks this as a mssqldb.HostDialer so the driver dials the configured host through
+// this dialer instead of resolving it locally, which keeps the real hostname in the LOGIN7
+// ServerName and TLS SNI.
+func (d *tunnelDialer) HostName() string {
+	if host, _, err := net.SplitHostPort(d.address); err == nil {
+		return host
+	}
+	return d.address
 }
 
 func configSchema() json.RawMessage {
@@ -272,10 +292,17 @@ func (db *sqlserverDatabase) connect(ctx context.Context) error {
 		"user":    db.config.User,
 	}).Info("connecting to database")
 
-	var conn, err = sql.Open("sqlserver", db.config.ToURI())
+	connector, err := mssqldb.NewConnector(db.config.ToURI())
 	if err != nil {
-		return fmt.Errorf("unable to connect to database: %w", err)
+		return fmt.Errorf("error creating connector: %w", err)
 	}
+	// The tunnel itself is started in connectSQLServer. Here we just redirect the driver's TCP
+	// dial to its local listener while leaving the real hostname in the DSN.
+	if cfg := db.config.NetworkTunnel; cfg != nil && cfg.SSHForwarding != nil && cfg.SSHForwarding.SSHEndpoint != "" {
+		connector.Dialer = &tunnelDialer{localAddr: "localhost:" + defaultPort, address: db.config.Address}
+	}
+
+	var conn = sql.OpenDB(connector)
 	if err := conn.PingContext(ctx); err != nil {
 		var mssqlErr mssqldb.Error
 		if errors.As(err, &mssqlErr) {

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -177,14 +177,11 @@ func (c *Config) SetDefaults() {
 }
 
 // ToURI converts the Config to a DSN string.
+//
+// The DSN host is always the real server address, even when tunneling. We dial localhost (the
+// tunnel) via tunnelDialer, but advertise the real server address as the LOGIN7 ServerName and
+// TLS SNI for SQL Server instances that rely on those being accurate.
 func (c *Config) ToURI() string {
-	// If SSH Tunnel is configured, we are going to create a tunnel from localhost
-	// to the target via the bastion server, so we use the tunnel's address.
-	var address = c.Address
-	if c.NetworkTunnel != nil && c.NetworkTunnel.SSHForwarding != nil && c.NetworkTunnel.SSHForwarding.SSHEndpoint != "" {
-		address = "localhost:" + defaultPort
-	}
-
 	var params = make(url.Values)
 	params.Add("app name", "Flow CDC Connector")
 	params.Add("encrypt", "true")
@@ -193,10 +190,33 @@ func (c *Config) ToURI() string {
 	var connectURL = &url.URL{
 		Scheme:   "sqlserver",
 		User:     url.UserPassword(c.User, c.Password),
-		Host:     address,
+		Host:     c.Address,
 		RawQuery: params.Encode(),
 	}
 	return connectURL.String()
+}
+
+// tunnelDialer redirects connections to the local end of the SSH tunnel while the driver keeps
+// the original hostname for its TLS SNI and TDS LOGIN7 ServerName fields, so that SQL Server
+// instances which route on the server name they receive see the real host, not "localhost".
+type tunnelDialer struct {
+	localAddr string // address of the tunnel's local listener, to which all dials are redirected
+	address   string // the server address being tunneled to
+}
+
+func (d *tunnelDialer) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	var dialer net.Dialer
+	return dialer.DialContext(ctx, network, d.localAddr)
+}
+
+// HostName marks this as a mssqldb.HostDialer so the driver dials the configured host through
+// this dialer instead of resolving it locally, which keeps the real hostname in the LOGIN7
+// ServerName and TLS SNI.
+func (d *tunnelDialer) HostName() string {
+	if host, _, err := net.SplitHostPort(d.address); err == nil {
+		return host
+	}
+	return d.address
 }
 
 func configSchema() json.RawMessage {
@@ -293,10 +313,17 @@ func (db *sqlserverDatabase) connect(ctx context.Context) error {
 		"user":    db.config.User,
 	}).Info("connecting to database")
 
-	var conn, err = sql.Open("sqlserver", db.config.ToURI())
+	connector, err := mssqldb.NewConnector(db.config.ToURI())
 	if err != nil {
-		return fmt.Errorf("unable to connect to database: %w", err)
+		return fmt.Errorf("error creating connector: %w", err)
 	}
+	// The tunnel itself is started in connectSQLServer; here we just redirect the driver's TCP
+	// dial to its local listener while leaving the real hostname in the DSN.
+	if cfg := db.config.NetworkTunnel; cfg != nil && cfg.SSHForwarding != nil && cfg.SSHForwarding.SSHEndpoint != "" {
+		connector.Dialer = &tunnelDialer{localAddr: "localhost:" + defaultPort, address: db.config.Address}
+	}
+
+	var conn = sql.OpenDB(connector)
 	if err := conn.PingContext(ctx); err != nil {
 		var mssqlErr mssqldb.Error
 		if errors.As(err, &mssqlErr) {


### PR DESCRIPTION
**Description:**

When an SSH tunnel is configured, both connectors rewrite the DSN host to `localhost` to point the TCP dial at the tunnel's local listener. But `go-mssqldb` also derives the advertised server name (TDS LOGIN7 `ServerName` and TLS SNI) from the DSN host, so the connectors were advertisiung `localhost` too.

Self-hosted SQL Server ignores that name, but Azure SQL uses it to route each connection to the correct backend behind its shared gateway. Receiving `localhost`, the gateway rejects the login (`error 40532: Cannot open server "localhost" requested by the login` or `Connection was denied because Deny Public Network Access is set to Yes`), which breaks tunneled Azure captures.

This PR fixes this by decoupling the dial target from the advertised name: `ToURI` keeps the real address in the DSN, and a custom `go-mssqldb` `HostDialer` redirects only the TCP dial to the tunnel.

**Notes for reviewers:**

Tested discovery with both connectors and an Azure SQLServer instance accessed via an SSH network tunnel. Before this PR's changes, login failed with `Connection was denied because Deny Pubic Network Access is set to Yes` (despite that setting not actually being enabled). After the changes, both connectors connected through the tunnel and completed discovery successfully.

Regarding all the CI failures, I anticipate they're related to the issue discussed in this [thread](https://estuaryworkspace.slack.com/archives/C03PF2FSM5H/p1780515277736809) and will be resolved once this [PR](https://github.com/estuary/flow/pull/2995) is merged. Edit: That PR's merged & the relevant CI runs are green now. 👍 

