### PR TITLE
materialize-redshift: set temporary table varchar size

### DIFF
--- a/materialize-redshift/.snapshots/TestSQLGeneration
+++ b/materialize-redshift/.snapshots/TestSQLGeneration
@@ -79,48 +79,6 @@ Flow publication date-time of this document
 auto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';
 --- End "a-schema".delta_updates createTargetTable ---
 
---- Begin "a-schema".key_value createStoreTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0 (
-	key1 BIGINT,
-	key2 BOOLEAN,
-	"key!binary" VARBYTE(1024000),
-	"array" SUPER,
-	"binary" VARBYTE(1024000),
-	boolean BOOLEAN,
-	field_with_projection TEXT,
-	flow_published_at TIMESTAMPTZ,
-	integer BIGINT,
-	"integerGt128Bit" NUMERIC(38,0),
-	"integerGt256Bit" NUMERIC(38,0),
-	"integerGt64Bit" NUMERIC(38,0),
-	"integerWithUserDDL" DECIMAL(20),
-	multiple SUPER,
-	"nonAsciiκόσμε" TEXT,
-	number DOUBLE PRECISION,
-	"numberCastToString" TEXT,
-	object SUPER,
-	string TEXT,
-	"stringInteger" NUMERIC(38,0),
-	"stringInteger18Chars" NUMERIC(38,0),
-	"stringInteger38Chars" NUMERIC(38,0),
-	"stringInteger39Chars" TEXT,
-	"stringInteger66Chars" TEXT,
-	"stringInteger77Chars" TEXT,
-	"stringNumber" DOUBLE PRECISION,
-	flow_document SUPER
-);
---- End "a-schema".key_value createStoreTable ---
-
---- Begin "a-schema".delta_updates createStoreTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1 (
-	"theKey" TEXT,
-	"aValue" BIGINT,
-	flow_published_at TIMESTAMPTZ
-);
---- End "a-schema".delta_updates createStoreTable ---
-
 --- Begin "a-schema".key_value mergeInto ---
 
 MERGE INTO "a-schema".key_value
@@ -204,22 +162,6 @@ SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
 
 --- End "a-schema".delta_updates loadQueryNoFlowDocument ---
 
---- Begin "a-schema".key_value createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
-  key1 BIGINT,
-  key2 BOOLEAN,
-  "key!binary" VARBYTE(1024000)
-);
---- End "a-schema".key_value createDeleteTable ---
-
---- Begin "a-schema".delta_updates createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
-  "theKey" TEXT
-);
---- End "a-schema".delta_updates createDeleteTable ---
-
 --- Begin "a-schema".key_value deleteQuery ---
 
 DELETE FROM "a-schema".key_value
@@ -259,6 +201,114 @@ CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" VARCHAR(400)
 );
 --- End "a-schema".delta_updates createLoadTable (with varchar length) ---
+
+--- Begin "a-schema".key_value createStoreTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARBYTE(1024000),
+	"array" SUPER,
+	"binary" VARBYTE(1024000),
+	boolean BOOLEAN,
+	field_with_projection TEXT,
+	flow_published_at TIMESTAMPTZ,
+	integer BIGINT,
+	"integerGt128Bit" NUMERIC(38,0),
+	"integerGt256Bit" NUMERIC(38,0),
+	"integerGt64Bit" NUMERIC(38,0),
+	"integerWithUserDDL" DECIMAL(20),
+	multiple SUPER,
+	"nonAsciiκόσμε" TEXT,
+	number DOUBLE PRECISION,
+	"numberCastToString" TEXT,
+	object SUPER,
+	string TEXT,
+	"stringInteger" NUMERIC(38,0),
+	"stringInteger18Chars" NUMERIC(38,0),
+	"stringInteger38Chars" NUMERIC(38,0),
+	"stringInteger39Chars" TEXT,
+	"stringInteger66Chars" TEXT,
+	"stringInteger77Chars" TEXT,
+	"stringNumber" DOUBLE PRECISION,
+	flow_document SUPER
+);
+--- End "a-schema".key_value createStoreTable (no varchar length) ---
+
+--- Begin "a-schema".key_value createStoreTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARBYTE(1024000),
+	"array" SUPER,
+	"binary" VARBYTE(1024000),
+	boolean BOOLEAN,
+	field_with_projection VARCHAR(48),
+	flow_published_at TIMESTAMPTZ,
+	integer BIGINT,
+	"integerGt128Bit" NUMERIC(38,0),
+	"integerGt256Bit" NUMERIC(38,0),
+	"integerGt64Bit" NUMERIC(38,0),
+	"integerWithUserDDL" DECIMAL(20),
+	multiple SUPER,
+	"nonAsciiκόσμε" VARCHAR(56),
+	number DOUBLE PRECISION,
+	"numberCastToString" VARCHAR(58),
+	object SUPER,
+	string VARCHAR(60),
+	"stringInteger" NUMERIC(38,0),
+	"stringInteger18Chars" NUMERIC(38,0),
+	"stringInteger38Chars" NUMERIC(38,0),
+	"stringInteger39Chars" VARCHAR(64),
+	"stringInteger66Chars" VARCHAR(65),
+	"stringInteger77Chars" VARCHAR(66),
+	"stringNumber" DOUBLE PRECISION,
+	flow_document SUPER
+);
+--- End "a-schema".key_value createStoreTable (with varchar length) ---
+
+--- Begin "a-schema".delta_updates createStoreTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	"theKey" TEXT,
+	"aValue" BIGINT,
+	flow_published_at TIMESTAMPTZ
+);
+--- End "a-schema".delta_updates createStoreTable (no varchar length) ---
+
+--- Begin "a-schema".delta_updates createStoreTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	"theKey" VARCHAR(42),
+	"aValue" BIGINT,
+	flow_published_at TIMESTAMPTZ
+);
+--- End "a-schema".delta_updates createStoreTable (with varchar length) ---
+
+--- Begin "a-schema".key_value createDeleteTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARBYTE(1024000)
+);
+--- End "a-schema".key_value createDeleteTable (no varchar length) ---
+
+--- Begin "a-schema".key_value createDeleteTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARBYTE(1024000)
+);
+--- End "a-schema".key_value createDeleteTable (with varchar length) ---
+
+--- Begin "a-schema".delta_updates createDeleteTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+	"theKey" TEXT
+);
+--- End "a-schema".delta_updates createDeleteTable (no varchar length) ---
+
+--- Begin "a-schema".delta_updates createDeleteTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+	"theKey" VARCHAR(42)
+);
+--- End "a-schema".delta_updates createDeleteTable (with varchar length) ---
 
 --- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---
 COPY my_temp_table

--- a/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
+++ b/materialize-redshift/.snapshots/TestSQLGeneration_NoNativeBinaryColumnType
@@ -79,48 +79,6 @@ Flow publication date-time of this document
 auto-generated projection of JSON at: /_meta/uuid with inferred types: [string]';
 --- End "a-schema".delta_updates createTargetTable ---
 
---- Begin "a-schema".key_value createStoreTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0 (
-	key1 BIGINT,
-	key2 BOOLEAN,
-	"key!binary" TEXT,
-	"array" SUPER,
-	"binary" TEXT,
-	boolean BOOLEAN,
-	field_with_projection TEXT,
-	flow_published_at TIMESTAMPTZ,
-	integer BIGINT,
-	"integerGt128Bit" NUMERIC(38,0),
-	"integerGt256Bit" NUMERIC(38,0),
-	"integerGt64Bit" NUMERIC(38,0),
-	"integerWithUserDDL" DECIMAL(20),
-	multiple SUPER,
-	"nonAsciiκόσμε" TEXT,
-	number DOUBLE PRECISION,
-	"numberCastToString" TEXT,
-	object SUPER,
-	string TEXT,
-	"stringInteger" NUMERIC(38,0),
-	"stringInteger18Chars" NUMERIC(38,0),
-	"stringInteger38Chars" NUMERIC(38,0),
-	"stringInteger39Chars" TEXT,
-	"stringInteger66Chars" TEXT,
-	"stringInteger77Chars" TEXT,
-	"stringNumber" DOUBLE PRECISION,
-	flow_document SUPER
-);
---- End "a-schema".key_value createStoreTable ---
-
---- Begin "a-schema".delta_updates createStoreTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1 (
-	"theKey" TEXT,
-	"aValue" BIGINT,
-	flow_published_at TIMESTAMPTZ
-);
---- End "a-schema".delta_updates createStoreTable ---
-
 --- Begin "a-schema".key_value mergeInto ---
 
 MERGE INTO "a-schema".key_value
@@ -204,22 +162,6 @@ SELECT * FROM (SELECT -1, CAST(NULL AS SUPER) LIMIT 0) as nodoc
 
 --- End "a-schema".delta_updates loadQueryNoFlowDocument ---
 
---- Begin "a-schema".key_value createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
-  key1 BIGINT,
-  key2 BOOLEAN,
-  "key!binary" TEXT
-);
---- End "a-schema".key_value createDeleteTable ---
-
---- Begin "a-schema".delta_updates createDeleteTable ---
-
-CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
-  "theKey" TEXT
-);
---- End "a-schema".delta_updates createDeleteTable ---
-
 --- Begin "a-schema".key_value deleteQuery ---
 
 DELETE FROM "a-schema".key_value
@@ -259,6 +201,114 @@ CREATE TEMPORARY TABLE flow_temp_table_1 (
 	"theKey" VARCHAR(400)
 );
 --- End "a-schema".delta_updates createLoadTable (with varchar length) ---
+
+--- Begin "a-schema".key_value createStoreTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" TEXT,
+	"array" SUPER,
+	"binary" TEXT,
+	boolean BOOLEAN,
+	field_with_projection TEXT,
+	flow_published_at TIMESTAMPTZ,
+	integer BIGINT,
+	"integerGt128Bit" NUMERIC(38,0),
+	"integerGt256Bit" NUMERIC(38,0),
+	"integerGt64Bit" NUMERIC(38,0),
+	"integerWithUserDDL" DECIMAL(20),
+	multiple SUPER,
+	"nonAsciiκόσμε" TEXT,
+	number DOUBLE PRECISION,
+	"numberCastToString" TEXT,
+	object SUPER,
+	string TEXT,
+	"stringInteger" NUMERIC(38,0),
+	"stringInteger18Chars" NUMERIC(38,0),
+	"stringInteger38Chars" NUMERIC(38,0),
+	"stringInteger39Chars" TEXT,
+	"stringInteger66Chars" TEXT,
+	"stringInteger77Chars" TEXT,
+	"stringNumber" DOUBLE PRECISION,
+	flow_document SUPER
+);
+--- End "a-schema".key_value createStoreTable (no varchar length) ---
+
+--- Begin "a-schema".key_value createStoreTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0 (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARCHAR(44),
+	"array" SUPER,
+	"binary" VARCHAR(46),
+	boolean BOOLEAN,
+	field_with_projection VARCHAR(48),
+	flow_published_at TIMESTAMPTZ,
+	integer BIGINT,
+	"integerGt128Bit" NUMERIC(38,0),
+	"integerGt256Bit" NUMERIC(38,0),
+	"integerGt64Bit" NUMERIC(38,0),
+	"integerWithUserDDL" DECIMAL(20),
+	multiple SUPER,
+	"nonAsciiκόσμε" VARCHAR(56),
+	number DOUBLE PRECISION,
+	"numberCastToString" VARCHAR(58),
+	object SUPER,
+	string VARCHAR(60),
+	"stringInteger" NUMERIC(38,0),
+	"stringInteger18Chars" NUMERIC(38,0),
+	"stringInteger38Chars" NUMERIC(38,0),
+	"stringInteger39Chars" VARCHAR(64),
+	"stringInteger66Chars" VARCHAR(65),
+	"stringInteger77Chars" VARCHAR(66),
+	"stringNumber" DOUBLE PRECISION,
+	flow_document SUPER
+);
+--- End "a-schema".key_value createStoreTable (with varchar length) ---
+
+--- Begin "a-schema".delta_updates createStoreTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	"theKey" TEXT,
+	"aValue" BIGINT,
+	flow_published_at TIMESTAMPTZ
+);
+--- End "a-schema".delta_updates createStoreTable (no varchar length) ---
+
+--- Begin "a-schema".delta_updates createStoreTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1 (
+	"theKey" VARCHAR(42),
+	"aValue" BIGINT,
+	flow_published_at TIMESTAMPTZ
+);
+--- End "a-schema".delta_updates createStoreTable (with varchar length) ---
+
+--- Begin "a-schema".key_value createDeleteTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" TEXT
+);
+--- End "a-schema".key_value createDeleteTable (no varchar length) ---
+
+--- Begin "a-schema".key_value createDeleteTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_0_deleted (
+	key1 BIGINT,
+	key2 BOOLEAN,
+	"key!binary" VARCHAR(44)
+);
+--- End "a-schema".key_value createDeleteTable (with varchar length) ---
+
+--- Begin "a-schema".delta_updates createDeleteTable (no varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+	"theKey" TEXT
+);
+--- End "a-schema".delta_updates createDeleteTable (no varchar length) ---
+
+--- Begin "a-schema".delta_updates createDeleteTable (with varchar length) ---
+CREATE TEMPORARY TABLE flow_temp_table_1_deleted (
+	"theKey" VARCHAR(42)
+);
+--- End "a-schema".delta_updates createDeleteTable (with varchar length) ---
 
 --- Begin Copy From S3 Without Case Sensitive Identifiers or Truncation ---
 COPY my_temp_table

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -22,8 +22,8 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
 
@@ -360,22 +360,22 @@ func prepareNewTransactor(
 }
 
 type binding struct {
-	target                  sql.Table
-	nullFieldsToStrip       []string
-	varcharColumnMetas      []varcharColumnMeta
-	loadFile                *stagedFile
-	storeFile               *stagedFile
-	deleteFile              *stagedFile
-	createLoadTableTemplate *template.Template
-	createStoreTableSQL     string
-	createDeleteTableSQL    string
-	mergeIntoSQL            string
-	deleteQuerySQL          string
-	loadQuerySQL            string
-	copyIntoLoadTableSQL    string
-	copyIntoMergeTableSQL   string
-	copyIntoDeleteTableSQL  string
-	copyIntoTargetTableSQL  string
+	target                    sql.Table
+	nullFieldsToStrip         []string
+	varcharColumnMetas        []VarcharColumnMeta
+	loadFile                  *stagedFile
+	storeFile                 *stagedFile
+	deleteFile                *stagedFile
+	createLoadTableTemplate   *template.Template
+	createStoreTableTemplate  *template.Template
+	createDeleteTableTemplate *template.Template
+	mergeIntoSQL              string
+	deleteQuerySQL            string
+	loadQuerySQL              string
+	copyIntoLoadTableSQL      string
+	copyIntoMergeTableSQL     string
+	copyIntoDeleteTableSQL    string
+	copyIntoTargetTableSQL    string
 
 	// A reference of all staged file cleanup operations that should be run once
 	// the commit has completed. Will be empty if not data was processed for
@@ -390,12 +390,12 @@ type binding struct {
 	mustMerge bool
 }
 
-// varcharColumnMeta contains metadata about Redshift varchar columns. Currently this is just the
+// VarcharColumnMeta contains metadata about Redshift varchar columns. Currently this is just the
 // maximum length of the field as reported from the database, populated upon connector startup.
-type varcharColumnMeta struct {
-	identifier string
-	maxLength  int
-	isVarchar  bool
+type VarcharColumnMeta struct {
+	Identifier string
+	MaxLength  int
+	IsVarchar  bool
 }
 
 func (t *transactor) addBinding(
@@ -454,8 +454,6 @@ func (t *transactor) addBinding(
 		sql *string
 		tpl *template.Template
 	}{
-		{&b.createStoreTableSQL, t.templates.createStoreTable},
-		{&b.createDeleteTableSQL, t.templates.createDeleteTable},
 		{&b.mergeIntoSQL, t.templates.mergeInto},
 		{&b.deleteQuerySQL, t.templates.deleteQuery},
 		{&b.loadQuerySQL, loadQueryTemplate},
@@ -466,23 +464,25 @@ func (t *transactor) addBinding(
 		}
 	}
 
-	// The load table template is re-evaluated every transaction to account for the specific string
-	// lengths observed for string keys in the load key set.
+	// The load/store/delete tables template are re-evaluated every transaction
+	// to account for the specific string lengths observed for string keys.
 	b.createLoadTableTemplate = t.templates.createLoadTable
+	b.createStoreTableTemplate = t.templates.createStoreTable
+	b.createDeleteTableTemplate = t.templates.createDeleteTable
 
 	// Retain column metadata information for this binding as a snapshot of the target table
 	// configuration when the connector started, indexed in the same order as values will be
 	// received from the runtime for Store requests. Only VARCHAR columns will have non-zero-valued
 	// varcharColumnMeta.
 	allColumns := target.Columns()
-	columnMetas := make([]varcharColumnMeta, len(allColumns))
+	columnMetas := make([]VarcharColumnMeta, len(allColumns))
 	for idx, col := range allColumns {
 		existing := is.GetResource(target.Path).GetField(col.Field)
 		if existing.Type == "character varying" {
-			columnMetas[idx] = varcharColumnMeta{
-				identifier: col.Identifier,
-				maxLength:  existing.CharacterMaxLength,
-				isVarchar:  true,
+			columnMetas[idx] = VarcharColumnMeta{
+				Identifier: col.Identifier,
+				MaxLength:  existing.CharacterMaxLength,
+				IsVarchar:  true,
 			}
 
 			log.WithFields(log.Fields{
@@ -718,21 +718,21 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		// See if we need to increase any VARCHAR column lengths.
 		for idx, c := range converted {
 			varcharMeta := b.varcharColumnMetas[idx]
-			if varcharMeta.isVarchar {
+			if varcharMeta.IsVarchar {
 				switch v := c.(type) {
 				case string:
 					// If the column is already at its maximum length, it can't be enlarged any
 					// more. The string values will be truncated by Redshift when loading them into
 					// the table.
-					if len(v) > varcharMeta.maxLength && varcharMeta.maxLength != redshiftVarcharMaxLength {
+					if len(v) > varcharMeta.MaxLength && varcharMeta.MaxLength != redshiftVarcharMaxLength {
 						log.WithFields(log.Fields{
 							"table":               b.target.Identifier,
-							"column":              varcharMeta.identifier,
-							"currentColumnLength": varcharMeta.maxLength,
+							"column":              varcharMeta.Identifier,
+							"currentColumnLength": varcharMeta.MaxLength,
 							"stringValueLength":   len(v),
 						}).Info("column will be altered to VARCHAR(MAX) to accommodate large string value")
-						varcharColumnUpdates[b.target.Identifier] = append(varcharColumnUpdates[b.target.Identifier], varcharMeta.identifier)
-						b.varcharColumnMetas[idx].maxLength = redshiftVarcharMaxLength // Do not need to alter this column again.
+						varcharColumnUpdates[b.target.Identifier] = append(varcharColumnUpdates[b.target.Identifier], varcharMeta.Identifier)
+						b.varcharColumnMetas[idx].MaxLength = redshiftVarcharMaxLength // Do not need to alter this column again.
 					}
 				case nil:
 					// Values for string fields may be null, in which case there is nothing to do.
@@ -740,7 +740,7 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 				default:
 					// Invariant: This value must either be a string or nil, since the column it is
 					// going into is a VARCHAR.
-					return nil, fmt.Errorf("expected type string or nil for column %s of table %s, got %T", varcharMeta.identifier, b.target.Identifier, c)
+					return nil, fmt.Errorf("expected type string or nil for column %s of table %s, got %T", varcharMeta.Identifier, b.target.Identifier, c)
 				}
 			}
 		}
@@ -860,7 +860,13 @@ func (d *transactor) commit(ctx context.Context, varcharColumnUpdates map[string
 			// Create the temporary table for staging values to delete from the target table.
 			// Redshift actually supports transactional DDL for creating tables, so this can be
 			// executed within the transaction.
-			if _, err := txn.Exec(ctx, b.createDeleteTableSQL); err != nil {
+			var createDeleteTableSQL strings.Builder
+			if err := b.createDeleteTableTemplate.Execute(&createDeleteTableSQL, deleteTableParams{
+				Target:            &b.target,
+				VarcharColumnMeta: b.varcharColumnMetas,
+			}); err != nil {
+				return fmt.Errorf("evaluating create delete table template: %w", err)
+			} else if _, err := txn.Exec(ctx, createDeleteTableSQL.String()); err != nil {
 				return fmt.Errorf("creating delete table: %w", err)
 			}
 
@@ -877,7 +883,13 @@ func (d *transactor) commit(ctx context.Context, varcharColumnUpdates map[string
 			// Create the temporary table for staging values to merge into the target table.
 			// Redshift actually supports transactional DDL for creating tables, so this can be
 			// executed within the transaction.
-			if _, err := txn.Exec(ctx, b.createStoreTableSQL); err != nil {
+			var createStoreTableSQL strings.Builder
+			if err := b.createStoreTableTemplate.Execute(&createStoreTableSQL, storeTableParams{
+				Target:            &b.target,
+				VarcharColumnMeta: b.varcharColumnMetas,
+			}); err != nil {
+				return fmt.Errorf("evaluating create store table template: %w", err)
+			} else if _, err := txn.Exec(ctx, createStoreTableSQL.String()); err != nil {
 				return fmt.Errorf("creating store table: %w", err)
 			}
 

--- a/materialize-redshift/sqlgen.go
+++ b/materialize-redshift/sqlgen.go
@@ -231,6 +231,16 @@ type loadTableParams struct {
 	VarCharLength int
 }
 
+type deleteTableParams struct {
+	Target            *sql.Table
+	VarcharColumnMeta []VarcharColumnMeta
+}
+
+type storeTableParams struct {
+	Target            *sql.Table
+	VarcharColumnMeta []VarcharColumnMeta
+}
+
 type templates struct {
 	createTargetTable         *template.Template
 	createLoadTable           *template.Template
@@ -290,19 +300,27 @@ CREATE TEMPORARY TABLE {{ template "temp_name" $.Target }} (
 -- Idempotent creation of the store table for staging new records.
 
 {{ define "createStoreTable" }}
-CREATE TEMPORARY TABLE {{ template "temp_name" . }} (
-{{- range $ind, $col := $.Columns }}
+CREATE TEMPORARY TABLE {{ template "temp_name" $.Target }} (
+{{- range $ind, $col := $.Target.Columns }}
 	{{- if $ind }},{{ end }}
-	{{ $col.Identifier }} {{ $col.DDL }}
+	{{ $col.Identifier }} {{ if and (eq $col.DDL "TEXT") (ne (index $.VarcharColumnMeta $ind).MaxLength 0) -}}
+		VARCHAR({{ (index $.VarcharColumnMeta $ind).MaxLength }})
+	{{- else }}
+		{{- $col.DDL }}
+	{{- end }}
 {{- end }}
 );
 {{ end }}
 
 {{ define "createDeleteTable" }}
-CREATE TEMPORARY TABLE {{ template "temp_name_deleted" . }} (
-{{- range $ind, $key := $.Keys }}
+CREATE TEMPORARY TABLE {{ template "temp_name_deleted" $.Target }} (
+{{- range $ind, $key := $.Target.Keys }}
 	{{- if $ind }},{{ end }}
-  {{ $key.Identifier }} {{ $key.DDL }}
+	{{ $key.Identifier }} {{ if and (eq $key.DDL "TEXT") (ne (index $.VarcharColumnMeta $ind).MaxLength 0) -}}
+		VARCHAR({{ (index $.VarcharColumnMeta $ind).MaxLength }})
+	{{- else }}
+		{{- $key.DDL }}
+	{{- end }}
 {{- end }}
 );
 {{ end }}

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -41,11 +41,9 @@ func runSQLGen(t *testing.T, testDialect sql.Dialect, testTemplates templates) {
 		sql.TestTemplates{
 			TableTemplates: []*template.Template{
 				testTemplates.createTargetTable,
-				testTemplates.createStoreTable,
 				testTemplates.mergeInto,
 				testTemplates.loadQuery,
 				testTemplates.loadQueryNoFlowDocument,
-				testTemplates.createDeleteTable,
 				testTemplates.deleteQuery,
 			},
 		},
@@ -76,6 +74,80 @@ func runSQLGen(t *testing.T, testDialect sql.Dialect, testTemplates templates) {
 		snap.WriteString("--- Begin " + testcase + " (with varchar length) ---")
 		require.NoError(t, tpl.Execute(snap, data))
 		snap.WriteString("--- End " + testcase + " (with varchar length) ---\n\n")
+	}
+
+	for _, tbl := range tables {
+		t.Run("createStoreTable/"+tbl.Identifier, func(t *testing.T) {
+			tpl := testTemplates.createStoreTable
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			meta := make([]VarcharColumnMeta, len(tbl.Columns()))
+			data := storeTableParams{
+				Target:            &tbl,
+				VarcharColumnMeta: meta,
+			}
+
+			snap.WriteString("--- Begin " + testcase + " (no varchar length) ---")
+			require.NoError(t, tpl.Execute(snap, data))
+			snap.WriteString("--- End " + testcase + " (no varchar length) ---\n\n")
+		})
+
+		t.Run("createStoreTable/"+tbl.Identifier+"/varchar", func(t *testing.T) {
+			tpl := testTemplates.createStoreTable
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			meta := make([]VarcharColumnMeta, len(tbl.Columns()))
+			for idx, col := range tbl.Columns() {
+				if col.DDL == "TEXT" {
+					meta[idx] = VarcharColumnMeta{MaxLength: idx + 42}
+				}
+			}
+			data := storeTableParams{
+				Target:            &tbl,
+				VarcharColumnMeta: meta,
+			}
+
+			snap.WriteString("--- Begin " + testcase + " (with varchar length) ---")
+			require.NoError(t, tpl.Execute(snap, data))
+			snap.WriteString("--- End " + testcase + " (with varchar length) ---\n\n")
+		})
+	}
+
+	for _, tbl := range tables {
+		t.Run("createDeleteTable/"+tbl.Identifier, func(t *testing.T) {
+			tpl := testTemplates.createDeleteTable
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			meta := make([]VarcharColumnMeta, len(tbl.Columns()))
+			data := deleteTableParams{
+				Target:            &tbl,
+				VarcharColumnMeta: meta,
+			}
+
+			snap.WriteString("--- Begin " + testcase + " (no varchar length) ---")
+			require.NoError(t, tpl.Execute(snap, data))
+			snap.WriteString("--- End " + testcase + " (no varchar length) ---\n\n")
+		})
+
+		t.Run("createDeleteTable/"+tbl.Identifier+"/varchar", func(t *testing.T) {
+			tpl := testTemplates.createDeleteTable
+			var testcase = tbl.Identifier + " " + tpl.Name()
+
+			meta := make([]VarcharColumnMeta, len(tbl.Columns()))
+			for idx, col := range tbl.Columns() {
+				if col.DDL == "TEXT" {
+					meta[idx] = VarcharColumnMeta{MaxLength: idx + 42}
+				}
+			}
+			data := deleteTableParams{
+				Target:            &tbl,
+				VarcharColumnMeta: meta,
+			}
+
+			snap.WriteString("--- Begin " + testcase + " (with varchar length) ---")
+			require.NoError(t, tpl.Execute(snap, data))
+			snap.WriteString("--- End " + testcase + " (with varchar length) ---\n\n")
+		})
 	}
 
 	var copyParams = copyFromS3Params{


### PR DESCRIPTION
The redshift connector resizes target tables according to the actual size of document values, but the temporary table for store and delete always uses TEXT, which is an alias for VARCHAR(256).  If the keys are are longer than this they will be truncated when copied into the table. This can result in the error during merge:
```
ERROR: Found multiple matches to update the same tuple. (SQLSTATE XX000)
```

With this change the varcharColumnMetas, set on startup from the actual column definitions and potentially updated in Load, is used to size the columns in the store and delete temporary tables.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

We should look into using the schema and migrations to resize columns more similarly to other materializations.  This was an easier change taking into account the current strategy.

