### PR TITLE
automatic feature flags setting for materializations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 verify-affected-*
 venv
 */**/.claude/
+.claude/*.lock
 tests/benchmark/materialize/runs/*
 !tests/benchmark/materialize/runs/baselines
 tests/benchmark/materialize/runs/baselines/*/run.*

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -32,6 +32,17 @@ var featureFlagDefaults = map[string]bool{
 }
 ```
 
+Materialization connectors instead hold `common.FlagDefault` values, so that a flag's
+default can be gated on the task's creation date — see
+[Changing Default Behaviors (Materializations)](#changing-default-behaviors-materializations):
+
+```go
+var featureFlagDefaults = map[string]common.FlagDefault{
+  // A short (one or two line) description of what this flag does when set/unset.
+  "do_something": common.FlagDisabled,
+}
+```
+
 Then at the appropriate point(s) in the code, introduce the new logic conditional on the
 flag setting:
 
@@ -51,9 +62,79 @@ Typically this should be default-off, but if it makes things clearer there shoul
 be anything wrong with adding a default-on flag instead and having `no_foobar` be the
 setting which opts into the new behavior.
 
-## Changing Default Behaviors
+## Changing Default Behaviors (Materializations)
 
-The process for changing a default connector behavior is as follows:
+Materialization connectors can gate a flag's default on when a task was created,
+which changes the default for new tasks only, with no config edits and no
+coordinated merge. This is the preferred approach; the manual bulk-editing process in
+the next section remains for captures, which don't yet resolve flags this way.
+
+The default-values map holds `common.FlagDefault` values rather than plain booleans:
+
+```go
+var featureFlagDefaults = map[string]common.FlagDefault{
+  // A short (one or two line) description of what this flag does when set/unset.
+  "do_something": common.FlagDisabled,
+  // Applies only to tasks created on or after the date this flag was released,
+  // so that tasks already running at that point keep the old behavior.
+  "new_thing": common.FlagEnabledForTasksCreatedAfter("2026-06-10"),
+}
+```
+
+Set the cutoff to the date the flag ships. Every task in existence at that point is
+older than the cutoff and keeps the old behavior for the rest of its life, while every
+task created afterwards gets the new behavior from its first publication. A user can
+still opt either way per-task with `new_thing` / `no_new_thing` in
+`/advanced/feature_flags`, which always wins over the cutoff.
+
+The cutoff is a date, not a timestamp, because a date is all a spec records about when
+a task was created — the two dates are compared directly. A flag therefore takes effect
+for the whole of the day it ships on, so pick the date accordingly if that matters.
+
+### How it resolves
+
+Built capture and materialization specs carry a `created_at` date (UTC, `YYYY-MM-DD`),
+derived by the control plane from the task's control-plane ID. The materialization
+boilerplate resolves flags from that date in every RPC:
+
+| RPC | Creation date taken from |
+| --- | --- |
+| Validate | `req.LastMaterialization` — absent for a task that has never been published |
+| Apply | `req.Materialization` |
+| Open | `req.Materialization` |
+
+Resolution is therefore a pure function of the spec: it is stable for the life of the
+task, identical across the three RPCs, and needs nothing persisted in connector state.
+
+The date is empty only during a task's very first build, before its creation is
+committed and an ID assigned. That means "brand new", and resolves as though the task
+were created now — enabling every cutoff-gated flag, which is correct because a cutoff
+is never in the future. Since the date is derived from the task's ID rather than
+recorded at build time, it is present on every spec built since the field was
+introduced, including those of long-running tasks.
+
+### Recording the resolved value in the config
+
+So that a task's flags can be read off its config rather than inferred from its
+creation date, Apply emits a [`configUpdate`](observable_logs.md) event restating the
+endpoint config with each cutoff-gated flag written out explicitly — `new_thing` or
+`no_new_thing` in `/advanced/feature_flags`. It is recomputed on every Apply and stops
+being emitted once the config contains the flag.
+
+This is a *record*, not a decision. The value written is the one the connector already
+resolved from the creation date, so the config can never contradict the connector's
+behavior, and a task behaves identically whether or not the update has landed yet —
+which is what makes it safe for the write to be asynchronous and best-effort. Failures
+are logged and ignored.
+
+Only cutoff-gated flags are recorded. Flags with a fixed default are deliberately left
+out: writing those into every config would freeze them per-task and defeat any later
+fleet-wide change of the default.
+
+## Changing Default Behaviors Manually
+
+For captures, and for materialization flags that can't be expressed as a creation-date
+cutoff, the process for changing a default connector behavior is as follows:
 
  - Add the feature flag `new_thing` with a default value corresponding to the old behavior (typically false).
  - Edit the endpoint configs of all tasks in production to add the `no_new_thing` flag setting.

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -116,10 +116,26 @@ introduced, including those of long-running tasks.
 ### Recording the resolved value in the config
 
 So that a task's flags can be read off its config rather than inferred from its
-creation date, Apply emits a [`configUpdate`](observable_logs.md) event restating the
+creation date, Open emits a [`configUpdate`](observable_logs.md) event restating the
 endpoint config with each cutoff-gated flag written out explicitly — `new_thing` or
-`no_new_thing` in `/advanced/feature_flags`. It is recomputed on every Apply and stops
+`no_new_thing` in `/advanced/feature_flags`. It is recomputed on every Open and stops
 being emitted once the config contains the flag.
+
+The restatement never decrypts and re-encrypts the config. Open carries the task's
+sealed config alongside its decrypted one, and the flag is written into the plaintext
+`sops.overlay` of that document: the runtime merges the overlay over the decrypted
+config, having first checked that every location it touches is annotated
+`nonsensitive: true` in the connector's config schema — which is why
+`/advanced/feature_flags` must carry `jsonschema_extras:"nonsensitive=true"`. The
+encrypted values are copied across untouched, so a config stays under the key it was
+encrypted with, including a customer-managed one that Estuary cannot itself encrypt to.
+A config that isn't encrypted has no ciphertext to preserve and is restated directly.
+
+Property order does matter to sops, which computes its MAC over a document's values in
+the order it encounters them — but it is not something the connector has to preserve.
+The control plane parses the emitted config and re-serializes it when applying the
+update, which sorts its properties, so the restatement is sorted here as well and a
+config that verifies once stored verifies as emitted.
 
 This is a *record*, not a decision. The value written is the one the connector already
 resolved from the creation date, so the config can never contradict the connector's

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -81,11 +81,11 @@ var featureFlagDefaults = map[string]common.FlagDefault{
 }
 ```
 
-Set the cutoff to the date the flag ships. Every task in existence at that point is
-older than the cutoff and keeps the old behavior for the rest of its life, while every
-task created afterwards gets the new behavior from its first publication. A user can
-still opt either way per-task with `new_thing` / `no_new_thing` in
-`/advanced/feature_flags`, which always wins over the cutoff.
+Set the cutoff to the day after the pull request merges. Every task in existence at
+that point is older than the cutoff and keeps the old behavior for the rest of its
+life, while every task created afterwards gets the new behavior from its first
+publication. A user can still opt either way per-task with `new_thing` /
+`no_new_thing` in `/advanced/feature_flags`, which always wins over the cutoff.
 
 The cutoff is a date, not a timestamp, because a date is all a spec records about when
 a task was created — the two dates are compared directly. A flag therefore takes effect
@@ -106,12 +106,11 @@ boilerplate resolves flags from that date in every RPC:
 Resolution is therefore a pure function of the spec: it is stable for the life of the
 task, identical across the three RPCs, and needs nothing persisted in connector state.
 
-The date is empty only during a task's very first build, before its creation is
-committed and an ID assigned. That means "brand new", and resolves as though the task
-were created now — enabling every cutoff-gated flag, which is correct because a cutoff
-is never in the future. Since the date is derived from the task's ID rather than
-recorded at build time, it is present on every spec built since the field was
-introduced, including those of long-running tasks.
+The date is absent in exactly one place: the Validate of a task that has not been
+published yet, which has no previous spec to carry one. Publishing the task creates
+it, so its very first Apply and Open — and every RPC after that — do have the date.
+An absent date means "brand new" and resolves against today's, which is the date the
+task is about to be created with.
 
 ### Recording the resolved value in the config
 

--- a/docs/observable_logs.md
+++ b/docs/observable_logs.md
@@ -1,0 +1,42 @@
+# Operator-observable logs
+
+By default, a connector's logs flow only to the user's `ops/<tenant>/logs`
+collection. They are _not_ shipped into Estuary's own observability pipeline
+(the data-plane reactor's log stream, which is forwarded to Loki/Grafana),
+because the full volume of connector logs is far too high to send there.
+
+A connector can opt a _specific_ log line into that pipeline by attaching the
+structured field `observable` set to `true`. The runtime forwards such lines into
+the reactor's log stream, tagged with the task name, so operators can alert and
+dashboard on them in Grafana.
+
+This is for **rare, high-signal lines an operator would want to monitor** — for
+example, a connector detecting that it has been rate-limited or blocked by an
+upstream API. It is not for bulk or routine connector output. Forwarding is gated
+by the reactor's configured log level, so a marked line below that level is still
+dropped.
+
+The line is still published to the user's `ops/<tenant>/logs` collection as usual;
+`observable` only adds the operator-facing copy.
+
+## Emitting an observable line
+
+The marker is just a field named `observable` in the log line's structured
+`fields`, with the JSON value `true`.
+
+### Python (estuary-cdk)
+
+Pass `observable=True` via the logger's `extra` mapping, which becomes a
+structured field:
+
+```python
+log.warning("upstream API rate-limited us", extra={"observable": True, "endpoint": "/v2/sync"})
+```
+
+### Go / raw JSON
+
+Connectors that emit `LOG_FORMAT=json` log lines include `observable` in `fields`:
+
+```json
+{"level":"warn","message":"upstream API rate-limited us","fields":{"observable":true,"endpoint":"/v2/sync"}}
+```

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.10
+	github.com/estuary/flow v0.6.12
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc
@@ -81,7 +81,7 @@ require (
 	github.com/tidwall/gjson v1.17.3
 	github.com/tidwall/sjson v1.2.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
+	go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c
 	go.mongodb.org/mongo-driver v1.17.7
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMD
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/estuary/flow v0.6.10 h1:Z+zM5Qct0aR5EQAhfHmi4bR3jZPDpNwK0R5KPlZz/Wc=
 github.com/estuary/flow v0.6.10/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.12 h1:6I3Yvyoju0ZIy4kfQB+NJw+xY5CG4MMSKgU8WElOsLc=
+github.com/estuary/flow v0.6.12/go.mod h1:5Enfc6/vlvHJY1D2wgfBrzKjiVGLcvAqbAUzqTwgnmo=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
@@ -1081,6 +1083,8 @@ go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
 go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee h1:yceN2m1184/i4YSN4tlfMSdpnV+xnePgnUf4KFa00oE=
 go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c h1:6oRaNmlNhFD4IaAkXSfOgXUxayPskHBTndhuNG7VSyw=
+go.gazette.dev/core v0.103.1-0.20260715211535-42c2cc160b2c/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
 go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=

--- a/go/common/config_update.go
+++ b/go/common/config_update.go
@@ -2,92 +2,60 @@ package common
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
-// defaultEncryptionURL is Estuary's config encryption service, which encrypts
-// any config properties marked as secret in the schema using sops.
-const defaultEncryptionURL = "https://config-encryption.estuary.dev/v1/encrypt-config"
-
-// EmitConfigUpdate encrypts a full restatement of the endpoint config against
-// its JSON schema and emits a "configUpdate" connector event. The control
-// plane reacts to the event by republishing the task's spec with its endpoint
-// config replaced wholesale by the emitted config, so config must be a
-// complete config document and not a partial patch.
-func EmitConfigUpdate(ctx context.Context, msg string, config, schema json.RawMessage) error {
-	encrypted, err := encryptConfig(ctx, config, schema)
-	if err != nil {
-		return fmt.Errorf("encrypting config: %w", err)
-	}
-
+// EmitConfigUpdate emits a "configUpdate" connector event carrying a full
+// restatement of the endpoint config. The control plane reacts to the event by
+// republishing the task's spec with its endpoint config replaced wholesale by
+// the emitted config, so config must be a complete config document and not a
+// partial patch.
+func EmitConfigUpdate(msg string, config json.RawMessage) {
 	log.WithFields(log.Fields{
 		"eventType": "configUpdate",
-		"config":    encrypted,
+		"config":    config,
 	}).Info(msg)
-
-	return nil
 }
 
-// encryptConfig submits the config and its schema to the config encryption
-// service and returns the encrypted config document.
-func encryptConfig(ctx context.Context, config, schema json.RawMessage) (json.RawMessage, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	// Flow always sorts object properties lexicographically, and sops relies
-	// on encountered property order when computing the HMAC portion of its
-	// stanza. Round-tripping through a map sorts keys recursively, since
-	// encoding/json marshals maps in sorted key order. UseNumber preserves
-	// numbers as json.Number instead of converting to float64.
-	var asMap map[string]any
-	var dec = json.NewDecoder(bytes.NewReader(config))
-	dec.UseNumber()
-	if err := dec.Decode(&asMap); err != nil {
-		return nil, fmt.Errorf("decoding config: %w", err)
+// SetSealedConfigProperty returns the task's sealed endpoint config with value
+// set at the given object path, as a complete config document ready to be
+// emitted with EmitConfigUpdate.
+//
+// A sops-encrypted config is never decrypted and re-encrypted to carry the new
+// value. The value is written into the plaintext `sops.overlay` of the config's
+// `sops` stanza instead, which the runtime merges over the decrypted config
+// (RFC 7396 merge patch) once it has checked that every location the overlay
+// touches is annotated `nonsensitive` in the connector's config schema. The
+// ciphertext is left alone, so the config keeps the key it was encrypted with
+// rather than being re-keyed to whatever an encryption service would pick, and
+// no secret is ever sent anywhere to be re-sealed.
+//
+// Encrypted values are copied across untouched, but the document is otherwise
+// re-serialized, which sorts its properties. That is safe despite sops computing
+// its MAC over values in the order it encounters them: the control plane parses
+// the emitted config into a `serde_json::Value` and re-serializes it when
+// applying the update, which sorts it the same way, so a config that verifies
+// after being stored verifies here too.
+func SetSealedConfigProperty(sealed json.RawMessage, path []string, value any) (json.RawMessage, error) {
+	var doc struct {
+		Sops json.RawMessage `json:"sops"`
+	}
+	if err := json.Unmarshal(sealed, &doc); err != nil {
+		return nil, fmt.Errorf("config is not a JSON object: %w", err)
 	}
 
-	body, err := json.Marshal(map[string]any{
-		"config": asMap,
-		"schema": schema,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("encoding request body: %w", err)
+	// A `sops` stanza is what marks the config as encrypted, so its absence means
+	// there is no ciphertext to protect and the value belongs in the document
+	// itself. Adding a stanza to such a config would send the runtime looking for
+	// ciphertext that isn't there.
+	if len(doc.Sops) != 0 && !bytes.Equal(doc.Sops, []byte("null")) {
+		path = append([]string{"sops", "overlay"}, path...)
 	}
 
-	var url = defaultEncryptionURL
-	if fromEnv := os.Getenv("ENCRYPTION_URL"); fromEnv != "" {
-		url = fromEnv
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("requesting config encryption: %w", err)
-	}
-	defer res.Body.Close()
-
-	resBody, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading config encryption response: %w", err)
-	}
-	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return nil, fmt.Errorf("config encryption returned status %d: %s", res.StatusCode, string(resBody))
-	}
-
-	return json.RawMessage(resBody), nil
+	return SetJSONProperty(sealed, path, value)
 }
 
 // SetJSONProperty returns doc with value set at the given object path,

--- a/go/common/config_update.go
+++ b/go/common/config_update.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// defaultEncryptionURL is Estuary's config encryption service, which encrypts
+// any config properties marked as secret in the schema using sops.
+const defaultEncryptionURL = "https://config-encryption.estuary.dev/v1/encrypt-config"
+
+// EmitConfigUpdate encrypts a full restatement of the endpoint config against
+// its JSON schema and emits a "configUpdate" connector event. The control
+// plane reacts to the event by republishing the task's spec with its endpoint
+// config replaced wholesale by the emitted config, so config must be a
+// complete config document and not a partial patch.
+func EmitConfigUpdate(ctx context.Context, msg string, config, schema json.RawMessage) error {
+	encrypted, err := encryptConfig(ctx, config, schema)
+	if err != nil {
+		return fmt.Errorf("encrypting config: %w", err)
+	}
+
+	log.WithFields(log.Fields{
+		"eventType": "configUpdate",
+		"config":    encrypted,
+	}).Info(msg)
+
+	return nil
+}
+
+// encryptConfig submits the config and its schema to the config encryption
+// service and returns the encrypted config document.
+func encryptConfig(ctx context.Context, config, schema json.RawMessage) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Flow always sorts object properties lexicographically, and sops relies
+	// on encountered property order when computing the HMAC portion of its
+	// stanza. Round-tripping through a map sorts keys recursively, since
+	// encoding/json marshals maps in sorted key order. UseNumber preserves
+	// numbers as json.Number instead of converting to float64.
+	var asMap map[string]any
+	var dec = json.NewDecoder(bytes.NewReader(config))
+	dec.UseNumber()
+	if err := dec.Decode(&asMap); err != nil {
+		return nil, fmt.Errorf("decoding config: %w", err)
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"config": asMap,
+		"schema": schema,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding request body: %w", err)
+	}
+
+	var url = defaultEncryptionURL
+	if fromEnv := os.Getenv("ENCRYPTION_URL"); fromEnv != "" {
+		url = fromEnv
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting config encryption: %w", err)
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading config encryption response: %w", err)
+	}
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return nil, fmt.Errorf("config encryption returned status %d: %s", res.StatusCode, string(resBody))
+	}
+
+	return json.RawMessage(resBody), nil
+}
+
+// SetJSONProperty returns doc with value set at the given object path,
+// creating intermediate objects as needed. Path elements other than the last
+// must be absent, null, or objects.
+func SetJSONProperty(doc json.RawMessage, path []string, value any) (json.RawMessage, error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("path must not be empty")
+	}
+
+	var root map[string]any
+	var dec = json.NewDecoder(bytes.NewReader(doc))
+	dec.UseNumber()
+	if err := dec.Decode(&root); err != nil {
+		return nil, fmt.Errorf("decoding document: %w", err)
+	}
+
+	var current = root
+	for _, p := range path[:len(path)-1] {
+		next, ok := current[p].(map[string]any)
+		if !ok {
+			if existing, present := current[p]; present && existing != nil {
+				return nil, fmt.Errorf("property %q is not an object", p)
+			}
+			next = make(map[string]any)
+			current[p] = next
+		}
+		current = next
+	}
+	current[path[len(path)-1]] = value
+
+	return json.Marshal(root)
+}

--- a/go/common/config_update_test.go
+++ b/go/common/config_update_test.go
@@ -1,0 +1,140 @@
+package common
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetJSONProperty(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		doc     string
+		path    []string
+		value   any
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "absent intermediate object",
+			doc:   `{"address":"db:5432"}`,
+			path:  []string{"advanced", "created_at"},
+			value: "2026-06-15T00:00:00Z",
+			want:  `{"address":"db:5432","advanced":{"created_at":"2026-06-15T00:00:00Z"}}`,
+		},
+		{
+			name:  "null intermediate object",
+			doc:   `{"advanced":null}`,
+			path:  []string{"advanced", "created_at"},
+			value: "2026-06-15T00:00:00Z",
+			want:  `{"advanced":{"created_at":"2026-06-15T00:00:00Z"}}`,
+		},
+		{
+			name:  "existing intermediate object is preserved",
+			doc:   `{"advanced":{"feature_flags":"foo"},"port":1234567890123456789}`,
+			path:  []string{"advanced", "created_at"},
+			value: "2026-06-15T00:00:00Z",
+			want:  `{"advanced":{"created_at":"2026-06-15T00:00:00Z","feature_flags":"foo"},"port":1234567890123456789}`,
+		},
+		{
+			name:  "overwrites existing value",
+			doc:   `{"advanced":{"created_at":"old"}}`,
+			path:  []string{"advanced", "created_at"},
+			value: "new",
+			want:  `{"advanced":{"created_at":"new"}}`,
+		},
+		{
+			name:  "top-level property",
+			doc:   `{}`,
+			path:  []string{"created_at"},
+			value: "2026-06-15T00:00:00Z",
+			want:  `{"created_at":"2026-06-15T00:00:00Z"}`,
+		},
+		{
+			name:    "non-object intermediate errors",
+			doc:     `{"advanced":"nope"}`,
+			path:    []string{"advanced", "created_at"},
+			value:   "x",
+			wantErr: `property "advanced" is not an object`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SetJSONProperty(json.RawMessage(tt.doc), tt.path, tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.JSONEq(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestEmitConfigUpdate(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		requestBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Write([]byte(`{"address":"db:5432","password_sops":"ENC[AES256_GCM,...]"}`))
+	}))
+	defer server.Close()
+	t.Setenv("ENCRYPTION_URL", server.URL)
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	// Out-of-order keys and a large integer that doesn't round-trip through
+	// float64, to verify key sorting and number fidelity.
+	config := json.RawMessage(`{"port":1234567890123456789,"advanced":{"feature_flags":"foo"},"address":"db:5432"}`)
+	schema := json.RawMessage(`{"type":"object"}`)
+
+	require.NoError(t, EmitConfigUpdate(t.Context(), "updating config", config, schema))
+
+	require.JSONEq(t, `{
+		"config": {"address":"db:5432","advanced":{"feature_flags":"foo"},"port":1234567890123456789},
+		"schema": {"type":"object"}
+	}`, string(requestBody))
+
+	// Keys of the encrypted config must be in sorted order for sops HMAC
+	// stability, which JSONEq alone doesn't verify.
+	var body struct {
+		Config json.RawMessage `json:"config"`
+	}
+	require.NoError(t, json.Unmarshal(requestBody, &body))
+	require.Equal(t,
+		`{"address":"db:5432","advanced":{"feature_flags":"foo"},"port":1234567890123456789}`,
+		string(body.Config),
+	)
+
+	require.Len(t, hook.Entries, 1)
+	entry := hook.LastEntry()
+	require.Equal(t, log.InfoLevel, entry.Level)
+	require.Equal(t, "updating config", entry.Message)
+	require.Equal(t, "configUpdate", entry.Data["eventType"])
+	require.JSONEq(t,
+		`{"address":"db:5432","password_sops":"ENC[AES256_GCM,...]"}`,
+		string(entry.Data["config"].(json.RawMessage)),
+	)
+}
+
+func TestEmitConfigUpdateEncryptionFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad schema", http.StatusBadRequest)
+	}))
+	defer server.Close()
+	t.Setenv("ENCRYPTION_URL", server.URL)
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	err := EmitConfigUpdate(t.Context(), "updating config", json.RawMessage(`{}`), json.RawMessage(`{}`))
+	require.ErrorContains(t, err, "status 400")
+	require.Empty(t, hook.Entries)
+}

--- a/go/common/config_update_test.go
+++ b/go/common/config_update_test.go
@@ -2,9 +2,6 @@ package common
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -77,64 +74,79 @@ func TestSetJSONProperty(t *testing.T) {
 }
 
 func TestEmitConfigUpdate(t *testing.T) {
-	var requestBody []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		requestBody, err = io.ReadAll(r.Body)
-		require.NoError(t, err)
-		w.Write([]byte(`{"address":"db:5432","password_sops":"ENC[AES256_GCM,...]"}`))
-	}))
-	defer server.Close()
-	t.Setenv("ENCRYPTION_URL", server.URL)
-
 	hook := logtest.NewGlobal()
 	defer hook.Reset()
 
-	// Out-of-order keys and a large integer that doesn't round-trip through
-	// float64, to verify key sorting and number fidelity.
-	config := json.RawMessage(`{"port":1234567890123456789,"advanced":{"feature_flags":"foo"},"address":"db:5432"}`)
-	schema := json.RawMessage(`{"type":"object"}`)
-
-	require.NoError(t, EmitConfigUpdate(t.Context(), "updating config", config, schema))
-
-	require.JSONEq(t, `{
-		"config": {"address":"db:5432","advanced":{"feature_flags":"foo"},"port":1234567890123456789},
-		"schema": {"type":"object"}
-	}`, string(requestBody))
-
-	// Keys of the encrypted config must be in sorted order for sops HMAC
-	// stability, which JSONEq alone doesn't verify.
-	var body struct {
-		Config json.RawMessage `json:"config"`
-	}
-	require.NoError(t, json.Unmarshal(requestBody, &body))
-	require.Equal(t,
-		`{"address":"db:5432","advanced":{"feature_flags":"foo"},"port":1234567890123456789}`,
-		string(body.Config),
-	)
+	config := json.RawMessage(`{"address":"db:5432","sops":{"mac":"ENC[AES256_GCM,data:yy]"}}`)
+	EmitConfigUpdate("updating config", config)
 
 	require.Len(t, hook.Entries, 1)
 	entry := hook.LastEntry()
 	require.Equal(t, log.InfoLevel, entry.Level)
 	require.Equal(t, "updating config", entry.Message)
 	require.Equal(t, "configUpdate", entry.Data["eventType"])
-	require.JSONEq(t,
-		`{"address":"db:5432","password_sops":"ENC[AES256_GCM,...]"}`,
-		string(entry.Data["config"].(json.RawMessage)),
-	)
+	require.Equal(t, config, entry.Data["config"])
 }
 
-func TestEmitConfigUpdateEncryptionFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "bad schema", http.StatusBadRequest)
-	}))
-	defer server.Close()
-	t.Setenv("ENCRYPTION_URL", server.URL)
+func TestSetSealedConfigProperty(t *testing.T) {
+	const sealed = `{"port":5432,"address":"db:5432","credentials":{"user":"flow","password_sops":"ENC[AES256_GCM,data:xx]"},"sops":{"encrypted_suffix":"_sops","mac":"ENC[AES256_GCM,data:yy]"}}`
 
-	hook := logtest.NewGlobal()
-	defer hook.Reset()
-
-	err := EmitConfigUpdate(t.Context(), "updating config", json.RawMessage(`{}`), json.RawMessage(`{}`))
-	require.ErrorContains(t, err, "status 400")
-	require.Empty(t, hook.Entries)
+	for _, tt := range []struct {
+		name    string
+		doc     string
+		path    []string
+		value   any
+		want    string
+		wantErr string
+	}{
+		{
+			// The encrypted values are carried across as they were: the overlay is
+			// what the runtime merges over them once they are decrypted.
+			name:  "sops document carries the value in an overlay",
+			doc:   sealed,
+			path:  []string{"advanced", "feature_flags"},
+			value: "gated_flag",
+			want:  `{"address":"db:5432","credentials":{"password_sops":"ENC[AES256_GCM,data:xx]","user":"flow"},"port":5432,"sops":{"encrypted_suffix":"_sops","mac":"ENC[AES256_GCM,data:yy]","overlay":{"advanced":{"feature_flags":"gated_flag"}}}}`,
+		},
+		{
+			name:  "existing overlay properties are kept",
+			doc:   `{"port":5432,"sops":{"overlay":{"other":true},"mac":"ENC[AES256_GCM,data:yy]"}}`,
+			path:  []string{"advanced", "feature_flags"},
+			value: "gated_flag",
+			want:  `{"port":5432,"sops":{"mac":"ENC[AES256_GCM,data:yy]","overlay":{"advanced":{"feature_flags":"gated_flag"},"other":true}}}`,
+		},
+		{
+			name:  "unencrypted config is set directly, without a sops stanza",
+			doc:   `{"port":5432,"address":"db:5432"}`,
+			path:  []string{"advanced", "feature_flags"},
+			value: "gated_flag",
+			want:  `{"address":"db:5432","advanced":{"feature_flags":"gated_flag"},"port":5432}`,
+		},
+		{
+			name: "null sops stanza is not a sops document",
+			// The runtime reads a null `sops` as an unencrypted config, so a
+			// restatement must not hand it an overlay to apply.
+			doc:   `{"port":5432,"sops":null}`,
+			path:  []string{"feature_flags"},
+			value: "gated_flag",
+			want:  `{"feature_flags":"gated_flag","port":5432,"sops":null}`,
+		},
+		{
+			name:    "non-object config",
+			doc:     `["not","a","config"]`,
+			path:    []string{"feature_flags"},
+			value:   "gated_flag",
+			wantErr: "config is not a JSON object",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SetSealedConfigProperty(json.RawMessage(tt.doc), tt.path, tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
 }

--- a/go/common/feature_flags.go
+++ b/go/common/feature_flags.go
@@ -16,8 +16,10 @@ const CreatedAtLayout = "2006-01-02"
 // about fails the RPC rather than silently resolving flags from a value nobody
 // understood.
 //
-// The zero value means the task is brand new: the control plane stamps no date
-// during a task's first build, because its creation is not yet committed.
+// The zero value means the task is brand new. That happens in one place: the
+// Validate of a task which has not been published yet, so there is no previous
+// spec to carry a date. Publishing creates the task, so its first Apply and Open
+// — and every RPC after — carry one.
 type CreatedAt struct {
 	date string
 }
@@ -63,9 +65,9 @@ var FlagDisabled = FlagDefault{value: false}
 // FlagEnabledForTasksCreatedAfter is a flag that defaults to true for tasks
 // created on or after the given cutoff date, and false for tasks created before
 // it. Use it to introduce a behavior change that must not disturb existing tasks:
-// set the cutoff to the date the flag is released, so every task in existence at
-// that point keeps the old behavior for the rest of its life while new tasks get
-// the new one.
+// set the cutoff to the day after the pull request merges, so every task in
+// existence at that point keeps the old behavior for the rest of its life while
+// new tasks get the new one.
 //
 // The cutoff may be in the future, but keep it close to the release: tasks
 // created between the release and the cutoff get the old behavior at first and

--- a/go/common/feature_flags.go
+++ b/go/common/feature_flags.go
@@ -67,9 +67,11 @@ var FlagDisabled = FlagDefault{value: false}
 // that point keeps the old behavior for the rest of its life while new tasks get
 // the new one.
 //
-// The cutoff may be in the future, which is usually the easier thing to do: pick a
-// date comfortably after the change is expected to merge, and every task created
-// before it keeps the old behavior even though the code is already deployed.
+// The cutoff may be in the future, but keep it close to the release: tasks
+// created between the release and the cutoff get the old behavior at first and
+// the new behavior once the cutoff passes, and flipping the behavior of tasks
+// that are already running can be very costly. Time the release and the cutoff
+// as close together as possible.
 //
 // The cutoff is a date in CreatedAtLayout form ("2026-06-10"), matching the
 // creation date stamped onto the task's built spec by the control plane, which is
@@ -77,13 +79,6 @@ var FlagDisabled = FlagDefault{value: false}
 // not be honored. The two dates are compared directly, and resolution is a pure
 // function of the spec, yielding the same answer in every RPC, forever, with
 // nothing to persist.
-//
-// The date is derived from the task's control-plane ID rather than recorded at
-// build time, so every spec built since the field was introduced carries it,
-// including those of long-running tasks. A spec built before the field existed
-// has no date at all and resolves as brand new (see Resolve) — but a task can
-// only reach a connector version that knows about this flag by being
-// republished, which rebuilds its spec and stamps the date.
 //
 // Panics if date is not a valid date in CreatedAtLayout form, which is a
 // connector programming error.
@@ -99,9 +94,7 @@ func FlagEnabledForTasksCreatedAfter(date string) FlagDefault {
 //
 // A brand-new task has no date yet, because its creation is only being committed
 // now — so it resolves against today's date, which is the date it is about to be
-// stamped with. That is what makes a cutoff in the future safe to set: such a task
-// resolves the same way before and after its date is stamped, rather than flipping
-// once the control plane fills the field in.
+// stamped with.
 func (d FlagDefault) Resolve(createdAt CreatedAt) bool {
 	if d.enabledFrom == "" {
 		return d.value

--- a/go/common/feature_flags.go
+++ b/go/common/feature_flags.go
@@ -1,6 +1,197 @@
 package common
 
-import "strings"
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CreatedAtLayout is the format of the task creation date carried by built
+// capture and materialization specs: a UTC date in RFC 3339 "full-date" form.
+const CreatedAtLayout = "2006-01-02"
+
+// CreatedAt is a task's validated creation date. Parse one with ParseCreatedAt
+// before resolving feature flags, so that a date the connector cannot reason
+// about fails the RPC rather than silently resolving flags from a value nobody
+// understood.
+//
+// The zero value means the task is brand new: the control plane stamps no date
+// during a task's first build, because its creation is not yet committed.
+type CreatedAt struct {
+	date string
+}
+
+// ParseCreatedAt validates the creation date of a task spec, which is a UTC date
+// in CreatedAtLayout form, or empty for a brand-new task whose creation is not
+// yet committed. Any other value is an error: it is a date the connector cannot
+// place relative to a cutoff, and guessing either way would silently give the
+// task the wrong behavior.
+func ParseCreatedAt(createdAt string) (CreatedAt, error) {
+	if createdAt == "" {
+		return CreatedAt{}, nil
+	} else if _, err := time.Parse(CreatedAtLayout, createdAt); err != nil {
+		return CreatedAt{}, fmt.Errorf("task creation date %q is not a %s date: %w", createdAt, CreatedAtLayout, err)
+	}
+	return CreatedAt{date: createdAt}, nil
+}
+
+// IsBrandNew reports whether the task's creation is not yet committed, and so
+// carries no date.
+func (c CreatedAt) IsBrandNew() bool { return c.date == "" }
+
+func (c CreatedAt) String() string { return c.date }
+
+// FlagDefault describes the default value of a feature flag: either a fixed
+// boolean, or one gated on when a task was created. Users can always override
+// the default by listing the flag (or its 'no_' negation) in their feature flags
+// string.
+type FlagDefault struct {
+	value bool
+	// enabledFrom, when non-empty, is the cutoff date in CreatedAtLayout form:
+	// the flag defaults to true for tasks created on or after it, and false for
+	// tasks created before it.
+	enabledFrom string
+}
+
+// FlagEnabled is a flag that defaults to true for all tasks.
+var FlagEnabled = FlagDefault{value: true}
+
+// FlagDisabled is a flag that defaults to false for all tasks.
+var FlagDisabled = FlagDefault{value: false}
+
+// FlagEnabledForTasksCreatedAfter is a flag that defaults to true for tasks
+// created on or after the given cutoff date, and false for tasks created before
+// it. Use it to introduce a behavior change that must not disturb existing tasks:
+// set the cutoff to the date the flag is released, so every task in existence at
+// that point keeps the old behavior for the rest of its life while new tasks get
+// the new one.
+//
+// The cutoff may be in the future, which is usually the easier thing to do: pick a
+// date comfortably after the change is expected to merge, and every task created
+// before it keeps the old behavior even though the code is already deployed.
+//
+// The cutoff is a date in CreatedAtLayout form ("2026-06-10"), matching the
+// creation date stamped onto the task's built spec by the control plane, which is
+// all a spec records: it carries no time of day, so a finer-grained cutoff could
+// not be honored. The two dates are compared directly, and resolution is a pure
+// function of the spec, yielding the same answer in every RPC, forever, with
+// nothing to persist.
+//
+// The date is derived from the task's control-plane ID rather than recorded at
+// build time, so every spec built since the field was introduced carries it,
+// including those of long-running tasks. A spec built before the field existed
+// has no date at all and resolves as brand new (see Resolve) — but a task can
+// only reach a connector version that knows about this flag by being
+// republished, which rebuilds its spec and stamps the date.
+//
+// Panics if date is not a valid date in CreatedAtLayout form, which is a
+// connector programming error.
+func FlagEnabledForTasksCreatedAfter(date string) FlagDefault {
+	if _, err := time.Parse(CreatedAtLayout, date); err != nil {
+		panic(fmt.Sprintf("invalid feature flag cutoff date %q: %s", date, err))
+	}
+	return FlagDefault{enabledFrom: date}
+}
+
+// Resolve returns the effective boolean default of the flag for a task created
+// on createdAt.
+//
+// A brand-new task has no date yet, because its creation is only being committed
+// now — so it resolves against today's date, which is the date it is about to be
+// stamped with. That is what makes a cutoff in the future safe to set: such a task
+// resolves the same way before and after its date is stamped, rather than flipping
+// once the control plane fills the field in.
+func (d FlagDefault) Resolve(createdAt CreatedAt) bool {
+	if d.enabledFrom == "" {
+		return d.value
+	}
+
+	date := createdAt.date
+	if createdAt.IsBrandNew() {
+		date = time.Now().UTC().Format(CreatedAtLayout)
+	}
+	// Both dates are validated, fixed-width and zero-padded, so they order
+	// lexicographically and compare directly.
+	return date >= d.enabledFrom
+}
+
+// ResolveFlagDefaults resolves a map of flag defaults into concrete booleans
+// for a task created on createdAt, suitable for layering user-provided flags on
+// top via ParseFeatureFlags.
+func ResolveFlagDefaults(defaults map[string]FlagDefault, createdAt CreatedAt) map[string]bool {
+	var resolved = make(map[string]bool, len(defaults))
+	for k, v := range defaults {
+		resolved[k] = v.Resolve(createdAt)
+	}
+	return resolved
+}
+
+// ResolveFlags computes the effective feature flags for a task created on
+// createdAt. An explicit entry in the raw config string always wins over the
+// resolved default.
+func ResolveFlags(raw string, defaults map[string]FlagDefault, createdAt CreatedAt) map[string]bool {
+	return ParseFeatureFlags(raw, ResolveFlagDefaults(defaults, createdAt))
+}
+
+// PendingFlagPins returns the cutoff-gated flags that are not yet explicitly
+// present in the raw config string, mapped to the value they resolve to for a
+// task created on createdAt. Writing these into the config leaves every task
+// with an explicit record of the flags its behavior depends on, rather than one
+// implied by its creation date.
+//
+// The pinned value is by construction the same value Resolve produces, so the
+// config can never contradict the connector's behavior and the write is purely a
+// record. That is what makes it safe to apply it lazily, out of band: a task
+// behaves identically before and after its config catches up.
+func PendingFlagPins(raw string, defaults map[string]FlagDefault, createdAt CreatedAt) map[string]bool {
+	mentioned := mentionedFlags(raw)
+	pins := map[string]bool{}
+	for flag, d := range defaults {
+		if d.enabledFrom == "" || mentioned[flag] {
+			continue
+		}
+		pins[flag] = d.Resolve(createdAt)
+	}
+	return pins
+}
+
+// PinnedFlagsString appends an explicit entry to the raw feature flags string
+// for each flag in toPin (which must not already be mentioned in raw),
+// recording its resolved value as a fixed per-task setting: true flags are
+// added by name, false flags with the 'no_' prefix.
+func PinnedFlagsString(raw string, toPin map[string]bool) string {
+	var pins []string
+	for flag, value := range toPin {
+		if value {
+			pins = append(pins, flag)
+		} else {
+			pins = append(pins, "no_"+flag)
+		}
+	}
+	if len(pins) == 0 {
+		return raw
+	}
+	sort.Strings(pins)
+
+	if strings.TrimSpace(raw) == "" {
+		return strings.Join(pins, ",")
+	}
+	return raw + "," + strings.Join(pins, ",")
+}
+
+// mentionedFlags returns the set of flag names mentioned in a raw feature flags
+// string, with any 'no_' prefix stripped.
+func mentionedFlags(raw string) map[string]bool {
+	mentioned := make(map[string]bool)
+	for _, flagName := range strings.Split(raw, ",") {
+		flagName = strings.TrimPrefix(strings.TrimSpace(flagName), "no_")
+		if flagName != "" {
+			mentioned[flagName] = true
+		}
+	}
+	return mentioned
+}
 
 // ParseFeatureFlags parses a comma-separated list of flag names and combines that with a
 // map describing default flag settings in the absence of any flags. A flag name can be

--- a/go/common/feature_flags_test.go
+++ b/go/common/feature_flags_test.go
@@ -1,0 +1,181 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var gatedFlag = FlagEnabledForTasksCreatedAfter("2026-06-10")
+
+// futureFlag's cutoff is far enough out to stay in the future for the life of
+// this test, so it exercises resolution of a not-yet-reached cutoff.
+var futureFlag = FlagEnabledForTasksCreatedAfter("2099-01-01")
+
+// mustCreatedAt is a test helper for dates known to be well-formed.
+func mustCreatedAt(t *testing.T, date string) CreatedAt {
+	t.Helper()
+	createdAt, err := ParseCreatedAt(date)
+	require.NoError(t, err)
+	return createdAt
+}
+
+func TestFlagDefaultResolve(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		def       FlagDefault
+		createdAt string
+		want      bool
+	}{
+		{"fixed true for old task", FlagEnabled, "2020-01-01", true},
+		{"fixed true for brand new task", FlagEnabled, "", true},
+		{"fixed false for old task", FlagDisabled, "2020-01-01", false},
+		{"fixed false for brand new task", FlagDisabled, "", false},
+		{"cutoff: created well before", gatedFlag, "2026-01-01", false},
+		{"cutoff: created day before", gatedFlag, "2026-06-09", false},
+		{"cutoff: created on the cutoff date", gatedFlag, "2026-06-10", true},
+		{"cutoff: created day after", gatedFlag, "2026-06-11", true},
+		{"cutoff: created in a later year", gatedFlag, "2027-01-01", true},
+		// An unstamped creation date means the task's creation isn't committed
+		// yet, i.e. it is brand new, so it resolves as created today.
+		{"cutoff: brand new task", gatedFlag, "", true},
+		// A cutoff that hasn't been reached yet is off for every task, including
+		// a brand-new one — which is what keeps a brand-new task's resolution
+		// stable across the publication that stamps its date.
+		{"future cutoff: brand new task", futureFlag, "", false},
+		{"future cutoff: created today", futureFlag, "2026-08-01", false},
+		{"future cutoff: created on the cutoff date", futureFlag, "2099-01-01", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.def.Resolve(mustCreatedAt(t, tt.createdAt)))
+		})
+	}
+}
+
+func TestParseCreatedAt(t *testing.T) {
+	t.Run("a well-formed date is carried through", func(t *testing.T) {
+		createdAt, err := ParseCreatedAt("2026-06-10")
+		require.NoError(t, err)
+		require.False(t, createdAt.IsBrandNew())
+		require.Equal(t, "2026-06-10", createdAt.String())
+	})
+
+	t.Run("an empty date is a brand new task, not an error", func(t *testing.T) {
+		createdAt, err := ParseCreatedAt("")
+		require.NoError(t, err)
+		require.True(t, createdAt.IsBrandNew())
+		require.Equal(t, CreatedAt{}, createdAt)
+	})
+
+	// A date we cannot place relative to a cutoff is a hard error: resolving
+	// flags around it either way would silently give the task the behavior of
+	// the wrong era.
+	t.Run("a malformed date is an error", func(t *testing.T) {
+		for _, date := range []string{
+			"not-a-date",
+			"2026-6-10",            // not zero-padded
+			"10-06-2026",           // wrong field order
+			"2026-06-10T00:00:00Z", // a timestamp: specs record only a date
+			"2026-13-01",           // no such month
+		} {
+			_, err := ParseCreatedAt(date)
+			require.ErrorContains(t, err, date)
+			require.ErrorContains(t, err, "task creation date")
+		}
+	})
+}
+
+func TestFlagEnabledForTasksCreatedAfterRejectsBadDates(t *testing.T) {
+	for _, date := range []string{
+		"",
+		"2026-6-10",            // not zero-padded
+		"10-06-2026",           // wrong field order
+		"2026-06-10T00:00:00Z", // a timestamp: specs record only a date
+		"tomorrow",
+	} {
+		require.Panics(t, func() { FlagEnabledForTasksCreatedAfter(date) }, date)
+	}
+}
+
+var resolveDefaults = map[string]FlagDefault{
+	"always_on":  FlagEnabled,
+	"always_off": FlagDisabled,
+	"gated":      gatedFlag,
+}
+
+func TestPendingFlagPins(t *testing.T) {
+	defaults := map[string]FlagDefault{
+		"always_on":   FlagEnabled,
+		"always_off":  FlagDisabled,
+		"gated":       gatedFlag,
+		"later_gated": FlagEnabledForTasksCreatedAfter("2026-08-01"),
+	}
+
+	t.Run("only cutoff-gated flags are pinned, at their resolved value", func(t *testing.T) {
+		// Fixed defaults are left out: pinning them would freeze a value we may
+		// want to change fleet-wide later. Each cutoff applies independently.
+		require.Equal(t, map[string]bool{"gated": false, "later_gated": false},
+			PendingFlagPins("", defaults, mustCreatedAt(t, "2026-01-01")))
+		require.Equal(t, map[string]bool{"gated": true, "later_gated": false},
+			PendingFlagPins("", defaults, mustCreatedAt(t, "2026-07-01")))
+		require.Equal(t, map[string]bool{"gated": true, "later_gated": true},
+			PendingFlagPins("", defaults, mustCreatedAt(t, "2026-09-01")))
+	})
+
+	t.Run("brand new task pins the enabled form", func(t *testing.T) {
+		require.Equal(t, map[string]bool{"gated": true, "later_gated": true},
+			PendingFlagPins("", defaults, mustCreatedAt(t, "")))
+	})
+
+	t.Run("flags already mentioned in the config are left alone", func(t *testing.T) {
+		require.Equal(t, map[string]bool{"later_gated": false},
+			PendingFlagPins("gated", defaults, mustCreatedAt(t, "2026-07-01")))
+		require.Equal(t, map[string]bool{"later_gated": false},
+			PendingFlagPins("no_gated", defaults, mustCreatedAt(t, "2026-07-01")))
+		require.Empty(t, PendingFlagPins("gated,no_later_gated", defaults, mustCreatedAt(t, "2026-07-01")))
+	})
+
+	t.Run("pinned value always matches what Resolve produces", func(t *testing.T) {
+		for _, createdAt := range []string{"", "2026-01-01", "2026-06-09", "2026-06-10", "2026-07-01", "2026-09-01"} {
+			pins := PendingFlagPins("", defaults, mustCreatedAt(t, createdAt))
+			resolved := ResolveFlags("", defaults, mustCreatedAt(t, createdAt))
+			for flag, pinned := range pins {
+				require.Equal(t, resolved[flag], pinned, "flag %s at %q", flag, createdAt)
+				// And re-resolving with the pin applied is a no-op.
+				withPin := ResolveFlags(PinnedFlagsString("", pins), defaults, mustCreatedAt(t, createdAt))
+				require.Equal(t, resolved[flag], withPin[flag], "flag %s at %q after pinning", flag, createdAt)
+			}
+		}
+	})
+}
+
+func TestPinnedFlagsString(t *testing.T) {
+	require.Equal(t, "gated_one,no_gated_two",
+		PinnedFlagsString("", map[string]bool{"gated_one": true, "gated_two": false}))
+	require.Equal(t, "existing,gated,no_other",
+		PinnedFlagsString("existing", map[string]bool{"gated": true, "other": false}))
+	require.Equal(t, "existing", PinnedFlagsString("existing", nil))
+}
+
+func TestResolveFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		raw       string
+		createdAt string
+		wantGated bool
+	}{
+		{"task created before the cutoff", "", "2026-01-01", false},
+		{"task created after the cutoff", "", "2026-07-01", true},
+		{"brand new task", "", "", true},
+		{"user disables for a new task", "no_gated", "2026-07-01", false},
+		{"user enables for an old task", "gated", "2026-01-01", true},
+		{"unrelated user flags don't disturb the cutoff", "other_flag", "2026-01-01", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := ResolveFlags(tt.raw, resolveDefaults, mustCreatedAt(t, tt.createdAt))
+			require.Equal(t, tt.wantGated, flags["gated"])
+			require.True(t, flags["always_on"])
+			require.False(t, flags["always_off"])
+		})
+	}
+}

--- a/materialize-azure-fabric-warehouse/client.go
+++ b/materialize-azure-fabric-warehouse/client.go
@@ -303,7 +303,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 	}
 
 	// Get feature flags and create dialect for preReqs function
-	_, featureFlags := cfg.FeatureFlags()
+	featureFlags := boilerplate.ParseFlags(cfg)
 	dialect := createDialect(featureFlags, caseInsensitiveResources)
 	var wh int
 	if err := db.QueryRowContext(pingCtx, fmt.Sprintf("SELECT 1 from sys.databases WHERE name = %s;", dialect.Literal(cfg.Warehouse))).Scan(&wh); err != nil {

--- a/materialize-azure-fabric-warehouse/client.go
+++ b/materialize-azure-fabric-warehouse/client.go
@@ -283,7 +283,7 @@ type badRequestResponseBody struct {
 	ErrorCodes       []int  `json:"error_codes"`
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, featureFlags map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	db, err := cfg.db()
@@ -302,8 +302,6 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		return errs
 	}
 
-	// Get feature flags and create dialect for preReqs function
-	featureFlags := boilerplate.ParseFlags(cfg)
 	dialect := createDialect(featureFlags, caseInsensitiveResources)
 	var wh int
 	if err := db.QueryRowContext(pingCtx, fmt.Sprintf("SELECT 1 from sys.databases WHERE name = %s;", dialect.Literal(cfg.Warehouse))).Scan(&wh); err != nil {

--- a/materialize-azure-fabric-warehouse/driver.go
+++ b/materialize-azure-fabric-warehouse/driver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -13,9 +14,9 @@ import (
 	"github.com/microsoft/go-mssqldb/azuread"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string": true,
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 }
 
 type advancedConfig struct {
@@ -90,7 +91,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 
@@ -128,7 +129,7 @@ func (r tableConfig) Parameters() ([]string, bool, error) {
 // SQL Server collations use _CI_ for case-insensitive and _CS_ for case-sensitive.
 func isCaseInsensitiveDatabase(ctx context.Context, db *stdsql.DB, warehouse string) (bool, error) {
 	// Create a temporary dialect just to get the Literal function for the query
-	tmpDialect := createDialect(featureFlagDefaults, false)
+	tmpDialect := createDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}), false)
 	var collation string
 	if err := db.QueryRowContext(ctx, fmt.Sprintf(
 		"SELECT DATABASEPROPERTYEX(%s, 'Collation')",

--- a/materialize-azure-fabric-warehouse/sqlgen_test.go
+++ b/materialize-azure-fabric-warehouse/sqlgen_test.go
@@ -5,11 +5,12 @@ import (
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createDialect(featureFlagDefaults, false)
+var testDialect = createDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}), false)
 var testTemplates = renderTemplates(testDialect)
 
 func TestSQLGeneration(t *testing.T) {

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -22,14 +23,14 @@ import (
 	"google.golang.org/api/option"
 )
 
-var featureFlagDefaults = map[string]bool{
+var featureFlagDefaults = map[string]common.FlagDefault{
 	// When set, object and array field types will be materialized as JSON
 	// columns, instead of the historical behavior of strings.
-	"objects_and_arrays_as_json":       true,
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"skip_cleanup":                     false,
-	"native_binary_column_type":        true,
+	"objects_and_arrays_as_json":       common.FlagEnabled,
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"skip_cleanup":                     common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type AuthType string
@@ -207,7 +208,7 @@ func (c config) DefaultNamespace() string {
 	return c.Dataset
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-bigquery/client.go
+++ b/materialize-bigquery/client.go
@@ -250,7 +250,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return fmt.Sprintf("CREATE DATASET %q.%q", c.cfg.ProjectID, schemaName), nil
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	credOption, err := cfg.CredentialsClientOption()

--- a/materialize-bigquery/sqlgen_test.go
+++ b/materialize-bigquery/sqlgen_test.go
@@ -5,11 +5,12 @@ import (
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = bqDialect(featureFlagDefaults)
+var testDialect = bqDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func TestSQLGeneration(t *testing.T) {

--- a/materialize-bigtable/driver.go
+++ b/materialize-bigtable/driver.go
@@ -15,6 +15,7 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -30,7 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]common.FlagDefault{}
 
 type AuthType string
 
@@ -111,7 +112,7 @@ func (c config) Validate() error {
 
 func (c config) DefaultNamespace() string { return "" }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-boilerplate/flags_test.go
+++ b/materialize-boilerplate/flags_test.go
@@ -1,0 +1,241 @@
+package boilerplate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/estuary/connectors/go/common"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+type flagsTestConfig struct {
+	raw string
+}
+
+func (c flagsTestConfig) Validate() error          { return nil }
+func (c flagsTestConfig) DefaultNamespace() string { return "" }
+func (c flagsTestConfig) FeatureFlags() (string, map[string]common.FlagDefault) {
+	return c.raw, map[string]common.FlagDefault{
+		"fixed_on":  common.FlagEnabled,
+		"fixed_off": common.FlagDisabled,
+		"gated":     common.FlagEnabledForTasksCreatedAfter("2026-06-10"),
+	}
+}
+
+func TestResolveFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		cfg       flagsTestConfig
+		createdAt string
+		wantGated bool
+	}{
+		{
+			name:      "task created before the cutoff resolves gated flag off",
+			createdAt: "2026-01-01",
+			wantGated: false,
+		},
+		{
+			name:      "task created after the cutoff resolves gated flag on",
+			createdAt: "2026-07-01",
+			wantGated: true,
+		},
+		{
+			// A brand-new task's creation isn't committed during its first
+			// build, so the runtime has no date to stamp onto the spec.
+			name:      "unstamped creation date resolves gated flag on",
+			createdAt: "",
+			wantGated: true,
+		},
+		{
+			name:      "explicit config entry wins over the cutoff",
+			cfg:       flagsTestConfig{raw: "no_gated"},
+			createdAt: "2026-07-01",
+			wantGated: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			createdAt, err := common.ParseCreatedAt(tt.createdAt)
+			require.NoError(t, err)
+			flags := resolveFlags(tt.cfg, createdAt)
+			require.Equal(t, tt.wantGated, flags["gated"])
+			require.True(t, flags["fixed_on"])
+			require.False(t, flags["fixed_off"])
+		})
+	}
+}
+
+func TestSpecCreatedAt(t *testing.T) {
+	for _, spec := range []*pf.MaterializationSpec{nil, {}} {
+		createdAt, err := specCreatedAt(spec)
+		require.NoError(t, err)
+		require.True(t, createdAt.IsBrandNew())
+	}
+
+	createdAt, err := specCreatedAt(&pf.MaterializationSpec{CreatedAt: "2026-07-01"})
+	require.NoError(t, err)
+	require.Equal(t, "2026-07-01", createdAt.String())
+
+	// A spec carrying a date the connector cannot place fails the RPC rather
+	// than resolving flags from a value nobody understood.
+	_, err = specCreatedAt(&pf.MaterializationSpec{CreatedAt: "not-a-date"})
+	require.ErrorContains(t, err, `task creation date "not-a-date"`)
+}
+
+// TestUnparseableCreatedAtFailsRPCs verifies that a spec carrying a creation
+// date the connector cannot parse fails the RPC, rather than being resolved
+// around and silently giving the task the behavior of the wrong era.
+func TestUnparseableCreatedAtFailsRPCs(t *testing.T) {
+	ctx := context.Background()
+	spec := loadMaterializerSpec(t, "base.flow.proto")
+	spec.CreatedAt = "6/10/2026"
+	is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+	fn := makeTestMaterializerFn(&testCalls{}, is)
+
+	_, err := RunValidate(ctx, &pm.Request_Validate{
+		Name:                spec.Name,
+		ConnectorType:       spec.ConnectorType,
+		ConfigJson:          spec.ConfigJson,
+		LastMaterialization: spec,
+	}, fn)
+	require.ErrorContains(t, err, `task creation date "6/10/2026"`)
+
+	_, err = RunApply(ctx, &pm.Request_Apply{Materialization: spec, LastMaterialization: spec}, fn)
+	require.ErrorContains(t, err, `task creation date "6/10/2026"`)
+
+	_, _, _, err = RunNewTransactor(ctx, pm.Request_Open{
+		Materialization: spec,
+		Version:         "aVersion",
+		Range:           &pf.RangeSpec{KeyEnd: math.MaxUint32, RClockEnd: math.MaxUint32},
+	}, nil, fn)
+	require.ErrorContains(t, err, `task creation date "6/10/2026"`)
+}
+
+// TestRunApplyRecordsFlagPinsInConfig verifies that Apply emits a configUpdate
+// event restating the endpoint config with the resolved value of a cutoff-gated
+// flag made explicit, and that the recorded value matches how the connector
+// itself resolved the flag from the task's creation date.
+func TestRunApplyRecordsFlagPinsInConfig(t *testing.T) {
+	ctx := context.Background()
+
+	// Stand in for the config encryption service by echoing the config back, so
+	// the emitted event carries an inspectable document.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Config json.RawMessage `json:"config"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		w.Write(body.Config)
+	}))
+	defer server.Close()
+	t.Setenv("ENCRYPTION_URL", server.URL)
+
+	// Connector events are only emitted with the runtime's JSON log format.
+	var logs bytes.Buffer
+	logger := log.StandardLogger()
+	priorFormatter, priorOut := logger.Formatter, logger.Out
+	logger.SetFormatter(&log.JSONFormatter{})
+	logger.SetOutput(&logs)
+	t.Cleanup(func() { logger.SetFormatter(priorFormatter); logger.SetOutput(priorOut) })
+
+	for _, tt := range []struct {
+		name      string
+		createdAt string
+		want      string
+	}{
+		{"task predating the cutoff records the disabled form", "2020-01-01", "no_test_gated"},
+		{"task postdating the cutoff records the enabled form", "2030-01-01", "test_gated"},
+		{"brand new task records the enabled form", "", "test_gated"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logs.Reset()
+			spec := loadMaterializerSpec(t, "base.flow.proto")
+			spec.CreatedAt = tt.createdAt
+			is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+
+			var gotFlags map[string]bool
+			capturingFn := func(
+				ctx context.Context,
+				materializationName string,
+				endpointConfig testEndpointConfiger,
+				featureFlags map[string]bool,
+			) (Materializer[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper], error) {
+				gotFlags = featureFlags
+				return &testMaterializer{calls: &testCalls{}, is: is}, nil
+			}
+
+			_, err := RunApply(ctx, &pm.Request_Apply{
+				Materialization:     spec,
+				LastMaterialization: spec,
+			}, capturingFn, WithConfigUpdates(json.RawMessage(`{}`), []string{"config", "advanced", "feature_flags"}))
+			require.NoError(t, err)
+
+			recorded := recordedFeatureFlags(t, logs.Bytes())
+			require.Equal(t, tt.want, recorded, "recorded feature flags")
+			// The recorded value must agree with the behavior of this very Apply.
+			require.Equal(t, gotFlags["test_gated"], recorded == "test_gated")
+		})
+	}
+
+	t.Run("a flag already present in the config is not re-recorded", func(t *testing.T) {
+		logs.Reset()
+		spec := loadMaterializerSpec(t, "base.flow.proto")
+		spec.CreatedAt = "2030-01-01"
+		cfg, err := common.SetJSONProperty(spec.ConfigJson, []string{"config", "advanced", "feature_flags"}, "no_test_gated")
+		require.NoError(t, err)
+		spec.ConfigJson = cfg
+		is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+
+		_, err = RunApply(ctx, &pm.Request_Apply{
+			Materialization:     spec,
+			LastMaterialization: spec,
+		}, makeTestMaterializerFn(&testCalls{}, is),
+			WithConfigUpdates(json.RawMessage(`{}`), []string{"config", "advanced", "feature_flags"}))
+		require.NoError(t, err)
+		require.Empty(t, recordedFeatureFlags(t, logs.Bytes()), "no configUpdate should be emitted")
+	})
+}
+
+// recordedFeatureFlags returns the feature flags string of the config carried by
+// a configUpdate event in the given JSON log lines, or "" if there is no such
+// event.
+func recordedFeatureFlags(t *testing.T, logs []byte) string {
+	t.Helper()
+
+	for _, line := range bytes.Split(logs, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var entry struct {
+			EventType string `json:"eventType"`
+			Config    struct {
+				Config struct {
+					Advanced struct {
+						FeatureFlags string `json:"feature_flags"`
+					} `json:"advanced"`
+				} `json:"config"`
+			} `json:"config"`
+		}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue // Not a structured line we care about.
+		}
+		if entry.EventType == "configUpdate" {
+			return entry.Config.Config.Advanced.FeatureFlags
+		}
+	}
+	return ""
+}
+
+func TestParseFlags(t *testing.T) {
+	// Without a spec to take a creation date from, date-gated flags resolve as
+	// they would for a brand-new task.
+	require.True(t, ParseFlags(flagsTestConfig{})["gated"])
+	require.False(t, ParseFlags(flagsTestConfig{raw: "no_gated"})["gated"])
+}

--- a/materialize-boilerplate/flags_test.go
+++ b/materialize-boilerplate/flags_test.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"math"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/estuary/connectors/go/common"
+	m "github.com/estuary/connectors/go/materialize"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	log "github.com/sirupsen/logrus"
@@ -118,24 +117,18 @@ func TestUnparseableCreatedAtFailsRPCs(t *testing.T) {
 	require.ErrorContains(t, err, `task creation date "6/10/2026"`)
 }
 
-// TestRunApplyRecordsFlagPinsInConfig verifies that Apply emits a configUpdate
-// event restating the endpoint config with the resolved value of a cutoff-gated
-// flag made explicit, and that the recorded value matches how the connector
-// itself resolved the flag from the task's creation date.
-func TestRunApplyRecordsFlagPinsInConfig(t *testing.T) {
-	ctx := context.Background()
+// sealedTestConfig is the sops-encrypted form of the test fixture's endpoint
+// config as the runtime provides it on Open. Only the `sops` stanza matters
+// here: it is what makes the restatement carry an overlay rather than set the
+// property directly.
+const sealedTestConfig = `{"config":{"address":"db:5432"},"sops":{"encrypted_suffix":"_sops","mac":"ENC[AES256_GCM,data:zz]"}}`
 
-	// Stand in for the config encryption service by echoing the config back, so
-	// the emitted event carries an inspectable document.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Config json.RawMessage `json:"config"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		w.Write(body.Config)
-	}))
-	defer server.Close()
-	t.Setenv("ENCRYPTION_URL", server.URL)
+// TestRunNewTransactorRecordsFlagPinsInConfig verifies that Open emits a
+// configUpdate event restating the endpoint config with the resolved value of a
+// cutoff-gated flag made explicit, and that the recorded value matches how the
+// connector itself resolved the flag from the task's creation date.
+func TestRunNewTransactorRecordsFlagPinsInConfig(t *testing.T) {
+	ctx := context.Background()
 
 	// Connector events are only emitted with the runtime's JSON log format.
 	var logs bytes.Buffer
@@ -171,18 +164,31 @@ func TestRunApplyRecordsFlagPinsInConfig(t *testing.T) {
 				return &testMaterializer{calls: &testCalls{}, is: is}, nil
 			}
 
-			_, err := RunApply(ctx, &pm.Request_Apply{
-				Materialization:     spec,
-				LastMaterialization: spec,
-			}, capturingFn, WithConfigUpdates(json.RawMessage(`{}`), []string{"config", "advanced", "feature_flags"}))
+			_, _, _, err := runTestTransactor(ctx, spec, json.RawMessage(sealedTestConfig), capturingFn)
 			require.NoError(t, err)
 
-			recorded := recordedFeatureFlags(t, logs.Bytes())
+			recorded := overlaidFeatureFlags(t, logs.Bytes())
 			require.Equal(t, tt.want, recorded, "recorded feature flags")
-			// The recorded value must agree with the behavior of this very Apply.
+			// The recorded value must agree with the behavior of this very Open.
 			require.Equal(t, gotFlags["test_gated"], recorded == "test_gated")
 		})
 	}
+
+	t.Run("an unencrypted config is restated without an overlay", func(t *testing.T) {
+		logs.Reset()
+		spec := loadMaterializerSpec(t, "base.flow.proto")
+		spec.CreatedAt = "2030-01-01"
+		is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+
+		// A config with no `sops` stanza has no ciphertext to preserve, so the
+		// property is set in the document itself. Adding an overlay would send
+		// the runtime looking for ciphertext that isn't there.
+		_, _, _, err := runTestTransactor(ctx, spec, spec.ConfigJson, makeTestMaterializerFn(&testCalls{}, is))
+		require.NoError(t, err)
+
+		require.Empty(t, overlaidFeatureFlags(t, logs.Bytes()), "an unencrypted config has no overlay")
+		require.Equal(t, "test_gated", directFeatureFlags(t, logs.Bytes()))
+	})
 
 	t.Run("a flag already present in the config is not re-recorded", func(t *testing.T) {
 		logs.Reset()
@@ -193,20 +199,54 @@ func TestRunApplyRecordsFlagPinsInConfig(t *testing.T) {
 		spec.ConfigJson = cfg
 		is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
 
-		_, err = RunApply(ctx, &pm.Request_Apply{
-			Materialization:     spec,
-			LastMaterialization: spec,
-		}, makeTestMaterializerFn(&testCalls{}, is),
-			WithConfigUpdates(json.RawMessage(`{}`), []string{"config", "advanced", "feature_flags"}))
+		_, _, _, err = runTestTransactor(ctx, spec, json.RawMessage(sealedTestConfig), makeTestMaterializerFn(&testCalls{}, is))
 		require.NoError(t, err)
-		require.Empty(t, recordedFeatureFlags(t, logs.Bytes()), "no configUpdate should be emitted")
+		require.Nil(t, recordedConfigUpdate(t, logs.Bytes()), "no configUpdate should be emitted")
+	})
+
+	t.Run("nothing is recorded without the sealed config", func(t *testing.T) {
+		logs.Reset()
+		spec := loadMaterializerSpec(t, "base.flow.proto")
+		spec.CreatedAt = "2030-01-01"
+		is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+
+		// Runtimes predating `sealed_config_json` send nothing, and an encrypted
+		// config cannot be restated without it.
+		_, _, _, err := runTestTransactor(ctx, spec, nil, makeTestMaterializerFn(&testCalls{}, is))
+		require.NoError(t, err)
+		require.Nil(t, recordedConfigUpdate(t, logs.Bytes()), "no configUpdate should be emitted")
 	})
 }
 
-// recordedFeatureFlags returns the feature flags string of the config carried by
-// a configUpdate event in the given JSON log lines, or "" if there is no such
-// event.
-func recordedFeatureFlags(t *testing.T, logs []byte) string {
+// runTestTransactor opens a transactor for spec with flag recording enabled,
+// as the runtime would with the given sealed endpoint config.
+func runTestTransactor(
+	ctx context.Context,
+	spec *pf.MaterializationSpec,
+	sealedConfig json.RawMessage,
+	fn NewMaterializerFn[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper],
+) (m.Transactor, *pm.Response_Opened, *m.MaterializeOptions, error) {
+	return RunNewTransactor(ctx, pm.Request_Open{
+		Materialization:  spec,
+		Version:          "aVersion",
+		Range:            &pf.RangeSpec{KeyEnd: math.MaxUint32, RClockEnd: math.MaxUint32},
+		SealedConfigJson: sealedConfig,
+	}, nil, fn, WithConfigUpdates([]string{"config", "advanced", "feature_flags"}))
+}
+
+// testConfigFlags mirrors the nesting of the test fixture's endpoint config down
+// to its feature flags property.
+type testConfigFlags struct {
+	Config struct {
+		Advanced struct {
+			FeatureFlags string `json:"feature_flags"`
+		} `json:"advanced"`
+	} `json:"config"`
+}
+
+// recordedConfigUpdate returns the restated config carried by a configUpdate
+// event in the given JSON log lines, or nil if there is no such event.
+func recordedConfigUpdate(t *testing.T, logs []byte) json.RawMessage {
 	t.Helper()
 
 	for _, line := range bytes.Split(logs, []byte("\n")) {
@@ -214,23 +254,51 @@ func recordedFeatureFlags(t *testing.T, logs []byte) string {
 			continue
 		}
 		var entry struct {
-			EventType string `json:"eventType"`
-			Config    struct {
-				Config struct {
-					Advanced struct {
-						FeatureFlags string `json:"feature_flags"`
-					} `json:"advanced"`
-				} `json:"config"`
-			} `json:"config"`
+			EventType string          `json:"eventType"`
+			Config    json.RawMessage `json:"config"`
 		}
 		if err := json.Unmarshal(line, &entry); err != nil {
 			continue // Not a structured line we care about.
-		}
-		if entry.EventType == "configUpdate" {
-			return entry.Config.Config.Advanced.FeatureFlags
+		} else if entry.EventType == "configUpdate" {
+			return entry.Config
 		}
 	}
-	return ""
+	return nil
+}
+
+// overlaidFeatureFlags returns the feature flags string a configUpdate event
+// carries in the `sops.overlay` of its restated config, or "" if there is no
+// such event.
+func overlaidFeatureFlags(t *testing.T, logs []byte) string {
+	t.Helper()
+
+	var doc struct {
+		Sops struct {
+			Overlay testConfigFlags `json:"overlay"`
+		} `json:"sops"`
+	}
+	if recorded := recordedConfigUpdate(t, logs); recorded == nil {
+		return ""
+	} else if err := json.Unmarshal(recorded, &doc); err != nil {
+		t.Fatalf("decoding recorded config: %s", err)
+	}
+
+	return doc.Sops.Overlay.Config.Advanced.FeatureFlags
+}
+
+// directFeatureFlags returns the feature flags string a configUpdate event
+// carries in the body of its restated config, or "" if there is no such event.
+func directFeatureFlags(t *testing.T, logs []byte) string {
+	t.Helper()
+
+	var doc testConfigFlags
+	if recorded := recordedConfigUpdate(t, logs); recorded == nil {
+		return ""
+	} else if err := json.Unmarshal(recorded, &doc); err != nil {
+		t.Fatalf("decoding recorded config: %s", err)
+	}
+
+	return doc.Config.Advanced.FeatureFlags
 }
 
 func TestParseFlags(t *testing.T) {

--- a/materialize-boilerplate/flags_test.go
+++ b/materialize-boilerplate/flags_test.go
@@ -301,9 +301,22 @@ func directFeatureFlags(t *testing.T, logs []byte) string {
 	return doc.Config.Advanced.FeatureFlags
 }
 
-func TestParseFlags(t *testing.T) {
-	// Without a spec to take a creation date from, date-gated flags resolve as
-	// they would for a brand-new task.
-	require.True(t, ParseFlags(flagsTestConfig{})["gated"])
-	require.False(t, ParseFlags(flagsTestConfig{raw: "no_gated"})["gated"])
+// TestResolveFlagsFromSpec covers the entry point used by connectors which
+// implement the materialization RPCs themselves: flags come from the spec's
+// creation date, and a date it cannot parse fails rather than resolving around.
+func TestResolveFlagsFromSpec(t *testing.T) {
+	before, err := ResolveFlags(flagsTestConfig{}, &pf.MaterializationSpec{CreatedAt: "2026-01-01"})
+	require.NoError(t, err)
+	require.False(t, before["gated"])
+
+	after, err := ResolveFlags(flagsTestConfig{}, &pf.MaterializationSpec{CreatedAt: "2026-07-01"})
+	require.NoError(t, err)
+	require.True(t, after["gated"])
+
+	override, err := ResolveFlags(flagsTestConfig{raw: "no_gated"}, &pf.MaterializationSpec{CreatedAt: "2026-07-01"})
+	require.NoError(t, err)
+	require.False(t, override["gated"])
+
+	_, err = ResolveFlags(flagsTestConfig{}, &pf.MaterializationSpec{CreatedAt: "6/10/2026"})
+	require.ErrorContains(t, err, `task creation date "6/10/2026"`)
 }

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -191,7 +191,7 @@ type EndpointConfiger interface {
 
 	// FeatureFlags returns the raw string of comma-separated feature flags, and
 	// the default feature flag values that should be applied.
-	FeatureFlags() (raw string, defaults map[string]bool)
+	FeatureFlags() (raw string, defaults map[string]common.FlagDefault)
 }
 
 // Resourcer represents a parsed resource config.
@@ -356,7 +356,14 @@ func RunValidate[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT
 		return nil, err
 	}
 
-	parsedFlags := ParseFlags(cfg)
+	// Validate carries no spec for the task being validated, only the last
+	// published one; a task with no last spec is brand new and has no creation
+	// date yet.
+	createdAt, err := specCreatedAt(req.LastMaterialization)
+	if err != nil {
+		return nil, err
+	}
+	parsedFlags := resolveFlags(cfg, createdAt)
 	materializer, err := newMaterializer(ctx, req.Name.String(), cfg, parsedFlags)
 	if err != nil {
 		return nil, err
@@ -413,14 +420,47 @@ func RunValidate[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT
 	return &pm.Response_Validated{Bindings: out}, nil
 }
 
+type applyOptions struct {
+	configSchema     json.RawMessage
+	featureFlagsPath []string
+}
+
+// ApplyOption customizes the behavior of RunApply.
+type ApplyOption func(*applyOptions)
+
+// WithConfigUpdates enables recording the resolved value of cutoff-gated feature
+// flags into the task's persisted endpoint config, via a configUpdate event, so
+// that every task ends up carrying an explicit list of the flags its behavior
+// depends on instead of one implied by its creation date. featureFlagsPath
+// locates the feature flags property within the config document, e.g.
+// ["advanced", "feature_flags"].
+//
+// The value written is the same value the connector resolves from the task's
+// creation date, so this is a record rather than a decision: the configUpdate is
+// published asynchronously and is only eventually consistent, but the task
+// behaves identically before and after it lands. It is recomputed on each Apply
+// and stops being emitted once the config contains it.
+func WithConfigUpdates(configSchema json.RawMessage, featureFlagsPath []string) ApplyOption {
+	return func(o *applyOptions) {
+		o.configSchema = configSchema
+		o.featureFlagsPath = featureFlagsPath
+	}
+}
+
 // RunApply produces an Applied response for an Apply request.
 func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT MappedTyper](
 	ctx context.Context,
 	req *pm.Request_Apply,
 	newMaterializer NewMaterializerFn[EC, FC, RC, MT],
+	opts ...ApplyOption,
 ) (*pm.Response_Applied, error) {
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("validating request: %w", err)
+	}
+
+	var applyOpts applyOptions
+	for _, opt := range opts {
+		opt(&applyOpts)
 	}
 
 	var endpointCfg EC
@@ -428,7 +468,11 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		return nil, err
 	}
 
-	parsedFlags := ParseFlags(endpointCfg)
+	createdAt, err := specCreatedAt(req.Materialization)
+	if err != nil {
+		return nil, err
+	}
+	parsedFlags := resolveFlags(endpointCfg, createdAt)
 	materializer, err := newMaterializer(ctx, req.Materialization.Name.String(), endpointCfg, parsedFlags)
 	if err != nil {
 		return nil, err
@@ -511,7 +555,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		setupActionDescriptions = append(setupActionDescriptions, desc)
 	}
 
-	common, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
+	updates, err := computeCommonUpdates(req.LastMaterialization, req.Materialization, is)
 	if err != nil {
 		return nil, err
 	}
@@ -524,7 +568,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 	destructiveBindings := make(map[int]bool)
 	drainBindings := make(map[int]bool)
 
-	for _, bindingIdx := range common.newBindings {
+	for _, bindingIdx := range updates.newBindings {
 		if mapped, err := buildMappedBinding(endpointCfg, materializer, *req.Materialization, bindingIdx); err != nil {
 			return nil, err
 		} else if desc, action, err := materializer.CreateResource(ctx, *mapped); err != nil {
@@ -535,7 +579,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 	}
 
 	validator := NewValidator(&constrainterAdapter[EC, FC, RC, MT]{m: materializer}, is, mCfg.MaxFieldLength, mCfg.CaseInsensitiveFields, parsedFlags)
-	for _, bindingIdx := range common.backfillBindings {
+	for _, bindingIdx := range updates.backfillBindings {
 		mapped, err := buildMappedBinding(endpointCfg, materializer, *req.Materialization, bindingIdx)
 		if err != nil {
 			return nil, err
@@ -613,7 +657,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 			if err != nil {
 				return nil, err
 			}
-			common.updatedBindings[bindingIdx] = *upd
+			updates.updatedBindings[bindingIdx] = *upd
 		} else {
 			// Check if retain_existing_data_on_backfill is enabled, and if so, return an error
 			if parsedFlags["retain_existing_data_on_backfill"] {
@@ -651,7 +695,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		}
 	}
 
-	for bindingIdx, commonUpdates := range common.updatedBindings {
+	for bindingIdx, commonUpdates := range updates.updatedBindings {
 		mb, err := buildMappedBinding(endpointCfg, materializer, *req.Materialization, bindingIdx)
 		if err != nil {
 			return nil, err
@@ -786,11 +830,52 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		}
 	}
 
+	if applyOpts.featureFlagsPath != nil {
+		pinFeatureFlags(ctx, endpointCfg, req.Materialization, createdAt, applyOpts)
+	}
+
 	allActions := append(namespaceActionDesciptions, setupActionDescriptions...)
 	allActions = append(allActions, truncationActionDescriptions...)
 	allActions = append(allActions, resourceActionDescriptions...)
 
 	return &pm.Response_Applied{ActionDescription: strings.Join(allActions, "\n")}, nil
+}
+
+// pinFeatureFlags records the resolved value of any cutoff-gated flag that the
+// endpoint config does not already mention, by emitting a configUpdate event
+// restating the config with those flags made explicit. Failures are logged and
+// otherwise ignored: the value is one the connector re-derives from the task's
+// creation date on every RPC, so the config is a record of behavior rather than
+// its source, and a task is unaffected by the write being late or lost.
+func pinFeatureFlags[EC EndpointConfiger](
+	ctx context.Context,
+	endpointCfg EC,
+	spec *pf.MaterializationSpec,
+	createdAt common.CreatedAt,
+	applyOpts applyOptions,
+) {
+	rawFlags, defaultFlags := endpointCfg.FeatureFlags()
+	toPin := common.PendingFlagPins(rawFlags, defaultFlags, createdAt)
+	if len(toPin) == 0 || applyOpts.configSchema == nil {
+		return
+	}
+
+	// Connector events are only consumed from the runtime's JSON-formatted task
+	// logs, so any other log format means this is a test or ad-hoc CLI
+	// invocation where emitting would only produce a pointless call to the
+	// encryption service.
+	if _, isJSONLogs := log.StandardLogger().Formatter.(*log.JSONFormatter); !isJSONLogs {
+		return
+	}
+
+	pinned, err := common.SetJSONProperty(spec.ConfigJson, applyOpts.featureFlagsPath, common.PinnedFlagsString(rawFlags, toPin))
+	if err != nil {
+		log.WithError(err).Warn("failed to record feature flag defaults in endpoint config")
+		return
+	}
+	if err := common.EmitConfigUpdate(ctx, "Recording default values for newly introduced settings in the endpoint config.", pinned, applyOpts.configSchema); err != nil {
+		log.WithError(err).Warn("failed to emit config update recording feature flag defaults")
+	}
 }
 
 // RunNewTransactor builds a transactor and Opened response from an Open
@@ -810,7 +895,11 @@ func RunNewTransactor[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC
 		return nil, nil, nil, err
 	}
 
-	featureFlags := ParseFlags(epCfg)
+	createdAt, err := specCreatedAt(req.Materialization)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	featureFlags := resolveFlags(epCfg, createdAt)
 	materializer, err := newMaterializer(ctx, req.Materialization.Name.String(), epCfg, featureFlags)
 	if err != nil {
 		return nil, nil, nil, err
@@ -1028,14 +1117,41 @@ func (c *constrainterAdapter[EC, FC, RC, MT]) DescriptionForType(p *pf.Projectio
 	return mt.String(), nil
 }
 
+// ParseFlags resolves feature flags without a task spec to take the creation
+// date from, and so resolves date-gated flags as for a brand-new task. It is
+// intended for call sites outside the Validate/Apply/Open RPCs, such as
+// prerequisite checks and tests.
 func ParseFlags(cfg EndpointConfiger) map[string]bool {
+	return resolveFlags(cfg, common.CreatedAt{})
+}
+
+// resolveFlags resolves the feature flags of a task created on createdAt. Since
+// the creation date is carried by every task spec, all of Validate, Apply and
+// Open resolve the same flags for a given task without persisting anything.
+func resolveFlags(cfg EndpointConfiger, createdAt common.CreatedAt) map[string]bool {
 	rawFlags, defaultFlags := cfg.FeatureFlags()
-	parsedFlags := common.ParseFeatureFlags(rawFlags, defaultFlags)
+	parsedFlags := common.ResolveFlags(rawFlags, defaultFlags, createdAt)
 	if rawFlags != "" {
 		log.WithField("flags", parsedFlags).Info("parsed feature flags")
 	}
 
 	return parsedFlags
+}
+
+// specCreatedAt returns the validated date on which a task was created. A spec
+// that is absent, or that predates the control plane stamping creation dates,
+// yields a brand-new CreatedAt. A date that cannot be parsed is an error rather
+// than something to resolve flags around: it would silently give the task the
+// behavior of the wrong era.
+func specCreatedAt(spec *pf.MaterializationSpec) (common.CreatedAt, error) {
+	if spec == nil {
+		return common.CreatedAt{}, nil
+	}
+	createdAt, err := common.ParseCreatedAt(spec.CreatedAt)
+	if err != nil {
+		return common.CreatedAt{}, fmt.Errorf("resolving feature flags: %w", err)
+	}
+	return createdAt, nil
 }
 
 func UnmarshalStrict[T pb.Validator](raw []byte, into *T) error {

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -420,13 +420,12 @@ func RunValidate[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT
 	return &pm.Response_Validated{Bindings: out}, nil
 }
 
-type applyOptions struct {
-	configSchema     json.RawMessage
+type openOptions struct {
 	featureFlagsPath []string
 }
 
-// ApplyOption customizes the behavior of RunApply.
-type ApplyOption func(*applyOptions)
+// OpenOption customizes the behavior of RunNewTransactor.
+type OpenOption func(*openOptions)
 
 // WithConfigUpdates enables recording the resolved value of cutoff-gated feature
 // flags into the task's persisted endpoint config, via a configUpdate event, so
@@ -438,11 +437,10 @@ type ApplyOption func(*applyOptions)
 // The value written is the same value the connector resolves from the task's
 // creation date, so this is a record rather than a decision: the configUpdate is
 // published asynchronously and is only eventually consistent, but the task
-// behaves identically before and after it lands. It is recomputed on each Apply
+// behaves identically before and after it lands. It is recomputed on each Open
 // and stops being emitted once the config contains it.
-func WithConfigUpdates(configSchema json.RawMessage, featureFlagsPath []string) ApplyOption {
-	return func(o *applyOptions) {
-		o.configSchema = configSchema
+func WithConfigUpdates(featureFlagsPath []string) OpenOption {
+	return func(o *openOptions) {
 		o.featureFlagsPath = featureFlagsPath
 	}
 }
@@ -452,15 +450,9 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 	ctx context.Context,
 	req *pm.Request_Apply,
 	newMaterializer NewMaterializerFn[EC, FC, RC, MT],
-	opts ...ApplyOption,
 ) (*pm.Response_Applied, error) {
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("validating request: %w", err)
-	}
-
-	var applyOpts applyOptions
-	for _, opt := range opts {
-		opt(&applyOpts)
 	}
 
 	var endpointCfg EC
@@ -830,10 +822,6 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		}
 	}
 
-	if applyOpts.featureFlagsPath != nil {
-		pinFeatureFlags(ctx, endpointCfg, req.Materialization, createdAt, applyOpts)
-	}
-
 	allActions := append(namespaceActionDesciptions, setupActionDescriptions...)
 	allActions = append(allActions, truncationActionDescriptions...)
 	allActions = append(allActions, resourceActionDescriptions...)
@@ -848,34 +836,31 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 // creation date on every RPC, so the config is a record of behavior rather than
 // its source, and a task is unaffected by the write being late or lost.
 func pinFeatureFlags[EC EndpointConfiger](
-	ctx context.Context,
 	endpointCfg EC,
-	spec *pf.MaterializationSpec,
+	sealedConfig json.RawMessage,
 	createdAt common.CreatedAt,
-	applyOpts applyOptions,
+	openOpts openOptions,
 ) {
 	rawFlags, defaultFlags := endpointCfg.FeatureFlags()
 	toPin := common.PendingFlagPins(rawFlags, defaultFlags, createdAt)
-	if len(toPin) == 0 || applyOpts.configSchema == nil {
+	if len(toPin) == 0 {
 		return
 	}
 
-	// Connector events are only consumed from the runtime's JSON-formatted task
-	// logs, so any other log format means this is a test or ad-hoc CLI
-	// invocation where emitting would only produce a pointless call to the
-	// encryption service.
-	if _, isJSONLogs := log.StandardLogger().Formatter.(*log.JSONFormatter); !isJSONLogs {
+	if len(sealedConfig) == 0 {
+		// The sealed config is what a restatement of an encrypted config is
+		// built from, and runtimes predating it send nothing.
+		log.Debug("not recording feature flag defaults: runtime did not provide the sealed endpoint config")
 		return
 	}
 
-	pinned, err := common.SetJSONProperty(spec.ConfigJson, applyOpts.featureFlagsPath, common.PinnedFlagsString(rawFlags, toPin))
+	pinned, err := common.SetSealedConfigProperty(sealedConfig, openOpts.featureFlagsPath, common.PinnedFlagsString(rawFlags, toPin))
 	if err != nil {
 		log.WithError(err).Warn("failed to record feature flag defaults in endpoint config")
 		return
 	}
-	if err := common.EmitConfigUpdate(ctx, "Recording default values for newly introduced settings in the endpoint config.", pinned, applyOpts.configSchema); err != nil {
-		log.WithError(err).Warn("failed to emit config update recording feature flag defaults")
-	}
+
+	common.EmitConfigUpdate("Recording default values for newly introduced settings in the endpoint config.", pinned)
 }
 
 // RunNewTransactor builds a transactor and Opened response from an Open
@@ -885,9 +870,15 @@ func RunNewTransactor[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC
 	req pm.Request_Open,
 	be *m.BindingEvents,
 	newMaterializer NewMaterializerFn[EC, FC, RC, MT],
+	opts ...OpenOption,
 ) (m.Transactor, *pm.Response_Opened, *m.MaterializeOptions, error) {
 	if err := req.Validate(); err != nil {
 		return nil, nil, nil, fmt.Errorf("validating request: %w", err)
+	}
+
+	var openOpts openOptions
+	for _, opt := range opts {
+		opt(&openOpts)
 	}
 
 	var epCfg EC
@@ -941,6 +932,10 @@ func RunNewTransactor[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC
 		if err := cp.Unmarshal(checkpoint); err != nil {
 			return nil, nil, nil, fmt.Errorf("unmarshalling checkpoint: %w", err)
 		}
+	}
+
+	if openOpts.featureFlagsPath != nil {
+		pinFeatureFlags(epCfg, req.SealedConfigJson, createdAt, openOpts)
 	}
 
 	return transactor, &pm.Response_Opened{

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -1112,12 +1112,23 @@ func (c *constrainterAdapter[EC, FC, RC, MT]) DescriptionForType(p *pf.Projectio
 	return mt.String(), nil
 }
 
-// ParseFlags resolves feature flags without a task spec to take the creation
-// date from, and so resolves date-gated flags as for a brand-new task. It is
-// intended for call sites outside the Validate/Apply/Open RPCs, such as
-// prerequisite checks and tests.
-func ParseFlags(cfg EndpointConfiger) map[string]bool {
-	return resolveFlags(cfg, common.CreatedAt{})
+// ResolveFlags returns the feature flags of the task described by spec, for
+// connectors which implement the materialization RPCs themselves rather than
+// through RunValidate, RunApply and RunNewTransactor.
+//
+// The spec is required: a date-gated default can only be resolved against the
+// creation date the runtime stamped onto it, and resolving one without a spec
+// would silently hand the task whichever behavior a brand-new task gets. Take it
+// from `req.LastMaterialization` in Validate, and from `req.Materialization` in
+// Apply and Open. Anywhere further from the RPC boundary, thread down the flags
+// resolved there instead of re-resolving them.
+func ResolveFlags[EC EndpointConfiger](cfg EC, spec *pf.MaterializationSpec) (map[string]bool, error) {
+	createdAt, err := specCreatedAt(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolveFlags(cfg, createdAt), nil
 }
 
 // resolveFlags resolves the feature flags of a task created on createdAt. Since

--- a/materialize-boilerplate/materializer_test.go
+++ b/materialize-boilerplate/materializer_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -378,6 +379,48 @@ type testMaterializer struct {
 	is    *InfoSchema
 }
 
+// TestRunApplyResolvesFlagsFromCreatedAt verifies that Apply resolves a
+// date-gated feature flag from the creation date stamped onto the task's spec,
+// with no dependence on connector state or on whether the task is being applied
+// for the first time.
+func TestRunApplyResolvesFlagsFromCreatedAt(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name      string
+		createdAt string
+		want      bool
+	}{
+		{"created before the flag's cutoff", "2020-01-01", false},
+		{"created after the flag's cutoff", "2030-01-01", true},
+		{"brand new task, creation not yet committed", "", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := loadMaterializerSpec(t, "base.flow.proto")
+			spec.CreatedAt = tt.createdAt
+			is := testInfoSchemaFromSpec(t, spec, func(in string) string { return in })
+
+			var gotFlags map[string]bool
+			capturingFn := func(
+				ctx context.Context,
+				materializationName string,
+				endpointConfig testEndpointConfiger,
+				featureFlags map[string]bool,
+			) (Materializer[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper], error) {
+				gotFlags = featureFlags
+				return &testMaterializer{calls: &testCalls{}, is: is}, nil
+			}
+
+			_, err := RunApply(ctx, &pm.Request_Apply{
+				Materialization:     spec,
+				LastMaterialization: spec,
+			}, capturingFn)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, gotFlags["test_gated"])
+		})
+	}
+}
+
 func makeTestMaterializerFn(got *testCalls, is *InfoSchema) NewMaterializerFn[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper] {
 	return func(
 		ctx context.Context,
@@ -469,7 +512,7 @@ func (c testEndpointConfiger) DefaultNamespace() string {
 	return ""
 }
 
-func (c testEndpointConfiger) FeatureFlags() (string, map[string]bool) {
+func (c testEndpointConfiger) FeatureFlags() (string, map[string]common.FlagDefault) {
 	featureFlags := ""
 	if advanced, ok := c.Config["advanced"].(map[string]any); ok {
 		if ff, ok := advanced["feature_flags"].(string); ok {
@@ -477,8 +520,9 @@ func (c testEndpointConfiger) FeatureFlags() (string, map[string]bool) {
 		}
 	}
 
-	return featureFlags, map[string]bool{
-		"retain_existing_data_on_backfill": false,
+	return featureFlags, map[string]common.FlagDefault{
+		"retain_existing_data_on_backfill": common.FlagDisabled,
+		"test_gated":                       common.FlagEnabledForTasksCreatedAfter("2026-06-10"),
 	}
 }
 

--- a/materialize-boilerplate/materializer_test.go
+++ b/materialize-boilerplate/materializer_test.go
@@ -593,7 +593,7 @@ func (m *testMaterializer) Close(ctx context.Context) {}
 type testTransactor struct{}
 
 func (t *testTransactor) RecoverCheckpoint(ctx context.Context, spec pf.MaterializationSpec, rangeSpec pf.RangeSpec) (m.RuntimeCheckpoint, error) {
-	panic("unimplemented")
+	return nil, nil
 }
 
 func (t *testTransactor) UnmarshalState(state json.RawMessage) error {

--- a/materialize-boilerplate/testutil/resources.go
+++ b/materialize-boilerplate/testutil/resources.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"gopkg.in/yaml.v3"
 )
 
@@ -143,7 +144,15 @@ func OpenResource[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger,
 		return nil, nil, fmt.Errorf("getting resource parameters: %w", err)
 	}
 
-	m, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	// These helpers read a destination back rather than run a task, so there is
+	// no runtime spec to take a creation date from and date-gated flags resolve
+	// as they do for a brand-new task.
+	flags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m, err := newMaterializer(ctx, taskName, cfg, flags)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating materializer: %w", err)
 	}

--- a/materialize-boilerplate/testutil/resources.go
+++ b/materialize-boilerplate/testutil/resources.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"gopkg.in/yaml.v3"
 )
 
@@ -146,7 +147,15 @@ func OpenResource[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger,
 		return nil, nil, fmt.Errorf("getting resource parameters: %w", err)
 	}
 
-	m, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	// These helpers read a destination back rather than run a task, so there is
+	// no runtime spec to take a creation date from and date-gated flags resolve
+	// as they do for a brand-new task.
+	flags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	m, err := newMaterializer(ctx, taskName, cfg, flags)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating materializer: %w", err)
 	}

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -222,7 +222,7 @@ func RunApplyTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger,
 
 	for _, taskName := range taskNames(bundled) {
 		cfg := decryptConfig[EC](t, bundled, taskName)
-		materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+		materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 		require.NoError(t, err)
 
 		var testResourcePaths [][]string
@@ -279,7 +279,7 @@ func RunApplyTestParallel[EC boilerplate.EndpointConfiger, FC boilerplate.FieldC
 	tsSuffix := testItemIdentifier + fmt.Sprintf("%d", time.Now().Unix())
 
 	names, results := RunTestAllTasksParallel(t, sourcePath, func(t *testing.T, bundled []byte, taskName string, cfg EC) string {
-		materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+		materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 		require.NoError(t, err)
 
 		var testResourcePaths [][]string
@@ -428,7 +428,7 @@ func runFeatureFlagMigrationForTask[EC boilerplate.EndpointConfiger, FC boilerpl
 	workingTaskName := taskName + rndSuffix
 
 	cfg := decryptConfig[EC](t, bundled, taskName)
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	res := makeResourceFn(workingTableName, false).WithDefaults(cfg)
@@ -547,7 +547,7 @@ func runMaterializationTestForTask[EC boilerplate.EndpointConfiger, FC boilerpla
 	cfg := decryptConfig[EC](t, bundled, taskName)
 	rt := rewriteTaskForTest[EC, RC](t, bundled, taskName, tsSuffix, cfg, makeResourceFn)
 
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -834,7 +834,7 @@ func runMigrationTestForTask[EC boilerplate.EndpointConfiger, FC boilerplate.Fie
 	bundledMigratedCollection := RunFlowctl(t, "raw", "bundle", "--source", relativePath(t, "testdata/integration/collections.migrate-migrated.flow.yaml"))
 
 	cfg := decryptConfig[EC](t, bundled, taskName)
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	bindings := gjson.GetBytes(bundled, fmt.Sprintf("materializations.%s.bindings", taskName)).Array()
@@ -1261,4 +1261,17 @@ func rawJson(t *testing.T, v any) json.RawMessage {
 	require.NoError(t, err)
 
 	return b
+}
+
+// harnessFlags resolves feature flags for a harness that has no runtime spec to
+// take a creation date from. Date-gated flags therefore resolve as they do for a
+// brand-new task; a harness which needs a specific era must resolve against a
+// spec carrying that CreatedAt itself.
+func harnessFlags[EC boilerplate.EndpointConfiger](t *testing.T, cfg EC) map[string]bool {
+	t.Helper()
+
+	flags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+	require.NoError(t, err)
+
+	return flags
 }

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -337,7 +337,7 @@ func RunApplyTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger,
 
 	for _, taskName := range taskNames(bundled) {
 		cfg := decryptConfig[EC](t, bundled, taskName)
-		materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+		materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 		require.NoError(t, err)
 
 		var testResourcePaths [][]string
@@ -394,7 +394,7 @@ func RunApplyTestParallel[EC boilerplate.EndpointConfiger, FC boilerplate.FieldC
 	tsSuffix := testItemIdentifier + fmt.Sprintf("%d", time.Now().Unix())
 
 	names, results := RunTestAllTasksParallel(t, sourcePath, func(t *testing.T, bundled []byte, taskName string, cfg EC) string {
-		materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+		materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 		require.NoError(t, err)
 
 		var testResourcePaths [][]string
@@ -543,7 +543,7 @@ func runFeatureFlagMigrationForTask[EC boilerplate.EndpointConfiger, FC boilerpl
 	workingTaskName := taskName + rndSuffix
 
 	cfg := decryptConfig[EC](t, bundled, taskName)
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	res := makeResourceFn(workingTableName, false).WithDefaults(cfg)
@@ -927,7 +927,7 @@ func runMigrationTestForTask[EC boilerplate.EndpointConfiger, FC boilerplate.Fie
 	bundledMigratedCollection := RunFlowctl(t, "raw", "bundle", "--source", relativePath(t, "testdata/integration/collections.migrate-migrated.flow.yaml"))
 
 	cfg := decryptConfig[EC](t, bundled, taskName)
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	bindings := gjson.GetBytes(bundled, fmt.Sprintf("materializations.%s.bindings", taskName)).Array()
@@ -1373,4 +1373,17 @@ func rawJson(t *testing.T, v any) json.RawMessage {
 	require.NoError(t, err)
 
 	return b
+}
+
+// harnessFlags resolves feature flags for a harness that has no runtime spec to
+// take a creation date from. Date-gated flags therefore resolve as they do for a
+// brand-new task; a harness which needs a specific era must resolve against a
+// spec carrying that CreatedAt itself.
+func harnessFlags[EC boilerplate.EndpointConfiger](t *testing.T, cfg EC) map[string]bool {
+	t.Helper()
+
+	flags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+	require.NoError(t, err)
+
+	return flags
 }

--- a/materialize-boilerplate/testutil/test_support_drain.go
+++ b/materialize-boilerplate/testutil/test_support_drain.go
@@ -37,7 +37,7 @@ func RunApplyDrainTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConf
 	ctx := context.Background()
 	configJson, resourceConfigJson := rawJson(t, cfg), rawJson(t, res)
 
-	materializer, err := newMaterializer(ctx, "apply-drain-test", cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, "apply-drain-test", cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	resourcePath, _, err := res.Parameters()

--- a/materialize-boilerplate/testutil/test_support_runtime.go
+++ b/materialize-boilerplate/testutil/test_support_runtime.go
@@ -170,7 +170,7 @@ func runMaterializationTestForTask[EC boilerplate.EndpointConfiger, FC boilerpla
 	cfg := decryptConfig[EC](t, bundled, taskName)
 	rt := rewriteTaskForTest[EC, RC](t, bundled, taskName, tsSuffix, cfg, makeResourceFn)
 
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -198,7 +198,7 @@ func runMaterializationTestForTask[EC boilerplate.EndpointConfiger, FC boilerpla
 		// And a fresh materializer to read it back with: a test materializer may
 		// cache what it read for the liveness run (eventbridge drains its queue
 		// once), or hold connections the liveness run's cleanup closes.
-		materializer, err = newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+		materializer, err = newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			CleanupTestResources(t, ctx, materializer, rt.resourcePaths, tsSuffix)

--- a/materialize-boilerplate/testutil/test_support_v2.go
+++ b/materialize-boilerplate/testutil/test_support_v2.go
@@ -173,7 +173,7 @@ func runMaterializationTestForTaskV2[EC boilerplate.EndpointConfiger, FC boilerp
 	cfg := decryptConfig[EC](t, bundled, taskName)
 	rt := rewriteTaskForTest[EC, RC](t, bundled, taskName, tsSuffix, cfg, makeResourceFn)
 
-	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	materializer, err := newMaterializer(ctx, taskName, cfg, harnessFlags(t, cfg))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -36,7 +36,7 @@ func newClient(_ context.Context, materializationName string, ep *sql.Endpoint[c
 	return &client{db: db, ep: ep}, nil
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	var errs = &cerrors.PrereqErr{}
 
 	var db = clickhouse.OpenDB(cfg.newClickhouseOptions())

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -115,7 +116,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, nil
 }
 

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -117,7 +118,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, nil
 }
 

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -80,7 +80,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var actual = preReqs(t.Context(), tt.cfg(cfg)).Unwrap()
+			var actual = preReqs(t.Context(), tt.cfg(cfg), nil).Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-databricks/client.go
+++ b/materialize-databricks/client.go
@@ -236,7 +236,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return fmt.Sprintf("CREATE SCHEMA %s;", schemaName), err
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	var wsConfig *databricks.Config

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -5,15 +5,16 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	"github.com/invopop/jsonschema"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 }
 
 // config represents the endpoint configuration for sql server.
@@ -175,7 +176,7 @@ func (c config) DefaultNamespace() string {
 	return c.SchemaName
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-databricks/config.go
+++ b/materialize-databricks/config.go
@@ -5,19 +5,20 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	"github.com/invopop/jsonschema"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 	// scale_out enables multi-shard operation under the v2 runtime: checkpoint
 	// state is scoped by shard key-range, and only the primary shard (key_begin
 	// 0) executes the staged MERGE/COPY queries of all shards at Acknowledge.
-	"scale_out": false,
+	"scale_out": common.FlagDisabled,
 }
 
 // config represents the endpoint configuration for sql server.
@@ -179,7 +180,7 @@ func (c config) DefaultNamespace() string {
 	return c.SchemaName
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-databricks/sqlgen_test.go
+++ b/materialize-databricks/sqlgen_test.go
@@ -5,11 +5,12 @@ import (
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createDatabricksDialect(featureFlagDefaults)
+var testDialect = createDatabricksDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func TestSQLGeneration(t *testing.T) {

--- a/materialize-dynamodb/driver.go
+++ b/materialize-dynamodb/driver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -24,8 +25,8 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 }
 
 type AuthType string
@@ -138,7 +139,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-elasticsearch/driver.go
+++ b/materialize-elasticsearch/driver.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v8"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -24,13 +25,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 
 	// Enable this flag to avoid a one time backfill due to change in date
 	// format in the mapping (a581ab1b761816b2b93b525c63153aac3493d49a).  This
 	// flag should not be used on tasks created after this commit.
-	"ignore_mapping_format_changes": false,
+	"ignore_mapping_format_changes": common.FlagDisabled,
 }
 
 type sshForwarding struct {
@@ -241,7 +242,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-eventbridge/driver.go
+++ b/materialize-eventbridge/driver.go
@@ -15,6 +15,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -115,7 +116,7 @@ func (c config) Validate() error {
 // EventBridge has no namespace concept; the bus name is endpoint-level.
 func (c config) DefaultNamespace() string { return "" }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, nil
 }
 

--- a/materialize-hubspot/config.go
+++ b/materialize-hubspot/config.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/estuary/connectors/go/common"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	"github.com/invopop/jsonschema"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"golang.org/x/time/rate"
 )
 
-var featureFlagDefaults = map[string]bool{}
+var featureFlagDefaults = map[string]common.FlagDefault{}
 
 type AuthType string
 
@@ -114,7 +115,7 @@ func (c *Config) DefaultNamespace() string {
 	return ""
 }
 
-func (c *Config) FeatureFlags() (raw string, defaults map[string]bool) {
+func (c *Config) FeatureFlags() (raw string, defaults map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-hubspot/driver.go
+++ b/materialize-hubspot/driver.go
@@ -55,7 +55,11 @@ func (d *Driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Re
 		return nil, err
 	}
 
-	parsedFlags := boilerplate.ParseFlags(cfg)
+	parsedFlags, err := boilerplate.ResolveFlags(cfg, req.LastMaterialization)
+	if err != nil {
+		return nil, err
+	}
+
 	materializer, err := NewMaterializer(ctx, req.Name.String(), cfg, parsedFlags)
 	if err != nil {
 		return nil, err
@@ -117,7 +121,11 @@ func (*Driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response_A
 		return nil, err
 	}
 
-	parsedFlags := boilerplate.ParseFlags(cfg)
+	parsedFlags, err := boilerplate.ResolveFlags(cfg, req.Materialization)
+	if err != nil {
+		return nil, err
+	}
+
 	materializer, err := NewMaterializer(ctx, req.Materialization.Name.String(), cfg, parsedFlags)
 	if err != nil {
 		return nil, err
@@ -268,7 +276,11 @@ func (*Driver) NewTransactor(
 		return nil, nil, nil, err
 	}
 
-	featureFlags := boilerplate.ParseFlags(cfg)
+	featureFlags, err := boilerplate.ResolveFlags(cfg, req.Materialization)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	materializer, err := NewMaterializer(ctx, req.Materialization.Name.String(), cfg, featureFlags)
 	if err != nil {
 		return nil, nil, nil, err

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -24,13 +25,13 @@ import (
 	"github.com/segmentio/encoding/json"
 )
 
-var featureFlagDefaults = map[string]bool{
+var featureFlagDefaults = map[string]common.FlagDefault{
 	// An alternate naming style for the Iceberg table data.  By default (when
 	// false), the naming is:
 	//   <base_location>/<namespace>_<table>_<hash>
 	// When this flag is enabled:
 	//   <base_location>/<namespace>/<table>.<hash>
-	"nested_dot_hash_location_style": false,
+	"nested_dot_hash_location_style": common.FlagDisabled,
 }
 
 // TODO(whb): It would be nice to have a configuration for making the table use
@@ -218,7 +219,7 @@ func (c config) DefaultNamespace() string {
 	}
 }
 
-func (c config) FeatureFlags() (raw string, defaults map[string]bool) {
+func (c config) FeatureFlags() (raw string, defaults map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-mongodb/config.go
+++ b/materialize-mongodb/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"net/url"
+
+	"github.com/estuary/connectors/go/common"
 )
 
 type sshForwarding struct {
@@ -57,8 +59,8 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
-	return c.Advanced.FeatureFlags, make(map[string]bool)
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
+	return c.Advanced.FeatureFlags, nil
 }
 
 // ToURI converts the Config to a DSN string.

--- a/materialize-motherduck/client.go
+++ b/materialize-motherduck/client.go
@@ -133,7 +133,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	db, err := cfg.db(ctx)

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	"github.com/invopop/jsonschema"
@@ -20,10 +21,10 @@ import (
 	"google.golang.org/api/option"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type config struct {
@@ -172,7 +173,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	"github.com/invopop/jsonschema"
@@ -21,10 +22,10 @@ import (
 	"google.golang.org/api/option"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type config struct {
@@ -173,7 +174,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-motherduck/sqlgen_test.go
+++ b/materialize-motherduck/sqlgen_test.go
@@ -1,20 +1,20 @@
 package connector
 
 import (
-	"maps"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createDuckDialect(featureFlagDefaults, false)
+var testDialect = createDuckDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}), false)
 var testTemplates = renderTemplates(testDialect)
 
 func flagsWithoutNativeBinary() map[string]bool {
-	out := maps.Clone(featureFlagDefaults)
+	out := common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
 	out["native_binary_column_type"] = false
 	return out
 }

--- a/materialize-motherduck/sqlgen_test.go
+++ b/materialize-motherduck/sqlgen_test.go
@@ -1,20 +1,20 @@
 package connector
 
 import (
-	"maps"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createDuckDialect(featureFlagDefaults)
+var testDialect = createDuckDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func flagsWithoutNativeBinary() map[string]bool {
-	out := maps.Clone(featureFlagDefaults)
+	out := common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
 	out["native_binary_column_type"] = false
 	return out
 }

--- a/materialize-mysql/client.go
+++ b/materialize-mysql/client.go
@@ -39,7 +39,7 @@ func prepareNewClient(tzLocation *time.Location) func(ctx context.Context, _ str
 	}
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	db, err := stdsql.Open("mysql", cfg.ToURI())

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -27,10 +28,10 @@ import (
 	"go.gazette.dev/core/consumer/protocol"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type sshForwarding struct {
@@ -109,7 +110,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-mysql/driver_test.go
+++ b/materialize-mysql/driver_test.go
@@ -5,6 +5,7 @@ import (
 	stdsql "database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/estuary/connectors/go/common"
 	"os/exec"
 	"slices"
 	"strings"
@@ -256,7 +257,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var actual = preReqs(ctx, tt.cfg(cfg)).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-mysql/driver_test.go
+++ b/materialize-mysql/driver_test.go
@@ -5,6 +5,7 @@ import (
 	stdsql "database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/estuary/connectors/go/common"
 	"os/exec"
 	"slices"
 	"strings"
@@ -257,7 +258,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var actual = preReqs(ctx, tt.cfg(cfg)).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = mysqlDialect(time.UTC, "flow", "mysql", featureFlagDefaults)
+var testDialect = mysqlDialect(time.UTC, "flow", "mysql", common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect, "mysql")
 
 func TestSQLGeneration(t *testing.T) {
@@ -20,7 +21,7 @@ func TestSQLGeneration(t *testing.T) {
 }
 
 func TestSQLGeneration_Singlestore(t *testing.T) {
-	dialect := mysqlDialect(time.UTC, "flow", "singlestore", featureFlagDefaults)
+	dialect := mysqlDialect(time.UTC, "flow", "singlestore", common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 	tpls := renderTemplates(dialect, "singlestore")
 	runSQLGen(t, dialect, tpls)
 }

--- a/materialize-postgres/client.go
+++ b/materialize-postgres/client.go
@@ -49,7 +49,7 @@ func newClient(ctx context.Context, materializationName string, ep *sql.Endpoint
 	}, nil
 }
 
-func preReqs(ctx context.Context, conf config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, conf config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	cfg := conf

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	iam "github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
@@ -50,12 +51,12 @@ const (
 	queryTimeout = 1 * time.Hour
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
-	"enum":                             true,
-	"jsonb":                            true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
+	"enum":                             common.FlagEnabled,
+	"jsonb":                            common.FlagEnabled,
 }
 
 func ctxWithQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -130,7 +131,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -152,7 +152,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, preReqs(context.Background(), tt.cfg(cfg)).Unwrap())
+			require.Equal(t, tt.want, preReqs(context.Background(), tt.cfg(cfg), testFlagDefaults()).Unwrap())
 		})
 	}
 }

--- a/materialize-postgres/enum_type_test.go
+++ b/materialize-postgres/enum_type_test.go
@@ -99,7 +99,7 @@ func TestCompatibleFallback(t *testing.T) {
 // TestCompatibleRoundTrip asserts that every name the generator produces is
 // recognized as compatible by Compatible, across the truncation/hash regimes.
 func TestCompatibleRoundTrip(t *testing.T) {
-	dialect := createPgDialect(featureFlagDefaults)
+	dialect := createPgDialect(testFlagDefaults())
 
 	cases := []struct {
 		name  string
@@ -128,7 +128,7 @@ func TestCompatibleRoundTrip(t *testing.T) {
 }
 
 func TestEnumTypeNamePartsNormal(t *testing.T) {
-	dialect := createPgDialect(featureFlagDefaults)
+	dialect := createPgDialect(testFlagDefaults())
 
 	// Short names: no hash, base <= 63 bytes
 	schema, base, typeName, err := enumTypeNameParts(dialect, []string{"public", "orders"}, "status")
@@ -140,7 +140,7 @@ func TestEnumTypeNamePartsNormal(t *testing.T) {
 }
 
 func TestEnumTypeNamePartsHashed(t *testing.T) {
-	dialect := createPgDialect(featureFlagDefaults)
+	dialect := createPgDialect(testFlagDefaults())
 
 	// Long field name triggers hash mode
 	longField := strings.Repeat("x", 50)
@@ -153,7 +153,7 @@ func TestEnumTypeNamePartsHashed(t *testing.T) {
 }
 
 func TestEnumTypeNamePartsLongTableName(t *testing.T) {
-	dialect := createPgDialect(featureFlagDefaults)
+	dialect := createPgDialect(testFlagDefaults())
 
 	// tableName at max length (63 bytes) — previously caused base to exceed 63 bytes
 	longTable := strings.Repeat("a", 63)
@@ -165,7 +165,7 @@ func TestEnumTypeNamePartsLongTableName(t *testing.T) {
 }
 
 func TestEnumTypeNamePartsSinglePathElement(t *testing.T) {
-	dialect := createPgDialect(featureFlagDefaults)
+	dialect := createPgDialect(testFlagDefaults())
 
 	schema, base, _, err := enumTypeNameParts(dialect, []string{"mytable"}, "col")
 	require.NoError(t, err)

--- a/materialize-postgres/sqlgen_test.go
+++ b/materialize-postgres/sqlgen_test.go
@@ -6,12 +6,19 @@ import (
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createPgDialect(featureFlagDefaults)
+// testFlagDefaults resolves flag defaults as they would be for a newly created
+// task, so that any date-gated flag is exercised in its enabled state.
+func testFlagDefaults() map[string]bool {
+	return common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
+}
+
+var testDialect = createPgDialect(testFlagDefaults())
 var testTemplates = renderTemplates(testDialect)
 
 func TestSQLGeneration(t *testing.T) {
@@ -166,10 +173,7 @@ func TestJSONBContentMediaType(t *testing.T) {
 // the contentMediaType is ignored entirely and every field collapses onto JSON,
 // preserving the pre-JSONB behavior.
 func TestJSONBFeatureFlagDisabled(t *testing.T) {
-	flags := map[string]bool{}
-	for k, v := range featureFlagDefaults {
-		flags[k] = v
-	}
+	flags := testFlagDefaults()
 	flags["jsonb"] = false
 	dialect := createPgDialect(flags)
 

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsHttp "github.com/aws/smithy-go/transport/http"
-	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -191,7 +190,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		errs.Err(err)
 	}
 
-	parsedFlags := common.ParseFeatureFlags(cfg.Advanced.FeatureFlags, featureFlagDefaults)
+	parsedFlags := boilerplate.ParseFlags(cfg)
 
 	s3client, err := cfg.toS3Client(ctx, parsedFlags)
 	if err != nil {

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -152,7 +152,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, featureFlags map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	db, err := stdsql.Open("pgx", cfg.toURI())
@@ -190,9 +190,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		errs.Err(err)
 	}
 
-	parsedFlags := boilerplate.ParseFlags(cfg)
-
-	s3client, err := cfg.toS3Client(ctx, parsedFlags)
+	s3client, err := cfg.toS3Client(ctx, featureFlags)
 	if err != nil {
 		// This is not caused by invalid S3 credentials, and would most likely be a logic error in
 		// the connector code.

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsHttp "github.com/aws/smithy-go/transport/http"
-	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -188,7 +187,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		errs.Err(err)
 	}
 
-	parsedFlags := common.ParseFeatureFlags(cfg.Advanced.FeatureFlags, featureFlagDefaults)
+	parsedFlags := boilerplate.ParseFlags(cfg)
 
 	s3client, err := cfg.toS3Client(ctx, parsedFlags)
 	if err != nil {

--- a/materialize-redshift/client.go
+++ b/materialize-redshift/client.go
@@ -149,7 +149,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return sql.StdCreateSchema(ctx, c.db, c.ep.Dialect, schemaName)
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, featureFlags map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	db, err := stdsql.Open("pgx", cfg.toURI())
@@ -187,9 +187,7 @@ func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
 		errs.Err(err)
 	}
 
-	parsedFlags := boilerplate.ParseFlags(cfg)
-
-	s3client, err := cfg.toS3Client(ctx, parsedFlags)
+	s3client, err := cfg.toS3Client(ctx, featureFlags)
 	if err != nil {
 		// This is not caused by invalid S3 credentials, and would most likely be a logic error in
 		// the connector code.

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -53,11 +54,11 @@ const (
 	redshiftTextColumnLength = 256
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"s3_use_dualstack_endpoints":       false,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"s3_use_dualstack_endpoints":       common.FlagDisabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type sshForwarding struct {
@@ -134,7 +135,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -57,11 +58,11 @@ const (
 	redshiftTextColumnLength = 256
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"s3_use_dualstack_endpoints":       false,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"s3_use_dualstack_endpoints":       common.FlagDisabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type sshForwarding struct {
@@ -138,7 +139,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -173,7 +173,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg)).Unwrap())
+			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap())
 		})
 	}
 }

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -55,7 +56,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("fence", func(t *testing.T) {
 		cfg := mustGetCfg(t)
-		var testDialect = createRsDialect(false, featureFlagDefaults)
+		var testDialect = createRsDialect(false, common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 		var testTemplates = renderTemplates(testDialect)
 
 		sql.RunFencingTest(

--- a/materialize-redshift/driver_test.go
+++ b/materialize-redshift/driver_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	testutil "github.com/estuary/connectors/materialize-boilerplate/testutil"
@@ -115,7 +116,7 @@ func TestIntegration(t *testing.T) {
 			// The drain applies under the fixture spec's own name and leaves
 			// its tokens row behind.
 			t.Cleanup(func() {
-				materializer, err := NewDriver().NewMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+				materializer, err := NewDriver().NewMaterializer(ctx, taskName, cfg, testFlags(t, cfg))
 				require.NoError(t, err)
 				defer materializer.Close(ctx)
 				require.NoError(t, materializer.CleanupTestTask(ctx, "test/sqlite"))
@@ -140,7 +141,7 @@ func stageRows(t *testing.T, cfg config, fields []string, rows [][]any) *stateIt
 	t.Helper()
 	ctx := context.Background()
 
-	client, err := cfg.toS3Client(ctx, boilerplate.ParseFlags(cfg))
+	client, err := cfg.toS3Client(ctx, testFlags(t, cfg))
 	require.NoError(t, err)
 
 	f := newStagedFile(newS3Store(client, cfg.Bucket), cfg.effectiveBucketPath(), fields)
@@ -161,7 +162,7 @@ func stageRows(t *testing.T, cfg config, fields []string, rows [][]any) *stateIt
 func runIdempotencyTest(t *testing.T, makeResourceFn func(string, bool) tableConfig) {
 	ctx := context.Background()
 	cfg := mustGetCfg(t)
-	flags := boilerplate.ParseFlags(cfg)
+	flags := testFlags(t, cfg)
 	suffix := fmt.Sprintf("%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
 
 	driver := NewDriver()
@@ -390,7 +391,18 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg)).Unwrap())
+			require.Equal(t, tt.want, preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap())
 		})
 	}
+}
+
+// testFlags resolves feature flags for a test that has no runtime spec to take a
+// creation date from, so date-gated flags resolve as for a brand-new task.
+func testFlags(t *testing.T, cfg config) map[string]bool {
+	t.Helper()
+
+	flags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+	require.NoError(t, err)
+
+	return flags
 }

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -1,22 +1,22 @@
 package connector
 
 import (
-	"maps"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	sqlDriver "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createRsDialect(false, featureFlagDefaults)
+var testDialect = createRsDialect(false, common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func flagsWithoutNativeBinary() map[string]bool {
-	out := maps.Clone(featureFlagDefaults)
+	out := common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
 	out["native_binary_column_type"] = false
 	return out
 }

--- a/materialize-redshift/sqlgen_test.go
+++ b/materialize-redshift/sqlgen_test.go
@@ -1,21 +1,21 @@
 package connector
 
 import (
-	"maps"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createRsDialect(false, featureFlagDefaults)
+var testDialect = createRsDialect(false, common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func flagsWithoutNativeBinary() map[string]bool {
-	out := maps.Clone(featureFlagDefaults)
+	out := common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
 	out["native_binary_column_type"] = false
 	return out
 }

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -20,6 +20,7 @@ import (
 	awsHttp "github.com/aws/smithy-go/transport/http"
 	"github.com/estuary/connectors/filesink"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -33,15 +34,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 
 	// An alternate naming style for the Iceberg table data.  By default (when
 	// false), the naming is:
 	//   <base_location>/<namespace>/<table>_<hash>
 	// When this flag is enabled:
 	//   <base_location>/<namespace>/<table>.<hash>
-	"nested_dot_hash_location_style": false,
+	"nested_dot_hash_location_style": common.FlagDisabled,
 }
 
 type catalogType string
@@ -247,7 +248,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	if c.Advanced == nil {
 		return "", featureFlagDefaults
 	}

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -21,6 +21,7 @@ import (
 	awsHttp "github.com/aws/smithy-go/transport/http"
 	"github.com/estuary/connectors/filesink"
 	"github.com/estuary/connectors/go/blob"
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -34,15 +35,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"retain_existing_data_on_backfill": false,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"retain_existing_data_on_backfill": common.FlagDisabled,
 
 	// An alternate naming style for the Iceberg table data.  By default (when
 	// false), the naming is:
 	//   <base_location>/<namespace>/<table>_<hash>
 	// When this flag is enabled:
 	//   <base_location>/<namespace>/<table>.<hash>
-	"nested_dot_hash_location_style": false,
+	"nested_dot_hash_location_style": common.FlagDisabled,
 }
 
 type catalogType string
@@ -249,7 +250,7 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	if c.Advanced == nil {
 		return "", featureFlagDefaults
 	}

--- a/materialize-snowflake/client.go
+++ b/materialize-snowflake/client.go
@@ -272,7 +272,7 @@ func (c *client) CreateSchema(ctx context.Context, schemaName string) (string, e
 	return sql.StdCreateSchema(ctx, c.dbNoSchema, c.ep.Dialect, schemaName)
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	dsn, err := cfg.toURI(false, "")

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -9,19 +9,20 @@ import (
 	"strings"
 
 	snowflake_auth "github.com/estuary/connectors/go/auth/snowflake"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	log "github.com/sirupsen/logrus"
 	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
-var featureFlagDefaults = map[string]bool{
+var featureFlagDefaults = map[string]common.FlagDefault{
 	// Use Snowpipe streaming for delta-updates bindings that use JWT
 	// authentication.
-	"snowpipe_streaming":               true,
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+	"snowpipe_streaming":               common.FlagEnabled,
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 // snowflakeTimestampType specifies how timestamp columns should be handled in Snowflake.
@@ -201,7 +202,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/estuary/connectors/go/common"
 	"os/exec"
 	"regexp"
 	"testing"
@@ -191,7 +192,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, preReqs(context.Background(), *tt.cfg(cfg)).Unwrap())
+			require.Equal(t, tt.want, preReqs(context.Background(), *tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap())
 		})
 	}
 }

--- a/materialize-snowflake/sqlgen_test.go
+++ b/materialize-snowflake/sqlgen_test.go
@@ -1,23 +1,23 @@
 package connector
 
 import (
-	"maps"
 	"testing"
 	"text/template"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = snowflakeDialect("PUBLIC", timestampTypeLTZ, featureFlagDefaults)
+var testDialect = snowflakeDialect("PUBLIC", timestampTypeLTZ, common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 // flagsWithoutNativeBinary returns a copy of featureFlagDefaults with
 // native_binary_column_type forced off, for snapshot tests that exercise the
 // flag-disabled code path.
 func flagsWithoutNativeBinary() map[string]bool {
-	out := maps.Clone(featureFlagDefaults)
+	out := common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})
 	out["native_binary_column_type"] = false
 	return out
 }

--- a/materialize-spanner/client.go
+++ b/materialize-spanner/client.go
@@ -93,7 +93,7 @@ func newClient(ctx context.Context, materializationName string, ep *sql.Endpoint
 	}, nil
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	// Build the database path

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -17,6 +17,7 @@ import (
 	databasepb "cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	instancepb "cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+	"github.com/estuary/connectors/go/common"
 	m "github.com/estuary/connectors/go/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -28,8 +29,8 @@ import (
 	"google.golang.org/api/option"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetimes_as_string": true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetimes_as_string": common.FlagEnabled,
 }
 
 // credentialConfig represents authentication options for Cloud Spanner
@@ -71,7 +72,7 @@ func (c config) Validate() error {
 	return nil
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-spanner/driver_test.go
+++ b/materialize-spanner/driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 )
 
@@ -32,7 +33,7 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("fence", func(t *testing.T) {
-		var testDialect = createSpannerDialect(featureFlagDefaults)
+		var testDialect = createSpannerDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 		var testTemplates = renderTemplates(testDialect, false)
 
 		sql.RunFencingTest(
@@ -56,4 +57,3 @@ func TestIntegration(t *testing.T) {
 		)
 	})
 }
-

--- a/materialize-spanner/driver_test.go
+++ b/materialize-spanner/driver_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/spanner"
+	"github.com/estuary/connectors/go/common"
 	sql "github.com/estuary/connectors/materialize-sql"
 )
 
@@ -33,7 +34,7 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("fence", func(t *testing.T) {
-		var testDialect = createSpannerDialect(featureFlagDefaults)
+		var testDialect = createSpannerDialect(common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 		var testTemplates = renderTemplates(testDialect, false)
 
 		sql.RunFencingTest(
@@ -57,4 +58,3 @@ func TestIntegration(t *testing.T) {
 		)
 	})
 }
-

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -71,7 +71,11 @@ func (d *Driver[EC, RC]) Validate(ctx context.Context, req *pm.Request_Validate)
 }
 
 func (d *Driver[EC, RC]) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response_Applied, error) {
-	return boilerplate.RunApply(ctx, req, d.NewMaterializer)
+	var opts []boilerplate.ApplyOption
+	if schema, err := schemagen.GenerateSchema("SQL Connection", new(EC)).MarshalJSON(); err == nil {
+		opts = append(opts, boilerplate.WithConfigUpdates(schema, []string{"advanced", "feature_flags"}))
+	}
+	return boilerplate.RunApply(ctx, req, d.NewMaterializer, opts...)
 }
 
 func (d *Driver[EC, RC]) NewTransactor(ctx context.Context, req pm.Request_Open, be *m.BindingEvents) (m.Transactor, *pm.Response_Opened, *m.MaterializeOptions, error) {

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -71,15 +71,12 @@ func (d *Driver[EC, RC]) Validate(ctx context.Context, req *pm.Request_Validate)
 }
 
 func (d *Driver[EC, RC]) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response_Applied, error) {
-	var opts []boilerplate.ApplyOption
-	if schema, err := schemagen.GenerateSchema("SQL Connection", new(EC)).MarshalJSON(); err == nil {
-		opts = append(opts, boilerplate.WithConfigUpdates(schema, []string{"advanced", "feature_flags"}))
-	}
-	return boilerplate.RunApply(ctx, req, d.NewMaterializer, opts...)
+	return boilerplate.RunApply(ctx, req, d.NewMaterializer)
 }
 
 func (d *Driver[EC, RC]) NewTransactor(ctx context.Context, req pm.Request_Open, be *m.BindingEvents) (m.Transactor, *pm.Response_Opened, *m.MaterializeOptions, error) {
-	return boilerplate.RunNewTransactor(ctx, req, be, d.NewMaterializer)
+	return boilerplate.RunNewTransactor(ctx, req, be, d.NewMaterializer,
+		boilerplate.WithConfigUpdates([]string{"advanced", "feature_flags"}))
 }
 
 type sqlMaterialization[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]] struct {

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -31,7 +31,9 @@ type Driver[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]] s
 	// connector, to as much of an extent as possible. The returned PrereqErr
 	// can include multiple separate errors if it possible to determine that
 	// there is more than one issue that needs corrected.
-	PreReqs func(ctx context.Context, cfg EC) *cerrors.PrereqErr
+	// featureFlags are the flags resolved for the task from its spec, so that a
+	// check which varies by flag uses the same values as the rest of the RPC.
+	PreReqs func(ctx context.Context, cfg EC, featureFlags map[string]bool) *cerrors.PrereqErr
 }
 
 var _ boilerplate.Connector = &Driver[boilerplate.EndpointConfiger, Resource]{}
@@ -125,7 +127,7 @@ var _ boilerplate.Materializer[
 ] = &sqlMaterialization[boilerplate.EndpointConfiger, Resource]{}
 
 func (s *sqlMaterialization[EC, RC]) CheckPrerequisites(ctx context.Context) *cerrors.PrereqErr {
-	return s.driver.PreReqs(ctx, s.endpoint.Config)
+	return s.driver.PreReqs(ctx, s.endpoint.Config, s.featureFlags)
 }
 
 func (s *sqlMaterialization[EC, RC]) Config() boilerplate.MaterializeCfg {

--- a/materialize-sql/driver_test.go
+++ b/materialize-sql/driver_test.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"github.com/estuary/connectors/go/common"
 	"testing"
 	"text/template"
 
@@ -13,9 +14,9 @@ import (
 
 type stateKeyTestConfig struct{}
 
-func (stateKeyTestConfig) Validate() error                         { return nil }
-func (stateKeyTestConfig) DefaultNamespace() string                { return "public" }
-func (stateKeyTestConfig) FeatureFlags() (string, map[string]bool) { return "", nil }
+func (stateKeyTestConfig) Validate() error                                       { return nil }
+func (stateKeyTestConfig) DefaultNamespace() string                              { return "public" }
+func (stateKeyTestConfig) FeatureFlags() (string, map[string]common.FlagDefault) { return "", nil }
 
 type stateKeyTestResource struct{}
 

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
-	"github.com/estuary/connectors/go/common"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	testutil "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -178,8 +177,7 @@ func RunFencingTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC
 
 		checkpointsTable := "temp_test_fencing_checkpoints" + rngSuffix
 
-		rawFlags, defaultFlags := cfg.FeatureFlags()
-		parsedFlags := common.ParseFeatureFlags(rawFlags, defaultFlags)
+		parsedFlags := boilerplate.ParseFlags(cfg)
 
 		ep, err := driver.NewEndpoint(ctx, cfg, parsedFlags)
 		require.NoError(t, err)

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -85,7 +85,10 @@ func DrainSeedInsertQuery[EC boilerplate.EndpointConfiger, RC boilerplate.Resour
 	t.Helper()
 	ctx := context.Background()
 
-	m, err := driver.NewMaterializer(ctx, "apply-drain-seed", cfg, boilerplate.ParseFlags(cfg))
+	flags, err := boilerplate.ResolveFlags(cfg, appliedSpec)
+	require.NoError(t, err)
+
+	m, err := driver.NewMaterializer(ctx, "apply-drain-seed", cfg, flags)
 	require.NoError(t, err)
 	defer m.Close(ctx)
 	s, ok := m.(*sqlMaterialization[EC, RC])
@@ -177,7 +180,10 @@ func RunFencingTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC
 
 		checkpointsTable := "temp_test_fencing_checkpoints" + rngSuffix
 
-		parsedFlags := boilerplate.ParseFlags(cfg)
+		// The fencing harness has no runtime spec to take a creation date from,
+		// so date-gated flags resolve as they do for a brand-new task.
+		parsedFlags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+		require.NoError(t, err)
 
 		ep, err := driver.NewEndpoint(ctx, cfg, parsedFlags)
 		require.NoError(t, err)

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -90,7 +90,10 @@ func DrainSeedInsertQuery[EC boilerplate.EndpointConfiger, RC boilerplate.Resour
 	t.Helper()
 	ctx := context.Background()
 
-	m, err := driver.NewMaterializer(ctx, "apply-drain-seed", cfg, boilerplate.ParseFlags(cfg))
+	flags, err := boilerplate.ResolveFlags(cfg, appliedSpec)
+	require.NoError(t, err)
+
+	m, err := driver.NewMaterializer(ctx, "apply-drain-seed", cfg, flags)
 	require.NoError(t, err)
 	defer m.Close(ctx)
 	s, ok := m.(*sqlMaterialization[EC, RC])
@@ -182,7 +185,10 @@ func RunFencingTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC
 
 		checkpointsTable := "temp_test_fencing_checkpoints" + rngSuffix
 
-		parsedFlags := boilerplate.ParseFlags(cfg)
+		// The fencing harness has no runtime spec to take a creation date from,
+		// so date-gated flags resolve as they do for a brand-new task.
+		parsedFlags, err := boilerplate.ResolveFlags(cfg, &pf.MaterializationSpec{})
+		require.NoError(t, err)
 
 		ep, err := driver.NewEndpoint(ctx, cfg, parsedFlags)
 		require.NoError(t, err)

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
-	"github.com/estuary/connectors/go/common"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	testutil "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -183,8 +182,7 @@ func RunFencingTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC
 
 		checkpointsTable := "temp_test_fencing_checkpoints" + rngSuffix
 
-		rawFlags, defaultFlags := cfg.FeatureFlags()
-		parsedFlags := common.ParseFeatureFlags(rawFlags, defaultFlags)
+		parsedFlags := boilerplate.ParseFlags(cfg)
 
 		ep, err := driver.NewEndpoint(ctx, cfg, parsedFlags)
 		require.NoError(t, err)

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -35,8 +36,8 @@ func (c config) DefaultNamespace() string {
 	return ""
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
-	return "", make(map[string]bool)
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
+	return "", nil
 }
 
 type tableConfig struct {

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -94,7 +94,7 @@ func NewSQLiteDriver() *sql.Driver[config, tableConfig] {
 				ConcurrentApply:     false,
 			}, nil
 		},
-		PreReqs: func(context.Context, config) *cerrors.PrereqErr { return &cerrors.PrereqErr{} },
+		PreReqs: func(context.Context, config, map[string]bool) *cerrors.PrereqErr { return &cerrors.PrereqErr{} },
 	}
 }
 

--- a/materialize-sqlserver/client.go
+++ b/materialize-sqlserver/client.go
@@ -41,7 +41,7 @@ func newClient(ctx context.Context, materializationName string, ep *sql.Endpoint
 	}, nil
 }
 
-func preReqs(ctx context.Context, cfg config) *cerrors.PrereqErr {
+func preReqs(ctx context.Context, cfg config, _ map[string]bool) *cerrors.PrereqErr {
 	errs := &cerrors.PrereqErr{}
 
 	connector, err := cfg.ToSQLConnector(ctx)

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/common"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -28,10 +29,10 @@ import (
 	"go.gazette.dev/core/consumer/protocol"
 )
 
-var featureFlagDefaults = map[string]bool{
-	"datetime_keys_as_string":          true,
-	"retain_existing_data_on_backfill": false,
-	"native_binary_column_type":        true,
+var featureFlagDefaults = map[string]common.FlagDefault{
+	"datetime_keys_as_string":          common.FlagEnabled,
+	"retain_existing_data_on_backfill": common.FlagDisabled,
+	"native_binary_column_type":        common.FlagEnabled,
 }
 
 type AuthType string
@@ -147,7 +148,7 @@ func (c config) DefaultNamespace() string {
 	return c.Schema
 }
 
-func (c config) FeatureFlags() (string, map[string]bool) {
+func (c config) FeatureFlags() (string, map[string]common.FlagDefault) {
 	return c.Advanced.FeatureFlags, featureFlagDefaults
 }
 

--- a/materialize-sqlserver/driver_test.go
+++ b/materialize-sqlserver/driver_test.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"github.com/estuary/connectors/go/common"
 	"os/exec"
 	"strings"
 	"testing"
@@ -126,7 +127,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var actual = preReqs(ctx, tt.cfg(cfg)).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-sqlserver/driver_test.go
+++ b/materialize-sqlserver/driver_test.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"github.com/estuary/connectors/go/common"
 	"os/exec"
 	"strings"
 	"testing"
@@ -127,7 +128,7 @@ func TestPrereqs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var actual = preReqs(ctx, tt.cfg(cfg)).Unwrap()
+			var actual = preReqs(ctx, tt.cfg(cfg), common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{})).Unwrap()
 
 			require.Equal(t, len(tt.want), len(actual))
 			for i := 0; i < len(tt.want); i++ {

--- a/materialize-sqlserver/sqlgen_test.go
+++ b/materialize-sqlserver/sqlgen_test.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/go/common"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
 
-var testDialect = createSqlServerDialect("Latin1_General_100_BIN2_UTF8", "dbo", featureFlagDefaults)
+var testDialect = createSqlServerDialect("Latin1_General_100_BIN2_UTF8", "dbo", common.ResolveFlagDefaults(featureFlagDefaults, common.CreatedAt{}))
 var testTemplates = renderTemplates(testDialect)
 
 func TestSQLGeneration(t *testing.T) {

--- a/source-hello-world/main.go
+++ b/source-hello-world/main.go
@@ -134,6 +134,8 @@ func (d driver) Apply(ctx context.Context, req *pc.Request_Apply) (*pc.Response_
 func (driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) error {
 	log.Debug("connector started")
 
+	log.WithField("observable", true).Info("a pass-through connector log")
+
 	var cfg config
 	if err := pf.UnmarshalStrict(open.Capture.ConfigJson, &cfg); err != nil {
 		return fmt.Errorf("parsing endpoint config: %w", err)


### PR DESCRIPTION
**Description:**

Materialization feature flags gain a third kind of default, alongside enabled-for-all and disabled-for-all: **enabled only for tasks created on or after a cutoff date**. This is how we change a default behavior without disturbing existing tasks, replacing the manual "bulk-edit `no_<flag>` into every production config, then merge a second PR flipping the default" process.

A connector author declares it in the defaults map:

```go
var featureFlagDefaults = map[string]common.FlagDefault{
	"existing_thing": common.FlagEnabled,
	"new_thing":      common.FlagEnabledForTasksCreatedAfter("2026-06-10"),
}
```

Resolution uses the `created_at` date that estuary/flow@4d66c8db stamps onto built task specs (requires flow v0.6.12, bumped here). Precedence per flag: an explicit `<flag>` / `no_<flag>` in `/advanced/feature_flags` wins, then the cutoff comparison, then the fixed default. `created_at` is empty only during a task's very first build, before its creation is committed — that means brand new, and resolves every cutoff-gated flag on.

Open then emits a `configUpdate` restating the endpoint config with each cutoff-gated flag written out explicitly, so a task's flags can be read off its config instead of inferred from its creation date. The restatement writes the flags into the sealed config's plaintext `sops.overlay` (#4941 marks `feature_flags` `nonsensitive`), so nothing is decrypted, re-encrypted, or re-keyed.

No flag uses a cutoff yet; this PR only wires up the mechanism.

**Workflow steps:**

For connector authors only — no user-visible change. To change a default behavior, add the flag with `FlagEnabledForTasksCreatedAfter(<ship date>)` and merge. Tasks that exist on that date keep the old behavior for the rest of their lives; tasks created afterwards get the new behavior from birth. Support can still override either way per-task via `/advanced/feature_flags`, which takes priority over the cutoff.

The cutoff is a date rather than a timestamp because a date is all a spec records about when a task was created, so the two are compared directly. A flag takes effect for the whole of the day it ships on.

**Documentation links affected:**

None user-facing. Internal `docs/feature_flags.md` gains a "Changing Default Behaviors (Materializations)" section covering resolution and the config recording; the existing bulk-edit workflow is relabelled as the fallback for captures.

**Notes for reviewers:**

- Resolution is a pure function of `(feature_flags string, spec.CreatedAt)`, so Validate, Apply and Open agree without persisting anything. Validate takes the date from `LastMaterialization` (the proposed spec isn't in the request), Apply and Open from `req.Materialization`. All three agree because the date is derived from the task's immutable control-plane ID.
- **Recording happens at Open** because `sealed_config_json` is an Open-only request field; Apply has no sealed config to restate. `WithConfigUpdates` is correspondingly an `OpenOption`.
- **The `configUpdate` is a record, not a decision.** It writes the value the connector already resolved, so the config can never contradict runtime behavior and the task behaves identically before and after it lands. That is what lets it be asynchronous and best-effort — failures are logged and ignored, and nothing is persisted in connector state.
- A `configUpdate` racing a user edit or another publication can't clobber it: the control plane only applies one whose build matches the task's current `last_build_id`, and publishes with `expect_pub_id`. So at most one config update takes effect per build, and stale ones are dropped.
- Only cutoff-gated flags are recorded with `configUpdate`. Recording fixed defaults would freeze them per-task and defeat any later fleet-wide change of a default.
- Encrypted values are copied across untouched; the restatement is otherwise re-serialized, which sorts its properties. That is safe even though sops MACs a document's values in the order it encounters them, because the control plane parses the emitted config into a `serde_json::Value` and re-serializes it when applying the update, sorting it the same way. An unencrypted config has no ciphertext to preserve and is restated directly, rather than being given a `sops` stanza the runtime would then look for ciphertext in.
- Emitting no longer contacts the config-encryption service, so no secret leaves the connector and a config keeps the key it was sealed with — including a customer-managed key Estuary cannot encrypt to.
- A spec built before flow stamped `created_at` has no date and would resolve as brand new. This means this PR has to wait 20 days since the release of the `created_at` change before we can release, to make sure all tasks that have been enabled, do have a `created_at`. Disabled tasks will end up having `created_at` when their enabling publication goes through.

**Verified end-to-end** on a local data plane (materialize-postgres, age-sealed config, cutoff-gated probe flag): the connector emits one `configUpdate` carrying `sops.overlay.advanced.feature_flags` with the ciphertext untouched; the control plane republishes; the task's next Open decrypts the round-tripped config and resolves the flag from it, so nothing is re-emitted on later builds. Publishing an overlay that also rewrites `/address` is rejected with `overlay modifies location '/address', which is not marked nonsensitive`.
