### PR TITLE
ci: workflow to bring delayed tag forward to latest version

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -204,6 +204,50 @@ def load_connector_images(ci_yaml: str, python_yaml: str) -> list:
     return images
 
 
+def resolve_family(connector_images: list, selected: str) -> list:
+    """
+    Return every ConnectorImage that shares the source_dir of `selected`
+    (matched by image_name) — i.e. the connector plus all of its variants,
+    regardless of whether the user named the parent or a variant.
+
+    Returns [] when `selected` is not a known image name.
+    """
+    match = next((c for c in connector_images if c.image_name == selected), None)
+    if match is None:
+        return []
+    return [c for c in connector_images if c.source_dir == match.source_dir]
+
+
+def resolve_version(source_dir: str, python_yaml: str) -> str:
+    """
+    Return the version tag (e.g. 'v3') CI publishes for a connector.
+
+    Python connectors carry their version in the python.yaml matrix; Go
+    connectors carry it in a VERSION file in the connector directory. We check
+    the matrix first because some Python connectors have no VERSION file.
+    Returns '' when neither source yields a version.
+    """
+    try:
+        out = subprocess.check_output(
+            ['yq',
+             f'.jobs.py_connector.strategy.matrix.connector[] '
+             f'| select(.name == "{source_dir}") | .version',
+             python_yaml],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+        for line in out.splitlines():
+            v = line.strip()
+            if v and v != 'null':
+                return v
+    except subprocess.CalledProcessError:
+        pass
+
+    version_file = Path(source_dir) / 'VERSION'
+    if version_file.exists():
+        return version_file.read_text().strip()
+    return ''
+
+
 # ---------------------------------------------------------------------------
 # GitHub API
 # ---------------------------------------------------------------------------
@@ -714,6 +758,44 @@ def cmd_check(args: argparse.Namespace) -> None:
     print(f'Tagging {len(safe)}/{len(plan)} connector(s) after hold filter')
 
 
+def cmd_forward(args: argparse.Namespace) -> None:
+    """
+    Resolve a user-selected connector to the (image, version) pairs whose
+    ':delayed' tag should be fast-forwarded to match the latest published
+    version tag. Writes a two-column 'image TAB version' file consumed by the
+    workflow's tagging step. Includes all variants of the selected connector.
+    """
+    selected = args.connector.strip()
+    images = load_connector_images(args.ci_yaml, args.python_yaml)
+    family = resolve_family(images, selected)
+    if not family:
+        print(
+            f'::error::unknown connector {selected!r}: not found in the '
+            f'ci.yaml / python.yaml connector matrices',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    source_dir = family[0].source_dir
+    version = resolve_version(source_dir, args.python_yaml)
+    if not version:
+        print(
+            f'::error::could not determine the version tag for {selected!r} '
+            f'(source dir {source_dir!r}/)',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(args.output, 'w') as f:
+        for ci in family:
+            f.write(f'{ci.image_name}\t{version}\n')
+
+    print(f'{selected}: version {version}, {len(family)} image(s) to fast-forward:')
+    for ci in family:
+        suffix = '' if ci.image_name == source_dir else ' (variant)'
+        print(f'  {ci.image_name}:{version} -> :delayed{suffix}')
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -740,8 +822,18 @@ def main(argv: Optional[list] = None) -> None:
     p.add_argument('--output-safe',     default='/tmp/safe_plan.tsv')
     p.add_argument('--output-verdicts', default='/tmp/claude_verdicts.tsv')
 
+    p = sub.add_parser(
+        'forward',
+        help="fast-forward a connector's ':delayed' tag to its latest version",
+    )
+    p.add_argument('--connector',   required=True,
+                   help='connector image name, e.g. source-postgres')
+    p.add_argument('--ci-yaml',     default='.github/workflows/ci.yaml')
+    p.add_argument('--python-yaml', default='.github/workflows/python.yaml')
+    p.add_argument('--output',      default='/tmp/forward_plan.tsv')
+
     args = parser.parse_args(argv)
-    {'plan': cmd_plan, 'check': cmd_check}[args.command](args)
+    {'plan': cmd_plan, 'check': cmd_check, 'forward': cmd_forward}[args.command](args)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -2,6 +2,7 @@
 
 import unittest
 from delayed_tag import (
+    ConnectorImage,
     PullRequest,
     PlanEntry,
     LaterEntry,
@@ -11,6 +12,7 @@ from delayed_tag import (
     find_boundary,
     parse_claude_verdict,
     pr_touches_dir,
+    resolve_family,
 )
 
 
@@ -296,6 +298,42 @@ class TestBuildClaudePrompt(unittest.TestCase):
     def test_no_later_prs(self):
         prompt = build_claude_prompt('img', 'dir', 5, 'chosen body', [])
         self.assertIn('PR #5', prompt)
+
+
+# ---------------------------------------------------------------------------
+# resolve_family
+# ---------------------------------------------------------------------------
+
+class TestResolveFamily(unittest.TestCase):
+    # source-postgres with two variants, plus an unrelated connector.
+    IMAGES = [
+        ConnectorImage('source-postgres', 'source-postgres'),
+        ConnectorImage('source-alloydb', 'source-postgres'),
+        ConnectorImage('source-amazon-rds-postgres', 'source-postgres'),
+        ConnectorImage('source-mysql', 'source-mysql'),
+    ]
+
+    def test_parent_returns_whole_family(self):
+        family = resolve_family(self.IMAGES, 'source-postgres')
+        self.assertEqual(
+            {c.image_name for c in family},
+            {'source-postgres', 'source-alloydb', 'source-amazon-rds-postgres'},
+        )
+
+    def test_variant_returns_whole_family(self):
+        # Selecting a variant still fast-forwards the entire family.
+        family = resolve_family(self.IMAGES, 'source-alloydb')
+        self.assertEqual(
+            {c.image_name for c in family},
+            {'source-postgres', 'source-alloydb', 'source-amazon-rds-postgres'},
+        )
+
+    def test_standalone_connector(self):
+        family = resolve_family(self.IMAGES, 'source-mysql')
+        self.assertEqual([c.image_name for c in family], ['source-mysql'])
+
+    def test_unknown_connector_is_empty(self):
+        self.assertEqual(resolve_family(self.IMAGES, 'source-nope'), [])
 
 
 if __name__ == '__main__':

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -28,7 +28,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  # Shared with the manual forward-delayed-tag workflow so the two never race
+  # on the same ':delayed' tag / DB rows.
+  group: delayed-tag
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/forward-delayed-tag.yaml
+++ b/.github/workflows/forward-delayed-tag.yaml
@@ -1,0 +1,140 @@
+name: Forward delayed tag
+
+# Manually fast-forward a single connector's ':delayed' tag to match its
+# latest published version tag (':vN'). This is the deliberate counterpart to
+# the nightly `delayed-tag.yaml` workflow, which holds ':delayed' two weeks
+# behind main.
+#
+# Use it to:
+#   - Ship a critical hotfix that already landed on the latest version to
+#     ':delayed' customers immediately, without waiting out the 2-week delay.
+#   - Re-sync ':delayed' with the current version tag so that a customer can be
+#     switched from ':vN' to ':delayed' without regressing onto an older image.
+#
+# The selected connector is resolved (via delayed_tag.py forward) to its image
+# name plus every variant in its VARIANTS file. For each, ':delayed' is pointed
+# at the same registry digest as ':<version>' — a manifest-only re-tag, no
+# layers are moved. The connector_tags DB row for ':delayed' is then re-queued.
+
+on:
+  workflow_dispatch:
+    inputs:
+      connector:
+        description: 'Connector image name (e.g. source-postgres). Variants are included automatically.'
+        required: true
+        type: string
+
+concurrency:
+  # Serialise with the nightly delayed-tag workflow so the two never race on
+  # the same ':delayed' tag / DB rows.
+  group: delayed-tag
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  forward_delayed:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub package docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Run unit tests
+        run: cd .github/scripts && python3 -m unittest test_delayed_tag -v
+
+      - name: Resolve connector to image + version
+        # Validates the selected connector against the ci.yaml / python.yaml
+        # matrices and expands variants. Reads the version from the connector's
+        # VERSION file (Go) or the python.yaml matrix (Python).
+        # Writes: /tmp/forward_plan.tsv  (image, version)
+        run: |
+          python3 .github/scripts/delayed_tag.py forward \
+            --connector "${{ inputs.connector }}" \
+            --output /tmp/forward_plan.tsv
+
+      - name: Fast-forward ':delayed' to the version tag
+        run: |
+          set -uo pipefail
+          tagged=0; failed=0
+          : > /tmp/tagged.txt
+          : > /tmp/forwarded.tsv
+          while IFS=$'\t' read -r IMAGE VERSION; do
+            [ -z "${IMAGE}" ] && continue
+            SRC="ghcr.io/estuary/${IMAGE}:${VERSION}"
+            DST="ghcr.io/estuary/${IMAGE}:delayed"
+            # `docker buildx imagetools create --tag DST SRC` is a manifest-only
+            # operation that points DST at the same digest as SRC. No image
+            # layers are downloaded or re-uploaded.
+            if ! docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
+              echo "::error::no image at ${SRC} — was the latest version built and pushed to GHCR?"
+              failed=$((failed + 1))
+              continue
+            fi
+            if docker buildx imagetools create --tag "${DST}" "${SRC}" >/dev/null; then
+              echo "tagged ${DST} -> :${VERSION}"
+              echo "${IMAGE}" >> /tmp/tagged.txt
+              printf '%s\t%s\n' "${IMAGE}" "${VERSION}" >> /tmp/forwarded.tsv
+              tagged=$((tagged + 1))
+            else
+              echo "::warning::failed to tag ${IMAGE}"
+              failed=$((failed + 1))
+            fi
+          done < /tmp/forward_plan.tsv
+          echo "Summary: tagged=${tagged} failed=${failed}"
+          if [ "${failed}" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Install psql
+        run: |
+          sudo apt update
+          sudo apt install -y postgresql-client
+
+      - name: Refresh connector_tags rows for ':delayed'
+        env:
+          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
+          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
+          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
+          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r IMAGE; do
+            [ -z "${IMAGE}" ] && continue
+            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
+                    WHERE connector_id IN (
+                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
+                    ) AND image_tag = ':delayed';" | psql
+          done < /tmp/tagged.txt
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -uo pipefail
+          {
+            echo "## Forward Delayed Tag — \`${{ inputs.connector }}\`"
+            echo ""
+            if [ -s /tmp/forwarded.tsv ]; then
+              echo "Fast-forwarded \`:delayed\` to the latest version tag:"
+              echo ""
+              echo "| Connector | Version |"
+              echo "|-----------|---------|"
+              while IFS=$'\t' read -r IMAGE VERSION; do
+                [ -z "${IMAGE}" ] && continue
+                echo "| \`${IMAGE}\` | \`${VERSION}\` |"
+              done < /tmp/forwarded.tsv
+            else
+              echo "No images were tagged."
+            fi
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
**Description:**

- A new, manually-triggered CI pipeline that brings the `delayed` tag of a connector up to the latest versioned tag. Used for shipping critical fixes to `delayed`, and also to bring `delayed` in sync with versions at the moment so that we can switch some customers to `delayed`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

