### PR TITLE
source-mysql: Fix bug in MariaDB JSON column DDL parsing

### DIFF
--- a/source-mysql/.snapshots/TestMariaDBAddJSONColumn
+++ b/source-mysql/.snapshots/TestMariaDBAddJSONColumn
@@ -2,10 +2,10 @@
 # Collection "acmeCo/test/test/mariadbaddjsoncolumn_31415926": 3 Documents
 # ================================
 {"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"MariaDBAddJSONColumn_31415926","cursor":"backfill:0"}},"data":"before","id":1}
-{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"obj","id":2,"j":{"bucket_id":1,"id":1}}
-{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"arr","id":3,"j":[{"bucket_id":1,"id":1}]}
+{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"obj","id":2,"j":"{\"bucket_id\": 1, \"id\": 1}"}
+{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"arr","id":3,"j":"[{\"bucket_id\": 1, \"id\": 1}]"}
 # ================================
 # Final State Checkpoint
 # ================================
-{"bindingStateV1":{"test%2FMariaDBAddJSONColumn_31415926":{"backfilled":1,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data","j"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"},"j":"json"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+{"bindingStateV1":{"test%2FMariaDBAddJSONColumn_31415926":{"backfilled":1,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data","j"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"},"j":{"charset":"utf8mb4","type":"longtext"}}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
 

--- a/source-mysql/.snapshots/TestMariaDBAddJSONColumn
+++ b/source-mysql/.snapshots/TestMariaDBAddJSONColumn
@@ -1,0 +1,11 @@
+# ================================
+# Collection "acmeCo/test/test/mariadbaddjsoncolumn_31415926": 3 Documents
+# ================================
+{"_meta":{"op":"c","source":{"schema":"test","snapshot":true,"table":"MariaDBAddJSONColumn_31415926","cursor":"backfill:0"}},"data":"before","id":1}
+{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"obj","id":2,"j":{"bucket_id":1,"id":1}}
+{"_meta":{"op":"c","source":{"schema":"test","table":"MariaDBAddJSONColumn_31415926","cursor":"binlog.000123:56789:123"}},"data":"arr","id":3,"j":[{"bucket_id":1,"id":1}]}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"test%2FMariaDBAddJSONColumn_31415926":{"backfilled":1,"key_columns":["id"],"metadata":{"charset":"utf8mb4","schema":{"columns":["id","data","j"],"types":{"data":{"charset":"utf8mb4","type":"text"},"id":{"type":"int"},"j":"json"}}},"mode":"Active"}},"cursor":"binlog.000123:56789"}
+

--- a/source-mysql/datatype_test.go
+++ b/source-mysql/datatype_test.go
@@ -301,3 +301,40 @@ func TestMariaDBTypeUUID(t *testing.T) {
 		cupaloy.SnapshotT(t, summary)
 	})
 }
+
+// TestMariaDBAddJSONColumn captures a JSON column added to a table via live DDL.
+//
+// In MariaDB the JSON type is an alias for LONGTEXT, so discovery (which reads
+// information_schema) reports such a column as a string. The replication DDL parser,
+// however, keys off the literal `JSON` keyword in the ALTER statement and so records the
+// column as a JSON type, causing its values to be emitted as bare JSON rather than as
+// strings. The result is a metadata inconsistency: the discovered collection schema says
+// the column is a string, but the captured documents contain bare JSON objects and arrays.
+func TestMariaDBAddJSONColumn(t *testing.T) {
+	if os.Getenv("TEST_MARIADB") != "yes" {
+		t.Skip("Skipping MariaDB specific test, set TEST_MARIADB=yes to enable")
+	}
+
+	var tb, ctx = mysqlTestBackend(t), context.Background()
+	var uniqueID = "31415926"
+	var tableName = tb.CreateTable(ctx, t, uniqueID, "(id INTEGER PRIMARY KEY, data TEXT)")
+
+	var cs = tb.CaptureSpec(ctx, t, regexp.MustCompile(uniqueID))
+	cs.Validator = &st.OrderedCaptureValidator{}
+	sqlcapture.TestShutdownAfterCaughtUp = true
+	t.Cleanup(func() { sqlcapture.TestShutdownAfterCaughtUp = false })
+
+	// Initial backfill of the table before the JSON column exists.
+	tb.Insert(ctx, t, tableName, [][]any{{1, "before"}})
+	cs.Capture(ctx, t, nil)
+
+	// Add the JSON column via live DDL and insert object and array-of-objects values.
+	tb.Query(ctx, t, fmt.Sprintf("ALTER TABLE %s ADD COLUMN j JSON;", tableName))
+	tb.Insert(ctx, t, tableName, [][]any{
+		{2, "obj", `{"bucket_id": 1, "id": 1}`},
+		{3, "arr", `[{"bucket_id": 1, "id": 1}]`},
+	})
+	cs.Capture(ctx, t, nil)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -1082,7 +1082,7 @@ func (rs *mysqlReplicationStream) handleAlterTable(ctx context.Context, stmt *sq
 			meta.Schema.Columns = slices.Delete(meta.Schema.Columns, oldIndex, oldIndex+1)
 
 			var newName = alter.NewColDefinition.Name.String()
-			var newType = translateDataType(meta, alter.NewColDefinition.Type, rs.db.featureFlags)
+			var newType = translateDataType(meta, alter.NewColDefinition.Type, rs.db.featureFlags, rs.db.versionProduct == "MariaDB")
 			var newIndex = oldIndex
 			if alter.First {
 				newIndex = 0
@@ -1107,7 +1107,7 @@ func (rs *mysqlReplicationStream) handleAlterTable(ctx context.Context, stmt *sq
 			colName = meta.Schema.Columns[oldIndex] // Use the actual column name from the metadata
 			meta.Schema.Columns = slices.Delete(meta.Schema.Columns, oldIndex, oldIndex+1)
 
-			var newType = translateDataType(meta, alter.NewColDefinition.Type, rs.db.featureFlags)
+			var newType = translateDataType(meta, alter.NewColDefinition.Type, rs.db.featureFlags, rs.db.versionProduct == "MariaDB")
 			var newIndex = oldIndex
 			if alter.First {
 				newIndex = 0
@@ -1138,7 +1138,7 @@ func (rs *mysqlReplicationStream) handleAlterTable(ctx context.Context, stmt *sq
 			var newCols []string
 			for _, col := range alter.Columns {
 				newCols = append(newCols, col.Name.String())
-				var dataType = translateDataType(meta, col.Type, rs.db.featureFlags)
+				var dataType = translateDataType(meta, col.Type, rs.db.featureFlags, rs.db.versionProduct == "MariaDB")
 				meta.Schema.ColumnTypes[col.Name.String()] = dataType
 			}
 
@@ -1187,7 +1187,7 @@ func findColumnIndex(columns []string, name string) int {
 	return -1
 }
 
-func translateDataType(meta *mysqlTableMetadata, t *sqlparser.ColumnType, featureFlags map[string]bool) any {
+func translateDataType(meta *mysqlTableMetadata, t *sqlparser.ColumnType, featureFlags map[string]bool, isMariaDB bool) any {
 	switch typeName := strings.ToLower(t.Type); typeName {
 	case "enum":
 		return &mysqlColumnType{Type: typeName, EnumValues: append([]string{""}, unquoteEnumValues(t.EnumValues)...)}
@@ -1204,17 +1204,17 @@ func translateDataType(meta *mysqlTableMetadata, t *sqlparser.ColumnType, featur
 	case "tinyint", "smallint", "mediumint", "int", "bigint":
 		return &mysqlColumnType{Type: typeName, Unsigned: t.Unsigned}
 	case "char", "varchar", "tinytext", "text", "mediumtext", "longtext":
-		var charset string
-		if t.Charset.Name != "" {
-			charset = t.Charset.Name // If explicitly specified, the declared charset wins
-		} else if t.Options.Collate != "" {
-			charset = charsetFromCollation(t.Options.Collate) // If only a collation is declared, figure out what charset that implies
-		} else if meta.DefaultCharset != "" {
-			charset = meta.DefaultCharset // In the absence of a column-specific declaration, use the default table charset
-		} else {
-			charset = mysqlDefaultCharset // Finally fall back to UTF-8 if nothing else supersedes that
+		return &mysqlColumnType{Type: typeName, Charset: columnCharset(meta, t)}
+	case "json":
+		// MySQL has a real JSON type, but in MariaDB the JSON type is an alias for
+		// `LONGTEXT COLLATE utf8mb4_bin`, and discovery (which reads information_schema)
+		// reports it as a longtext with charset utf8mb4. Thus we have to mirror that here
+		// so a JSON column added via live DDL is captured as a string, consistent with the
+		// discovered schema.
+		if isMariaDB {
+			return &mysqlColumnType{Type: "longtext", Charset: "utf8mb4"}
 		}
-		return &mysqlColumnType{Type: typeName, Charset: charset}
+		return typeName
 	case "binary":
 		var columnLength int
 		if t.Length == nil {
@@ -1226,6 +1226,20 @@ func translateDataType(meta *mysqlTableMetadata, t *sqlparser.ColumnType, featur
 	default:
 		return typeName
 	}
+}
+
+// columnCharset resolves the character set of a text column declared in a DDL statement,
+// preferring an explicit column charset, then the charset implied by an explicit collation,
+// then the table default, and finally falling back to UTF-8.
+func columnCharset(meta *mysqlTableMetadata, t *sqlparser.ColumnType) string {
+	if t.Charset.Name != "" {
+		return t.Charset.Name
+	} else if t.Options.Collate != "" {
+		return charsetFromCollation(t.Options.Collate)
+	} else if meta.DefaultCharset != "" {
+		return meta.DefaultCharset
+	}
+	return mysqlDefaultCharset
 }
 
 func resolveTableName(defaultSchema string, name sqlparser.TableName) sqlcapture.StreamID {


### PR DESCRIPTION
**Description:**

In MariaDB the "JSON" column type is an alias for "LONGTEXT COLLATE utf8mb4_bin" and so normally `source-mariadb` (`source-mysql`) discovers such columns as strings and captures them as strings.

However, we didn't previously have any logic to resolve that alias when processing a _DDL alteration_ on such a column, so if one were to issue an `ALTER TABLE ... ADD COLUMN foo JSON` on a table which was already part of an ongoing capture, the internal metadata would treat that as a `json` column type, which happens to mean the _MySQL_ JSON column type. Once this happened, subsequent capture outputs would contain bare JSON values which wouldn't match the discovered type.

This PR fixes that by resolving the "JSON" column type to "LONGTEXT" when the target database is MariaDB, so that DDL tracking again matches the discovery-initialization metadata pathway.

(Note: We should _also_ consider adding a feature flag and eventually flipping the default behavior so that MariaDB JSON columns are captured as JSON values consistent with most other databases. However the immediate issue being solved in this PR is just that we can get into a state where we capture values which don't match our own discovered schemas)

Fixes https://github.com/estuary/connectors/issues/4638
