### PR TITLE
ci: remove extra "," in Claude instructions

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -536,7 +536,7 @@ def build_claude_prompt(
         f"to the pull-request causing the regression being fixed, however you cannot\n"
         f"take this explicit statement of regression as granted. It is possible that\n"
         f"no such explicit mention of a regression is there, but the pull-request is still\n"
-        f"a roll-forward fix of a previous PR. Use the explicit statement as additional\n",
+        f"a roll-forward fix of a previous PR. Use the explicit statement as additional\n"
         f"information and not as the sole source of truth.\n\n"
         f"Note: this repo uses rebase-and-merge, so each PR's commits land on main\n"
         f"as a linear sequence — judge PRs as units, not individual commits.\n\n"


### PR DESCRIPTION
**Description:**

- there was an extra "," in the pipeline

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

