### PR TITLE
ci: re-queue connector tags over PostgREST instead of direct psql

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -4,17 +4,11 @@ inputs:
   connector:
     description: Image name of this connector.
     required: true
-  pg_database:
-    description: Postgres database to use.
+  rt_id:
+    description: Control-plane refresh token id for the github_action_connector_refresh role.
     required: true
-  pg_host:
-    description: Postgres host to use.
-    required: true
-  pg_password:
-    description: Postgres password to use.
-    required: true
-  pg_user:
-    description: Postgres user to use.
+  rt_secret:
+    description: Control-plane refresh token secret for the github_action_connector_refresh role.
     required: true
   tag_sha:
     description: Short tag of the commit SHA1, such as 'f32dc1a'.
@@ -55,11 +49,6 @@ runs:
           docker image push ghcr.io/estuary/${VARIANT}:${{ inputs.tag_version }};
         done
 
-    - name: Install psql
-      if: ${{ github.event_name == 'push' }}
-      shell: bash
-      run: sudo apt install postgresql
-
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -67,19 +56,35 @@ runs:
           connector:
             - "${{ inputs.connector }}/**"
 
-    - name: Refresh connector tags for ${{ inputs.connector }}
+    # Re-queue connector tag publishing over PostgREST (HTTPS) instead of a direct
+    # psql connection from CI.
+    # A revocable refresh token is exchanged for a short-lived access token whose
+    # role claim is github_action_connector_refresh; PostgREST runs requeue_connector_tag
+    # under that role.
+    - name: Re-queue connector tags for ${{ inputs.connector }}
       if: github.event_name == 'push' && steps.filter.outputs.connector == 'true'
       shell: bash
       env:
-        PGDATABASE: ${{ inputs.pg_database }}
-        PGHOST: ${{ inputs.pg_host }}
-        PGPASSWORD: ${{ inputs.pg_password }}
-        PGUSER: ${{ inputs.pg_user }}
+        RT_ID: ${{ inputs.rt_id }}
+        RT_SECRET: ${{ inputs.rt_secret }}
       run: |
+        set -euo pipefail
+        SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+        # Public anon key, used only as the PostgREST apikey header.
+        ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
+
+        access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+          -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+          -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+        if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+          echo "failed to obtain control-plane access token"; exit 1
+        fi
+
         for VARIANT in ${{ inputs.connector }} ${{ inputs.variants }}; do
-          echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                  WHERE connector_id IN (
-                    SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${VARIANT}'
-                  ) AND image_tag IN (':${{ inputs.tag_version }}', ':dev');" | psql;
+          echo "Re-queuing tags for ghcr.io/estuary/${VARIANT}";
+          curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+            -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "{\"image_name\": \"ghcr.io/estuary/${VARIANT}\", \"image_tags\": [\":${{ inputs.tag_version }}\", \":dev\"]}";
         done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -354,12 +354,6 @@ jobs:
             docker image push ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.version }};
           done
 
-      - name: Install psql
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          sudo apt update
-          sudo apt install postgresql
-
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -367,17 +361,30 @@ jobs:
             connector:
               - "${{ matrix.connector }}/**"
 
-      - name: Refresh connector tags for ${{ matrix.connector }}
+      # Re-queue connector tag publishing over PostgREST (HTTPS) instead of a direct
+      # psql connection from CI.
+      - name: Re-queue connector tags for ${{ matrix.connector }}
         if: github.event_name == 'push' && steps.filter.outputs.connector == 'true'
         env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+          RT_ID: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          RT_SECRET: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
         run: |
+          set -euo pipefail
+          SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+          # Public anon key, used only as the PostgREST apikey header.
+          ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
+
+          access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+            -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+            -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+          if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+            echo "failed to obtain control-plane access token"; exit 1
+          fi
+
           for VARIANT in ${{ steps.prep.outputs.variants }}; do
-            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                    WHERE connector_id IN (
-                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${VARIANT}'
-                    ) AND image_tag IN (':${{ steps.prep.outputs.version }}', ':dev');" | psql;
+            echo "Re-queuing tags for ghcr.io/estuary/${VARIANT}";
+            curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+              -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+              -H "Content-Type: application/json" \
+              -d "{\"image_name\": \"ghcr.io/estuary/${VARIANT}\", \"image_tags\": [\":${{ steps.prep.outputs.version }}\", \":dev\"]}";
           done

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -118,25 +118,31 @@ jobs:
             exit 1
           fi
 
-      - name: Install psql
-        run: |
-          sudo apt update
-          sudo apt install -y postgresql-client
-
-      - name: Refresh connector_tags rows for ':delayed'
+      # Re-queue the ':delayed' connector tags over PostgREST (HTTPS) instead of a
+      # direct psql connection from CI.
+      - name: Re-queue connector_tags rows for ':delayed'
         env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+          RT_ID: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          RT_SECRET: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
         run: |
           set -euo pipefail
+          SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+          # Public anon key, used only as the PostgREST apikey header.
+          ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
+
+          access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+            -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+            -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+          if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+            echo "failed to obtain control-plane access token"; exit 1
+          fi
+
           while IFS= read -r IMAGE; do
             [ -z "${IMAGE}" ] && continue
-            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                    WHERE connector_id IN (
-                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
-                    ) AND image_tag = ':delayed';" | psql
+            curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+              -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+              -H "Content-Type: application/json" \
+              -d "{\"image_name\": \"ghcr.io/estuary/${IMAGE}\", \"image_tags\": [\":delayed\"]}"
           done < /tmp/tagged.txt
 
       - name: Write job summary

--- a/.github/workflows/forward-delayed-tag.yaml
+++ b/.github/workflows/forward-delayed-tag.yaml
@@ -96,25 +96,31 @@ jobs:
             exit 1
           fi
 
-      - name: Install psql
-        run: |
-          sudo apt update
-          sudo apt install -y postgresql-client
-
-      - name: Refresh connector_tags rows for ':delayed'
+      # Re-queue the ':delayed' connector tags over PostgREST (HTTPS) instead of a
+      # direct psql connection from CI.
+      - name: Re-queue connector_tags rows for ':delayed'
         env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+          RT_ID: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          RT_SECRET: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
         run: |
           set -euo pipefail
+          SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+          # Public anon key, used only as the PostgREST apikey header.
+          ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
+
+          access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+            -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+            -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+          if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+            echo "failed to obtain control-plane access token"; exit 1
+          fi
+
           while IFS= read -r IMAGE; do
             [ -z "${IMAGE}" ] && continue
-            echo "UPDATE connector_tags SET job_status='{\"type\": \"queued\"}'
-                    WHERE connector_id IN (
-                      SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${IMAGE}'
-                    ) AND image_tag = ':delayed';" | psql
+            curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+              -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+              -H "Content-Type: application/json" \
+              -d "{\"image_name\": \"ghcr.io/estuary/${IMAGE}\", \"image_tags\": [\":delayed\"]}"
           done < /tmp/tagged.txt
 
       - name: Write job summary

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -447,10 +447,8 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           connector: ${{ matrix.connector.name }}
-          pg_database: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
-          pg_host: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          pg_password: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          pg_user: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
+          rt_id: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          rt_secret: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
           tag_sha: ${{ steps.setup.outputs.tag_sha }}
           tag_version: ${{ matrix.connector.version }}
           variants: ${{ matrix.connector.variants }}


### PR DESCRIPTION
**Description:**

Replaces the direct psql connection used to re-queue `connector_tags` with authenticated calls to the control-plane API (PostgREST over HTTPS), so connector publishes no longer require a direct database connection from CI.

Each refresh step exchanges a revocable refresh token for a short-lived access token whose `role` claim is `github_action_connector_refresh`, then calls the `requeue_connector_tag` RPC. Converted in five places:

- `.github/workflows/ci.yaml` (Go connectors, inline)
- `.github/workflows/python.yaml` via the `.github/actions/deploy/action.yaml` composite action (Python connectors)
- `.github/workflows/delayed-tag.yaml` and `.github/workflows/forward-delayed-tag.yaml` (the `:delayed` tag)

**Depends on (draft until both are done):**

- estuary/flow#3013 (adds `requeue_connector_tag` and the scoped-role wiring) deployed first.
- New repo secrets `CONNECTOR_REFRESH_RT_ID` and `CONNECTOR_REFRESH_RT_SECRET`, minted via `create_scoped_refresh_token('github_action_connector_refresh', ...)`.

Replaces the `POSTGRES_CONNECTOR_REFRESH_*` secrets, which can be removed after cutover.

**Notes for reviewers:**

- No new database permissions: this is the same `connector_tags.job_status` UPDATE the role already holds. `requeue_connector_tag` covers the `:delayed` case via its `image_tags` array.
- Kept as a draft until flow#3013 is deployed and the secrets are set.
