### PR TITLE
estuary-cdk: set extra="allow" on BaseDocument

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/document.py
+++ b/estuary-cdk/estuary_cdk/capture/document.py
@@ -3,7 +3,7 @@ from typing import Generic, Literal, TypeVar
 from pydantic import BaseModel, Field
 
 
-class BaseDocument(BaseModel):
+class BaseDocument(BaseModel, extra="allow"):
     class Meta(BaseModel):
         op: Literal["c", "u", "d"] = Field(
             default="u",

--- a/estuary-cdk/tests/test_webhook_server.py
+++ b/estuary-cdk/tests/test_webhook_server.py
@@ -203,7 +203,7 @@ class TestWebhookHandler:
 
     @pytest.mark.asyncio
     async def test_subclassed_document_model_respected(self):
-        class CustomDoc(WebhookDocument, extra="allow"):
+        class CustomDoc(WebhookDocument):
             @model_validator(mode="before")
             @classmethod
             def uppercase_name(cls, data: Any) -> Any:

--- a/source-ada/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-ada/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -31,6 +31,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -254,6 +255,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -323,6 +325,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -392,6 +395,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-appsflyer/tests/snapshots/snapshots__discover__stdout.json
@@ -198,6 +198,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -368,6 +369,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -538,6 +540,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -708,6 +711,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -878,6 +882,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1048,6 +1053,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1218,6 +1224,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1388,6 +1395,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1558,6 +1566,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1728,6 +1737,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1898,6 +1908,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -2068,6 +2079,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -2238,6 +2250,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -2408,6 +2421,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-facebook-marketing-native/tests/e2e/snapshots/snapshots__discover__capture.stdout.json
@@ -133,6 +133,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -202,6 +203,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1175,6 +1177,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-front/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-front/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -173,6 +173,7 @@
         }
       ],
       "ticket_ids": [],
+      "type": "discussion",
       "updated_at": 1731618543.11,
       "waiting_since": 1731600573.113
     }

--- a/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-greenhouse-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1544,6 +1544,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -122,7 +122,7 @@
         "hs_last_sales_activity_date": null,
         "hs_last_sales_activity_timestamp": null,
         "hs_last_sales_activity_type": null,
-        "hs_lastmodifieddate": "2025-01-18T21:49:41.259Z",
+        "hs_lastmodifieddate": "redacted",
         "hs_latest_createdate_of_active_subscriptions": null,
         "hs_latest_intent_signal_occurred_at": null,
         "hs_latest_intent_signal_timestamp": null,
@@ -387,50 +387,7 @@
           }
         ],
         "hs_date_entered_lead": "redacted",
-        "hs_lastmodifieddate": [
-          {
-            "sourceType": "DATA_ENRICHMENT",
-            "timestamp": "2025-01-18T21:49:41.259000Z",
-            "value": "2025-01-18T21:49:41.259Z"
-          },
-          {
-            "sourceType": "CALCULATED",
-            "timestamp": "2024-10-28T16:39:23.486000Z",
-            "value": "2024-10-28T16:39:23.486Z"
-          },
-          {
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2024-10-28T16:39:21.729000Z",
-            "value": "2024-10-28T16:39:21.729Z"
-          },
-          {
-            "sourceType": "CALCULATED",
-            "timestamp": "2024-10-28T16:39:18.872000Z",
-            "value": "2024-10-28T16:39:18.872Z"
-          },
-          {
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2024-10-28T16:39:06.146000Z",
-            "value": "2024-10-28T16:39:06.146Z"
-          },
-          {
-            "sourceType": "CALCULATED",
-            "timestamp": "2024-10-28T16:39:02.248000Z",
-            "value": "2024-10-28T16:39:02.248Z"
-          },
-          {
-            "sourceId": "RecordSourceDetailsWriterWorker",
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2024-10-28T16:39:01.568000Z",
-            "value": "2024-10-28T16:39:01.568Z"
-          },
-          {
-            "sourceId": "FetchAssociatedCompanyIdStep",
-            "sourceType": "COMPANIES",
-            "timestamp": "2024-10-28T16:39:01.173000Z",
-            "value": "2024-10-28T16:39:01.173Z"
-          }
-        ],
+        "hs_lastmodifieddate": "redacted",
         "hs_logo_url": [
           {
             "sourceType": "DATA_ENRICHMENT",
@@ -817,7 +774,7 @@
         "hs_last_sales_activity_type": null,
         "hs_last_sms_send_date": null,
         "hs_last_sms_send_name": null,
-        "hs_lastmodifieddate": null,
+        "hs_lastmodifieddate": "redacted",
         "hs_latest_disqualified_lead_date": null,
         "hs_latest_meeting_activity": null,
         "hs_latest_open_lead_date": null,
@@ -872,6 +829,7 @@
         "hs_predictivecontactscore_v2": null,
         "hs_predictivecontactscorebucket": null,
         "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_email_id": null,
         "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": "0",
         "hs_prospecting_agent_enrollment_status": null,
@@ -882,6 +840,8 @@
         "hs_quarantined_emails": null,
         "hs_read_only": null,
         "hs_recent_closed_order_date": null,
+        "hs_reddit_ad_clicked": null,
+        "hs_reddit_click_id": null,
         "hs_registered_member": "0",
         "hs_registration_method": null,
         "hs_returning_to_office_detected_date": null,
@@ -986,7 +946,7 @@
         "job_function": null,
         "jobtitle": "Salesperson",
         "kloutscoregeneral": null,
-        "lastmodifieddate": "2024-10-28T16:40:17.996Z",
+        "lastmodifieddate": "redacted",
         "lastname": "Johnson (Sample Contact)",
         "lifecyclestage": "lead",
         "linkedinbio": null,
@@ -1411,35 +1371,7 @@
             "value": "Salesperson"
           }
         ],
-        "lastmodifieddate": [
-          {
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:40:17.996000Z",
-            "value": "2024-10-28T16:40:17.996Z"
-          },
-          {
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:10.630000Z",
-            "value": "2024-10-28T16:39:10.630Z"
-          },
-          {
-            "sourceType": "CALCULATED",
-            "timestamp": "2024-10-28T16:39:01.522000Z",
-            "value": "2024-10-28T16:39:01.522Z"
-          },
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:01.010000Z",
-            "value": "2024-10-28T16:39:01.010Z"
-          },
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:00.846000Z",
-            "value": "2024-10-28T16:39:00.846Z"
-          }
-        ],
+        "lastmodifieddate": "redacted",
         "lastname": [
           {
             "sourceId": "sample-contact",
@@ -1679,7 +1611,7 @@
         "hs_last_sales_activity_type": null,
         "hs_last_sms_send_date": null,
         "hs_last_sms_send_name": null,
-        "hs_lastmodifieddate": null,
+        "hs_lastmodifieddate": "redacted",
         "hs_latest_disqualified_lead_date": null,
         "hs_latest_meeting_activity": null,
         "hs_latest_open_lead_date": null,
@@ -1734,6 +1666,7 @@
         "hs_predictivecontactscore_v2": null,
         "hs_predictivecontactscorebucket": null,
         "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_email_id": null,
         "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": "0",
         "hs_prospecting_agent_enrollment_status": null,
@@ -1744,6 +1677,8 @@
         "hs_quarantined_emails": null,
         "hs_read_only": null,
         "hs_recent_closed_order_date": null,
+        "hs_reddit_ad_clicked": null,
+        "hs_reddit_click_id": null,
         "hs_registered_member": "0",
         "hs_registration_method": null,
         "hs_returning_to_office_detected_date": null,
@@ -1848,7 +1783,7 @@
         "job_function": null,
         "jobtitle": "Executive Chairperson",
         "kloutscoregeneral": null,
-        "lastmodifieddate": "2024-10-28T16:40:20.553Z",
+        "lastmodifieddate": "redacted",
         "lastname": "Halligan (Sample Contact)",
         "lifecyclestage": "lead",
         "linkedinbio": null,
@@ -2257,35 +2192,7 @@
             "value": "Executive Chairperson"
           }
         ],
-        "lastmodifieddate": [
-          {
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:40:20.553000Z",
-            "value": "2024-10-28T16:40:20.553Z"
-          },
-          {
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:14.522000Z",
-            "value": "2024-10-28T16:39:14.522Z"
-          },
-          {
-            "sourceType": "CALCULATED",
-            "timestamp": "2024-10-28T16:39:02.286000Z",
-            "value": "2024-10-28T16:39:02.286Z"
-          },
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:01.442000Z",
-            "value": "2024-10-28T16:39:01.442Z"
-          },
-          {
-            "sourceId": "sample-contact",
-            "sourceType": "API",
-            "timestamp": "2024-10-28T16:39:01.326000Z",
-            "value": "2024-10-28T16:39:01.326Z"
-          }
-        ],
+        "lastmodifieddate": "redacted",
         "lastname": [
           {
             "sourceId": "sample-contact",
@@ -2537,7 +2444,7 @@
         "hs_last_sales_activity_type": null,
         "hs_last_sms_send_date": null,
         "hs_last_sms_send_name": null,
-        "hs_lastmodifieddate": null,
+        "hs_lastmodifieddate": "redacted",
         "hs_latest_disqualified_lead_date": null,
         "hs_latest_meeting_activity": null,
         "hs_latest_open_lead_date": null,
@@ -2570,7 +2477,7 @@
         "hs_membership_has_accessed_private_content": "0",
         "hs_membership_last_private_content_access_date": null,
         "hs_merged_object_ids": null,
-        "hs_messaging_engagement_score": null,
+        "hs_messaging_engagement_score": "0.474357",
         "hs_mobile_sdk_push_tokens": null,
         "hs_notes_last_activity": null,
         "hs_notes_next_activity": null,
@@ -2592,6 +2499,7 @@
         "hs_predictivecontactscore_v2": null,
         "hs_predictivecontactscorebucket": null,
         "hs_predictivescoringtier": null,
+        "hs_prospecting_agent_activation_email_id": null,
         "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": "0",
         "hs_prospecting_agent_enrollment_status": null,
@@ -2602,6 +2510,8 @@
         "hs_quarantined_emails": null,
         "hs_read_only": null,
         "hs_recent_closed_order_date": null,
+        "hs_reddit_ad_clicked": null,
+        "hs_reddit_click_id": null,
         "hs_registered_member": "0",
         "hs_registration_method": null,
         "hs_returning_to_office_detected_date": null,
@@ -2706,7 +2616,7 @@
         "job_function": null,
         "jobtitle": null,
         "kloutscoregeneral": null,
-        "lastmodifieddate": "2026-06-02T17:19:18.431Z",
+        "lastmodifieddate": "redacted",
         "lastname": "Doe",
         "lifecyclestage": "lead",
         "linkedinbio": null,
@@ -2958,6 +2868,14 @@
             "value": "0"
           }
         ],
+        "hs_messaging_engagement_score": [
+          {
+            "sourceId": "MessagingContactEngagementScoreEvaluator",
+            "sourceType": "EMAIL",
+            "timestamp": "2026-06-03T01:33:01.277000Z",
+            "value": "0.474357"
+          }
+        ],
         "hs_num_associated_open_deals": [
           {
             "sourceId": "InitialRollupProperties",
@@ -3149,26 +3067,7 @@
             "value": "true"
           }
         ],
-        "lastmodifieddate": [
-          {
-            "sourceType": "API",
-            "timestamp": "2026-06-02T17:19:18.431000Z",
-            "value": "2026-06-02T17:19:18.431Z"
-          },
-          {
-            "sourceId": "RecordSourceDetailsWriterWorker",
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2026-06-02T17:19:08.187000Z",
-            "value": "2026-06-02T17:19:08.187Z"
-          },
-          {
-            "sourceId": "76185710",
-            "sourceType": "IMPORT",
-            "timestamp": "2026-06-02T17:19:07.527000Z",
-            "updatedByUserId": 73074756,
-            "value": "2026-06-02T17:19:07.527Z"
-          }
-        ],
+        "lastmodifieddate": "redacted",
         "lastname": [
           {
             "sourceId": "76185710",
@@ -3311,7 +3210,7 @@
         "hs_last_meeting_id_with_followups": null,
         "hs_last_partner_shared_message_date": null,
         "hs_last_shared_message_create_date": null,
-        "hs_lastmodifieddate": "2025-04-03T12:59:43.469Z",
+        "hs_lastmodifieddate": "redacted",
         "hs_latest_approval_status": null,
         "hs_latest_approval_status_approval_id": null,
         "hs_latest_marketing_email_click_date": null,
@@ -3656,32 +3555,7 @@
             "value": "1"
           }
         ],
-        "hs_lastmodifieddate": [
-          {
-            "sourceId": "DealStageProbabilityHandler",
-            "sourceType": "CALCULATED",
-            "timestamp": "2025-04-03T12:59:43.469000Z",
-            "value": "2025-04-03T12:59:43.469Z"
-          },
-          {
-            "sourceType": "API",
-            "timestamp": "2025-04-03T12:59:19.747000Z",
-            "value": "2025-04-03T12:59:19.747Z"
-          },
-          {
-            "sourceId": "DealStageProcessor:userId:Optional.empty",
-            "sourceType": "INTERNAL_PROCESSING",
-            "timestamp": "2025-04-03T12:59:11.666000Z",
-            "value": "2025-04-03T12:59:11.666Z"
-          },
-          {
-            "sourceId": "userId:73074756",
-            "sourceType": "CRM_UI",
-            "timestamp": "2025-04-03T12:59:10.726000Z",
-            "updatedByUserId": 73074756,
-            "value": "2025-04-03T12:59:10.726Z"
-          }
-        ],
+        "hs_lastmodifieddate": "redacted",
         "hs_num_associated_active_deal_registrations": [
           {
             "sourceId": "InitialRollupProperties",
@@ -4210,7 +4084,7 @@
         "hs_is_canceled": "false",
         "hs_is_closed": "true",
         "hs_landing_site": null,
-        "hs_lastmodifieddate": "2026-01-14T19:18:04.972Z",
+        "hs_lastmodifieddate": "redacted",
         "hs_merged_object_ids": null,
         "hs_object_id": "520214166401",
         "hs_object_source": "CRM_UI",
@@ -4339,15 +4213,7 @@
             "value": "true"
           }
         ],
-        "hs_lastmodifieddate": [
-          {
-            "sourceId": "userId:73074756",
-            "sourceType": "CRM_UI",
-            "timestamp": "2026-01-14T19:18:04.972000Z",
-            "updatedByUserId": 73074756,
-            "value": "2026-01-14T19:18:04.972Z"
-          }
-        ],
+        "hs_lastmodifieddate": "redacted",
         "hs_object_id": [
           {
             "sourceId": "userId:73074756",

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -2392,6 +2392,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -2461,6 +2462,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-hubspot-native/tests/test_snapshots.py
+++ b/source-hubspot-native/tests/test_snapshots.py
@@ -17,6 +17,8 @@ def test_capture(request, snapshot):
         re.compile(r"^hs_time_in_"),
         re.compile(r"^hs_date_entered_"),
         re.compile(r"^hs_date_exited_"),
+        re.compile(r"^lastmodifieddate$"),
+        re.compile(r"^hs_lastmodifieddate$"),
     ]
 
     result = subprocess.run(

--- a/source-hubspot/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -74,24 +74,31 @@
         "hs_country_code": null,
         "hs_created_by_user_id": null,
         "hs_createdate": null,
-        "hs_date_entered_customer": null,
-        "hs_date_entered_evangelist": null,
-        "hs_date_entered_lead": "2024-10-28T16:39:01.173000+00:00",
-        "hs_date_entered_marketingqualifiedlead": null,
-        "hs_date_entered_opportunity": null,
-        "hs_date_entered_other": null,
-        "hs_date_entered_salesqualifiedlead": null,
-        "hs_date_entered_subscriber": null,
-        "hs_date_exited_customer": null,
-        "hs_date_exited_evangelist": null,
-        "hs_date_exited_lead": null,
-        "hs_date_exited_marketingqualifiedlead": null,
-        "hs_date_exited_opportunity": null,
-        "hs_date_exited_other": null,
-        "hs_date_exited_salesqualifiedlead": null,
-        "hs_date_exited_subscriber": null,
+        "hs_current_customer": null,
+        "hs_date_entered_customer": "redacted",
+        "hs_date_entered_evangelist": "redacted",
+        "hs_date_entered_lead": "redacted",
+        "hs_date_entered_marketingqualifiedlead": "redacted",
+        "hs_date_entered_opportunity": "redacted",
+        "hs_date_entered_other": "redacted",
+        "hs_date_entered_salesqualifiedlead": "redacted",
+        "hs_date_entered_subscriber": "redacted",
+        "hs_date_exited_customer": "redacted",
+        "hs_date_exited_evangelist": "redacted",
+        "hs_date_exited_lead": "redacted",
+        "hs_date_exited_marketingqualifiedlead": "redacted",
+        "hs_date_exited_opportunity": "redacted",
+        "hs_date_exited_other": "redacted",
+        "hs_date_exited_salesqualifiedlead": "redacted",
+        "hs_date_exited_subscriber": "redacted",
         "hs_employee_range": null,
         "hs_excluded_from_cross_account_data_mirroring": null,
+        "hs_geohash_1": null,
+        "hs_geohash_2": null,
+        "hs_geohash_3": null,
+        "hs_geohash_4": null,
+        "hs_geohash_5": null,
+        "hs_geohash_6": null,
         "hs_ideal_customer_profile": null,
         "hs_industry_group": null,
         "hs_inferred_domain": null,
@@ -110,6 +117,7 @@
         "hs_last_sales_activity_type": null,
         "hs_lastmodifieddate": "2025-01-18T21:49:41.259000+00:00",
         "hs_latest_createdate_of_active_subscriptions": null,
+        "hs_latest_intent_signal_occurred_at": null,
         "hs_latest_intent_signal_timestamp": null,
         "hs_latest_meeting_activity": null,
         "hs_latest_prospecting_agent_monitoring_date": null,
@@ -158,14 +166,14 @@
         "hs_target_account_recommendation_state": null,
         "hs_task_label": "HubSpot",
         "hs_tax_id": null,
-        "hs_time_in_customer": null,
-        "hs_time_in_evangelist": null,
+        "hs_time_in_customer": "redacted",
+        "hs_time_in_evangelist": "redacted",
         "hs_time_in_lead": "redacted",
-        "hs_time_in_marketingqualifiedlead": null,
+        "hs_time_in_marketingqualifiedlead": "redacted",
         "hs_time_in_opportunity": "redacted",
-        "hs_time_in_other": null,
-        "hs_time_in_salesqualifiedlead": null,
-        "hs_time_in_subscriber": null,
+        "hs_time_in_other": "redacted",
+        "hs_time_in_salesqualifiedlead": "redacted",
+        "hs_time_in_subscriber": "redacted",
         "hs_total_deal_value": null,
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": null,
@@ -212,8 +220,8 @@
         "website": "hubspot.com",
         "zip": null
       },
-      "updatedAt": "2025-01-18T21:49:41.259Z",
-      "url": "https://app.hubspot.com/contacts/47912630/record/0-2/25177527565"
+      "updatedAt": "redacted",
+      "url": "redacted"
     }
   ],
   [
@@ -221,32 +229,28 @@
     {
       "_meta": {
         "op": "u",
-        "row_id": 0,
+        "row_id": 2,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "archived": false,
-      "companies": [
-        "25177527565",
-        "25177527565"
-      ],
-      "createdAt": "2024-10-28T16:39:00.846Z",
-      "id": "72810357568",
+      "createdAt": "2026-06-02T17:19:07.527Z",
+      "id": "225877317544",
       "properties": {
         "address": null,
         "annualrevenue": null,
-        "associatedcompanyid": 25177527565,
+        "associatedcompanyid": null,
         "associatedcompanylastupdated": null,
-        "city": "Brisbane",
+        "city": null,
         "closedate": null,
-        "company": "HubSpot",
+        "company": null,
         "company_size": null,
         "country": null,
-        "createdate": "2024-10-28T16:39:00.846000+00:00",
+        "createdate": "2026-06-02T17:19:07.527000+00:00",
         "currentlyinworkflow": null,
         "date_of_birth": null,
         "days_to_close": null,
         "degree": null,
-        "email": "emailmaria@hubspot.com",
+        "email": "test@test.com",
         "engagements_last_meeting_booked": null,
         "engagements_last_meeting_booked_campaign": null,
         "engagements_last_meeting_booked_medium": null,
@@ -256,17 +260,17 @@
         "first_conversion_date": null,
         "first_conversion_event_name": null,
         "first_deal_created_date": null,
-        "firstname": "Maria",
+        "firstname": "John",
         "gender": null,
         "graduation_date": null,
         "hs_additional_emails": null,
         "hs_all_accessible_team_ids": null,
-        "hs_all_contact_vids": "72810357568",
+        "hs_all_contact_vids": "225877317544",
         "hs_all_owner_ids": null,
         "hs_all_team_ids": null,
         "hs_analytics_average_page_views": 0,
         "hs_analytics_first_referrer": null,
-        "hs_analytics_first_timestamp": "2024-10-28T16:39:00.612000+00:00",
+        "hs_analytics_first_timestamp": "2026-06-02T17:19:00+00:00",
         "hs_analytics_first_touch_converting_campaign": null,
         "hs_analytics_first_url": null,
         "hs_analytics_first_visit_timestamp": null,
@@ -280,8 +284,8 @@
         "hs_analytics_num_visits": 0,
         "hs_analytics_revenue": 0.0,
         "hs_analytics_source": "OFFLINE",
-        "hs_analytics_source_data_1": "API",
-        "hs_analytics_source_data_2": "sample-contact",
+        "hs_analytics_source_data_1": "IMPORT",
+        "hs_analytics_source_data_2": "76185710",
         "hs_associated_target_accounts": 0,
         "hs_avatar_filemanager_key": null,
         "hs_buying_role": null,
@@ -311,17 +315,18 @@
         "hs_count_is_worked": null,
         "hs_country_region_code": null,
         "hs_created_by_conversations": null,
-        "hs_created_by_user_id": null,
+        "hs_created_by_user_id": 73074756,
         "hs_createdate": null,
         "hs_cross_account_note": null,
         "hs_cross_sell_opportunity": null,
+        "hs_current_customer": null,
         "hs_document_last_revisited": null,
         "hs_email_bad_address": null,
         "hs_email_bounce": null,
         "hs_email_click": null,
         "hs_email_customer_quarantined_reason": null,
         "hs_email_delivered": null,
-        "hs_email_domain": "hubspot.com",
+        "hs_email_domain": "test.com",
         "hs_email_first_click_date": null,
         "hs_email_first_open_date": null,
         "hs_email_first_reply_date": null,
@@ -355,7 +360,7 @@
         "hs_first_order_closed_date": null,
         "hs_first_outreach_date": null,
         "hs_first_subscription_create_date": null,
-        "hs_full_name_or_email": "Maria Johnson (Sample Contact)",
+        "hs_full_name_or_email": "John Doe",
         "hs_geohash_1": null,
         "hs_geohash_2": null,
         "hs_geohash_3": null,
@@ -370,6 +375,7 @@
         "hs_ip_timezone": null,
         "hs_is_contact": true,
         "hs_is_enriched": null,
+        "hs_is_mass_marketing_activation_disallowed": null,
         "hs_is_unworked": true,
         "hs_language": null,
         "hs_last_metered_enrichment_timestamp": null,
@@ -389,9 +395,9 @@
         "hs_latest_sequence_finished_date": null,
         "hs_latest_sequence_unenrolled_date": null,
         "hs_latest_source": "OFFLINE",
-        "hs_latest_source_data_1": "API",
-        "hs_latest_source_data_2": "sample-contact",
-        "hs_latest_source_timestamp": "2024-10-28",
+        "hs_latest_source_data_1": "IMPORT",
+        "hs_latest_source_data_2": "76185710",
+        "hs_latest_source_timestamp": "2026-06-02",
         "hs_latest_subscription_create_date": null,
         "hs_lead_status": null,
         "hs_legal_basis": null,
@@ -403,26 +409,31 @@
         "hs_membership_has_accessed_private_content": 0,
         "hs_membership_last_private_content_access_date": null,
         "hs_merged_object_ids": null,
-        "hs_messaging_engagement_score": null,
+        "hs_messaging_engagement_score": 0.474357,
         "hs_mobile_sdk_push_tokens": null,
         "hs_notes_last_activity": null,
         "hs_notes_next_activity": null,
         "hs_notes_next_activity_type": null,
-        "hs_object_id": 72810357568,
-        "hs_object_source": "API",
-        "hs_object_source_detail_1": null,
+        "hs_object_id": 225877317544,
+        "hs_object_source": "IMPORT",
+        "hs_object_source_detail_1": "Marketing Events Attendance Test Data",
         "hs_object_source_detail_2": null,
         "hs_object_source_detail_3": null,
-        "hs_object_source_id": "sample-contact",
-        "hs_object_source_label": "INTERNAL_PROCESSING",
-        "hs_object_source_user_id": null,
+        "hs_object_source_id": "76185710",
+        "hs_object_source_label": "IMPORT",
+        "hs_object_source_user_id": 73074756,
         "hs_owning_teams": null,
         "hs_persona": null,
         "hs_pinned_engagement_id": null,
         "hs_pipeline": "contacts-lifecycle-pipeline",
+        "hs_prospecting_agent_activation_email_id": null,
+        "hs_prospecting_agent_activation_status": null,
         "hs_prospecting_agent_actively_enrolled_count": 0,
+        "hs_prospecting_agent_enrollment_status": null,
+        "hs_prospecting_agent_enrollment_status_raw": null,
         "hs_prospecting_agent_last_enrolled": null,
-        "hs_prospecting_agent_total_enrolled_count": null,
+        "hs_prospecting_agent_sender": null,
+        "hs_prospecting_agent_total_enrolled_count": 0,
         "hs_quarantined_emails": null,
         "hs_read_only": null,
         "hs_recent_closed_order_date": null,
@@ -445,6 +456,7 @@
         "hs_sequences_is_enrolled": null,
         "hs_source_object_id": null,
         "hs_source_portal_id": null,
+        "hs_sourced_contact_origin": null,
         "hs_state_code": null,
         "hs_sub_role": null,
         "hs_testpurge": null,
@@ -454,13 +466,13 @@
         "hs_time_to_first_engagement": null,
         "hs_timezone": null,
         "hs_unique_creation_key": null,
-        "hs_updated_by_user_id": null,
+        "hs_updated_by_user_id": 73074756,
         "hs_user_ids_of_all_notification_followers": null,
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": null,
         "hs_v2_date_entered_customer": null,
         "hs_v2_date_entered_evangelist": null,
-        "hs_v2_date_entered_lead": "2024-10-28T16:39:00.612000+00:00",
+        "hs_v2_date_entered_lead": "2026-06-02T17:19:07.527000+00:00",
         "hs_v2_date_entered_marketingqualifiedlead": null,
         "hs_v2_date_entered_opportunity": null,
         "hs_v2_date_entered_other": null,
@@ -474,8 +486,9 @@
         "hs_v2_date_exited_other": null,
         "hs_v2_date_exited_salesqualifiedlead": null,
         "hs_v2_date_exited_subscriber": null,
-        "hs_was_imported": null,
+        "hs_was_imported": true,
         "hs_whatsapp_phone_number": null,
+        "hs_why_this_contact": null,
         "hubspot_owner_assigneddate": null,
         "hubspot_owner_id": null,
         "hubspot_team_id": null,
@@ -489,9 +502,9 @@
         "ip_state_code": null,
         "ip_zipcode": null,
         "job_function": null,
-        "jobtitle": "Salesperson",
-        "lastmodifieddate": "2024-10-28T16:40:17.996000+00:00",
-        "lastname": "Johnson (Sample Contact)",
+        "jobtitle": null,
+        "lastmodifieddate": "2026-06-03T01:33:01.284000+00:00",
+        "lastname": "Doe",
         "lifecyclestage": "lead",
         "marital_status": null,
         "message": null,
@@ -503,7 +516,7 @@
         "num_associated_deals": null,
         "num_contacted_notes": null,
         "num_conversion_events": 0,
-        "num_notes": null,
+        "num_notes": 0,
         "num_unique_conversion_events": 0,
         "numemployees": null,
         "phone": null,
@@ -521,12 +534,12 @@
         "total_revenue": null,
         "twitterhandle": null,
         "webinareventlastupdated": null,
-        "website": "http://www.HubSpot.com",
+        "website": null,
         "work_email": null,
         "zip": null
       },
-      "updatedAt": "2024-10-28T16:40:17.996Z",
-      "url": "https://app.hubspot.com/contacts/47912630/record/0-1/72810357568"
+      "updatedAt": "redacted",
+      "url": "redacted"
     }
   ],
   [
@@ -556,7 +569,7 @@
             "probability": "0.2"
           },
           "stageId": "appointmentscheduled",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -568,7 +581,7 @@
             "probability": "0.4"
           },
           "stageId": "qualifiedtobuy",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -580,7 +593,7 @@
             "probability": "0.8"
           },
           "stageId": "decisionmakerboughtin",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -592,7 +605,7 @@
             "probability": "0.9"
           },
           "stageId": "contractsent",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -604,7 +617,7 @@
             "probability": "0.0"
           },
           "stageId": "closedlost",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -616,7 +629,7 @@
             "probability": "1.0"
           },
           "stageId": "closedwon",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         },
         {
           "active": true,
@@ -628,10 +641,10 @@
             "probability": "0.6"
           },
           "stageId": "presentationscheduled",
-          "updatedAt": 1743685150749
+          "updatedAt": "redacted"
         }
       ],
-      "updatedAt": 1743685150749
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -794,8 +807,8 @@
         "num_notes": 0,
         "pipeline": "default"
       },
-      "updatedAt": "2025-04-03T12:59:43.469Z",
-      "url": "https://app.hubspot.com/contacts/47912630/record/0-3/35447325508"
+      "updatedAt": "redacted",
+      "url": "redacted"
     }
   ],
   [
@@ -833,7 +846,7 @@
       "id": "83700335",
       "lastName": "Lazo",
       "type": "PERSON",
-      "updatedAt": "2025-10-20T15:18:28.094Z",
+      "updatedAt": "redacted",
       "userId": 83700335,
       "userIdIncludingInactive": 83700335
     }

--- a/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -660,6 +660,12 @@
                 "string"
               ]
             },
+            "hs_current_customer": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_date_entered_customer": {
               "format": "date-time",
               "type": [
@@ -784,6 +790,42 @@
                 "boolean"
               ]
             },
+            "hs_geohash_1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_geohash_2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_geohash_3": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_geohash_4": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_geohash_5": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_geohash_6": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_ideal_customer_profile": {
               "type": [
                 "null",
@@ -896,6 +938,13 @@
               ]
             },
             "hs_latest_createdate_of_active_subscriptions": {
+              "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_latest_intent_signal_occurred_at": {
               "format": "date-time",
               "type": [
                 "null",
@@ -2372,6 +2421,12 @@
                 "boolean"
               ]
             },
+            "hs_current_customer": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_document_last_revisited": {
               "format": "date-time",
               "type": [
@@ -2715,6 +2770,12 @@
                 "boolean"
               ]
             },
+            "hs_is_mass_marketing_activation_disallowed": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
             "hs_is_unworked": {
               "type": [
                 "null",
@@ -3032,14 +3093,44 @@
                 "string"
               ]
             },
+            "hs_prospecting_agent_activation_email_id": {
+              "type": [
+                "null",
+                "number"
+              ]
+            },
+            "hs_prospecting_agent_activation_status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_prospecting_agent_actively_enrolled_count": {
               "type": [
                 "null",
                 "number"
               ]
             },
+            "hs_prospecting_agent_enrollment_status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_prospecting_agent_enrollment_status_raw": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_prospecting_agent_last_enrolled": {
               "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_prospecting_agent_sender": {
               "type": [
                 "null",
                 "string"
@@ -3186,6 +3277,12 @@
               "type": [
                 "null",
                 "number"
+              ]
+            },
+            "hs_sourced_contact_origin": {
+              "type": [
+                "null",
+                "string"
               ]
             },
             "hs_state_code": {
@@ -3385,6 +3482,12 @@
               ]
             },
             "hs_whatsapp_phone_number": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_why_this_contact": {
               "type": [
                 "null",
                 "string"
@@ -7624,6 +7727,12 @@
                 "string"
               ]
             },
+            "hs_call_voice_agent_total_ms": {
+              "type": [
+                "null",
+                "number"
+              ]
+            },
             "hs_call_zoom_meeting_uuid": {
               "type": [
                 "null",
@@ -8152,6 +8261,12 @@
               "type": [
                 "null",
                 "string"
+              ]
+            },
+            "hs_email_body_redacted": {
+              "type": [
+                "null",
+                "boolean"
               ]
             },
             "hs_email_bounce_error_detail_message": {
@@ -9075,6 +9190,12 @@
                 "string"
               ]
             },
+            "hs_has_meeting_transcript": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
             "hs_i_cal_uid": {
               "type": [
                 "null",
@@ -9179,6 +9300,18 @@
                 "string"
               ]
             },
+            "hs_meeting_recording_duration": {
+              "type": [
+                "null",
+                "number"
+              ]
+            },
+            "hs_meeting_recording_url": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_meeting_source": {
               "type": [
                 "null",
@@ -9202,6 +9335,12 @@
               "type": [
                 "null",
                 "string"
+              ]
+            },
+            "hs_meeting_transcription_id": {
+              "type": [
+                "null",
+                "number"
               ]
             },
             "hs_meeting_web_conference_meeting_id": {
@@ -10103,76 +10242,6 @@
                 "string"
               ]
             },
-            "hs_date_entered_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_entered_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_entered_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_entered_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_entered_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_exited_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_exited_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_exited_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_exited_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "hs_date_exited_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
-              "format": "date-time",
-              "type": [
-                "null",
-                "string"
-              ]
-            },
             "hs_engagement_source": {
               "type": [
                 "null",
@@ -10636,36 +10705,6 @@
               ]
             },
             "hs_task_uncompleted_sub_task_ids": {
-              "type": [
-                "null",
-                "number"
-              ]
-            },
-            "hs_time_in_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
-              "type": [
-                "null",
-                "number"
-              ]
-            },
-            "hs_time_in_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
-              "type": [
-                "null",
-                "number"
-              ]
-            },
-            "hs_time_in_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
-              "type": [
-                "null",
-                "number"
-              ]
-            },
-            "hs_time_in_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
-              "type": [
-                "null",
-                "number"
-              ]
-            },
-            "hs_time_in_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
               "type": [
                 "null",
                 "number"
@@ -13347,6 +13386,12 @@
                 "boolean"
               ]
             },
+            "hs_current_customer": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_document_last_revisited": {
               "format": "date-time",
               "type": [
@@ -13690,6 +13735,12 @@
                 "boolean"
               ]
             },
+            "hs_is_mass_marketing_activation_disallowed": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
             "hs_is_unworked": {
               "type": [
                 "null",
@@ -14007,14 +14058,44 @@
                 "string"
               ]
             },
+            "hs_prospecting_agent_activation_email_id": {
+              "type": [
+                "null",
+                "number"
+              ]
+            },
+            "hs_prospecting_agent_activation_status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_prospecting_agent_actively_enrolled_count": {
               "type": [
                 "null",
                 "number"
               ]
             },
+            "hs_prospecting_agent_enrollment_status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_prospecting_agent_enrollment_status_raw": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "hs_prospecting_agent_last_enrolled": {
               "format": "date-time",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_prospecting_agent_sender": {
               "type": [
                 "null",
                 "string"
@@ -14161,6 +14242,12 @@
               "type": [
                 "null",
                 "number"
+              ]
+            },
+            "hs_sourced_contact_origin": {
+              "type": [
+                "null",
+                "string"
               ]
             },
             "hs_state_code": {
@@ -14360,6 +14447,12 @@
               ]
             },
             "hs_whatsapp_phone_number": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "hs_why_this_contact": {
               "type": [
                 "null",
                 "string"
@@ -15165,6 +15258,18 @@
               "type": [
                 "null",
                 "string"
+              ]
+            },
+            "hs_exclude_from_cx_score": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "hs_exclude_from_qa_score": {
+              "type": [
+                "null",
+                "boolean"
               ]
             },
             "hs_external_object_ids": {

--- a/source-hubspot/tests/test_snapshots.py
+++ b/source-hubspot/tests/test_snapshots.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -7,7 +8,41 @@ import pytest_insta.format as insta_format
 
 from estuary_cdk.utils import compare_capture_records, compare_values
 
-insta_format.FmtJson.dump = lambda _self, path, value: path.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", "utf-8")
+insta_format.FmtJson.dump = lambda _self, path, value: path.write_text(
+    json.dumps(value, sort_keys=True, indent=2) + "\n", "utf-8"
+)
+
+
+FIELDS_TO_REDACT = [
+    "url",
+    "updatedAt",
+]
+
+PROPERTY_PATTERNS_TO_REDACT = [
+    re.compile(r"^hs_time_in_"),
+    re.compile(r"^hs_date_entered_"),
+    re.compile(r"^hs_date_exited_"),
+]
+
+
+def redact_nested_fields(value: list | dict) -> None:
+    """
+    Recursively redact volatile fields wherever they appear so snapshots stay
+    stable across captures. HubSpot surfaces `updatedAt` at the record root,
+    inside `properties`, and on nested association objects, so redacting only
+    the top level leaves the nested copies to churn.
+    """
+    if isinstance(value, list):
+        for element in value:
+            redact_nested_fields(element)
+    elif isinstance(value, dict):
+        for key, nested in value.items():
+            if key in FIELDS_TO_REDACT or any(
+                pattern.match(key) for pattern in PROPERTY_PATTERNS_TO_REDACT
+            ):
+                value[key] = "redacted"
+            else:
+                redact_nested_fields(nested)
 
 
 def compare_discover_records(actual: list, expected: list) -> list[str]:
@@ -29,13 +64,6 @@ def compare_discover_records(actual: list, expected: list) -> list[str]:
 
 
 def test_capture(request, snapshot):
-    PROPERTIES_TO_REDACT = [
-        "hs_time_in_lead",
-        "hs_time_in_opportunity",
-        "hs_time_in_appointmentscheduled",
-        "updatedAt",
-    ]
-
     result = subprocess.run(
         [
             "flowctl",
@@ -65,13 +93,13 @@ def test_capture(request, snapshot):
             rec["timestamp"] = "redacted"
             rec["value"] = "redacted"
 
-        if "properties" in rec:
-            for property in PROPERTIES_TO_REDACT:
-                if property in rec["properties"]:
-                    rec["properties"][property] = "redacted"
+        redact_nested_fields(rec)
 
-
-    snapshot_path = Path(request.fspath.dirname) / "snapshots" / "snapshots__capture__capture.stdout.json"
+    snapshot_path = (
+        Path(request.fspath.dirname)
+        / "snapshots"
+        / "snapshots__capture__capture.stdout.json"
+    )
     insta_mode = request.config.getoption("--insta", default=None)
 
     if insta_mode == "update" or not snapshot_path.exists():
@@ -95,7 +123,7 @@ def test_discover(request, snapshot):
             request.fspath.dirname + "/../test.flow.yaml",
             "-o",
             "json",
-            "--emit-raw"
+            "--emit-raw",
         ],
         stdout=subprocess.PIPE,
         text=True,
@@ -103,7 +131,11 @@ def test_discover(request, snapshot):
     assert result.returncode == 0
     lines = [json.loads(l) for l in result.stdout.splitlines()]
 
-    snapshot_path = Path(request.fspath.dirname) / "snapshots" / "snapshots__discover__capture.stdout.json"
+    snapshot_path = (
+        Path(request.fspath.dirname)
+        / "snapshots"
+        / "snapshots__discover__capture.stdout.json"
+    )
     insta_mode = request.config.getoption("--insta", default=None)
 
     if insta_mode == "update" or not snapshot_path.exists():

--- a/source-incident-io/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-incident-io/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -114,6 +114,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -349,6 +350,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -584,6 +586,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -902,6 +905,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-intercom-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-intercom-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -31,6 +31,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -100,6 +101,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -169,6 +171,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -238,6 +241,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -307,6 +311,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -376,6 +381,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-iterable-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -243,6 +243,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -502,6 +503,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -571,6 +573,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -640,6 +643,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -709,6 +713,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-klaviyo-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -118,6 +118,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -187,6 +188,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -691,6 +693,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -847,6 +850,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1003,6 +1007,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -1072,6 +1077,7 @@
           "type": "object"
         }
       },
+      "additionalProperties": true,
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",

--- a/source-notion/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-notion/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -134,7 +134,7 @@
           "type": "text"
         }
       ],
-      "url": "https://www.notion.so/20e1921fa1844b40bfb1513ad5bb90af"
+      "url": "https://app.notion.com/p/20e1921fa1844b40bfb1513ad5bb90af"
     }
   ],
   [
@@ -194,7 +194,7 @@
         }
       ],
       "public_url": null,
-      "url": "https://www.notion.so/044986dfd173437c9bf9014296e5d4d2"
+      "url": "https://app.notion.com/p/044986dfd173437c9bf9014296e5d4d2"
     }
   ],
   [
@@ -256,7 +256,7 @@
         }
       ],
       "public_url": null,
-      "url": "https://www.notion.so/some-blocks-45c1fbd92cc9416093a43ebb94f77914"
+      "url": "https://app.notion.com/p/some-blocks-45c1fbd92cc9416093a43ebb94f77914"
     }
   ],
   [
@@ -334,7 +334,7 @@
         }
       ],
       "public_url": null,
-      "url": "https://www.notion.so/second-row-9291c59df8dd4af8a37aa6646988c5d2"
+      "url": "https://app.notion.com/p/second-row-9291c59df8dd4af8a37aa6646988c5d2"
     }
   ],
   [
@@ -396,7 +396,7 @@
         }
       ],
       "public_url": null,
-      "url": "https://www.notion.so/embedded-page-a541710271014972aa35eda60453e20c"
+      "url": "https://app.notion.com/p/embedded-page-a541710271014972aa35eda60453e20c"
     }
   ],
   [
@@ -480,7 +480,7 @@
         }
       ],
       "public_url": null,
-      "url": "https://www.notion.so/first-row-cc5f401824ed43009e1d440d9bd43676"
+      "url": "https://app.notion.com/p/first-row-cc5f401824ed43009e1d440d9bd43676"
     }
   ]
 ]

--- a/source-posthog/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-posthog/tests/snapshots/snapshots__capture__stdout.json
@@ -125,6 +125,7 @@
       "allow_publicly_shared_resources": true,
       "available_product_features": [
         {
+          "category": null,
           "description": "Ingest, search, and analyze logs from your applications.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -135,6 +136,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create as many surveys as you want.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -145,6 +147,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Rating scale (for NPS and the like), multiple choice, single choice, emoji rating, link, free text.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -155,6 +158,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Ask multiple questions in a single survey.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -165,6 +169,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Target by URL, user property, or feature flag when used with Feature flags.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -175,6 +180,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Sample users to only survey a portion of the users who match the criteria.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -185,6 +191,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Add custom HTML to your survey text.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -195,6 +202,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Using Popover or Feedback button surveys? No more code required. But if want to create your own UI, we have a full API.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -205,6 +213,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "See feedback summarized and broken down per response, plus completion rates and drop offs.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -215,6 +224,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Use our templates to get started quickly with NPS, customer satisfaction surveys, user interviews, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -225,6 +235,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Track user sentiment in distinct iterations of a survey.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -235,6 +246,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Activate surveys based on user events.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -245,6 +257,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Keep a historical record of your data.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -255,6 +268,7 @@
           "unit": "year"
         },
         {
+          "category": null,
           "description": "PostHog AI builds insights, automates manual tasks, and routes more complex tasks to other AI agents for specialized work.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -265,6 +279,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Zapier lets you connect PostHog with thousands of the most popular apps, so you can automate your work and have more time for what matters most\u2014no code required.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -275,6 +290,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get notified about new actions in Slack.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -285,6 +301,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get notified about new actions in Microsoft Teams.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -295,6 +312,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get notified about new actions in Discord.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -305,6 +323,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Use transformations to filter or modify your incoming data (destinations not included, see the data pipelines addon for product analytics).",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -315,6 +334,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Schedule regular data exports to your warehouse or other tools like BigQuery, Redshift, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -325,6 +345,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create as many feature flags as you need.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -335,6 +356,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Turn features on and off for specific users.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -345,6 +367,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create three or more variants of a feature flag to test or release different versions of a feature.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -355,6 +378,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Persist feature flags across authentication events so that flag values don't change when an anonymous user logs in and becomes identified.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -365,6 +389,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Use JSON payloads to change text, visuals, or entire blocks of code without subsequent deployments.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -375,6 +400,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Customize your rollout strategy by user or group properties, cohort, or trafic percentage.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -385,6 +411,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "For any release condition, specify which flag value the users or groups in that condition should receive.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -395,6 +422,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Target feature flag release conditions by group properties, not just user properties.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -405,6 +433,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Bootstrap flags on initialization so all flags are available immediately, without having to make extra network requests.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -415,6 +444,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "See how many times a flag has been evaluated, how many times each variant has been returned, and what values users received.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -425,6 +455,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Test changes to your product and evaluate the impacts those changes make.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -435,6 +466,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Measure the impact of a change on a aggregate values or a series of events, like a signup flow.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -445,6 +477,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Track additional metrics to see how your experiment affects other parts of your app or different flows.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -455,6 +488,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get a statistical analysis of your experiment results to see if the results are significant, or if they're likely just due to chance.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -465,6 +499,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Keep a historical record of your data.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -475,6 +510,7 @@
           "unit": "year"
         },
         {
+          "category": null,
           "description": "Keep a historical record of your data.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -485,17 +521,19 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Overview dashboard with usage metrics, costs, and performance.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_dashboard",
           "limit": null,
-          "name": "LLM analytics dashboard",
+          "name": "AI observability dashboard",
           "note": null,
           "unit": null
         },
         {
-          "description": "Full interaction timelines grouping related LLM calls.",
+          "category": null,
+          "description": "Full interaction timelines grouping related AI calls.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_traces",
@@ -505,7 +543,8 @@
           "unit": null
         },
         {
-          "description": "Track individual LLM requests with conversation history.",
+          "category": null,
+          "description": "Track individual AI requests with conversation history.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_generations",
@@ -515,6 +554,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Capture atomic operations like vector searches and tool calls.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -525,16 +565,18 @@
           "unit": null
         },
         {
-          "description": "Test and debug LLM interactions.",
+          "category": null,
+          "description": "Test and debug AI interactions.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_playground",
           "limit": null,
-          "name": "LLM playground",
+          "name": "AI playground",
           "note": null,
           "unit": null
         },
         {
+          "category": null,
           "description": "Python SDK support for OpenAI, Anthropic, Google Gemini, LangChain, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -545,6 +587,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Node.js SDK support for OpenAI, Anthropic, Google Gemini, Vercel AI SDK, LangChain, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -555,6 +598,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Automatic cost calculation per request.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -565,6 +609,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Track input, output, and cached token usage.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -575,6 +620,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Monitor response times and performance.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -585,7 +631,8 @@
           "unit": null
         },
         {
-          "description": "Analyze LLM usage with dashboards, funnels, retention, and custom SQL queries.",
+          "category": null,
+          "description": "Analyze AI usage with dashboards, funnels, retention, and custom SQL queries.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_product_analytics",
@@ -595,7 +642,8 @@
           "unit": null
         },
         {
-          "description": "Monitor, debug, and resolve LLM-generated errors automatically.",
+          "category": null,
+          "description": "Monitor, debug, and resolve AI-generated errors automatically.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_error_tracking",
@@ -605,7 +653,8 @@
           "unit": null
         },
         {
-          "description": "Watch session recordings to see exactly how users interact with your LLM features.",
+          "category": null,
+          "description": "Watch session recordings to see exactly how users interact with your AI features.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "llm_analytics_session_replay",
@@ -615,6 +664,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Exclude sensitive data from tracking.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -625,6 +675,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Add metadata and custom properties.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -635,6 +686,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Record and replay mobile app sessions.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -645,6 +697,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Sync data from Stripe, Hubspot, Zendesk, Snowflake, Postgres, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -655,6 +708,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create views to model your data and streamline queries.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -665,6 +719,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Link directly to your data sources such as S3, Google Cloud Storage, and Cloudflare R2. Data stays on your servers.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -675,6 +730,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Join data from any source, including your PostHog analytics data, to easily get the answers you need.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -685,6 +741,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Query all your business and product data directly inside PostHog.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -695,6 +752,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create insights from the data you import and add them to your PostHog dashboards.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -705,6 +763,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Sync only the data that has changed since the last sync.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -715,6 +774,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Choose how often you want to sync your data - daily, weekly, or monthly.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -725,6 +785,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Automatically capture unhandled exceptions in your code.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -735,6 +796,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Upload source maps to get code context.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -745,6 +807,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Watch a users session when they encounter an error.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -755,6 +818,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get notified of new issues by email, Slack, or webhook.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -765,6 +829,7 @@
           "unit": "alerts"
         },
         {
+          "category": null,
           "description": "Debug issues faster by browsing the user's console.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -775,6 +840,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "See your end-user's network performance and information alongside session recordings.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -785,6 +851,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Analyze performance and network calls.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -795,16 +862,18 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Create playlists of certain session recordings to easily find and watch them again in the future.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "recordings_playlists",
           "limit": null,
           "name": "Recording playlists",
-          "note": "unlimited",
+          "note": null,
           "unit": null
         },
         {
+          "category": null,
           "description": "Keep a historical record of your data. Up to 5 years of retention available with add-on packages.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -815,6 +884,7 @@
           "unit": "month"
         },
         {
+          "category": null,
           "description": "Disable capturing data from any DOM element with HTML attributes or a customizable config.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -825,6 +895,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Share replays directly via URL or embed via iframe.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -835,6 +906,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "See a history of everything that happened in a user's session.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -845,6 +917,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Filter by person properties to quickly find relevant recordings.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -855,6 +928,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Filter by events to quickly find relevant recordings.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -865,6 +939,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Freeze snapshots of recordings and explore the DOM with your browser dev tools.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -875,6 +950,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Restrict the percentage of sessions that will be recorded.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -885,6 +961,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Only record sessions longer than the minimum duration.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -895,6 +972,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Only record sessions for users that have the flag enabled.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -905,6 +983,7 @@
           "unit": null
         },
         {
+          "category": "Platforms",
           "description": "Record sessions on your web app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -915,6 +994,7 @@
           "unit": null
         },
         {
+          "category": "Platforms",
           "description": "Record sessions on your Android app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -925,6 +1005,7 @@
           "unit": null
         },
         {
+          "category": "Platforms",
           "description": "Record sessions on your iOS app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -935,6 +1016,7 @@
           "unit": null
         },
         {
+          "category": "Platforms",
           "description": "Record sessions on your React Native app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -945,6 +1027,7 @@
           "unit": null
         },
         {
+          "category": "Platforms",
           "description": "Record sessions on your Flutter app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -955,6 +1038,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Enhance your user data with properties and attribution data. Great for tracking user behavior across devices and sessions and tracking person changes over time.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -965,6 +1049,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Send emails to your users with workflows.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -975,6 +1060,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Save trends, funnels, and other insights for easy reference by your whole team.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -985,6 +1071,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Visualize user dropoff between a sequence of events. See conversion rate over time, use flexible step ordering, set exclusion steps, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -995,6 +1082,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Plot any number of events or actions over time.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1005,6 +1093,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Customize columns across the app.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1015,6 +1104,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Limited paths excludes: customizing path insights by setting the maximum number of paths, number of people on each path, how path names appear",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1025,6 +1115,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Keep a historical record of your data.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1035,16 +1126,29 @@
           "unit": "year"
         },
         {
+          "category": null,
           "description": "Set up alerts to notify you when certain events happen.",
           "entitlement_only": false,
           "is_plan_default": true,
           "key": "alerts",
-          "limit": 2,
+          "limit": 5,
           "name": "Alerts",
           "note": null,
           "unit": "alert"
         },
         {
+          "category": null,
+          "description": "Create a subscription for any insight or dashboard in PostHog to receive regular reports with their updates.",
+          "entitlement_only": false,
+          "is_plan_default": true,
+          "key": "subscriptions",
+          "limit": 5,
+          "name": "Insight & dashboard subscriptions",
+          "note": null,
+          "unit": "subscription"
+        },
+        {
+          "category": null,
           "description": "Track users across devices and sessions.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1055,6 +1159,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "PostHog doesn't charge per seat add your entire team!",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1065,6 +1170,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Organize environments within a project. Share dashboards, insights and more across environments without duplicating work.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1075,6 +1181,7 @@
           "unit": "project"
         },
         {
+          "category": null,
           "description": "Access your data via our developer-friendly API.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1085,6 +1192,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Log in to PostHog with your Google, Github, or Gitlab account.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1095,6 +1203,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get help from other users and PostHog team members in our Community forums.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1105,6 +1214,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Secure your PostHog account with two-factor authentication.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1115,6 +1225,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get help from our team!",
           "entitlement_only": true,
           "is_plan_default": true,
@@ -1125,6 +1236,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Configure settings for publicly shared resources like insights and dashboards.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1135,6 +1247,7 @@
           "unit": "configuration"
         },
         {
+          "category": "Features",
           "description": "Use our managed proxy service to send events through your own domain. Capture more usage data that might otherwise be intercepted by ad blockers without needing to set up and maintain the proxy yourself.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1145,6 +1258,7 @@
           "unit": "proxies"
         },
         {
+          "category": null,
           "description": "Instantly send data to hundreds of third-party tools to trigger automations, send emails, enhance ads, and more.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1155,6 +1269,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Send data to internal tools like Slack so you get notified whenever important events happen.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1165,6 +1280,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Transform, enrich, sample, or drop events as they arrive \u2014 before ingestion, at no extra cost.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1175,6 +1291,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Get a massive free allowance every month to try the integrations you need, and only pay for usage at scale.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1185,6 +1302,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Send your data to 100+ destinations with workflows.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1195,6 +1313,7 @@
           "unit": null
         },
         {
+          "category": null,
           "description": "Sync free historical rows in the first 7 days for each new source.",
           "entitlement_only": false,
           "is_plan_default": true,
@@ -1214,11 +1333,16 @@
       "id": "019c2351-c712-0000-8470-cf277880e65a",
       "is_active": true,
       "is_ai_data_processing_approved": false,
+      "is_ai_training_cta_shown": true,
+      "is_ai_training_locked": true,
+      "is_ai_training_opted_in": false,
+      "is_hipaa": false,
       "is_member_join_email_enabled": true,
       "is_not_active_reason": null,
       "is_pending_deletion": false,
       "logo_media_id": null,
       "member_count": 1,
+      "members_can_create_projects": false,
       "members_can_invite": true,
       "members_can_use_personal_api_keys": true,
       "membership_level": 15,

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -20,7 +20,7 @@
           "image": {
             "altText": "Gift card that shows text: Generated data gift card",
             "height": 2881,
-            "id": "gid://shopify/ImageSource/26929507041325",
+            "id": "gid://shopify/ImageSource/26890923409453",
             "url": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/gift_card.png?v=1736867416",
             "width": 2881
           },

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -197,6 +197,7 @@
       "phone_number_id": 28835744176276,
       "post_call_summary": null,
       "post_call_summary_created": null,
+      "post_call_transcription": null,
       "post_call_transcription_created": null,
       "quality_issues": [
         "none"
@@ -250,6 +251,7 @@
         "custom_objects": {},
         "end_user_list_access": "full",
         "end_user_profile_access": "readonly",
+        "execute_it_asset_management_actions": false,
         "explore_access": "readonly",
         "explore_reports": {
           "brands_ticket_access": "all",
@@ -265,6 +267,7 @@
         "it_asset_management_access": "view",
         "light_agent": true,
         "macro_access": "readonly",
+        "manage_api_credentials": false,
         "manage_approval_requests": false,
         "manage_automations": false,
         "manage_business_rules": false,
@@ -284,6 +287,7 @@
         "manage_roles": "none",
         "manage_skills": false,
         "manage_slas": false,
+        "manage_support_apps": false,
         "manage_suspended_tickets": false,
         "manage_team_members": "readonly",
         "manage_ticket_fields": false,
@@ -309,6 +313,7 @@
         "ticket_redaction": false,
         "ticket_tag_editing": false,
         "twitter_search_access": false,
+        "update_api_settings": false,
         "update_user_own_alias": false,
         "update_user_own_name": false,
         "update_user_own_signature": false,
@@ -1046,6 +1051,14 @@
           {
             "id": 48494958189844,
             "value": null
+          },
+          {
+            "id": 49220324710292,
+            "value": null
+          },
+          {
+            "id": 49220324714132,
+            "value": null
           }
         ],
         "custom_status_id": 28835714727188,
@@ -1070,6 +1083,14 @@
           },
           {
             "id": 48494958189844,
+            "value": null
+          },
+          {
+            "id": 49220324710292,
+            "value": null
+          },
+          {
+            "id": 49220324714132,
             "value": null
           }
         ],
@@ -1148,6 +1169,14 @@
         {
           "id": 48494958189844,
           "value": null
+        },
+        {
+          "id": 49220324710292,
+          "value": null
+        },
+        {
+          "id": 49220324714132,
+          "value": null
         }
       ],
       "custom_status_id": 28835714727188,
@@ -1171,6 +1200,14 @@
         },
         {
           "id": 48494958189844,
+          "value": null
+        },
+        {
+          "id": 49220324710292,
+          "value": null
+        },
+        {
+          "id": 49220324714132,
           "value": null
         }
       ],

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -410,7 +410,7 @@
       },
       "assigned_at": "2024-07-26T15:41:04Z",
       "assignee_stations": 1,
-      "assignee_updated_at": "2024-08-01T14:45:47Z",
+      "assignee_updated_at": "redacted",
       "created_at": "2024-07-26T15:41:04Z",
       "custom_status_updated_at": "2024-07-26T15:41:04Z",
       "first_resolution_time_in_minutes": {
@@ -498,6 +498,14 @@
           {
             "id": 48494958189844,
             "value": null
+          },
+          {
+            "id": 49220324710292,
+            "value": null
+          },
+          {
+            "id": 49220324714132,
+            "value": null
           }
         ],
         "custom_status_id": 28835714727188,
@@ -523,13 +531,21 @@
           {
             "id": 48494958189844,
             "value": null
+          },
+          {
+            "id": 49220324710292,
+            "value": null
+          },
+          {
+            "id": 49220324714132,
+            "value": null
           }
         ],
         "follower_ids": [],
         "followup_ids": [],
         "forum_topic_id": null,
         "from_messaging_channel": false,
-        "generated_timestamp": 1722523548,
+        "generated_timestamp": "redacted",
         "group_id": 28835740822676,
         "has_incidents": false,
         "id": 1,
@@ -555,7 +571,7 @@
         ],
         "ticket_form_id": 28835740693908,
         "type": "incident",
-        "updated_at": "2024-08-01T14:45:47Z",
+        "updated_at": "redacted",
         "url": "https://d3v-estuary.zendesk.com/api/v2/tickets/1.json",
         "via": {
           "channel": "sample_ticket",
@@ -601,6 +617,14 @@
         {
           "id": 48494958189844,
           "value": null
+        },
+        {
+          "id": 49220324710292,
+          "value": null
+        },
+        {
+          "id": 49220324714132,
+          "value": null
         }
       ],
       "custom_status_id": 28835714727188,
@@ -625,13 +649,21 @@
         {
           "id": 48494958189844,
           "value": null
+        },
+        {
+          "id": 49220324710292,
+          "value": null
+        },
+        {
+          "id": 49220324714132,
+          "value": null
         }
       ],
       "follower_ids": [],
       "followup_ids": [],
       "forum_topic_id": null,
       "from_messaging_channel": false,
-      "generated_timestamp": 1722523548,
+      "generated_timestamp": "redacted",
       "group_id": 28835740822676,
       "has_incidents": false,
       "id": 1,
@@ -763,6 +795,7 @@
         "custom_objects": {},
         "end_user_list_access": "full",
         "end_user_profile_access": "readonly",
+        "execute_it_asset_management_actions": false,
         "explore_access": "readonly",
         "explore_reports": {
           "brands_ticket_access": "all",
@@ -778,6 +811,7 @@
         "it_asset_management_access": "view",
         "light_agent": true,
         "macro_access": "readonly",
+        "manage_api_credentials": false,
         "manage_approval_requests": false,
         "manage_automations": false,
         "manage_business_rules": false,
@@ -797,6 +831,7 @@
         "manage_roles": "none",
         "manage_skills": false,
         "manage_slas": false,
+        "manage_support_apps": false,
         "manage_suspended_tickets": false,
         "manage_team_members": "readonly",
         "manage_ticket_fields": false,
@@ -822,6 +857,7 @@
         "ticket_redaction": false,
         "ticket_tag_editing": false,
         "twitter_search_access": false,
+        "update_api_settings": false,
         "update_user_own_alias": false,
         "update_user_own_name": false,
         "update_user_own_signature": false,

--- a/source-zendesk-support/tests/test_snapshots.py
+++ b/source-zendesk-support/tests/test_snapshots.py
@@ -7,6 +7,32 @@ import pytest
 from estuary_cdk.utils import compare_capture_records
 
 
+FIELDS_TO_REDACT = [
+    "updated_at",
+    "last_login_at",
+    "assignee_updated_at",
+    "generated_timestamp",
+]
+
+
+def redact_nested_fields(value: list | dict) -> None:
+    """
+    Recursively redact volatile timestamp/cursor fields wherever they appear so
+    snapshots stay stable across captures. Zendesk surfaces `updated_at` on
+    nested objects (not just the record root), and incremental exports stamp a
+    fresh `generated_timestamp` on every run.
+    """
+    if isinstance(value, list):
+        for element in value:
+            redact_nested_fields(element)
+    elif isinstance(value, dict):
+        for key, nested in value.items():
+            if key in FIELDS_TO_REDACT:
+                value[key] = "redacted"
+            else:
+                redact_nested_fields(nested)
+
+
 def test_capture(request, snapshot):
     OMITTED_STREAMS = [
         "acmeCo/tags",
@@ -41,11 +67,8 @@ def test_capture(request, snapshot):
     for l in unique_stream_lines:
         stream, rec = l[0], l[1]
 
-        rec['_meta']['row_id'] = 0
-        if "updated_at" in rec:
-            rec["updated_at"] = "redacted"
-        if "last_login_at" in rec:
-            rec["last_login_at"] = "redacted"
+        rec["_meta"]["row_id"] = 0
+        redact_nested_fields(rec)
 
         if stream == "acmeCo/ticket_audits":
             rec["id"] = "redacted"
@@ -53,7 +76,11 @@ def test_capture(request, snapshot):
             rec["events"] = "redacted"
             rec["ticket_id"] = "redacted"
 
-    snapshot_path = Path(request.fspath.dirname) / "snapshots" / "snapshots__capture__capture.stdout.json"
+    snapshot_path = (
+        Path(request.fspath.dirname)
+        / "snapshots"
+        / "snapshots__capture__capture.stdout.json"
+    )
     insta_mode = request.config.getoption("--insta", default=None)
 
     if insta_mode == "update" or not snapshot_path.exists():


### PR DESCRIPTION
**Description:**

Sets the CDK's BaseDocument model to accept new properties by default.

This change allows incremental JSON/CSV processors to use the class as its validation model for HTTP responses where no specific fields are required. Additionally, it fixes a bug in webhook captures where additional properties were being ignored.

No other side effects are expected: most sources explicitly use either extra="allow" or fixed schemas. There are four exceptions:

- `source-jira-native`'s `AbbreviatedProject` explicitly sets extra="ignore"
- `source-apple-app-store`'s `EndpointConfig` explicitly sets extra="forbid"
- `source-qualtrics`'s `QualtricsResource` and `source-posthog`'s `ProjectScopedMixin` are abstract classes with co-parents that explicitly set `extra="allow"`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

