### PR TITLE
materialize-postgres: fix compatible enum name matching

### DIFF
--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -138,7 +138,7 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 		}
 		if res := is.GetResource([]string{ts, tn}); res != nil {
 			if field := res.GetField(cn); field != nil {
-				field.Meta = pgFieldMeta{UDTName: udt}
+				field.Meta = pgFieldMeta{UDTName: udt, Path: []string{ts, tn}}
 			}
 		}
 	}

--- a/materialize-postgres/enum_type.go
+++ b/materialize-postgres/enum_type.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 	"unicode/utf8"
@@ -13,10 +12,6 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	log "github.com/sirupsen/logrus"
 )
-
-// hashedEnumSuffix matches the "_<fieldPart>_<8hexchars>_flow_enum" tail of a hashed enum type
-// name, capturing the (possibly truncated) field portion in group 1.
-var hashedEnumSuffix = regexp.MustCompile(`_([^_]+)_[0-9a-f]{8}_flow_enum$`)
 
 // PgEnum represents a PostgreSQL ENUM type for a specific column.
 // TypeName is empty until resolved via resolveEnumTypes at apply time.
@@ -31,39 +26,30 @@ func (e *PgEnum) DDL() string {
 }
 
 // pgFieldMeta is attached to ExistingField.Meta by PopulateInfoSchema to carry
-// the udt_name for USER-DEFINED columns, needed for compatibility checks.
+// the udt_name and resource path for USER-DEFINED columns, needed for
+// compatibility checks.
 type pgFieldMeta struct {
 	UDTName string
+	Path    []string
 }
 
 // Compatible returns true when an existing column is a USER-DEFINED type whose
-// udt_name matches the expected enum type name for this field. Two naming
-// patterns are recognized:
-//
-//   - Normal: ends with "_<field>_flow_enum"
-//   - Hashed: ends with "_<truncatedField>_<8hexchars>_flow_enum" (for long names)
+// udt_name matches the enum type name this field would generate. It recomputes
+// the expected base name with the same generator used to create the type, so
+// the round-trip is exactly the same as when creating the type
 func (e *PgEnum) Compatible(existing boilerplate.ExistingField) bool {
 	if !strings.EqualFold(existing.Type, "USER-DEFINED") {
 		return false
 	}
-	var udtName string
-	if m, ok := existing.Meta.(pgFieldMeta); ok {
-		udtName = m.UDTName
+	m, ok := existing.Meta.(pgFieldMeta)
+	if !ok {
+		return false
 	}
-	udtLower := strings.ToLower(udtName)
-	fieldLower := strings.ToLower(e.Field)
-
-	// Normal case: tablename_field_flow_enum
-	if strings.HasSuffix(udtLower, "_"+fieldLower+"_flow_enum") {
-		return true
+	expected, err := enumBaseName(m.Path, e.Field)
+	if err != nil {
+		return false
 	}
-	// Hashed case: tablename_truncatedfield_<8hexchars>_flow_enum.
-	// The field component may be truncated, so check that fieldLower starts with
-	// whatever field portion was retained before the hash.
-	if m := hashedEnumSuffix.FindStringSubmatch(udtLower); m != nil && strings.HasPrefix(fieldLower, m[1]) {
-		return true
-	}
-	return false
+	return strings.EqualFold(m.UDTName, expected)
 }
 
 var _ sql.DDLer = (*PgEnum)(nil)
@@ -145,8 +131,24 @@ func enumTypeNameParts(dialect sql.Dialect, path []string, field string) (schema
 	default:
 		return "", "", "", fmt.Errorf("unexpected resource path length %d for enum type naming: %v", len(path), path)
 	}
+	if base, err = enumBaseName(path, field); err != nil {
+		return "", "", "", err
+	}
+	typeName = dialect.Identifier(schema, base)
+	return
+}
+
+// enumBaseName computes the unqualified base name (the "_flow_enum"-suffixed
+// identifier, before schema-qualification and quoting) for a column's enum
+// type. Generation (enumTypeNameParts) and the compatibility check (Compatible)
+// share this single source of truth so that recognizing the connector's own
+// type names is exact regardless of truncation or hashing.
+func enumBaseName(path []string, field string) (string, error) {
+	if len(path) == 0 {
+		return "", fmt.Errorf("unexpected empty resource path for enum type naming")
+	}
 	tableName := truncatedIdentifier(path[len(path)-1])
-	base = tableName + "_" + field + "_flow_enum"
+	base := tableName + "_" + field + "_flow_enum"
 
 	if len([]byte(base)) > 63 {
 		// Hash mode: <tableName>_<truncatedField>_<8hexHash>_flow_enum
@@ -161,8 +163,7 @@ func enumTypeNameParts(dialect sql.Dialect, path []string, field string) (schema
 		base = tableName + "_" + fieldPart + "_" + hash + "_flow_enum"
 	}
 
-	typeName = dialect.Identifier(schema, base)
-	return
+	return base, nil
 }
 
 // truncateToBytes truncates s to at most maxBytes bytes while retaining valid UTF-8.

--- a/materialize-postgres/enum_type_test.go
+++ b/materialize-postgres/enum_type_test.go
@@ -12,62 +12,71 @@ func TestCompatibleFallback(t *testing.T) {
 	tests := []struct {
 		name         string
 		field        string
+		path         []string
 		existingType string
 		udtName      string
+		noMeta       bool
 		wantOk       bool
 	}{
 		{
 			name:    "normal match",
 			field:   "status",
+			path:    []string{"public", "orders"},
 			udtName: "orders_status_flow_enum",
 			wantOk:  true,
 		},
 		{
+			// udt_name as reported by Postgres may differ in case; the
+			// comparison is case-insensitive.
 			name:    "normal match case-insensitive",
-			field:   "Status",
+			field:   "status",
+			path:    []string{"public", "orders"},
 			udtName: "orders_STATUS_flow_enum",
 			wantOk:  true,
 		},
 		{
 			name:    "normal no match wrong field",
 			field:   "state",
+			path:    []string{"public", "orders"},
 			udtName: "orders_status_flow_enum",
 			wantOk:  false,
 		},
 		{
 			name:         "not user-defined type",
 			field:        "status",
+			path:         []string{"public", "orders"},
 			existingType: "text",
 			udtName:      "orders_status_flow_enum",
 			wantOk:       false,
 		},
 		{
-			// Hashed case: field exactly matches the truncated segment
-			name:    "hashed match exact field truncation",
-			field:   "some_very_long_field_name_for_testing",
-			udtName: "table_some_abcd1234_flow_enum",
-			wantOk:  true,
-		},
-		{
-			// Hashed case: field prefix is 1 byte
-			name:    "hashed match single byte field prefix",
+			// A pre-existing user-defined type not managed by the connector.
+			name:    "foreign user-defined type",
 			field:   "status",
-			udtName: "table_s_abcd1234_flow_enum",
-			wantOk:  true,
-		},
-		{
-			// Hashed suffix with wrong field prefix should not match
-			name:    "hashed no match wrong field prefix",
-			field:   "color",
-			udtName: "table_s_abcd1234_flow_enum",
+			path:    []string{"public", "orders"},
+			udtName: "my_custom_enum",
 			wantOk:  false,
 		},
 		{
-			// 8-char suffix is not hex — should not match hashed pattern
-			name:    "hashed suffix not hex",
-			field:   "status",
-			udtName: "table_status_ZZZZZZZZ_flow_enum",
-			wantOk:  false,
+			// No metadata attached (e.g. udt_name was never populated) cannot
+			// be confirmed compatible.
+			name:   "missing meta",
+			field:  "status",
+			path:   []string{"public", "orders"},
+			noMeta: true,
+			wantOk: false,
+		},
+		{
+			// Regression: a field starting with "_" on a long table truncates
+			// its retained field portion down to a single underscore, producing
+			// a "..._<hash>_flow_enum" name the old reverse-parsing regex could
+			// not recognize — causing an endless backfill. The recompute path
+			// recognizes it.
+			name:    "underscore field on long table (meta/op)",
+			field:   "_meta/op",
+			path:    []string{"somelongtenant", "somelongtenant_baaaaaaaaaaaaaaaaaaaaaaaaaaaadocuments"},
+			udtName: "somelongtenant_baaaaaaaaaaaaaaaaaaaaaaaaaa___33e4d166_flow_enum",
+			wantOk:  true,
 		},
 	}
 
@@ -78,15 +87,45 @@ func TestCompatibleFallback(t *testing.T) {
 			if existingType == "" {
 				existingType = "USER-DEFINED"
 			}
-			existing := boilerplate.ExistingField{
-				Type: existingType,
-				Meta: pgFieldMeta{UDTName: tt.udtName},
+			existing := boilerplate.ExistingField{Type: existingType}
+			if !tt.noMeta {
+				existing.Meta = pgFieldMeta{UDTName: tt.udtName, Path: tt.path}
 			}
 			require.Equal(t, tt.wantOk, e.Compatible(existing))
 		})
 	}
 }
 
+// TestCompatibleRoundTrip asserts that every name the generator produces is
+// recognized as compatible by Compatible, across the truncation/hash regimes.
+func TestCompatibleRoundTrip(t *testing.T) {
+	dialect := createPgDialect(featureFlagDefaults)
+
+	cases := []struct {
+		name  string
+		path  []string
+		field string
+	}{
+		{"short", []string{"public", "orders"}, "status"},
+		{"long field hashes", []string{"public", "orders"}, strings.Repeat("x", 60)},
+		{"long table hashes", []string{"public", strings.Repeat("a", 60)}, "status"},
+		{"underscore field long table", []string{"somelongtenant", "somelongtenant_baaaaaaaaaaaaaaaaaaaaaaaaaaaadocuments"}, "_meta/op"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, base, _, err := enumTypeNameParts(dialect, tc.path, tc.field)
+			require.NoError(t, err)
+
+			e := &PgEnum{Field: tc.field}
+			existing := boilerplate.ExistingField{
+				Type: "USER-DEFINED",
+				Meta: pgFieldMeta{UDTName: base, Path: tc.path},
+			}
+			require.True(t, e.Compatible(existing), "generated base %q must be compatible", base)
+		})
+	}
+}
 
 func TestEnumTypeNamePartsNormal(t *testing.T) {
 	dialect := createPgDialect(featureFlagDefaults)


### PR DESCRIPTION
**Regression?**

Yes #4537 introduced this bug

**Description:**

- A bug in the regex matching logic was causing enum fields on very long table names to not match. I changed the logic so that instead of regex matching we re-construct the enum name and do an exact comparison (this was not originally possible easily in my initial PR, but after introducing `pgFieldMeta` it was trivial, but I overlooked it)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

