### PR TITLE
source-hubspot-native: allow delayed streams to checkpoint between chunks

### DIFF
--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -13,7 +13,10 @@ from ..models import (
     Names,
     OldRecentCompanies,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 from .shared import (
     ms_to_dt,
@@ -62,7 +65,7 @@ def fetch_recent_companies(
 
 def fetch_delayed_companies(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Company], None]:
+) -> AsyncGenerator[tuple[datetime, str, Company] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
@@ -71,6 +74,6 @@ def fetch_delayed_companies(
             Names.companies, log, http, since, until, page
         )
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.companies, Company, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -12,6 +12,8 @@ from ..models import (
     Company,
     Names,
     OldRecentCompanies,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -30,11 +32,11 @@ def fetch_recent_companies(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Company], None]:
+) -> AsyncGenerator[TimestampedObject[Company], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         if count >= 9_900:
             log.warn("limit of 9,900 recent companies reached")
             return [], None
@@ -46,10 +48,10 @@ def fetch_recent_companies(
             await http.request(log, url, params=params)
         )
         next_page: PageCursor = result.hasMore and result.offset
-        records: list[tuple[datetime, str]] = []
+        records: list[TimestampedId] = []
         for r in result.results:
             ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
-            records.append((ts, str(r.companyId)))
+            records.append(TimestampedId(ts, str(r.companyId)))
             if ts <= since:
                 # This endpoint returns records newest-first, so once a page
                 # reaches one as old as `since` there's nothing older worth
@@ -65,11 +67,11 @@ def fetch_recent_companies(
 
 def fetch_delayed_companies(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Company] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Company] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.companies, log, http, since, until, page
         )

--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -42,10 +42,18 @@ def fetch_recent_companies(
         result = OldRecentCompanies.model_validate_json(
             await http.request(log, url, params=params)
         )
-        return (
-            (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.companyId))
-            for r in result.results
-        ), result.hasMore and result.offset
+        next_page: PageCursor = result.hasMore and result.offset
+        records: list[tuple[datetime, str]] = []
+        for r in result.results:
+            ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
+            records.append((ts, str(r.companyId)))
+            if ts <= since:
+                # This endpoint returns records newest-first, so once a page
+                # reaches one as old as `since` there's nothing older worth
+                # paging for.
+                next_page = None
+
+        return records, next_page
 
     return fetch_changes_with_associations(
         Names.companies, Company, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -13,7 +13,10 @@ from ..models import (
     Names,
     OldRecentContacts,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 from .shared import (
     ms_to_dt,
@@ -67,7 +70,7 @@ def fetch_recent_contacts(
 
 def fetch_delayed_contacts(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Contact], None]:
+) -> AsyncGenerator[tuple[datetime, str, Contact] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
@@ -76,6 +79,6 @@ def fetch_delayed_contacts(
             Names.contacts, log, http, since, until, page, "lastmodifieddate"
         )
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.contacts, Contact, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -12,6 +12,8 @@ from ..models import (
     Contact,
     Names,
     OldRecentContacts,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -29,10 +31,10 @@ def fetch_recent_contacts(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Contact], None]:
+) -> AsyncGenerator[TimestampedObject[Contact], None]:
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         if count >= 9_900:
             # There is actually no documented limit on the number of contacts
             # that can be returned by this API, other than that it goes back a
@@ -51,10 +53,10 @@ def fetch_recent_contacts(
             await http.request(log, url, params=params)
         )
         next_page: PageCursor = result.has_more and result.time_offset
-        records: list[tuple[datetime, str]] = []
+        records: list[TimestampedId] = []
         for r in result.contacts:
             ts = ms_to_dt(int(r.properties.lastmodifieddate.value))
-            records.append((ts, str(r.vid)))
+            records.append(TimestampedId(ts, str(r.vid)))
             if ts <= since:
                 # This endpoint returns records newest-first, so once a page
                 # reaches one as old as `since` there's nothing older worth
@@ -70,11 +72,11 @@ def fetch_recent_contacts(
 
 def fetch_delayed_contacts(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Contact] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Contact] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.contacts, log, http, since, until, page, "lastmodifieddate"
         )

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -47,10 +47,18 @@ def fetch_recent_contacts(
         result = OldRecentContacts.model_validate_json(
             await http.request(log, url, params=params)
         )
-        return (
-            (ms_to_dt(int(r.properties.lastmodifieddate.value)), str(r.vid))
-            for r in result.contacts
-        ), result.has_more and result.time_offset
+        next_page: PageCursor = result.has_more and result.time_offset
+        records: list[tuple[datetime, str]] = []
+        for r in result.contacts:
+            ts = ms_to_dt(int(r.properties.lastmodifieddate.value))
+            records.append((ts, str(r.vid)))
+            if ts <= since:
+                # This endpoint returns records newest-first, so once a page
+                # reaches one as old as `since` there's nothing older worth
+                # paging for.
+                next_page = None
+
+        return records, next_page
 
     return fetch_changes_with_associations(
         Names.contacts, Contact, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -12,6 +12,8 @@ from ..models import (
     CustomObject,
     CustomObjectSchema,
     PageResult,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -28,11 +30,11 @@ def fetch_recent_custom_objects(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, CustomObject], None]:
+) -> AsyncGenerator[TimestampedObject[CustomObject], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             object_name, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -50,11 +52,11 @@ def fetch_delayed_custom_objects(
     with_history: bool,
     since: datetime,
     until: datetime,
-) -> AsyncGenerator[tuple[datetime, str, CustomObject] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[CustomObject] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(object_name, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -13,7 +13,10 @@ from ..models import (
     CustomObjectSchema,
     PageResult,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 from .shared import HUB
 
@@ -47,14 +50,14 @@ def fetch_delayed_custom_objects(
     with_history: bool,
     since: datetime,
     until: datetime,
-) -> AsyncGenerator[tuple[datetime, str, CustomObject], None]:
+) -> AsyncGenerator[tuple[datetime, str, CustomObject] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(object_name, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         object_name, CustomObject, do_fetch, log, http, with_history, since, until
     )
 

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -43,10 +43,18 @@ def fetch_recent_deals(
             await http.request(log, url, params=params)
         )
 
-        return (
-            (ms_to_dt(r.properties.hs_lastmodifieddate.timestamp), str(r.dealId))
-            for r in result.results
-        ), result.hasMore and result.offset
+        next_page: PageCursor = result.hasMore and result.offset
+        records: list[tuple[datetime, str]] = []
+        for r in result.results:
+            ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
+            records.append((ts, str(r.dealId)))
+            if ts <= since:
+                # This endpoint returns records newest-first, so once a page
+                # reaches one as old as `since` there's nothing older worth
+                # paging for.
+                next_page = None
+
+        return records, next_page
 
     return fetch_changes_with_associations(
         Names.deals, Deal, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -12,6 +12,8 @@ from ..models import (
     Deal,
     Names,
     OldRecentDeals,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -30,11 +32,11 @@ def fetch_recent_deals(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Deal], None]:
+) -> AsyncGenerator[TimestampedObject[Deal], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         if count >= 9_900:
             log.warn("limit of 9,900 recent deals reached")
             return [], None
@@ -47,10 +49,10 @@ def fetch_recent_deals(
         )
 
         next_page: PageCursor = result.hasMore and result.offset
-        records: list[tuple[datetime, str]] = []
+        records: list[TimestampedId] = []
         for r in result.results:
             ts = ms_to_dt(r.properties.hs_lastmodifieddate.timestamp)
-            records.append((ts, str(r.dealId)))
+            records.append(TimestampedId(ts, str(r.dealId)))
             if ts <= since:
                 # This endpoint returns records newest-first, so once a page
                 # reaches one as old as `since` there's nothing older worth
@@ -66,11 +68,11 @@ def fetch_recent_deals(
 
 def fetch_delayed_deals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Deal] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Deal] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(Names.deals, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -13,7 +13,10 @@ from ..models import (
     Names,
     OldRecentDeals,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 from .shared import (
     ms_to_dt,
@@ -63,13 +66,13 @@ def fetch_recent_deals(
 
 def fetch_delayed_deals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Deal], None]:
+) -> AsyncGenerator[tuple[datetime, str, Deal] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(Names.deals, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.deals, Deal, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/email_events.py
+++ b/source-hubspot-native/source_hubspot_native/api/email_events.py
@@ -15,6 +15,7 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     EmailEvent,
     EmailEventsResponse,
+    TimestampedObject,
 )
 from .shared import (
     dt_to_ms,
@@ -51,7 +52,7 @@ async def fetch_email_events_page(
 
 async def _fetch_email_events(
     log: Logger, http: HTTPSession, since: datetime, until: datetime | None
-) -> AsyncGenerator[tuple[datetime, str, EmailEvent], None]:
+) -> AsyncGenerator[TimestampedObject[EmailEvent], None]:
     url = f"{HUB}/email/public/v1/events"
 
     input: Dict[str, Any] = {
@@ -67,7 +68,7 @@ async def _fetch_email_events(
         )
 
         for event in result.events:
-            yield event.created, event.id, event
+            yield TimestampedObject(event.created, event.id, event)
 
         if not result.hasMore:
             break
@@ -77,13 +78,13 @@ async def _fetch_email_events(
 
 def fetch_recent_email_events(
     log: Logger, http: HTTPSession, _: bool, since: datetime, until: datetime | None
-) -> AsyncGenerator[tuple[datetime, str, EmailEvent], None]:
+) -> AsyncGenerator[TimestampedObject[EmailEvent], None]:
 
     return _fetch_email_events(log, http, since + timedelta(milliseconds=1), until)
 
 
 def fetch_delayed_email_events(
     log: Logger, http: HTTPSession, _: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, EmailEvent], None]:
+) -> AsyncGenerator[TimestampedObject[EmailEvent], None]:
 
     return _fetch_email_events(log, http, since, until)

--- a/source-hubspot-native/source_hubspot_native/api/engagements.py
+++ b/source-hubspot-native/source_hubspot_native/api/engagements.py
@@ -58,7 +58,7 @@ async def _fetch_engagements_modified_after(
 
 
 async def _fetch_recently_modified_engagements(
-    log: Logger, http: HTTPSession, page: PageCursor, count: int
+    log: Logger, http: HTTPSession, since: datetime, page: PageCursor, count: int
 ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
     if count >= 9_900:
         # "Engagements" as we are capturing them has a 10k limit on how many
@@ -74,10 +74,17 @@ async def _fetch_recently_modified_engagements(
     result = OldRecentEngagements.model_validate_json(
         await http.request(log, url, params=params)
     )
-    return (
-        (ms_to_dt(r.engagement.lastUpdated), str(r.engagement.id))
-        for r in result.results
-    ), result.hasMore and result.offset
+    next_page: PageCursor = result.hasMore and result.offset
+    records: list[tuple[datetime, str]] = []
+    for r in result.results:
+        ts = ms_to_dt(r.engagement.lastUpdated)
+        records.append((ts, str(r.engagement.id)))
+        if ts <= since:
+            # This endpoint returns records newest-first, so once a page reaches
+            # one as old as `since` there's nothing older worth paging for.
+            next_page = None
+
+    return records, next_page
 
 
 def fetch_recent_engagements(
@@ -90,7 +97,7 @@ def fetch_recent_engagements(
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
-        functools.partial(_fetch_recently_modified_engagements, log, http),
+        functools.partial(_fetch_recently_modified_engagements, log, http, since),
         log,
         http,
         with_history,

--- a/source-hubspot-native/source_hubspot_native/api/engagements.py
+++ b/source-hubspot-native/source_hubspot_native/api/engagements.py
@@ -14,6 +14,8 @@ from ..models import (
     EngagementsModifiedAfter,
     Names,
     OldRecentEngagements,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import fetch_changes_with_associations
 from .shared import (
@@ -31,13 +33,13 @@ async def _fetch_engagements_modified_after(
     until: datetime,
     page: PageCursor,
     count: int,
-) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+) -> tuple[Iterable[TimestampedId], PageCursor]:
     # Unlike the "recent/modified" endpoint used by the realtime stream,
     # "modified/after" is cursor-paginated with no 10k offset cap and reads
     # forward from a timestamp. The results aren't ordered, so we fully
     # enumerate the result set here and return everything at once.
     url = f"{HUB}/engagements/v1/engagements/modified/after"
-    output: list[tuple[datetime, str]] = []
+    output: list[TimestampedId] = []
     after: int | str = dt_to_ms(since)
 
     while True:
@@ -46,7 +48,7 @@ async def _fetch_engagements_modified_after(
             await http.request(log, url, params=params)
         )
         output.extend(
-            (ts, str(r.engagement.id))
+            TimestampedId(ts, str(r.engagement.id))
             for r in result.results
             if (ts := ms_to_dt(r.engagement.lastUpdated)) <= until
         )
@@ -59,7 +61,7 @@ async def _fetch_engagements_modified_after(
 
 async def _fetch_recently_modified_engagements(
     log: Logger, http: HTTPSession, since: datetime, page: PageCursor, count: int
-) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+) -> tuple[Iterable[TimestampedId], PageCursor]:
     if count >= 9_900:
         # "Engagements" as we are capturing them has a 10k limit on how many
         # items the API can return, and there is no other API that can be used
@@ -75,10 +77,10 @@ async def _fetch_recently_modified_engagements(
         await http.request(log, url, params=params)
     )
     next_page: PageCursor = result.hasMore and result.offset
-    records: list[tuple[datetime, str]] = []
+    records: list[TimestampedId] = []
     for r in result.results:
         ts = ms_to_dt(r.engagement.lastUpdated)
-        records.append((ts, str(r.engagement.id)))
+        records.append(TimestampedId(ts, str(r.engagement.id)))
         if ts <= since:
             # This endpoint returns records newest-first, so once a page reaches
             # one as old as `since` there's nothing older worth paging for.
@@ -93,7 +95,7 @@ def fetch_recent_engagements(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Engagement], None]:
+) -> AsyncGenerator[TimestampedObject[Engagement], None]:
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,
@@ -108,7 +110,7 @@ def fetch_recent_engagements(
 
 def fetch_delayed_engagements(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Engagement], None]:
+) -> AsyncGenerator[TimestampedObject[Engagement], None]:
     return fetch_changes_with_associations(
         Names.engagements,
         Engagement,

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -11,6 +11,8 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     FeedbackSubmission,
     Names,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -25,11 +27,11 @@ def fetch_recent_feedback_submissions(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
+) -> AsyncGenerator[TimestampedObject[FeedbackSubmission], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.feedback_submissions, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -49,11 +51,11 @@ def fetch_recent_feedback_submissions(
 
 def fetch_delayed_feedback_submissions(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[FeedbackSubmission] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.feedback_submissions, log, http, since, until, page
         )

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -12,17 +12,19 @@ from ..models import (
     FeedbackSubmission,
     Names,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 
 
-def _fetch_feedback_submissions(
+def fetch_recent_feedback_submissions(
     log: Logger,
     http: HTTPSession,
     with_history: bool,
     since: datetime,
     until: datetime | None,
-    should_crash_on_unordered_results: bool,
 ) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
 
     async def do_fetch(
@@ -30,7 +32,7 @@ def _fetch_feedback_submissions(
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(
             Names.feedback_submissions, log, http, since, until, page,
-            should_crash_on_unordered_results=should_crash_on_unordered_results,
+            should_crash_on_unordered_results=False,
         )
 
     return fetch_changes_with_associations(
@@ -45,23 +47,24 @@ def _fetch_feedback_submissions(
     )
 
 
-def fetch_recent_feedback_submissions(
-    log: Logger,
-    http: HTTPSession,
-    with_history: bool,
-    since: datetime,
-    until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
-    return _fetch_feedback_submissions(
-        log, http, with_history, since, until,
-        should_crash_on_unordered_results=False,
-    )
-
-
 def fetch_delayed_feedback_submissions(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission], None]:
-    return _fetch_feedback_submissions(
-        log, http, with_history, since, until,
-        should_crash_on_unordered_results=True,
+) -> AsyncGenerator[tuple[datetime, str, FeedbackSubmission] | datetime, None]:
+
+    async def do_fetch(
+        page: PageCursor, count: int
+    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+        return await fetch_search_objects(
+            Names.feedback_submissions, log, http, since, until, page
+        )
+
+    return fetch_chunked_changes_with_associations(
+        Names.feedback_submissions,
+        FeedbackSubmission,
+        do_fetch,
+        log,
+        http,
+        with_history,
+        since,
+        until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -11,6 +11,8 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     Goals,
     Names,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -25,11 +27,11 @@ def fetch_recent_goals(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Goals], None]:
+) -> AsyncGenerator[TimestampedObject[Goals], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.goals, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -42,11 +44,11 @@ def fetch_recent_goals(
 
 def fetch_delayed_goals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Goals] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Goals] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(Names.goals, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -12,7 +12,10 @@ from ..models import (
     Goals,
     Names,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 
 
@@ -39,13 +42,13 @@ def fetch_recent_goals(
 
 def fetch_delayed_goals(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Goals], None]:
+) -> AsyncGenerator[tuple[datetime, str, Goals] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(Names.goals, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.goals, Goals, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -11,6 +11,8 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     LineItem,
     Names,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -25,11 +27,11 @@ def fetch_recent_line_items(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, LineItem], None]:
+) -> AsyncGenerator[TimestampedObject[LineItem], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.line_items, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -42,11 +44,11 @@ def fetch_recent_line_items(
 
 def fetch_delayed_line_items(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, LineItem] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[LineItem] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.line_items, log, http, since, until, page
         )

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -12,7 +12,10 @@ from ..models import (
     LineItem,
     Names,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 
 
@@ -39,7 +42,7 @@ def fetch_recent_line_items(
 
 def fetch_delayed_line_items(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, LineItem], None]:
+) -> AsyncGenerator[tuple[datetime, str, LineItem] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
@@ -48,6 +51,6 @@ def fetch_delayed_line_items(
             Names.line_items, log, http, since, until, page
         )
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.line_items, LineItem, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/marketing_emails.py
+++ b/source-hubspot-native/source_hubspot_native/api/marketing_emails.py
@@ -13,6 +13,7 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     MarketingEmail,
     PageResult,
+    TimestampedObject,
 )
 from .shared import (
     dt_to_str,
@@ -53,7 +54,7 @@ async def _fetch_marketing_emails_updated_between(
     http: HTTPSession,
     start: datetime,
     end: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, MarketingEmail], None]:
+) -> AsyncGenerator[TimestampedObject[MarketingEmail], None]:
     if not end:
         end = datetime.now(tz=UTC)
 
@@ -85,7 +86,7 @@ async def _fetch_marketing_emails_updated_between(
             async for email in _paginate_through_marketing_emails(log, http, params):
                 if email.id not in seen_ids:
                     seen_ids.add(email.id)
-                    yield (email.updatedAt, email.id, email)
+                    yield TimestampedObject(email.updatedAt, email.id, email)
 
 
 async def fetch_marketing_emails_page(
@@ -115,7 +116,7 @@ def fetch_recent_marketing_emails(
     _: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, MarketingEmail], None]:
+) -> AsyncGenerator[TimestampedObject[MarketingEmail], None]:
 
     return _fetch_marketing_emails_updated_between(log, http, since, until)
 
@@ -126,6 +127,6 @@ def fetch_delayed_marketing_emails(
     _: bool,
     since: datetime,
     until: datetime,
-) -> AsyncGenerator[tuple[datetime, str, MarketingEmail], None]:
+) -> AsyncGenerator[TimestampedObject[MarketingEmail], None]:
 
     return _fetch_marketing_emails_updated_between(log, http, since, until)

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -35,12 +35,15 @@ _FetchIdsFn = Callable[
     Awaitable[tuple[Iterable[tuple[datetime, str]], PageCursor]],
 ]
 """
-Returns a stream of object IDs that can be used to fetch the full object details
-along with its associations. Used in `fetch_changes_with_associations`.
+Returns a page of object IDs that can be used to fetch the full object details
+along with its associations, plus a PageCursor for the next page (or a falsy
+value, e.g. None, when no more pages remain). Used by
+`fetch_changes_with_associations`.
 
-IDs may be returned in any order, but iteration will be stopped upon seeing an
-entry that's as-old or older than the datetime cursor. Entries newer than the
-until datetime will be discarded.
+IDs may be returned in any order. The fetcher is responsible for signaling
+completion via a falsy next_page: fetchers that page newest-first should do so
+once they reach an entry as-old-or-older than `since`, and window-bounded
+fetchers do so when their window is exhausted.
 """
 
 
@@ -222,9 +225,9 @@ async def _fetch_id_chunks(
     since: datetime,
     until: datetime | None,
 ) -> AsyncGenerator[tuple[list[tuple[datetime, str]], bool], None]:
-    # Walk pages of recent IDs until we see one which is as-old
-    # as `since`, or no pages remain. Each fetcher page is yielded as its own
-    # chunk, along with whether more pages remain.
+    # Walk pages of IDs until the fetcher reports no more pages remain via a falsy
+    # next_page. Each fetcher page is yielded as its own chunk, along with
+    # whether more pages remain.
     next_page: PageCursor = None
     count = 0
 
@@ -245,8 +248,6 @@ async def _fetch_id_chunks(
                 # changes stream only runs every 5 minutes or so it shouldn't be
                 # a huge load on the connector.
                 chunk.append((ts, id))
-            else:
-                next_page = None
 
         yield chunk, bool(next_page)
 

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -217,27 +217,22 @@ async def fetch_batch_with_associations(
     return batch
 
 
-async def fetch_changes_with_associations(
-    object_name: str,
-    cls: type[CRMObject],
+async def _fetch_id_chunks(
     fetcher: _FetchIdsFn,
-    log: Logger,
-    http: HTTPSession,
-    with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
-
+) -> AsyncGenerator[tuple[list[tuple[datetime, str]], bool], None]:
     # Walk pages of recent IDs until we see one which is as-old
-    # as `since`, or no pages remain.
-    recent: list[tuple[datetime, str]] = []
+    # as `since`, or no pages remain. Each fetcher page is yielded as its own
+    # chunk, along with whether more pages remain.
     next_page: PageCursor = None
     count = 0
 
     while True:
-        iter, next_page = await fetcher(next_page, count)
+        ids, next_page = await fetcher(next_page, count)
 
-        for ts, id in iter:
+        chunk: list[tuple[datetime, str]] = []
+        for ts, id in ids:
             count += 1
             if until and ts > until:
                 continue
@@ -249,45 +244,64 @@ async def fetch_changes_with_associations(
                 # top-level filtering works in production. Since the delayed
                 # changes stream only runs every 5 minutes or so it shouldn't be
                 # a huge load on the connector.
-                recent.append((ts, id))
+                chunk.append((ts, id))
             else:
                 next_page = None
+
+        yield chunk, bool(next_page)
 
         if not next_page:
             break
 
+
+async def _fetch_batch_with_retries(
+    log: Logger,
+    cls: type[CRMObject],
+    http: HTTPSession,
+    with_history: bool,
+    object_name: str,
+    batch: list[tuple[datetime, str]],
+) -> Iterable[tuple[datetime, str, CRMObject]]:
+    # Enable lookup of datetimes for IDs from the result batch.
+    dts = {id: dt for dt, id in batch}
+
+    attempt = 1
+    while True:
+        try:
+            documents: BatchResult[CRMObject] = await fetch_batch_with_associations(
+                log, cls, http, with_history, object_name, [id for _, id in batch]
+            )
+            break
+        except Exception as e:
+            if attempt == 5:
+                raise
+            log.warning(
+                "failed to fetch batch with associations (will retry)",
+                {"error": str(e), "attempt": attempt},
+            )
+            await asyncio.sleep(attempt * 2)
+            attempt += 1
+
+    return ((dts[str(doc.id)], str(doc.id), doc) for doc in documents.results)
+
+
+async def _emit_batches(
+    log: Logger,
+    cls: type[CRMObject],
+    http: HTTPSession,
+    with_history: bool,
+    object_name: str,
+    recent: list[tuple[datetime, str]],
+) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
     recent.sort()  # Oldest updates first.
-
-    async def _do_batch_fetch(
-        batch: list[tuple[datetime, str]],
-    ) -> Iterable[tuple[datetime, str, CRMObject]]:
-        # Enable lookup of datetimes for IDs from the result batch.
-        dts = {id: dt for dt, id in batch}
-
-        attempt = 1
-        while True:
-            try:
-                documents: BatchResult[CRMObject] = await fetch_batch_with_associations(
-                    log, cls, http, with_history, object_name, [id for _, id in batch]
-                )
-                break
-            except Exception as e:
-                if attempt == 5:
-                    raise
-                log.warning(
-                    "failed to fetch batch with associations (will retry)",
-                    {"error": str(e), "attempt": attempt},
-                )
-                await asyncio.sleep(attempt * 2)
-                attempt += 1
-
-        return ((dts[str(doc.id)], str(doc.id), doc) for doc in documents.results)
 
     async def _batches_gen() -> (
         AsyncGenerator[Awaitable[Iterable[tuple[datetime, str, CRMObject]]], None]
     ):
         for batch_it in itertools.batched(recent, 50 if with_history else 100):
-            yield _do_batch_fetch(list(batch_it))
+            yield _fetch_batch_with_retries(
+                log, cls, http, with_history, object_name, list(batch_it)
+            )
 
     total = len(recent)
     if total >= 10_000:
@@ -305,3 +319,22 @@ async def fetch_changes_with_associations(
                     {"count": count, "total": total},
                 )
             yield ts, id, doc
+
+
+async def fetch_changes_with_associations(
+    object_name: str,
+    cls: type[CRMObject],
+    fetcher: _FetchIdsFn,
+    log: Logger,
+    http: HTTPSession,
+    with_history: bool,
+    since: datetime,
+    until: datetime | None,
+) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
+
+    recent: list[tuple[datetime, str]] = []
+    async for chunk, _ in _fetch_id_chunks(fetcher, since, until):
+        recent.extend(chunk)
+
+    async for res in _emit_batches(log, cls, http, with_history, object_name, recent):
+        yield res

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -21,7 +21,10 @@ from ..models import (
     Association,
     BatchResult,
     CRMObject,
+    IdChunk,
     PageResult,
+    TimestampedId,
+    TimestampedObject,
 )
 from .properties import fetch_properties
 from .shared import (
@@ -32,7 +35,7 @@ from .shared import (
 
 _FetchIdsFn = Callable[
     [PageCursor, int],
-    Awaitable[tuple[Iterable[tuple[datetime, str]], PageCursor]],
+    Awaitable[tuple[Iterable[TimestampedId], PageCursor]],
 ]
 """
 Returns a page of object IDs that can be used to fetch the full object details
@@ -236,7 +239,7 @@ async def _fetch_id_chunks(
     fetcher: _FetchIdsFn,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[list[tuple[datetime, str]], bool], None]:
+) -> AsyncGenerator[IdChunk, None]:
     # Walk pages of IDs until the fetcher reports no more pages remain via a falsy
     # next_page. Each fetcher page is yielded as its own chunk, along with
     # whether more pages remain.
@@ -246,12 +249,12 @@ async def _fetch_id_chunks(
     while True:
         ids, next_page = await fetcher(next_page, count)
 
-        chunk: list[tuple[datetime, str]] = []
-        for ts, id in ids:
+        chunk: list[TimestampedId] = []
+        for entry in ids:
             count += 1
-            if until and ts > until:
+            if until and entry.ts > until:
                 continue
-            elif ts > since:
+            elif entry.ts > since:
                 # TODO(whb): It may be worth consulting the emitted changes
                 # cache here to see if we have already emitted a more recent
                 # change event before we do all the associations fetching work.
@@ -259,9 +262,9 @@ async def _fetch_id_chunks(
                 # top-level filtering works in production. Since the delayed
                 # changes stream only runs every 5 minutes or so it shouldn't be
                 # a huge load on the connector.
-                chunk.append((ts, id))
+                chunk.append(entry)
 
-        yield chunk, bool(next_page)
+        yield IdChunk(chunk, bool(next_page))
 
         if not next_page:
             break
@@ -273,8 +276,8 @@ async def _fetch_batch_with_retries(
     http: HTTPSession,
     with_history: bool,
     object_name: str,
-    batch: list[tuple[datetime, str]],
-) -> Iterable[tuple[datetime, str, CRMObject]]:
+    batch: list[TimestampedId],
+) -> Iterable[TimestampedObject[CRMObject]]:
     # Enable lookup of datetimes for IDs from the result batch.
     dts = {id: dt for dt, id in batch}
 
@@ -295,7 +298,10 @@ async def _fetch_batch_with_retries(
             await asyncio.sleep(attempt * 2)
             attempt += 1
 
-    return ((dts[str(doc.id)], str(doc.id), doc) for doc in documents.results)
+    return (
+        TimestampedObject(dts[str(doc.id)], str(doc.id), doc)
+        for doc in documents.results
+    )
 
 
 async def _emit_batches(
@@ -304,12 +310,12 @@ async def _emit_batches(
     http: HTTPSession,
     with_history: bool,
     object_name: str,
-    recent: list[tuple[datetime, str]],
-) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
+    recent: list[TimestampedId],
+) -> AsyncGenerator[TimestampedObject[CRMObject], None]:
     recent.sort()  # Oldest updates first.
 
     async def _batches_gen() -> (
-        AsyncGenerator[Awaitable[Iterable[tuple[datetime, str, CRMObject]]], None]
+        AsyncGenerator[Awaitable[Iterable[TimestampedObject[CRMObject]]], None]
     ):
         for batch_it in itertools.batched(recent, 50 if with_history else 100):
             yield _fetch_batch_with_retries(
@@ -324,14 +330,14 @@ async def _emit_batches(
 
     count = 0
     async for res in buffer_ordered(_batches_gen(), 3):
-        for ts, id, doc in res:
+        for obj in res:
             count += 1
             if count > 0 and count % 10_000 == 0:
                 log.info(
                     "fetching changes with associations",
                     {"count": count, "total": total},
                 )
-            yield ts, id, doc
+            yield obj
 
 
 async def fetch_changes_with_associations(
@@ -343,11 +349,11 @@ async def fetch_changes_with_associations(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, CRMObject], None]:
+) -> AsyncGenerator[TimestampedObject[CRMObject], None]:
 
-    recent: list[tuple[datetime, str]] = []
-    async for chunk, _ in _fetch_id_chunks(fetcher, since, until):
-        recent.extend(chunk)
+    recent: list[TimestampedId] = []
+    async for chunk in _fetch_id_chunks(fetcher, since, until):
+        recent.extend(chunk.ids)
 
     async for res in _emit_batches(log, cls, http, with_history, object_name, recent):
         yield res
@@ -362,20 +368,20 @@ async def fetch_chunked_changes_with_associations(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, CRMObject] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[CRMObject] | datetime, None]:
     """
     Like fetch_changes_with_associations, but emits each fetcher page's documents
     as its own chunk and then yields the chunk's newest timestamp as an intermediate
     checkpoint boundary. This lets a delayed stream checkpoint progress within a
     large window instead of processing the whole window as one atomic, un-checkpointed unit.
     """
-    async for chunk, has_more in _fetch_id_chunks(fetcher, since, until):
+    async for chunk in _fetch_id_chunks(fetcher, since, until):
         async for res in _emit_batches(
-            log, cls, http, with_history, object_name, chunk
+            log, cls, http, with_history, object_name, chunk.ids
         ):
             yield res
 
         # Emit an intermediate checkpoint. fetch_delayed_changes handles emitting
         # the final checkpoint once all chunks have been read.
-        if has_more and chunk:
-            yield max(ts for ts, _ in chunk)
+        if chunk.has_more and chunk.ids:
+            yield max(entry.ts for entry in chunk.ids)

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -47,6 +47,18 @@ fetchers do so when their window is exhausted.
 """
 
 
+# An alias of _FetchIdsFn, identical to the type checker. The distinct name and
+# docstring document the stronger contract that fetch_chunked_changes_with_associations
+# relies on. They are not enforced, so it's on each fetcher to honor it.
+_OrderedFetchIdsFn = _FetchIdsFn
+"""
+A _FetchIdsFn whose pages never leave gaps: every record at or before a page's
+newest timestamp is in that page or an earlier one, and successive pages advance
+in time. This is what lets fetch_chunked_changes_with_associations treat each
+page's newest timestamp as a safe intermediate checkpoint.
+"""
+
+
 async def fetch_page_with_associations(
     # Closed over via functools.partial:
     cls: type[CRMObject],
@@ -339,3 +351,31 @@ async def fetch_changes_with_associations(
 
     async for res in _emit_batches(log, cls, http, with_history, object_name, recent):
         yield res
+
+
+async def fetch_chunked_changes_with_associations(
+    object_name: str,
+    cls: type[CRMObject],
+    fetcher: _OrderedFetchIdsFn,
+    log: Logger,
+    http: HTTPSession,
+    with_history: bool,
+    since: datetime,
+    until: datetime | None,
+) -> AsyncGenerator[tuple[datetime, str, CRMObject] | datetime, None]:
+    """
+    Like fetch_changes_with_associations, but emits each fetcher page's documents
+    as its own chunk and then yields the chunk's newest timestamp as an intermediate
+    checkpoint boundary. This lets a delayed stream checkpoint progress within a
+    large window instead of processing the whole window as one atomic, un-checkpointed unit.
+    """
+    async for chunk, has_more in _fetch_id_chunks(fetcher, since, until):
+        async for res in _emit_batches(
+            log, cls, http, with_history, object_name, chunk
+        ):
+            yield res
+
+        # Emit an intermediate checkpoint. fetch_delayed_changes handles emitting
+        # the final checkpoint once all chunks have been read.
+        if has_more and chunk:
+            yield max(ts for ts, _ in chunk)

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -11,6 +11,8 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     Names,
     Order,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -25,11 +27,11 @@ def fetch_recent_orders(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Order], None]:
+) -> AsyncGenerator[TimestampedObject[Order], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.orders, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -42,11 +44,11 @@ def fetch_recent_orders(
 
 def fetch_delayed_orders(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Order] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Order] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(Names.orders, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -12,7 +12,10 @@ from ..models import (
     Names,
     Order,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 
 
@@ -39,13 +42,13 @@ def fetch_recent_orders(
 
 def fetch_delayed_orders(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Order], None]:
+) -> AsyncGenerator[tuple[datetime, str, Order] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(Names.orders, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.orders, Order, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -11,6 +11,8 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     Names,
     Product,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -25,11 +27,11 @@ def fetch_recent_products(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Product], None]:
+) -> AsyncGenerator[TimestampedObject[Product], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
             Names.products, log, http, since, until, page,
             should_crash_on_unordered_results=False,
@@ -42,11 +44,11 @@ def fetch_recent_products(
 
 def fetch_delayed_products(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Product] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Product] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(Names.products, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -12,7 +12,10 @@ from ..models import (
     Names,
     Product,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 
 
@@ -39,13 +42,13 @@ def fetch_recent_products(
 
 def fetch_delayed_products(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Product], None]:
+) -> AsyncGenerator[tuple[datetime, str, Product] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(Names.products, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.products, Product, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -14,6 +14,7 @@ from ..models import (
 )
 from .shared import (
     dt_to_str,
+    str_to_dt,
     HUB,
 )
 
@@ -24,30 +25,43 @@ async def fetch_search_objects(
     http: HTTPSession,
     since: datetime,
     until: datetime | None,
-    _: PageCursor,
+    page: PageCursor,
     last_modified_property_name: str = "hs_lastmodifieddate",
     should_crash_on_unordered_results: bool = True,
 ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
     """
-    Retrieve all records between 'since' and 'until' (or the present time).
+    Retrieve a single chunk of records modified at or after 'since' and at or
+    before 'until' if provided, in ascending order of last-modified time.
 
-    The HubSpot Search API has an undocumented maximum offset of 10,000 items,
-    so the logic here will completely enumerate all available records, kicking
-    off new searches if needed to work around that limit. The returned
-    PageCursor is always None.
+    The HubSpot Search API has an undocumented maximum offset of 10,000 items.
+    Rather than enumerate the whole window in one call, this returns one chunk
+    that ends at the offset boundary, along with a resume PageCursor (a
+    last-modified timestamp string) to continue from on the next call. When the
+    whole window has been read, the returned PageCursor is None.
+
+    Chunks never leave gaps. A chunk contains every record in the window
+    modified at or before the chunk's newest timestamp, except records already
+    returned by an earlier chunk. The returned cursor is the first millisecond the
+    chunk does NOT cover. Records the search read at that millisecond are
+    withheld from the chunk, since the offset cap may have cut that millisecond
+    off partway. Passing the cursor back as 'page' starts a fresh search at
+    that millisecond, which re-reads it in full and continues on.
 
     Multiple records can have the same "last modified" property value, and
-    indeed large runs of these may have the same value. So a "new" search will
-    inevitably grab some records again, and deduplication is handled here via
-    the set.
+    indeed large runs of these may have the same value. When more than 10,000
+    records share a single millisecond (a "cycle"), the whole instant is drained
+    via fetch_search_objects_modified_at and the resume cursor steps forward by
+    one millisecond.
     """
+
+    if isinstance(page, str):
+        since = str_to_dt(page)
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
     limit = 200
     output_items: set[tuple[datetime, str]] = set()
     cursor: int | None = None
     max_updated: datetime = since
-    original_since = since
     original_total: int | None = None
 
     while True:
@@ -126,60 +140,60 @@ async def fetch_search_objects(
             output_items.add((this_mod_time, str(r.id)))
 
         if not result.paging:
-            if since is not original_since:
-                log.info(
-                    "finished multi-request fetch",
-                    {
-                        "final_count": len(output_items),
-                        "total": original_total,
-                    },
-                )
-            break
+            # The whole window has been read and no more chunks remain.
+            return sorted(output_items), None
 
         cursor = int(result.paging.next.after)
-        if cursor + limit > 10_000:
-            # Further attempts to read this search result will not accepted by
-            # the search API, so a new search must be initiated to complete the
-            # request.
-            cursor = None
+        if cursor + limit <= 10_000:
+            # Still within the offset cap; keep paginating this same search.
+            continue
 
-            if since == max_updated:
-                log.info(
-                    "cycle detected for lastmodifieddate, fetching all ids for records modified at that instant",
-                    {"object_name": object_name, "instant": since},
-                )
-                output_items.update(
-                    await fetch_search_objects_modified_at(
-                        object_name, log, http, max_updated, last_modified_property_name
-                    )
-                )
-
-                # HubSpot APIs use millisecond resolution, so move the time
-                # cursor forward by that minimum amount now that we know we have
-                # all of the records modified at the common `max_updated` time.
-                max_updated = max_updated + timedelta(milliseconds=1)
-
-                if until and max_updated > until:
-                    # Unlikely edge case, but this would otherwise result in an
-                    # error from the API.
-                    break
-
-            since = max_updated
+        # Hit the 10,000-offset cap. End this chunk here and return a resume
+        # cursor so the caller can continue with a fresh search.
+        if since == max_updated:
+            # More than 10,000 records share a single millisecond, so paginating
+            # by time can't make progress. Drain every record at that instant
+            # and step the resume cursor forward by the minimum (1ms) amount.
             log.info(
-                "initiating a new search to satisfy requested time range",
-                {
-                    "object_name": object_name,
-                    "since": since,
-                    "until": until,
-                    "original_since": original_since,
-                    "count": len(output_items),
-                    "total": original_total,
-                },
+                "cycle detected for lastmodifieddate, fetching all ids for records modified at that instant",
+                {"object_name": object_name, "instant": since},
+            )
+            output_items.update(
+                await fetch_search_objects_modified_at(
+                    object_name, log, http, max_updated, last_modified_property_name
+                )
             )
 
-    # Sort newest to oldest to match the convention of most of "fetch ID"
-    # functions.
-    return sorted(list(output_items), reverse=True), None
+            # HubSpot APIs use millisecond resolution, so move the time cursor
+            # forward by that minimum amount now that we know we have all of the
+            # records modified at the common `max_updated` time.
+            max_updated = max_updated + timedelta(milliseconds=1)
+
+            chunk = sorted(output_items)
+
+            if until and max_updated > until:
+                # Unlikely edge case, but resuming past `until` would otherwise
+                # result in an error from the API. The window is fully read.
+                return chunk, None
+        else:
+            # Withhold the in-progress `max_updated` millisecond from the chunk;
+            # the offset cap may have cut it off partway, so the next call
+            # re-reads it.
+            chunk = sorted(item for item in output_items if item[0] < max_updated)
+
+        log.info(
+            "search window chunk complete; resuming with a new search",
+            {
+                "object_name": object_name,
+                "since": since,
+                "until": until,
+                "max_updated": dt_to_str(max_updated),
+                "count": len(output_items),
+                "total": original_total,
+            },
+        )
+
+        return chunk, dt_to_str(max_updated)
 
 
 async def fetch_search_objects_modified_at(

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -11,6 +11,7 @@ from estuary_cdk.http import HTTPSession
 from ..models import (
     CustomObjectSearchResult,
     SearchPageResult,
+    TimestampedId,
 )
 from .shared import (
     dt_to_str,
@@ -28,7 +29,7 @@ async def fetch_search_objects(
     page: PageCursor,
     last_modified_property_name: str = "hs_lastmodifieddate",
     should_crash_on_unordered_results: bool = True,
-) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+) -> tuple[Iterable[TimestampedId], PageCursor]:
     """
     Retrieve a single chunk of records modified at or after 'since' and at or
     before 'until' if provided, in ascending order of last-modified time.
@@ -59,7 +60,7 @@ async def fetch_search_objects(
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
     limit = 200
-    output_items: set[tuple[datetime, str]] = set()
+    output_items: set[TimestampedId] = set()
     cursor: int | None = None
     max_updated: datetime = since
     original_total: int | None = None
@@ -137,7 +138,7 @@ async def fetch_search_objects(
                 continue
 
             max_updated = this_mod_time
-            output_items.add((this_mod_time, str(r.id)))
+            output_items.add(TimestampedId(this_mod_time, str(r.id)))
 
         if not result.paging:
             # The whole window has been read and no more chunks remain.
@@ -179,7 +180,7 @@ async def fetch_search_objects(
             # Withhold the in-progress `max_updated` millisecond from the chunk;
             # the offset cap may have cut it off partway, so the next call
             # re-reads it.
-            chunk = sorted(item for item in output_items if item[0] < max_updated)
+            chunk = sorted(item for item in output_items if item.ts < max_updated)
 
         log.info(
             "search window chunk complete; resuming with a new search",
@@ -202,7 +203,7 @@ async def fetch_search_objects_modified_at(
     http: HTTPSession,
     modified: datetime,
     last_modified_property_name: str = "hs_lastmodifieddate",
-) -> set[tuple[datetime, str]]:
+) -> set[TimestampedId]:
     """
     Fetch all of the ids of the given object that were modified at the given
     time. Used exclusively for breaking out of cycles in the search API
@@ -216,7 +217,7 @@ async def fetch_search_objects_modified_at(
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
     limit = 200
-    output_items: set[tuple[datetime, str]] = set()
+    output_items: set[TimestampedId] = set()
     id_cursor: int | None = None
     round = 0
 
@@ -255,7 +256,9 @@ async def fetch_search_objects_modified_at(
                 # figure it out.
                 raise Exception(f"unexpected id order: {r.id} <= {id_cursor}")
             id_cursor = r.id
-            output_items.add((r.properties.hs_lastmodifieddate, str(r.id)))
+            output_items.add(
+                TimestampedId(r.properties.hs_lastmodifieddate, str(r.id))
+            )
 
         # Log every 10,000 returned records, since there are 200 per page.
         if round % 50 == 0:

--- a/source-hubspot-native/source_hubspot_native/api/shared.py
+++ b/source-hubspot-native/source_hubspot_native/api/shared.py
@@ -11,6 +11,8 @@ import estuary_cdk.emitted_changes_cache as cache
 from estuary_cdk.capture.common import LogCursor, Triggers
 from estuary_cdk.http import HTTPSession
 
+from ..models import TimestampedObject
+
 # Hubspot returns a 500 internal server error if querying for data at the EPOCH.
 EPOCH_PLUS_ONE_SECOND = datetime(1970, 1, 1, tzinfo=UTC) + timedelta(seconds=1)
 HUB = "https://api.hubapi.com"
@@ -36,7 +38,7 @@ class MustBackfillBinding(Exception):
 
 FetchRecentFn = Callable[
     [Logger, HTTPSession, bool, datetime, datetime | None],
-    AsyncGenerator[tuple[datetime, str, Any], None],
+    AsyncGenerator[TimestampedObject[Any], None],
 ]
 """
 Returns a stream of (timestamp, key, document) tuples that represent a
@@ -54,7 +56,7 @@ which if not None is a hint that more recent documents are not needed.
 
 FetchDelayedFn = Callable[
     [Logger, HTTPSession, bool, datetime, datetime],
-    AsyncGenerator[tuple[datetime, str, Any] | datetime, None],
+    AsyncGenerator[TimestampedObject[Any] | datetime, None],
 ]
 """
 Returns a stream of (timestamp, key, document) tuples that represent a complete

--- a/source-hubspot-native/source_hubspot_native/api/shared.py
+++ b/source-hubspot-native/source_hubspot_native/api/shared.py
@@ -54,12 +54,17 @@ which if not None is a hint that more recent documents are not needed.
 
 FetchDelayedFn = Callable[
     [Logger, HTTPSession, bool, datetime, datetime],
-    AsyncGenerator[tuple[datetime, str, Any], None],
+    AsyncGenerator[tuple[datetime, str, Any] | datetime, None],
 ]
 """
 Returns a stream of (timestamp, key, document) tuples that represent a complete
 stream of not-so-recent documents. The key is used for seeing if a more recent
 change event document has already been emitted by the FetchRecentFn.
+
+A bare datetime may be interleaved between tuples to mark an intermediate
+checkpoint boundary: every document at or before that timestamp has already
+been yielded, so fetch_delayed_changes can safely checkpoint there. Chunked
+delayed fetchers use this to checkpoint progress within a large window.
 
 Similar to FetchRecentFn, documents may be returned in any order and iteration
 stops when seeing an entry that's as-old or older than the "since" datetime
@@ -197,17 +202,44 @@ async def fetch_delayed_changes(
         return
 
     max_ts = lower_bound
+    last_checkpoint = lower_bound
     cache_hits = 0
     emitted = 0
 
+    def _log_progress(cursor: datetime) -> None:
+        evicted = cache.cleanup(object_name, cursor)
+        log.info(
+            "fetched delayed events for stream",
+            {
+                "object_name": object_name,
+                "since": lower_bound,
+                "until": cursor,
+                "emitted": emitted,
+                "cache_hits": cache_hits,
+                "evicted": evicted,
+                "new_size": cache.count_for(object_name),
+            },
+        )
+
     try:
-        async for ts, key, obj in fetch_delayed(
+        async for item in fetch_delayed(
             log,
             http,
             with_history,
             lower_bound,
             upper_bound,
         ):
+            if isinstance(item, datetime):
+                # An intermediate checkpoint boundary yielded by a chunked
+                # fetcher. Every document at or before this timestamp has
+                # already been yielded.
+                if item > last_checkpoint:
+                    _log_progress(item)
+                    last_checkpoint = item
+                    yield item
+                continue
+
+            ts, key, obj = item
             if ts > upper_bound:
                 # In case the FetchDelayedFn is unable to filter based on upper_bound.
                 continue
@@ -228,18 +260,6 @@ async def fetch_delayed_changes(
     if upper_bound < horizon:
         max_ts = upper_bound
 
-    if max_ts != lower_bound:
-        evicted = cache.cleanup(object_name, max_ts)
-        log.info(
-            "fetched delayed events for stream",
-            {
-                "object_name": object_name,
-                "since": lower_bound,
-                "until": upper_bound,
-                "emitted": emitted,
-                "cache_hits": cache_hits,
-                "evicted": evicted,
-                "new_size": cache.count_for(object_name),
-            },
-        )
+    if max_ts > last_checkpoint:
+        _log_progress(max_ts)
         yield max_ts

--- a/source-hubspot-native/source_hubspot_native/api/tickets.py
+++ b/source-hubspot-native/source_hubspot_native/api/tickets.py
@@ -13,6 +13,8 @@ from ..models import (
     Names,
     OldRecentTicket,
     Ticket,
+    TimestampedId,
+    TimestampedObject,
 )
 from .object_with_associations import (
     fetch_changes_with_associations,
@@ -31,11 +33,11 @@ def fetch_recent_tickets(
     with_history: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Ticket], None]:
+) -> AsyncGenerator[TimestampedObject[Ticket], None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         # This API will return a maximum of 1000 tickets, and does not appear to
         # ever return an error. It just ends at the 1000 most recently modified
         # tickets.
@@ -45,7 +47,9 @@ def fetch_recent_tickets(
         result = TypeAdapter(list[OldRecentTicket]).validate_json(
             await http.request(log, url, params=params)
         )
-        return ((ms_to_dt(r.timestamp), str(r.objectId)) for r in result), None
+        return (
+            TimestampedId(ms_to_dt(r.timestamp), str(r.objectId)) for r in result
+        ), None
 
     return fetch_changes_with_associations(
         Names.tickets, Ticket, do_fetch, log, http, with_history, since, until
@@ -54,11 +58,11 @@ def fetch_recent_tickets(
 
 def fetch_delayed_tickets(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Ticket] | datetime, None]:
+) -> AsyncGenerator[TimestampedObject[Ticket] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
-    ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
+    ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(Names.tickets, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/tickets.py
+++ b/source-hubspot-native/source_hubspot_native/api/tickets.py
@@ -14,7 +14,10 @@ from ..models import (
     OldRecentTicket,
     Ticket,
 )
-from .object_with_associations import fetch_changes_with_associations
+from .object_with_associations import (
+    fetch_changes_with_associations,
+    fetch_chunked_changes_with_associations,
+)
 from .search_objects import fetch_search_objects
 from .shared import (
     ms_to_dt,
@@ -51,13 +54,13 @@ def fetch_recent_tickets(
 
 def fetch_delayed_tickets(
     log: Logger, http: HTTPSession, with_history: bool, since: datetime, until: datetime
-) -> AsyncGenerator[tuple[datetime, str, Ticket], None]:
+) -> AsyncGenerator[tuple[datetime, str, Ticket] | datetime, None]:
 
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[tuple[datetime, str]], PageCursor]:
         return await fetch_search_objects(Names.tickets, log, http, since, until, page)
 
-    return fetch_changes_with_associations(
+    return fetch_chunked_changes_with_associations(
         Names.tickets, Ticket, do_fetch, log, http, with_history, since, until
     )

--- a/source-hubspot-native/source_hubspot_native/api/workflows.py
+++ b/source-hubspot-native/source_hubspot_native/api/workflows.py
@@ -11,6 +11,7 @@ from estuary_cdk.capture.common import (
 from estuary_cdk.http import HTTPSession
 
 from ..models import (
+    TimestampedObject,
     Workflow,
     WorkflowsResponse,
 )
@@ -24,7 +25,7 @@ async def _fetch_workflows_updated_between(
     http: HTTPSession,
     start: datetime,
     end: datetime | None = None,
-) -> AsyncGenerator[tuple[datetime, str, Workflow], None]:
+) -> AsyncGenerator[TimestampedObject[Workflow], None]:
     if not end:
         end = datetime.now(tz=UTC)
 
@@ -38,7 +39,7 @@ async def _fetch_workflows_updated_between(
 
     for workflow in response.workflows:
         if start <= workflow.updatedAt <= end:
-            yield (workflow.updatedAt, str(workflow.id), workflow)
+            yield TimestampedObject(workflow.updatedAt, str(workflow.id), workflow)
 
 
 async def fetch_workflows_page(
@@ -67,7 +68,7 @@ def fetch_recent_workflows(
     _: bool,
     since: datetime,
     until: datetime | None,
-) -> AsyncGenerator[tuple[datetime, str, Workflow], None]:
+) -> AsyncGenerator[TimestampedObject[Workflow], None]:
     return _fetch_workflows_updated_between(log, http, since, until)
 
 
@@ -77,5 +78,5 @@ def fetch_delayed_workflows(
     _: bool,
     since: datetime,
     until: datetime,
-) -> AsyncGenerator[tuple[datetime, str, Workflow], None]:
+) -> AsyncGenerator[TimestampedObject[Workflow], None]:
     return _fetch_workflows_updated_between(log, http, since, until)

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -9,6 +9,7 @@ from typing import (
     ClassVar,
     Generic,
     Literal,
+    NamedTuple,
     Self,
     TypeVar,
 )
@@ -432,6 +433,37 @@ class BaseCRMObject(BaseDocument, extra="allow"):
 
 # CRMObject is a generic, concrete subclass of BaseCRMObject.
 CRMObject = TypeVar("CRMObject", bound=BaseCRMObject)
+
+
+class TimestampedId(NamedTuple):
+    """An object's id paired with its last-modified timestamp. The unit that the
+    ID fetchers return and that flows through the batch-read chunking layer."""
+
+    ts: datetime
+    id: str
+
+
+class IdChunk(NamedTuple):
+    """One page of TimestampedIds yielded by _fetch_id_chunks, plus whether the
+    underlying fetcher reports more pages remain."""
+
+    ids: list[TimestampedId]
+    has_more: bool
+
+
+# The document type carried by a TimestampedObject. Its bound is intentionally
+# open: object_with_associations specializes it to CRMObject, while the
+# FetchRecentFn/FetchDelayedFn aliases in api/shared.py use TimestampedObject[Any].
+Doc = TypeVar("Doc")
+
+
+class TimestampedObject(NamedTuple, Generic[Doc]):
+    """A fetched document with its last-modified timestamp and id. The id doubles
+    as the emitted-changes cache key."""
+
+    ts: datetime
+    id: str
+    doc: Doc
 
 
 class Company(BaseCRMObject):

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -1,0 +1,261 @@
+"""Unit tests for the chunked delayed-stream path.
+
+These cover the pieces that make delayed streams checkpoint progress within a
+large window:
+  - fetch_search_objects returning a fully-read chunk plus a resume cursor at the
+    Search API's 10k offset boundary,
+  - fetch_chunked_changes_with_associations yielding each chunk's maximum
+    timestamp as the intermediate checkpoint, and
+  - fetch_delayed_changes treating an interleaved bare datetime as an
+    intermediate, strictly-increasing checkpoint.
+"""
+
+import json
+from datetime import datetime, timedelta, UTC
+from logging import getLogger
+from typing import Any
+
+import pytest
+
+import estuary_cdk.emitted_changes_cache as cache
+from source_hubspot_native.api.object_with_associations import (
+    fetch_chunked_changes_with_associations,
+)
+from source_hubspot_native.api.properties import properties_cache
+from source_hubspot_native.api.search_objects import fetch_search_objects
+from source_hubspot_native.api.shared import dt_to_str, fetch_delayed_changes
+from source_hubspot_native.models import Product
+
+log = getLogger("test_search_objects")
+
+
+class FakeHTTP:
+    """Returns canned response bodies in FIFO order, recording each request."""
+
+    def __init__(self, responses: list[bytes]):
+        self._responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    async def request(
+        self, log, url, method="GET", params=None, json=None, **kwargs
+    ) -> bytes:
+        self.requests.append({"url": url, "method": method, "json": json})
+        assert self._responses, f"unexpected request: {json}"
+        return self._responses.pop(0)
+
+
+def _search_page(items: list[tuple[datetime, int]], next_after: str | None) -> bytes:
+    """Build a SearchPageResult[CustomObjectSearchResult] JSON body."""
+    body: dict[str, Any] = {
+        "total": len(items),
+        "results": [
+            {"id": id, "properties": {"hs_lastmodifieddate": ts.isoformat()}}
+            for ts, id in items
+        ],
+    }
+    if next_after is not None:
+        body["paging"] = {"next": {"after": next_after}}
+    return json.dumps(body).encode()
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_fully_read_chunk_and_inclusive_resume():
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    t1, t2, t3 = base, base + timedelta(seconds=1), base + timedelta(seconds=2)
+    since = base - timedelta(seconds=10)
+
+    http = FakeHTTP(
+        [
+            # First page hits the offset cap (after=10000). t3 is the in-progress
+            # millisecond and may have more records past the cap, so it's
+            # withheld; the chunk covers only up to t2.
+            _search_page([(t1, 1), (t2, 2), (t3, 3)], next_after="10000"),
+            # Resuming from the cursor re-searches GTE t3 and finds the rest.
+            _search_page([(t3, 3), (t3 + timedelta(seconds=1), 4)], next_after=None),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, since, None, None)
+    assert items == [(t1, "1"), (t2, "2")]  # ascending, t3 dropped
+    assert page == dt_to_str(t3)
+
+    items2, page2 = await fetch_search_objects("deals", log, http, since, None, page)
+    # The resume search starts at the cursor inclusively, re-reading the
+    # withheld t3 instant.
+    assert http.requests[1]["json"]["filters"][0]["value"] == dt_to_str(t3)
+    assert page2 is None
+    assert set(items2) == {(t3, "3"), (t3 + timedelta(seconds=1), "4")}
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_drains_dense_millisecond_cycle():
+    instant = datetime(2026, 1, 1, tzinfo=UTC)
+    since = instant  # every record shares `since`'s millisecond
+
+    http = FakeHTTP(
+        [
+            # The whole capped page sits at a single instant, so advancing by
+            # timestamp can't make progress: a cycle.
+            _search_page([(instant, i) for i in range(1, 6)], next_after="10000"),
+            # The modified-at drain returns every record at that instant, in
+            # ascending hs_object_id order, with no further pages.
+            _search_page([(instant, i) for i in range(1, 9)], next_after=None),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, since, None, None)
+
+    # All ids at the instant are returned, and the cursor steps one ms past it.
+    assert {id for _, id in items} == {str(i) for i in range(1, 9)}
+    assert page == dt_to_str(instant + timedelta(milliseconds=1))
+
+
+def _properties_page(names: list[str]) -> bytes:
+    """Build a Properties JSON body."""
+    return json.dumps(
+        {"results": [{"name": n, "type": "string"} for n in names]}
+    ).encode()
+
+
+def _batch_page(items: list[tuple[datetime, int]]) -> bytes:
+    """Build a BatchResult[Product] JSON body echoing the requested ids."""
+    return json.dumps(
+        {
+            "status": "COMPLETE",
+            "results": [
+                {
+                    "id": id,
+                    "createdAt": ts.isoformat(),
+                    "updatedAt": ts.isoformat(),
+                    "archived": False,
+                    "properties": {},
+                }
+                for ts, id in items
+            ],
+            "startedAt": "2026-01-01T00:00:00+00:00",
+            "completedAt": "2026-01-01T00:00:00+00:00",
+        }
+    ).encode()
+
+
+@pytest.mark.asyncio
+async def test_fetch_chunked_changes_yields_max_ts_as_checkpoint():
+    since = datetime(2026, 1, 1, tzinfo=UTC)
+    t1, t2, t3 = (since + timedelta(minutes=i) for i in (1, 2, 3))
+
+    # The fetcher's cursor is opaque to the chunked layer; only its presence
+    # (more pages remain) matters. IDs are deliberately out of order within the
+    # chunk since the chunked layer is order-agnostic.
+    pages = [
+        ([(t2, "2"), (t1, "1")], "opaque-resume-cursor-1"),
+        ([], "opaque-resume-cursor-2"),  # empty non-final chunk
+        ([(t3, "3")], None),  # final page
+    ]
+
+    async def fake_fetcher(page: Any, count: int) -> Any:
+        return pages.pop(0)
+
+    # Product has no associated entities, so each non-empty chunk costs exactly
+    # one batch-read request (plus one properties fetch, cached after the first).
+    properties_cache.pop("products", None)
+    http = FakeHTTP(
+        [
+            _properties_page(["hs_lastmodifieddate"]),
+            _batch_page([(t1, 1), (t2, 2)]),
+            _batch_page([(t3, 3)]),
+        ]
+    )
+
+    out = []
+    async for item in fetch_chunked_changes_with_associations(
+        "products", Product, fake_fetcher, log, http, False, since, None
+    ):
+        out.append(item)
+
+    checkpoints = [x for x in out if isinstance(x, datetime)]
+    docs = [(ts, id) for x in out if not isinstance(x, datetime) for ts, id, _ in [x]]
+
+    # Documents are emitted oldest-first within each chunk.
+    assert docs == [(t1, "1"), (t2, "2"), (t3, "3")]
+    # Only the first chunk checkpoints, at its newest timestamp: the empty
+    # chunk has no safe checkpoint of its own, and the final page's checkpoint
+    # is the window edge emitted by fetch_delayed_changes instead.
+    assert checkpoints == [t2]
+    # The checkpoint lands between the first chunk's documents and the rest.
+    assert out.index(t2) == 2
+
+
+def _make_delayed(items: list[Any]):
+    async def fake_delayed(log, http, with_history, since, until):
+        for item in items:
+            yield item
+
+    return fake_delayed
+
+
+@pytest.mark.asyncio
+async def test_fetch_delayed_changes_checkpoints_at_boundary_datetimes():
+    object_name = "test_delayed_checkpoints"
+    cache.emitted_cache.pop(object_name, None)
+
+    # Window is [lower_bound, lower_bound + 1h]; keep every timestamp inside it.
+    lower_bound = datetime.now(UTC) - timedelta(hours=2)
+    ta = lower_bound + timedelta(minutes=5)
+    c1 = lower_bound + timedelta(minutes=10)
+    tb = lower_bound + timedelta(minutes=15)
+    c2 = lower_bound + timedelta(minutes=20)
+    tc = lower_bound + timedelta(minutes=25)
+
+    fake_delayed = _make_delayed(
+        [(ta, "k1", "doc1"), c1, (tb, "k2", "doc2"), c2, (tc, "k3", "doc3")]
+    )
+
+    out = []
+    async for item in fetch_delayed_changes(
+        object_name, fake_delayed, None, False, log, lower_bound
+    ):
+        out.append(item)
+
+    docs = [x for x in out if isinstance(x, str)]
+    cursors = [x for x in out if isinstance(x, datetime)]
+
+    assert docs == ["doc1", "doc2", "doc3"]
+    # Intermediate cursors land exactly on the boundary datetimes, plus a final
+    # window checkpoint covering the last chunk's documents.
+    assert cursors[0] == c1
+    assert cursors[1] == c2
+    assert cursors[-1] > c2
+    assert all(b > a for a, b in zip(cursors, cursors[1:]))  # strictly increasing
+    assert all(c > lower_bound for c in cursors)
+
+
+@pytest.mark.asyncio
+async def test_fetch_delayed_changes_ignores_duplicate_and_regressing_datetimes():
+    object_name = "test_delayed_regressing"
+    cache.emitted_cache.pop(object_name, None)
+
+    lower_bound = datetime.now(UTC) - timedelta(hours=2)
+    ta = lower_bound + timedelta(minutes=5)
+    c1 = lower_bound + timedelta(minutes=10)
+    tb = lower_bound + timedelta(minutes=15)
+
+    fake_delayed = _make_delayed(
+        [
+            (ta, "k1", "doc1"),
+            c1,
+            c1,  # duplicate -> ignored
+            lower_bound + timedelta(minutes=3),  # regressing (< c1) -> ignored
+            (tb, "k2", "doc2"),
+        ]
+    )
+
+    out = []
+    async for item in fetch_delayed_changes(
+        object_name, fake_delayed, None, False, log, lower_bound
+    ):
+        out.append(item)
+
+    cursors = [x for x in out if isinstance(x, datetime)]
+
+    assert cursors.count(c1) == 1
+    assert all(b > a for a, b in zip(cursors, cursors[1:]))  # strictly increasing

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -24,7 +24,7 @@ from source_hubspot_native.api.object_with_associations import (
 from source_hubspot_native.api.properties import properties_cache
 from source_hubspot_native.api.search_objects import fetch_search_objects
 from source_hubspot_native.api.shared import dt_to_str, fetch_delayed_changes
-from source_hubspot_native.models import Product
+from source_hubspot_native.models import Product, TimestampedId
 
 log = getLogger("test_search_objects")
 
@@ -147,9 +147,9 @@ async def test_fetch_chunked_changes_yields_max_ts_as_checkpoint():
     # (more pages remain) matters. IDs are deliberately out of order within the
     # chunk since the chunked layer is order-agnostic.
     pages = [
-        ([(t2, "2"), (t1, "1")], "opaque-resume-cursor-1"),
+        ([TimestampedId(t2, "2"), TimestampedId(t1, "1")], "opaque-resume-cursor-1"),
         ([], "opaque-resume-cursor-2"),  # empty non-final chunk
-        ([(t3, "3")], None),  # final page
+        ([TimestampedId(t3, "3")], None),  # final page
     ]
 
     async def fake_fetcher(page: Any, count: int) -> Any:


### PR DESCRIPTION
**Description:**

Delayed CRM streams previously emitted an entire `[since, until]` window as a single unit without intermediate checkpoints. If a date window was particularly dense, all records in that window had to be fetched before any checkpoints were yielded. This made it very difficult for delayed streams to make progress when there were 300k+ changes in a single hour; the connector couldn't fetch all records in the window before getting restarted.

This PR makes each delayed stream that uses the `fetch_search_objects` ID fetcher emit intermediate checkpoints after a chunk of ~10k records, which will let the delayed stream make incremental progress when working through a large chunk of changes.

The main changes in this PR include:
- `fetch_search_objects` now returns chunks of ~10k results in ascending timestamp order plus a `PageCursor` to allow the caller to fetch the next chunk of results. If there are no more results in the requested `[since, until]` window, a falsy `PageCursor` is returned to signal that pagination has ended.
- `_fetch_id_chunks` no longer ends pagination when it sees records with a timestamp below `since`. Instead, it relies on the fetcher function to signal the end of pagination with a falsy `PageCursor`.
- `fetch_chunked_changes_with_associations` works with the new chunking strategy by emitting a chunk of documents then the maximum timestamp within that chunk as an intermediate checkpoint. It assumes that chunks provided to it contain all records between its minimum and maximum timestamps & successive chunks advance in time, which `fetch_search_objects` does now.
- `fetch_delayed_changes` passes those intermediate datetime checkpoints from `fetch_chunked_changes_with_associations` through with some defensive guards to ensure checkpoints are strictly increasing.

**Notes for reviewers:**

We _may_ want to rewrite the real-time streams that use `fetch_search_objects` to use the chunking and intermediate checkpoint strategy as well, but right now they're not the ones struggling to make progress & I'd like to ensure the chunking strategy works well for the delayed streams before rolling it out for the real-time streams.

