### PR TITLE
source-shopify-native: conditionally add `retailLocation` to `orders` stream

### DIFF
--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -13,6 +13,7 @@ from source_shopify_native.graphql.bulk_job_manager import BulkJobManager
 from source_shopify_native.models import (
     BaseResponseData,
     ShopifyGraphQLResource,
+    StoreCapabilities,
     StoreValidationContext,
     TShopifyGraphQLResource,
 )
@@ -31,13 +32,14 @@ async def bulk_fetch_incremental(
     bulk_job_manager: BulkJobManager,
     model: type[ShopifyGraphQLResource],
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[ShopifyGraphQLResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
     max_end = log_cursor + window_size
     end = min(max_end, datetime.now(tz=UTC))
-    query = model.build_query(log_cursor, end)
+    query = model.build_query(log_cursor, end, capabilities=capabilities)
 
     url = await bulk_job_manager.execute(model, query)
 
@@ -63,10 +65,11 @@ async def bulk_fetch_full_refresh(
     bulk_job_manager: BulkJobManager,
     model: type[ShopifyGraphQLResource],
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
 ) -> AsyncGenerator[ShopifyGraphQLResource, None]:
     end = datetime.now(tz=UTC)
-    query = model.build_query(start_date, end)
+    query = model.build_query(start_date, end, capabilities=capabilities)
 
     url = await bulk_job_manager.execute(model, query)
 
@@ -90,6 +93,7 @@ async def _paginate_through_resources(
     start: datetime,
     end: datetime,
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
 ) -> AsyncGenerator[TShopifyGraphQLResource, None]:
     after: str | None = None
@@ -101,6 +105,7 @@ async def _paginate_through_resources(
             end=end,
             first=PAGE_SIZE,
             after=after,
+            capabilities=capabilities,
         )
 
         data = await client.request(query, data_model, log, context=ctx)
@@ -120,6 +125,7 @@ async def fetch_incremental_unsorted(
     model: type[TShopifyGraphQLResource],
     data_model: type[BaseResponseData[TShopifyGraphQLResource]],
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TShopifyGraphQLResource | LogCursor, None]:
@@ -135,6 +141,7 @@ async def fetch_incremental_unsorted(
         start=log_cursor,
         end=end,
         store=store,
+        capabilities=capabilities,
         log=log,
     ):
         cursor_value = doc.get_cursor_value()
@@ -153,6 +160,7 @@ async def fetch_incremental(
     model: type[TShopifyGraphQLResource],
     data_model: type[BaseResponseData[TShopifyGraphQLResource]],
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[TShopifyGraphQLResource | LogCursor, None]:
@@ -169,6 +177,7 @@ async def fetch_incremental(
         start=log_cursor,
         end=end,
         store=store,
+        capabilities=capabilities,
         log=log,
     ):
         cursor_value = doc.get_cursor_value()
@@ -193,6 +202,7 @@ async def backfill_incremental(
     model: type[TShopifyGraphQLResource],
     data_model: type[BaseResponseData[TShopifyGraphQLResource]],
     store: str,
+    capabilities: StoreCapabilities,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
@@ -213,6 +223,7 @@ async def backfill_incremental(
         start=start,
         end=cutoff,
         store=store,
+        capabilities=capabilities,
         log=log,
     ):
         cursor_value = doc.get_cursor_value()

--- a/source-shopify-native/source_shopify_native/graphql/abandoned_checkouts.py
+++ b/source-shopify-native/source_shopify_native/graphql/abandoned_checkouts.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, AsyncGenerator
 
 from .common import money_bag_fragment
-from ..models import ShopifyGraphQLResource, SortKey
+from ..models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class AbandonedCheckouts(ShopifyGraphQLResource):
@@ -116,6 +116,7 @@ class AbandonedCheckouts(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return AbandonedCheckouts.build_query_with_fragment(
             start,
@@ -123,6 +124,7 @@ class AbandonedCheckouts(ShopifyGraphQLResource):
             first=first,
             after=after,
             includeLegacyId=False,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/collections/collections.py
+++ b/source-shopify-native/source_shopify_native/graphql/collections/collections.py
@@ -3,7 +3,7 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator, ClassVar, Literal
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class _Collections(ShopifyGraphQLResource):
@@ -56,6 +56,7 @@ class _Collections(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return _Collections.build_query_with_fragment(
             start,
@@ -64,6 +65,7 @@ class _Collections(ShopifyGraphQLResource):
             first=first,
             after=after,
             includeCreatedAt=False,
+            capabilities=capabilities,
         )
 
     @staticmethod
@@ -72,6 +74,7 @@ class _Collections(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         raise NotImplementedError("build_query method must be implemented")
 
@@ -149,8 +152,9 @@ class CustomCollections(_Collections):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
-        return _Collections.build_query_with_type("custom", start, end, first=first, after=after)
+        return _Collections.build_query_with_type("custom", start, end, first=first, after=after, capabilities=capabilities)
 
     @staticmethod
     def process_result(
@@ -169,8 +173,9 @@ class SmartCollections(_Collections):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
-        return _Collections.build_query_with_type("smart", start, end, first=first, after=after)
+        return _Collections.build_query_with_type("smart", start, end, first=first, after=after, capabilities=capabilities)
 
     @staticmethod
     def process_result(

--- a/source-shopify-native/source_shopify_native/graphql/collections/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/collections/metafields.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import AsyncGenerator
 from ..metafields import MetafieldsResource
 
-from source_shopify_native.models import SortKey
+from source_shopify_native.models import SortKey, StoreCapabilities
 
 
 class CustomCollectionMetafields(MetafieldsResource):
@@ -19,6 +19,7 @@ class CustomCollectionMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return CustomCollectionMetafields.build_query_with_fragment(
             start,
@@ -27,6 +28,7 @@ class CustomCollectionMetafields(MetafieldsResource):
             first=first,
             after=after,
             includeCreatedAt=False,
+            capabilities=capabilities,
         )
 
     @staticmethod
@@ -51,6 +53,7 @@ class SmartCollectionMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return SmartCollectionMetafields.build_query_with_fragment(
             start,
@@ -59,6 +62,7 @@ class SmartCollectionMetafields(MetafieldsResource):
             first=first,
             after=after,
             includeCreatedAt=False,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/customers/customers.py
+++ b/source-shopify-native/source_shopify_native/graphql/customers/customers.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class Customers(ShopifyGraphQLResource):
@@ -65,12 +65,14 @@ class Customers(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return Customers.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/customers/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/customers/metafields.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import AsyncGenerator
 from ..metafields import MetafieldsResource
 
-from source_shopify_native.models import SortKey
+from source_shopify_native.models import SortKey, StoreCapabilities
 
 class CustomerMetafields(MetafieldsResource):
     NAME = "customer_metafields"
@@ -18,12 +18,14 @@ class CustomerMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return CustomerMetafields.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/inventory/inventory_items.py
+++ b/source-shopify-native/source_shopify_native/graphql/inventory/inventory_items.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource
+from ...models import ShopifyGraphQLResource, StoreCapabilities
 
 
 class InventoryItems(ShopifyGraphQLResource):
@@ -43,12 +43,14 @@ class InventoryItems(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return InventoryItems.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/inventory/inventory_levels.py
+++ b/source-shopify-native/source_shopify_native/graphql/inventory/inventory_levels.py
@@ -3,7 +3,7 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator
 
-from ...models import ShopifyGraphQLResource
+from ...models import ShopifyGraphQLResource, StoreCapabilities
 
 
 class InventoryLevels(ShopifyGraphQLResource):
@@ -55,12 +55,14 @@ class InventoryLevels(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return InventoryLevels.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/locations/locations.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/locations.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource
+from ...models import ShopifyGraphQLResource, StoreCapabilities
 
 
 class Locations(ShopifyGraphQLResource):
@@ -51,12 +51,14 @@ class Locations(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return Locations.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
@@ -3,6 +3,8 @@ from logging import Logger
 from typing import AsyncGenerator
 from ..metafields import MetafieldsResource
 
+from ...models import StoreCapabilities
+
 
 class LocationMetafields(MetafieldsResource):
     NAME = "location_metafields"
@@ -16,12 +18,14 @@ class LocationMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return LocationMetafields.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/metafields.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 from typing import Any, AsyncGenerator, ClassVar
 
-from ..models import ShopifyGraphQLResource
+from ..models import ShopifyGraphQLResource, StoreCapabilities
 
 
 class MetafieldsResource(ShopifyGraphQLResource):
@@ -47,6 +47,7 @@ class MetafieldsResource(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         # This method should be implemented by subclasses
         # pylint: disable=unused-argument

--- a/source-shopify-native/source_shopify_native/graphql/orders/agreements.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/agreements.py
@@ -4,7 +4,7 @@ from logging import Logger
 from typing import AsyncGenerator, Any
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class OrderAgreements(ShopifyGraphQLResource):
@@ -59,12 +59,14 @@ class OrderAgreements(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return OrderAgreements.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/fulfillment_orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/fulfillment_orders.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator, Any
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class FulfillmentOrders(ShopifyGraphQLResource):
@@ -120,12 +120,14 @@ class FulfillmentOrders(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return FulfillmentOrders.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class Fulfillments(ShopifyGraphQLResource):
@@ -74,12 +74,14 @@ class Fulfillments(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return Fulfillments.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/metafields.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import AsyncGenerator
 from ..metafields import MetafieldsResource
 
-from source_shopify_native.models import SortKey
+from source_shopify_native.models import SortKey, StoreCapabilities
 
 
 class OrderMetafields(MetafieldsResource):
@@ -19,12 +19,14 @@ class OrderMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return OrderMetafields.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -4,7 +4,13 @@ import json
 from typing import Any, AsyncGenerator, Dict
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
+from ...models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+    requires_any_scope,
+)
 
 
 class Orders(ShopifyGraphQLResource):
@@ -352,8 +358,20 @@ class Orders(ShopifyGraphQLResource):
         ..._MoneyBagFields
     }
     totalWeight
+    # {{ retailLocation }}
     """
     FRAGMENTS = [money_bag_fragment]
+    CONDITIONAL_FIELDS = [
+        # retailLocation requires the read_locations scope, which
+        # the orders stream does not otherwise need.
+        ConditionalField(
+            placeholder="# {{ retailLocation }}",
+            fields="""retailLocation {
+        id
+    }""",
+            is_available=requires_any_scope("read_locations"),
+        ),
+    ]
 
     @staticmethod
     def build_query(

--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, AsyncGenerator, Dict
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class Orders(ShopifyGraphQLResource):
@@ -361,12 +361,14 @@ class Orders(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return Orders.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import AsyncGenerator
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class OrderRefunds(ShopifyGraphQLResource):
@@ -61,12 +61,14 @@ class OrderRefunds(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return OrderRefunds.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/risks.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/risks.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class OrderRisks(ShopifyGraphQLResource):
@@ -71,12 +71,14 @@ class OrderRisks(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return OrderRisks.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/orders/transactions.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/transactions.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import AsyncGenerator
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class OrderTransactions(ShopifyGraphQLResource):
@@ -68,12 +68,14 @@ class OrderTransactions(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return OrderTransactions.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/products/media.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/media.py
@@ -3,7 +3,7 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator
 
-from source_shopify_native.models import ShopifyGraphQLResource, SortKey
+from source_shopify_native.models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class ProductMedia(ShopifyGraphQLResource):
@@ -35,12 +35,14 @@ class ProductMedia(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return ProductMedia.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/products/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/metafields.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, AsyncGenerator
 from ..metafields import MetafieldsResource
 
-from source_shopify_native.models import SortKey
+from source_shopify_native.models import SortKey, StoreCapabilities
 
 
 class ProductMetafields(MetafieldsResource):
@@ -20,12 +20,14 @@ class ProductMetafields(MetafieldsResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return ProductMetafields.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod
@@ -80,10 +82,15 @@ class ProductVariantMetafields(MetafieldsResource):
     """
 
     @staticmethod
-    def build_query(start: datetime, end: datetime) -> str:
+    def build_query(
+        start: datetime,
+        end: datetime,
+        capabilities: StoreCapabilities | None = None,
+    ) -> str:
         return ProductVariantMetafields.build_query_with_fragment(
             start,
             end,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/products/products.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/products.py
@@ -3,7 +3,7 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator
 
-from source_shopify_native.models import ShopifyGraphQLResource, SortKey
+from source_shopify_native.models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class Products(ShopifyGraphQLResource):
@@ -130,12 +130,14 @@ class Products(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return Products.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/products/variants.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/variants.py
@@ -3,7 +3,7 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator
 
-from source_shopify_native.models import ShopifyGraphQLResource, SortKey
+from source_shopify_native.models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class ProductVariants(ShopifyGraphQLResource):
@@ -54,12 +54,14 @@ class ProductVariants(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return ProductVariants.build_query_with_fragment(
             start,
             end,
             first=first,
             after=after,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/subscriptions/subscription_contracts.py
+++ b/source-shopify-native/source_shopify_native/graphql/subscriptions/subscription_contracts.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from logging import Logger
 from typing import Any, AsyncGenerator
 
-from ...models import ShopifyGraphQLResource, SortKey
+from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
 
 class SubscriptionContracts(ShopifyGraphQLResource):
@@ -161,11 +161,13 @@ class SubscriptionContracts(ShopifyGraphQLResource):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
     ) -> str:
         return SubscriptionContracts.build_query_with_fragment(
             start,
             end,
             includeLegacyId=False,
+            capabilities=capabilities,
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -408,6 +408,19 @@ class StoreValidationContext:
     store: str
 
 
+@dataclass(frozen=True, slots=True)
+class StoreCapabilities:
+    """Per-store capabilities derived from granted scopes and the store's Shopify plan.
+
+    Carries everything a ConditionalField predicate might need to gate a field.
+    """
+
+    scopes: frozenset[str]
+    # Whether the store is on a Shopify Plus or Advanced plan or a partner dev store.
+    # Some fields are only queryable on these tiers regardless of granted scopes.
+    is_plus_or_advanced: bool = False
+
+
 class ShopifyGraphQLResource(BaseDocument):
     QUERY: ClassVar[str] = ""
     QUERY_ROOT: ClassVar[str] = ""

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -8,6 +8,7 @@ from typing import (
     Annotated,
     Any,
     AsyncGenerator,
+    Callable,
     ClassVar,
     Generic,
     Literal,
@@ -410,7 +411,7 @@ class StoreValidationContext:
 
 @dataclass(frozen=True, slots=True)
 class StoreCapabilities:
-    """Per-store capabilities derived from granted scopes and the store's Shopify plan.
+    """Per-store capabilities used to decide which conditional query fields are available.
 
     Carries everything a ConditionalField predicate might need to gate a field.
     """
@@ -421,6 +422,45 @@ class StoreCapabilities:
     is_plus_or_advanced: bool = False
 
 
+@dataclass(slots=True)
+class ConditionalField:
+    """A GraphQL fragment spliced into a query only when available for the store.
+
+    `placeholder` must appear verbatim in the resource's QUERY at the position where
+    `fields` belongs. When `is_available` returns False, the placeholder is replaced
+    with an empty string. Because substitution is positional, this works at any nesting
+    depth, not just the query root.
+
+    Placeholders are written as GraphQL comments (`# ...`) so that a marker which is
+    never substituted degrades to a harmless comment rather than producing an invalid
+    query. ShopifyGraphQLResource validates at class-definition time that each placeholder
+    is actually present in QUERY.
+    """
+
+    placeholder: str
+    fields: str
+    is_available: Callable[["StoreCapabilities"], bool]
+
+    def __post_init__(self) -> None:
+        # The degrade-to-no-op guarantee only holds if the placeholder is a comment, so
+        # that an unsubstituted marker is ignored by GraphQL rather than parsed as a field.
+        if not self.placeholder.lstrip().startswith("#"):
+            raise ValueError(
+                f"ConditionalField placeholder must be a GraphQL comment (start with "
+                f"'#'), got {self.placeholder!r}."
+            )
+
+
+def requires_any_scope(*scopes: str) -> Callable[["StoreCapabilities"], bool]:
+    """Build an `is_available` predicate that holds when any of `scopes` is granted.
+
+    Mirrors the any-of semantics of QUALIFYING_SCOPES. A field reachable via any one of
+    several scopes is available if at least one is present.
+    """
+    required = frozenset(scopes)
+    return lambda capabilities: not required.isdisjoint(capabilities.scopes)
+
+
 class ShopifyGraphQLResource(BaseDocument):
     QUERY: ClassVar[str] = ""
     QUERY_ROOT: ClassVar[str] = ""
@@ -429,8 +469,24 @@ class ShopifyGraphQLResource(BaseDocument):
     SORT_KEY: ClassVar[SortKey | None] = None
     SHOULD_USE_BULK_QUERIES: ClassVar[bool] = True
     QUALIFYING_SCOPES: ClassVar[set[str]] = set()
+    # Fields included in the query only when the store's capabilities allow it. See
+    # ConditionalField for placeholder/substitution semantics.
+    CONDITIONAL_FIELDS: ClassVar[list[ConditionalField]] = []
 
     model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        # A placeholder absent from QUERY would be silently dropped during substitution,
+        # so reject it at class-definition time instead.
+        for field in cls.CONDITIONAL_FIELDS:
+            if cls.QUERY and field.placeholder not in cls.QUERY:
+                raise ValueError(
+                    f"{cls.__name__} declares a ConditionalField with placeholder "
+                    f"{field.placeholder!r}, but that marker is not present in its QUERY. "
+                    f"Embed the placeholder verbatim where the field belongs."
+                )
 
     class Meta(BaseDocument.Meta):
         model_config = ConfigDict(validate_assignment=True)
@@ -486,6 +542,7 @@ class ShopifyGraphQLResource(BaseDocument):
         end: datetime,
         first: int | None = None,
         after: str | None = None,
+        capabilities: "StoreCapabilities | None" = None,
     ) -> str:
         raise NotImplementedError("build_query method must be implemented")
 
@@ -519,6 +576,23 @@ class ShopifyGraphQLResource(BaseDocument):
             yield current_record
 
     @classmethod
+    def _resolve_conditional_fields(
+        cls, capabilities: "StoreCapabilities | None"
+    ) -> str:
+        """Splice the resource's CONDITIONAL_FIELDS into QUERY based on capabilities.
+
+        Each placeholder is replaced by its fragment when available, else by "".
+        """
+        caps = capabilities or StoreCapabilities(scopes=frozenset())
+        body = cls.QUERY
+        for field in cls.CONDITIONAL_FIELDS:
+            body = body.replace(
+                field.placeholder,
+                field.fields if field.is_available(caps) else "",
+            )
+        return body
+
+    @classmethod
     def build_query_with_fragment(
         cls,
         start: datetime,
@@ -529,9 +603,11 @@ class ShopifyGraphQLResource(BaseDocument):
         includeLegacyId: bool = True,
         includeCreatedAt: bool = True,
         includeUpdatedAt: bool = True,
+        capabilities: "StoreCapabilities | None" = None,
     ) -> str:
         lower_bound = dt_to_str(start)
         upper_bound = dt_to_str(end)
+        query_body = cls._resolve_conditional_fields(capabilities)
 
         query = f"""
         {{
@@ -549,7 +625,7 @@ class ShopifyGraphQLResource(BaseDocument):
                         {"legacyResourceId" if includeLegacyId else ""}
                         {"createdAt" if includeCreatedAt else ""}
                         {"updatedAt" if includeUpdatedAt else ""}
-                        {cls.QUERY}
+                        {query_body}
                     }}
                 }}
                 {

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -593,6 +593,7 @@ async def all_resources(
                             ctx.bulk_job_manager,
                             model,
                             store_id,
+                            ctx.capabilities,
                         )
                     elif model.SORT_KEY is None:
                         fetch_changes[store_id] = functools.partial(
@@ -601,6 +602,7 @@ async def all_resources(
                             model,
                             data_model,
                             store_id,
+                            ctx.capabilities,
                         )
                     else:
                         fetch_changes[store_id] = functools.partial(
@@ -609,6 +611,7 @@ async def all_resources(
                             model,
                             data_model,
                             store_id,
+                            ctx.capabilities,
                         )
                         fetch_page[store_id] = functools.partial(
                             backfill_incremental,
@@ -616,6 +619,7 @@ async def all_resources(
                             model,
                             data_model,
                             store_id,
+                            ctx.capabilities,
                         )
 
                 open_binding(

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -39,6 +39,7 @@ from .models import (
     ShopDetails,
     ShopifyClientCredentials,
     ShopifyGraphQLResource,
+    StoreCapabilities,
     StoreConfig,
     create_response_data_model,
 )
@@ -94,7 +95,7 @@ class StoreContext:
     http: StoreHTTP
     client: gql.ShopifyGraphQLClient
     bulk_job_manager: BulkJobManager
-    scopes: set[str]
+    capabilities: StoreCapabilities
     available_resources: set[type[ShopifyGraphQLResource]]
 
 
@@ -187,18 +188,26 @@ async def _create_store_context(
         store_config.credentials, (AccessToken, ShopifyClientCredentials)
     )
     can_access_pii = True
+    is_plus_or_advanced = False
     if uses_custom_app_token:
-        can_access_pii = await _check_plan_allows_pii(store_http, client.url, log)
+        plan = await _get_shop_plan(store_http, client.url, log)
+        can_access_pii = _plan_allows_pii(plan, log)
+        is_plus_or_advanced = _plan_is_plus_or_advanced(plan)
 
     available_resources = _get_available_resources(
         granted_scopes, uses_custom_app_token, can_access_pii
+    )
+
+    capabilities = StoreCapabilities(
+        scopes=frozenset(granted_scopes),
+        is_plus_or_advanced=is_plus_or_advanced,
     )
 
     store_context = StoreContext(
         http=store_http,
         client=client,
         bulk_job_manager=bulk_job_manager,
-        scopes=granted_scopes,
+        capabilities=capabilities,
         available_resources=available_resources,
     )
 
@@ -351,13 +360,18 @@ async def _reconcile_connector_state(
         await task.checkpoint(ConnectorState(bindingStateV1={binding.stateKey: state}))
 
 
-async def _check_plan_allows_pii(http: HTTPMixin, url: str, log: Logger) -> bool:
-    """Check if the Shopify plan allows access to PII data."""
+async def _get_shop_plan(
+    http: HTTPMixin, url: str, log: Logger
+) -> ShopDetails.Data.Shop.Plan:
+    """Fetch the store's Shopify plan details."""
     response = ShopDetails.model_validate_json(
         await http.request(log, url, method="POST", json={"query": ShopDetails.query()})
     )
-    plan = response.data.shop.plan
+    return response.data.shop.plan
 
+
+def _plan_allows_pii(plan: ShopDetails.Data.Shop.Plan, log: Logger) -> bool:
+    """Check if the Shopify plan allows access to PII data."""
     if plan.partnerDevelopment or plan.shopifyPlus:
         return True
 
@@ -372,6 +386,18 @@ async def _check_plan_allows_pii(http: HTTPMixin, url: str, log: Logger) -> bool
         f"Assuming PII access is supported."
     )
     return True
+
+
+def _plan_is_plus_or_advanced(plan: ShopDetails.Data.Shop.Plan) -> bool:
+    """Whether the plan can query fields restricted to Plus/Advanced tiers.
+
+    Partner development stores have the same access as Plus for testing purposes.
+    """
+    return (
+        plan.shopifyPlus
+        or plan.partnerDevelopment
+        or plan.displayName == PlanName.ADVANCED
+    )
 
 
 async def _get_granted_scopes(http: HTTPMixin, url: str, log: Logger) -> set[str]:
@@ -535,7 +561,7 @@ async def all_resources(
                 if model == gql.FulfillmentOrders:
                     fo_scopes = gql.FulfillmentOrders.QUALIFYING_SCOPES
                     for store_id in stores_with_access:
-                        granted = store_contexts[store_id].scopes
+                        granted = store_contexts[store_id].capabilities.scopes
                         if fo_scopes & granted and not fo_scopes <= granted:
                             missing = fo_scopes - granted
                             task.log.warning(

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -94,7 +94,7 @@
       "title": "Gift Card",
       "totalInventory": 0,
       "tracksInventory": false,
-      "updatedAt": "2025-08-29T12:12:00Z",
+      "updatedAt": "redacted",
       "variantsCount": {
         "count": 4,
         "precision": "EXACT"
@@ -124,7 +124,7 @@
           }
         }
       ],
-      "updatedAt": "2025-08-29T12:12:00Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -138,7 +138,7 @@
       "id": "gid://shopify/Product/8086707830829",
       "legacyResourceId": "8086707830829",
       "metafields": [],
-      "updatedAt": "2025-08-29T12:12:00Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -151,7 +151,7 @@
       "createdAt": "2025-01-14T15:10:14Z",
       "id": "gid://shopify/Product/8086707830829",
       "legacyResourceId": "8086707830829",
-      "updatedAt": "2025-08-29T12:12:00Z",
+      "updatedAt": "redacted",
       "variants": [
         {
           "__parentId": "gid://shopify/Product/8086707830829",
@@ -314,7 +314,7 @@
           "value": "true"
         }
       ],
-      "updatedAt": "2025-08-29T12:12:00Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -419,7 +419,7 @@
       ],
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -433,7 +433,7 @@
       "fulfillments": [],
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -866,7 +866,7 @@
         }
       },
       "totalWeight": "0",
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -983,7 +983,7 @@
       "createdAt": "2025-04-10T17:42:58Z",
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -997,7 +997,7 @@
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
       "metafields": [],
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1011,7 +1011,7 @@
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
       "transactions": [],
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1027,7 +1027,7 @@
       "id": "gid://shopify/Order/5714619858989",
       "legacyResourceId": "5714619858989",
       "refunds": [],
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1087,7 +1087,7 @@
         ],
         "recommendation": "NONE"
       },
-      "updatedAt": "2025-04-10T17:54:23Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1108,7 +1108,7 @@
       "sku": null,
       "tracked": false,
       "unitCost": null,
-      "updatedAt": "2025-08-29T12:12:00Z",
+      "updatedAt": "redacted",
       "variant": {
         "id": "gid://shopify/ProductVariant/43217823334445",
         "legacyResourceId": "43217823334445",
@@ -1191,7 +1191,7 @@
         }
       ],
       "scheduledChanges": [],
-      "updatedAt": "2025-01-14T15:10:14Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1246,7 +1246,7 @@
       "sortOrder": "BEST_SELLING",
       "templateSuffix": null,
       "title": "Home page",
-      "updatedAt": "2025-04-10T17:45:43Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1320,7 +1320,7 @@
       "sortOrder": "BEST_SELLING",
       "templateSuffix": null,
       "title": "Automated Collection",
-      "updatedAt": "2026-06-06T09:39:22Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1333,7 +1333,7 @@
       "id": "gid://shopify/Collection/295442513965",
       "legacyResourceId": "295442513965",
       "metafields": [],
-      "updatedAt": "2025-04-10T17:45:43Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1346,7 +1346,7 @@
       "id": "gid://shopify/Collection/295442612269",
       "legacyResourceId": "295442612269",
       "metafields": [],
-      "updatedAt": "2026-06-06T09:39:22Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1382,7 +1382,7 @@
       "legacyResourceId": "73871392813",
       "name": "Shop location",
       "shipsInventory": true,
-      "updatedAt": "2025-01-14T15:09:43Z"
+      "updatedAt": "redacted"
     }
   ],
   [
@@ -1396,7 +1396,7 @@
       "id": "gid://shopify/Location/73871392813",
       "legacyResourceId": "73871392813",
       "metafields": [],
-      "updatedAt": "2025-01-14T15:09:43Z"
+      "updatedAt": "redacted"
     }
   ]
 ]

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -782,6 +782,9 @@
       },
       "referrerUrl": null,
       "registeredSourceUrl": null,
+      "retailLocation": {
+        "id": "gid://shopify/Location/73871392813"
+      },
       "shippingAddress": null,
       "sourceIdentifier": null,
       "sourceName": "shopify_draft_order",
@@ -1317,7 +1320,7 @@
       "sortOrder": "BEST_SELLING",
       "templateSuffix": null,
       "title": "Automated Collection",
-      "updatedAt": "2025-04-24T20:25:42Z"
+      "updatedAt": "2026-06-06T09:39:22Z"
     }
   ],
   [
@@ -1343,7 +1346,7 @@
       "id": "gid://shopify/Collection/295442612269",
       "legacyResourceId": "295442612269",
       "metafields": [],
-      "updatedAt": "2025-04-24T20:25:42Z"
+      "updatedAt": "2026-06-06T09:39:22Z"
     }
   ],
   [

--- a/source-shopify-native/tests/test_conditional_fields.py
+++ b/source-shopify-native/tests/test_conditional_fields.py
@@ -1,0 +1,117 @@
+"""
+Tests for the scope/plan-gated conditional-fields mechanism: fields that are spliced
+into a resource's GraphQL query only when the store's capabilities allow it.
+"""
+
+from datetime import datetime, UTC
+
+import pytest
+
+from source_shopify_native.graphql.orders.orders import Orders
+from source_shopify_native.models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+    requires_any_scope,
+)
+
+START = datetime(2024, 1, 1, tzinfo=UTC)
+END = datetime(2024, 2, 1, tzinfo=UTC)
+
+
+def test_placeholder_substituted_at_any_depth():
+    """The mechanism splices at the placeholder's position, not only the query root."""
+
+    class _Nested(ShopifyGraphQLResource):
+        NAME = "nested_test"
+        QUERY_ROOT = "things"
+        SORT_KEY = SortKey.UPDATED_AT
+        QUERY = """
+        lineItems {
+            edges {
+                node {
+                    id
+                    # {{ scopedField }}
+                }
+            }
+        }
+        """
+        CONDITIONAL_FIELDS = [
+            ConditionalField(
+                placeholder="# {{ scopedField }}",
+                fields="scopedField { id }",
+                is_available=requires_any_scope("some_scope"),
+            ),
+        ]
+
+        @staticmethod
+        def build_query(start, end, first=None, after=None, capabilities=None):
+            return _Nested.build_query_with_fragment(
+                start, end, first=first, after=after, capabilities=capabilities
+            )
+
+    granted = _Nested.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"some_scope"}))
+    )
+    denied = _Nested.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset())
+    )
+
+    # When granted, the field appears nested inside lineItems' node, not at the root.
+    node_block = granted[granted.index("lineItems") :]
+    assert "scopedField { id }" in node_block
+    assert "scopedField" not in denied
+
+
+def test_placeholder_absent_from_query_is_rejected_at_definition():
+    """A marker missing from QUERY fails loudly at class-definition time."""
+    with pytest.raises(ValueError, match="not present in its QUERY"):
+
+        class _Broken(ShopifyGraphQLResource):
+            NAME = "broken_test"
+            QUERY_ROOT = "things"
+            SORT_KEY = SortKey.UPDATED_AT
+            # QUERY deliberately omits the `# {{ ghost }}` marker.
+            QUERY = "id"
+            CONDITIONAL_FIELDS = [
+                ConditionalField(
+                    placeholder="# {{ ghost }}",
+                    fields="ghost { id }",
+                    is_available=requires_any_scope("some_scope"),
+                ),
+            ]
+
+
+def test_non_comment_placeholder_is_rejected():
+    """A placeholder that isn't a comment can't degrade to a no-op, so it's rejected."""
+    with pytest.raises(ValueError, match="must be a GraphQL comment"):
+        ConditionalField(
+            placeholder="retailLocation",
+            fields="retailLocation { id }",
+            is_available=requires_any_scope("read_locations"),
+        )
+
+
+def test_predicate_can_gate_on_plan_tier():
+    """is_available is an arbitrary predicate, so plan-tier gating works (e.g. #4227)."""
+    cond = ConditionalField(
+        placeholder="# {{ staffMember }}",
+        fields="staffMember { id }",
+        is_available=lambda caps: "read_users" in caps.scopes
+        and caps.is_plus_or_advanced,
+    )
+
+    plus_with_scope = StoreCapabilities(
+        scopes=frozenset({"read_users"}), is_plus_or_advanced=True
+    )
+    basic_with_scope = StoreCapabilities(
+        scopes=frozenset({"read_users"}), is_plus_or_advanced=False
+    )
+    plus_without_scope = StoreCapabilities(
+        scopes=frozenset(), is_plus_or_advanced=True
+    )
+
+    assert cond.is_available(plus_with_scope)
+    assert not cond.is_available(basic_with_scope)
+    assert not cond.is_available(plus_without_scope)

--- a/source-shopify-native/tests/test_conditional_fields.py
+++ b/source-shopify-native/tests/test_conditional_fields.py
@@ -20,6 +20,27 @@ START = datetime(2024, 1, 1, tzinfo=UTC)
 END = datetime(2024, 2, 1, tzinfo=UTC)
 
 
+def test_orders_retail_location_included_only_with_read_locations():
+    with_scope = Orders.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_locations"}))
+    )
+    without_scope = Orders.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_orders"}))
+    )
+
+    assert "retailLocation" in with_scope
+    assert "retailLocation" not in without_scope
+
+
+def test_orders_missing_capabilities_omits_conditional_fields():
+    """A query built without capabilities must not request scope-gated fields."""
+    query = Orders.build_query(START, END)
+
+    assert "retailLocation" not in query
+    # The placeholder itself must not leak into the emitted query.
+    assert "{{ retailLocation }}" not in query
+
+
 def test_placeholder_substituted_at_any_depth():
     """The mechanism splices at the placeholder's position, not only the query root."""
 

--- a/source-shopify-native/tests/test_snapshots.py
+++ b/source-shopify-native/tests/test_snapshots.py
@@ -22,6 +22,10 @@ def sanitize_tokens(data):
 
 
 def test_capture(request, snapshot):
+    FIELDS_TO_REDACT = [
+        "updatedAt"
+    ]
+
     result = subprocess.run(
         [
             "flowctl",
@@ -43,9 +47,14 @@ def test_capture(request, snapshot):
     seen = set()
 
     for line in lines:
-        stream = line[0]
+        stream, record = line[0], line[1]
         if stream not in seen:
-            sanitize_tokens(line[1])
+            sanitize_tokens(record)
+
+            for field in FIELDS_TO_REDACT:
+                if field in record:
+                    record[field] = "redacted"
+
             unique_stream_lines.append(line)
             seen.add(stream)
 


### PR DESCRIPTION
**Regression?**

No

**Description:**

Addresses #4342. 

The `retailLocation` can only be queried on `orders` when the `read_locations` scope is granted, which the `orders` stream doesn't need otherwise. Instead of forcing every user that enables `orders` to grant the `read_locations` scope, this PR adds a general mechanism for conditionally including query fields based on various per-store capabilities (mostly scopes and the store type), and the connector now uses that mechanism to include `retailLocation.id` in `orders` when we have the `read_locations` scope.

**Notes for reviewers:**

The various infrastructure around conditionally including fields in queries may seem a little overkill when only the `retailLocation` field in `orders` uses it, but I'm going to update the connector to conditionally include more fields over the next week & the more general handling will pay off then.

I recommend reviewing commit-by-commit.

