### PR TITLE
materialize-snowflake: treat dual as reserved word

### DIFF
--- a/materialize-snowflake/reserved_words.go
+++ b/materialize-snowflake/reserved_words.go
@@ -29,6 +29,7 @@ var SF_RESERVED_WORDS = []string{
 	"delete",
 	"distinct",
 	"drop",
+	"dual", // https://en.wikipedia.org/wiki/DUAL_table
 	"else",
 	"exists",
 	"false",


### PR DESCRIPTION
**Regression?**

No

**Description:**

In some database, including snowflake, there exists a special dual table[^1].  If you are materializing to a table with the same name and do not fully qualify the path then it will try to use the built in table which won't have the expected columns and you will see this error:
```
SQL compilation error: error line 2 at position 18 invalid identifier 'DUAL.FLOW_DOCUMENT'
```

There are a few ways I looked into fixing this.  I decided to add dual to the reserved words so that it will be quoted.  This has the side effect of changing the casing of the materialization table.

Another option is to qualified all identifiers with the schema in all statements, this is not done currently to avoid breaking bindings that were created before the schema was added to the path[^2].  This would be a pretty large change.

I also considered changing the resource path to include the schema, this changes the path so the binding is treated as new.

[^1]: https://en.wikipedia.org/wiki/DUAL_table
[^2]: https://github.com/estuary/connectors/blob/8d119a719dc4cb771f6651593adb1c76de70ebab/materialize-snowflake/snowflake.go#L85

**Workflow steps:**

Materializing a collection named `dual` will now be named "dual" (case sensitive).  I checked for existing specs and did not find any outside of the one that triggered this issue.

**Documentation links affected:**

None

**Notes for reviewers:**

Something similar might cause problems in other databases, but I haven't tested any others.

