### PR TITLE
source-shopify-native: add `staff_members` stream

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -747,6 +747,28 @@ def open(
     return (response.Opened(explicitAcknowledgements=requires_explicit_acks), _run)
 
 
+def _tombstone_discriminator_values(
+    tombstone: BaseDocument, key: list[str]
+) -> tuple[object, ...]:
+    """Return a tombstone's collection-key values other than the CDK-managed
+    /_meta/row_id, in key order. These are what must differ between snapshot
+    subtasks: two subtasks sharing them would emit tombstones into the same
+    (discriminator, row_id) keyspace."""
+    dump = tombstone.model_dump(by_alias=True)
+    values: list[object] = []
+    for key_pointer in key:
+        # row_id is assigned per-pass by the CDK and is identical across
+        # subtasks, so it can't distinguish them.
+        if key_pointer == "/_meta/row_id":
+            continue
+        node: Any = dump
+        for field in key_pointer.strip("/").split("/"):
+            # A KeyError here means the tombstone is missing a key field.
+            node = node[field]
+        values.append(node)
+    return tuple(values)
+
+
 def open_binding(
     binding: CaptureBinding[_ResourceConfig],
     binding_index: int,
@@ -907,6 +929,19 @@ def open_binding(
             ), (
                 "fetch_snapshot subtasks requires a tombstone dict with "
                 "the same keys, each carrying the subtask discriminator. "
+            )
+
+            # Each subtask numbers row_id independently from zero, so the
+            # non-row_id key field(s) are all that distinguish one subtask's
+            # tombstones from another's. If two subtasks shared a discriminator,
+            # a deletion from one would land on the other's keyspace.
+            discriminators = [
+                _tombstone_discriminator_values(subtask_tombstone, key)
+                for subtask_tombstone in tombstone.values()
+            ]
+            assert len(set(discriminators)) == len(discriminators), (
+                f"fetch_snapshot subtask tombstones must carry distinct key "
+                f"discriminator values, one per subtask. Got: {discriminators}"
             )
 
             snapshot_state = resource_state.snapshot

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -268,7 +268,9 @@ class ResourceState(BaseResourceState, BaseModel, extra="forbid"):
         description="Backfill progress, or None if no backfill is occurring",
     )
 
-    snapshot: Snapshot | None = Field(default=None, description="Snapshot progress")
+    snapshot: Snapshot | dict[str, Snapshot | None] | None = Field(
+        default=None, description="Snapshot progress"
+    )
 
     last_initialized: datetime | None = Field(
         default=None, description="The last time this state was initialized."
@@ -757,8 +759,10 @@ def open_binding(
     | RecurringFetchPageFn[_BaseDocument]
     | dict[str, FetchPageFn[_BaseDocument]]
     | None = None,
-    fetch_snapshot: FetchSnapshotFn[_BaseDocument] | None = None,
-    tombstone: _BaseDocument | None = None,
+    fetch_snapshot: FetchSnapshotFn[_BaseDocument]
+    | dict[str, FetchSnapshotFn[_BaseDocument]]
+    | None = None,
+    tombstone: _BaseDocument | dict[str, _BaseDocument] | None = None,
 ):
     """
     open_binding() is intended to be called by closures set as Resource.open Callables.
@@ -870,24 +874,78 @@ def open_binding(
             )
 
     if fetch_snapshot:
-        if tombstone is None:
-            # Default tombstone for snapshot bindings so callers don't need to
-            # provide one. The cast satisfies the _BaseDocument TypeVar since
-            # BaseDocument is its bound.
-            tombstone = cast(_BaseDocument, BaseDocument(_meta=BaseDocument.Meta(op="d")))
 
-        async def closure(task: Task):
-            assert tombstone is not None
+        async def snapshot_closure(
+            task: Task,
+            fetch_snapshot: FetchSnapshotFn[_BaseDocument],
+            state: ResourceState.Snapshot | None,
+            tombstone: _BaseDocument,
+            subtask_id: str | None = None,
+        ):
             await _binding_snapshot_task(
                 binding,
                 binding_index,
                 fetch_snapshot,
-                resource_state.snapshot,
+                state,
                 task,
                 tombstone,
+                subtask_id,
             )
 
-        task.spawn_child(f"{prefix}.snapshot", closure)
+        if isinstance(fetch_snapshot, dict):
+            key = binding.collection.key
+            assert "/_meta/row_id" in key and len(key) > 1, (
+                f"A fetch_snapshot subtask requires a compound collection "
+                f"key containing /_meta/row_id plus a subtask discriminator. "
+                f"Got: {key}"
+            )
+            # The CDK can set _meta/row_id but not the connector-specific discriminator, so
+            # each subtask must supply its own tombstone with that field pre-set.
+            assert (
+                isinstance(tombstone, dict)
+                and tombstone.keys() == fetch_snapshot.keys()
+            ), (
+                "fetch_snapshot subtasks requires a tombstone dict with "
+                "the same keys, each carrying the subtask discriminator. "
+            )
+
+            snapshot_state = resource_state.snapshot
+            assert snapshot_state is None or isinstance(snapshot_state, dict)
+
+            for subtask_id, subtask_fetch_snapshot in fetch_snapshot.items():
+                subtask_state = (
+                    snapshot_state.get(subtask_id) if snapshot_state else None
+                )
+                task.spawn_child(
+                    f"{prefix}.snapshot.{subtask_id}",
+                    functools.partial(
+                        snapshot_closure,
+                        fetch_snapshot=subtask_fetch_snapshot,
+                        state=subtask_state,
+                        tombstone=tombstone[subtask_id],
+                        subtask_id=subtask_id,
+                    ),
+                )
+        else:
+            if tombstone is None:
+                # Default tombstone for snapshot bindings so callers don't need to
+                # provide one. The cast satisfies the _BaseDocument TypeVar since
+                # BaseDocument is its bound.
+                tombstone = cast(
+                    _BaseDocument, BaseDocument(_meta=BaseDocument.Meta(op="d"))
+                )
+            assert not isinstance(tombstone, dict)
+            assert not isinstance(resource_state.snapshot, dict)
+
+            task.spawn_child(
+                f"{prefix}.snapshot",
+                functools.partial(
+                    snapshot_closure,
+                    fetch_snapshot=fetch_snapshot,
+                    state=resource_state.snapshot,
+                    tombstone=tombstone,
+                ),
+            )
 
 
 async def _binding_snapshot_task(
@@ -897,6 +955,7 @@ async def _binding_snapshot_task(
     state: ResourceState.Snapshot | None,
     task: Task,
     tombstone: _BaseDocument,
+    subtask_id: str | None = None,
 ):
     """Snapshot the content of a resource at a regular interval."""
 
@@ -907,9 +966,14 @@ async def _binding_snapshot_task(
             last_digest="",
         )
 
-    connector_state = ConnectorState(
-        bindingStateV1={binding.stateKey: ResourceState(snapshot=state)}
-    )
+    if subtask_id is not None:
+        connector_state = ConnectorState(
+            bindingStateV1={binding.stateKey: ResourceState(snapshot={subtask_id: state})}
+        )
+    else:
+        connector_state = ConnectorState(
+            bindingStateV1={binding.stateKey: ResourceState(snapshot=state)}
+        )
 
     while True:
         # Yield to the event loop to prevent starvation.
@@ -938,15 +1002,22 @@ async def _binding_snapshot_task(
 
         count = 0
         async for doc in fetch_snapshot(task.log):
+            # Set only op/row_id, preserving any other _meta fields (e.g. a
+            # connector-injected subtask discriminator that is part of a
+            # compound key) rather than replacing _meta wholesale.
+            op = "u" if count < state.last_count else "c"
             if isinstance(doc, dict):
-                doc["meta_"] = {
-                    "op": "u" if count < state.last_count else "c",
-                    "row_id": count,
-                }
+                meta = doc.get("meta_")
+                if not isinstance(meta, dict):
+                    meta = {}
+                    doc["meta_"] = meta
+                meta["op"] = op
+                meta["row_id"] = count
             else:
-                doc.meta_ = BaseDocument.Meta(
-                    op="u" if count < state.last_count else "c", row_id=count
-                )
+                # Reassign so meta_ is marked as explicitly set on
+                # the parent document and included when serializing
+                # with model_dump(exclude_unset=True).
+                doc.meta_ = doc.meta_.model_copy(update={"op": op, "row_id": count})
             task.captured(binding_index, doc)
             count += 1
 
@@ -963,7 +1034,10 @@ async def _binding_snapshot_task(
 
         if digest != state.last_digest:
             for del_id in range(count, state.last_count):
-                tombstone.meta_ = BaseDocument.Meta(op="d", row_id=del_id)
+                # Mutate only op/row_id so the tombstone
+                # keeps any fields the caller pre-set.
+                tombstone.meta_.op = "d"
+                tombstone.meta_.row_id = del_id
                 task.captured(binding_index, tombstone)
 
             state.last_count = count

--- a/estuary-cdk/tests/test_snapshot_subtasks.py
+++ b/estuary-cdk/tests/test_snapshot_subtasks.py
@@ -294,3 +294,18 @@ class TestOpenBindingSnapshotDict:
                 fetch_snapshot={"A": self._noop, "B": self._noop},
                 tombstone={"A": _doc("A", "")},  # missing "B"
             )
+
+    def test_requires_distinct_discriminators(self):
+        output = io.BytesIO()
+        task = _task(output, Task.Stopping())
+        with pytest.raises(AssertionError, match="distinct key discriminator"):
+            open_binding(
+                _binding(COMPOUND_KEY),
+                0,
+                self._state(),
+                task,
+                fetch_snapshot={"A": self._noop, "B": self._noop},
+                # Both tombstones carry store "A": their (store, row_id)
+                # keyspaces would overlap and clobber each other.
+                tombstone={"A": _doc("A", ""), "B": _doc("A", "")},
+            )

--- a/estuary-cdk/tests/test_snapshot_subtasks.py
+++ b/estuary-cdk/tests/test_snapshot_subtasks.py
@@ -1,0 +1,296 @@
+import io
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from functools import partial
+from typing import Any, AsyncGenerator, BinaryIO
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import Field
+
+from estuary_cdk.capture.common import (
+    ResourceConfig,
+    ResourceState,
+    _binding_snapshot_task,  # pyright: ignore[reportPrivateUsage]
+    open_binding,
+)
+from estuary_cdk.capture.document import BaseDocument
+from estuary_cdk.capture.task import Task
+from estuary_cdk.capture.transactor import Transactor
+from estuary_cdk.flow import CaptureBinding, CollectionSpec
+
+COMPOUND_KEY = ["/_meta/store", "/_meta/row_id"]
+
+
+class StoreDoc(BaseDocument):
+    """A document whose _meta carries a connector-specific `store` discriminator,
+    mirroring how a multi-store connector keys a snapshot on [store, row_id]."""
+
+    class Meta(BaseDocument.Meta):
+        store: str = ""
+
+    meta_: Meta = Field(
+        default_factory=lambda: StoreDoc.Meta(op="u"),
+        alias="_meta",
+    )
+    id: str
+
+
+def _doc(store: str, id: str) -> StoreDoc:
+    return StoreDoc(id=id, _meta=StoreDoc.Meta(op="u", store=store))
+
+
+def _binding(key: list[str], name: str = "staff_members") -> CaptureBinding[ResourceConfig]:
+    return CaptureBinding(
+        collection=CollectionSpec(name="c/" + name, key=key, writeSchema={}),
+        resourceConfig=ResourceConfig(name=name, interval=timedelta()),
+        resourcePath=[name],
+        stateKey=name,
+    )
+
+
+def _task(output: BinaryIO, stopping: Task.Stopping) -> Task:
+    return Task(
+        log=logging.getLogger("test-snapshot"),
+        connector_status=MagicMock(),
+        name="test-snapshot",
+        output=output,
+        stopping=stopping,
+        tg=MagicMock(),
+        transactor=Transactor(output),
+        requires_ack=False,
+    )
+
+
+def _read(output: BinaryIO) -> list[dict[str, Any]]:
+    _ = output.seek(0)
+    return [json.loads(line) for line in output.read().decode().splitlines() if line]
+
+
+class _Passes:
+    """Drives fetch_snapshot deterministically: yields the documents for each
+    pass in turn, and sets the stopping event after `stop_after` passes so the
+    snapshot loop exits."""
+
+    def __init__(
+        self,
+        passes: list[list[StoreDoc]],
+        stopping: Task.Stopping,
+        stop_after: int,
+    ):
+        self._passes = passes
+        self._i = 0
+        self._stopping = stopping
+        self._stop_after = stop_after
+
+    def __call__(self, log: logging.Logger) -> AsyncGenerator[StoreDoc, None]:
+        async def gen() -> AsyncGenerator[StoreDoc, None]:
+            for d in self._passes[self._i]:
+                yield d
+            self._i += 1
+            if self._i >= self._stop_after:
+                self._stopping.event.set()
+
+        return gen()
+
+
+def _captured_docs(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r["captured"]["doc"] for r in records if "captured" in r]
+
+
+def _checkpoints(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        r["checkpoint"]["state"]["updated"] for r in records if "checkpoint" in r
+    ]
+
+
+class TestBindingSnapshotSubtask:
+    @pytest.mark.asyncio
+    async def test_preserves_store_and_assigns_row_id(self):
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        task = _task(output, stopping)
+        binding = _binding(COMPOUND_KEY)
+
+        fetch = _Passes(
+            [[_doc("A", "a1"), _doc("A", "a2"), _doc("A", "a3")]],
+            stopping,
+            stop_after=1,
+        )
+        tombstone = _doc("A", "")
+
+        await _binding_snapshot_task(
+            binding, 0, fetch, None, task, tombstone, subtask_id="A"
+        )
+
+        docs = _captured_docs(_read(output))
+        assert len(docs) == 3
+        # Every emitted doc keeps its store and gets a positional row_id; first
+        # snapshot is all creates.
+        for i, doc in enumerate(docs):
+            assert doc["_meta"]["store"] == "A"
+            assert doc["_meta"]["row_id"] == i
+            assert doc["_meta"]["op"] == "c"
+
+    @pytest.mark.asyncio
+    async def test_checkpoints_dict_keyed_snapshot_state(self):
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        task = _task(output, stopping)
+        binding = _binding(COMPOUND_KEY)
+
+        fetch = _Passes([[_doc("A", "a1")]], stopping, stop_after=1)
+
+        await _binding_snapshot_task(
+            binding, 0, fetch, None, task, _doc("A", ""), subtask_id="A"
+        )
+
+        checkpoints = _checkpoints(_read(output))
+        assert checkpoints
+        snapshot = checkpoints[-1]["bindingStateV1"]["staff_members"]["snapshot"]
+        # Dict-keyed by subtask id so the runtime merge-patches per subtask
+        # rather than letting siblings clobber each other.
+        assert set(snapshot.keys()) == {"A"}
+        assert snapshot["A"]["last_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_deletion_tombstone_carries_store(self):
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        task = _task(output, stopping)
+        binding = _binding(COMPOUND_KEY)
+
+        # Pass 1: three docs. Pass 2: a2 removed -> snapshot shrinks to two, so
+        # the trailing row_id (2) must be tombstoned, carrying store "A".
+        fetch = _Passes(
+            [
+                [_doc("A", "a1"), _doc("A", "a2"), _doc("A", "a3")],
+                [_doc("A", "a1"), _doc("A", "a3")],
+            ],
+            stopping,
+            stop_after=2,
+        )
+
+        await _binding_snapshot_task(
+            binding, 0, fetch, None, task, _doc("A", ""), subtask_id="A"
+        )
+
+        docs = _captured_docs(_read(output))
+        tombstones = [d for d in docs if d["_meta"]["op"] == "d"]
+        assert len(tombstones) == 1
+        assert tombstones[0]["_meta"] == {"op": "d", "row_id": 2, "store": "A"}
+
+    @pytest.mark.asyncio
+    async def test_unchanged_snapshot_is_suppressed(self):
+        output = io.BytesIO()
+        stopping = Task.Stopping()
+        task = _task(output, stopping)
+        binding = _binding(COMPOUND_KEY)
+
+        # Three identical passes. Pass 1 emits creates; pass 2 emits updates
+        # (op flips c->u, so its digest differs and it is NOT suppressed and
+        # establishes the steady-state digest); pass 3 is byte-identical to
+        # pass 2, so its documents are reset (suppressed). Emitting 4 (2+2+0)
+        # rather than 6 docs confirms suppression.
+        same = [_doc("A", "a1"), _doc("A", "a2")]
+        fetch = _Passes(
+            [list(same), list(same), list(same)], stopping, stop_after=3
+        )
+
+        await _binding_snapshot_task(
+            binding, 0, fetch, None, task, _doc("A", ""), subtask_id="A"
+        )
+
+        docs = _captured_docs(_read(output))
+        assert len(docs) == 4  # pass 3 suppressed
+        assert not [d for d in docs if d["_meta"]["op"] == "d"]
+
+
+class TestOpenBindingSnapshotDict:
+    def _state(self) -> ResourceState:
+        return ResourceState(
+            snapshot={
+                "A": ResourceState.Snapshot(
+                    updated_at=datetime.now(tz=UTC), last_count=0, last_digest=""
+                ),
+                "B": None,
+            }
+        )
+
+    async def _noop(self, log: logging.Logger) -> AsyncGenerator[StoreDoc, None]:
+        if False:
+            yield  # pragma: no cover
+
+    def test_spawns_one_subtask_per_store_with_wired_state(self):
+        output = io.BytesIO()
+        task = _task(output, Task.Stopping())
+        task.spawn_child = MagicMock()  # type: ignore[method-assign]
+
+        state = self._state()
+        fetch = {"A": self._noop, "B": self._noop}
+        tombstone = {"A": _doc("A", ""), "B": _doc("B", "")}
+
+        open_binding(
+            _binding(COMPOUND_KEY),
+            0,
+            state,
+            task,
+            fetch_snapshot=fetch,
+            tombstone=tombstone,
+        )
+
+        assert task.spawn_child.call_count == 2
+        by_name = {
+            call.args[0]: call.args[1] for call in task.spawn_child.call_args_list
+        }
+        assert set(by_name) == {
+            "staff_members.snapshot.A",
+            "staff_members.snapshot.B",
+        }
+        a = by_name["staff_members.snapshot.A"].keywords
+        assert a["subtask_id"] == "A"
+        assert a["tombstone"] is tombstone["A"]
+        assert a["state"] is state.snapshot["A"]
+        # A store with no prior snapshot state is wired with None (the task
+        # self-initializes it).
+        assert by_name["staff_members.snapshot.B"].keywords["state"] is None
+
+    def test_requires_compound_key(self):
+        output = io.BytesIO()
+        task = _task(output, Task.Stopping())
+        with pytest.raises(AssertionError, match="compound collection key"):
+            open_binding(
+                _binding(["/_meta/row_id"]),
+                0,
+                self._state(),
+                task,
+                fetch_snapshot={"A": self._noop},
+                tombstone={"A": _doc("A", "")},
+            )
+
+    def test_requires_row_id_in_key(self):
+        output = io.BytesIO()
+        task = _task(output, Task.Stopping())
+        with pytest.raises(AssertionError, match="compound collection key"):
+            open_binding(
+                _binding(["/_meta/store", "/id"]),
+                0,
+                self._state(),
+                task,
+                fetch_snapshot={"A": self._noop},
+                tombstone={"A": _doc("A", "")},
+            )
+
+    def test_requires_matching_tombstone_dict(self):
+        output = io.BytesIO()
+        task = _task(output, Task.Stopping())
+        with pytest.raises(AssertionError, match="tombstone dict"):
+            open_binding(
+                _binding(COMPOUND_KEY),
+                0,
+                self._state(),
+                task,
+                fetch_snapshot={"A": self._noop, "B": self._noop},
+                tombstone={"A": _doc("A", "")},  # missing "B"
+            )

--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -59,23 +59,22 @@ async def bulk_fetch_incremental(
     yield end
 
 
-async def bulk_fetch_full_refresh(
+async def bulk_fetch_snapshot(
     http: HTTPMixin,
-    start_date: datetime,
     bulk_job_manager: BulkJobManager,
     model: type[ShopifyGraphQLResource],
     store: str,
     capabilities: StoreCapabilities,
     log: Logger,
 ) -> AsyncGenerator[ShopifyGraphQLResource, None]:
-    end = datetime.now(tz=UTC)
-    query = model.build_query(start_date, end, capabilities=capabilities)
+    now = datetime.now(tz=UTC)
+    query = model.build_query(now, now, capabilities=capabilities)
 
     url = await bulk_job_manager.execute(model, query)
 
     if url is None:
         log.info(
-            f"[{store}] Bulk query job found no results between {start_date} and {end} for {model.__name__}."
+            f"[{store}] Bulk query job found no results for {model.__name__}."
         )
         return
 
@@ -118,6 +117,28 @@ async def _paginate_through_resources(
             return
 
         after = page_info.endCursor
+
+
+async def fetch_snapshot(
+    client: ShopifyGraphQLClient,
+    model: type[TShopifyGraphQLResource],
+    data_model: type[BaseResponseData[TShopifyGraphQLResource]],
+    store: str,
+    capabilities: StoreCapabilities,
+    log: Logger,
+) -> AsyncGenerator[TShopifyGraphQLResource, None]:
+    now = datetime.now(tz=UTC)
+    async for doc in _paginate_through_resources(
+        client=client,
+        model=model,
+        data_model=data_model,
+        start=now,
+        end=now,
+        store=store,
+        capabilities=capabilities,
+        log=log,
+    ):
+        yield doc
 
 
 async def fetch_incremental_unsorted(

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -25,9 +25,11 @@ from .orders.refunds import OrderRefunds
 from .orders.risks import OrderRisks
 from .orders.transactions import OrderTransactions
 from .subscriptions.subscription_contracts import SubscriptionContracts
+from .staff_members import StaffMembers
 
 
 __all__ = [
+    "StaffMembers",
     "AbandonedCheckouts",
     "ShopifyGraphQLClient",
     "CustomCollections",

--- a/source-shopify-native/source_shopify_native/graphql/staff_members.py
+++ b/source-shopify-native/source_shopify_native/graphql/staff_members.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from logging import Logger
+from typing import AsyncGenerator
+
+from ..models import ShopifyGraphQLResource, StoreCapabilities
+
+
+class StaffMembers(ShopifyGraphQLResource):
+    """Staff members of a Shopify store.
+
+    StaffMember has no `updatedAt` and the `staffMembers` connection cannot filter
+    or sort by date, so there is no usable incremental cursor.
+
+    The `staffMembers` query requires the `read_users` scope and is only available
+    on Shopify Plus / Advanced stores or finance embedded apps.
+    """
+
+    NAME = "staff_members"
+    QUERY_ROOT = "staffMembers"
+    SHOULD_USE_BULK_QUERIES = False
+    QUALIFYING_SCOPES = {"read_users"}
+    REQUIRES_PLUS_OR_ADVANCED_PLAN = True
+    QUERY = """
+    id
+    active
+    accountType
+    email
+    exists
+    firstName
+    lastName
+    name
+    initials
+    isShopOwner
+    locale
+    phone
+    privateData {
+        accountSettingsUrl
+        createdAt
+    }
+    """
+
+    @staticmethod
+    def build_query(
+        start: datetime,
+        end: datetime,
+        first: int | None = None,
+        after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
+    ) -> str:
+        # An unfiltered, cursor-paginated query: StaffMember has no updated_at and
+        # the staffMembers connection cannot filter or sort by date, so `start`/
+        # `end` are unused and the full set is re-fetched each snapshot.
+        return f"""
+        {{
+            staffMembers(
+                {f"first: {first}" if first else ""}
+                {f'after: "{after}"' if after else ""}
+            ) {{
+                edges {{
+                    node {{
+                        {StaffMembers.QUERY}
+                    }}
+                }}
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+            }}
+        }}
+        """
+
+    @staticmethod
+    async def process_result(
+        log: Logger, lines: AsyncGenerator[bytes, None]
+    ) -> AsyncGenerator[dict, None]:
+        async for record in StaffMembers._process_result(
+            log, lines, "gid://shopify/StaffMember/"
+        ):
+            yield record

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -469,6 +469,9 @@ class ShopifyGraphQLResource(BaseDocument):
     SORT_KEY: ClassVar[SortKey | None] = None
     SHOULD_USE_BULK_QUERIES: ClassVar[bool] = True
     QUALIFYING_SCOPES: ClassVar[set[str]] = set()
+    # Some resources are only queryable on Shopify Plus / Advanced plans or
+    # partner dev stores regardless of granted scopes.
+    REQUIRES_PLUS_OR_ADVANCED_PLAN: ClassVar[bool] = False
     # Fields included in the query only when the store's capabilities allow it. See
     # ConditionalField for placeholder/substitution semantics.
     CONDITIONAL_FIELDS: ClassVar[list[ConditionalField]] = []

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -47,6 +47,7 @@ scopes = [
     "read_inventory",  # InventoryItems, InventoryLevels, Locations
     "read_customers",  # Customers
     "read_own_subscription_contracts",  # SubscriptionContracts
+    "read_users", # StaffMembers
     # FulfillmentOrder requires one of the following 4 scopes (not read_fulfillments).
     # See: https://shopify.dev/docs/api/admin-graphql/latest/objects/FulfillmentOrder
     "read_assigned_fulfillment_orders",

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -10,6 +10,7 @@ from estuary_cdk.capture.common import (
     Resource,
     ResourceConfig,
     ResourceState,
+    SnapshotResource,
     open_binding,
 )
 from estuary_cdk.flow import (
@@ -27,8 +28,10 @@ from .graphql.bulk_job_manager import BulkJobManager
 from .api import (
     backfill_incremental,
     bulk_fetch_incremental,
+    bulk_fetch_snapshot,
     fetch_incremental,
     fetch_incremental_unsorted,
+    fetch_snapshot,
 )
 from .utils import dt_to_str
 from .models import (
@@ -164,6 +167,8 @@ PII_RESOURCES: set[type[ShopifyGraphQLResource]] = {
     gql.FulfillmentOrders,
 }
 
+FULL_REFRESH_RESOURCES: list[type[ShopifyGraphQLResource]] = []
+
 
 async def _create_store_context(
     log: Logger,
@@ -195,7 +200,7 @@ async def _create_store_context(
         is_plus_or_advanced = _plan_is_plus_or_advanced(plan)
 
     available_resources = _get_available_resources(
-        granted_scopes, uses_custom_app_token, can_access_pii
+        granted_scopes, uses_custom_app_token, can_access_pii, is_plus_or_advanced
     )
 
     capabilities = StoreCapabilities(
@@ -218,16 +223,21 @@ def _get_available_resources(
     granted_scopes: set[str],
     uses_custom_app_token: bool,
     can_access_pii: bool,
+    is_plus_or_advanced: bool,
 ) -> set[type[ShopifyGraphQLResource]]:
     """Determine which resources are available based on scopes and plan."""
     available: set[type[ShopifyGraphQLResource]] = set()
 
-    for resource in INCREMENTAL_RESOURCES:
+    for resource in INCREMENTAL_RESOURCES + FULL_REFRESH_RESOURCES:
         # Skip if none of the qualifying scopes are granted
         if resource.QUALIFYING_SCOPES.isdisjoint(granted_scopes):
             continue
         # Skip PII resources for custom app tokens when plan doesn't allow PII
         if uses_custom_app_token and resource in PII_RESOURCES and not can_access_pii:
+            continue
+        # Skip resources only queryable on Plus/Advanced plans when the store
+        # isn't on one.
+        if resource.REQUIRES_PLUS_OR_ADVANCED_PLAN and not is_plus_or_advanced:
             continue
         available.add(resource)
 
@@ -487,7 +497,7 @@ async def all_resources(
         else:
             excluded = [
                 m.NAME
-                for m in INCREMENTAL_RESOURCES
+                for m in INCREMENTAL_RESOURCES + FULL_REFRESH_RESOURCES
                 if m not in result.available_resources
             ]
             if excluded:
@@ -645,6 +655,85 @@ async def all_resources(
                 schema_inference=True,
                 initial_config=ResourceConfig(
                     name=model.NAME, interval=timedelta(minutes=5)
+                ),
+            )
+        )
+
+    # Build snapshot resources. Each is a single binding keyed on
+    # [/_meta/store, /_meta/row_id] whose snapshot fans out into one per-store
+    # subtask
+    snapshot_key = ["/_meta/store", "/_meta/row_id"]
+    for model in FULL_REFRESH_RESOURCES:
+        stores_with_access = [
+            store_id
+            for store_id, ctx in store_contexts.items()
+            if model in ctx.available_resources
+        ]
+
+        if not stores_with_access:
+            continue
+
+        def create_snapshot_open_fn(
+            model: type[ShopifyGraphQLResource],
+            stores_with_access: list[str],
+        ):
+            async def open(
+                binding: CaptureBinding[ResourceConfig],
+                binding_index: int,
+                state: ResourceState,
+                task: Task,
+                _all_bindings,
+            ):
+                data_model = create_response_data_model(model)
+
+                fetch_snapshot_fns: dict[str, functools.partial] = {}
+                tombstones: dict[str, ShopifyGraphQLResource] = {}
+                for store_id in stores_with_access:
+                    ctx = store_contexts[store_id]
+                    if model.SHOULD_USE_BULK_QUERIES:
+                        fetch_snapshot_fns[store_id] = functools.partial(
+                            bulk_fetch_snapshot,
+                            ctx.http,
+                            ctx.bulk_job_manager,
+                            model,
+                            store_id,
+                            ctx.capabilities,
+                        )
+                    else:
+                        fetch_snapshot_fns[store_id] = functools.partial(
+                            fetch_snapshot,
+                            ctx.client,
+                            model,
+                            data_model,
+                            store_id,
+                            ctx.capabilities,
+                        )
+                    # The tombstone must carry the /_meta/store discriminator so
+                    # deletes target the correct [store, row_id] key. The CDK only
+                    # fills in op/row_id.
+                    tombstones[store_id] = ShopifyGraphQLResource(
+                        id="",
+                        _meta=ShopifyGraphQLResource.Meta(op="d", store=store_id),
+                    )
+
+                open_binding(
+                    binding,
+                    binding_index,
+                    state,
+                    task,
+                    fetch_snapshot=fetch_snapshot_fns,
+                    tombstone=tombstones,
+                )
+
+            return open
+
+        resources.append(
+            SnapshotResource(
+                name=model.NAME,
+                key=snapshot_key,
+                open=create_snapshot_open_fn(model, stores_with_access),
+                initial_config=ResourceConfig(
+                    name=model.NAME, interval=timedelta(minutes=15)
                 ),
             )
         )

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -167,7 +167,9 @@ PII_RESOURCES: set[type[ShopifyGraphQLResource]] = {
     gql.FulfillmentOrders,
 }
 
-FULL_REFRESH_RESOURCES: list[type[ShopifyGraphQLResource]] = []
+FULL_REFRESH_RESOURCES: list[type[ShopifyGraphQLResource]] = [
+    gql.StaffMembers,
+]
 
 
 async def _create_store_context(


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes:
- Updating the CDK to support multiple `fetch_snapshot` subtasks. We previously weren't sure how this would work since the CDK automatically manages the `_meta/row_id` field and emits tombstones to infer deletions between snapshots, but multiple `fetch_snapshot` subtasks should actually work fine as long as the collection key includes an additional discriminator that identifies which subtask documents and tombstones came from. ex: If the collection key is `["_meta/subtask_id", "_meta/row_id"]`, then the CDK's deletion inference mechanism should work still since deletions between each subtask's snapshots will have a unique identifier per subtask.
- Updating `source-shopify-native` to support full refresh streams, using the CDK's `fetch_snapshot` subtask support & a collection key of `["_meta/store", "_meta/row_id"]`.
- Adding `staff_members` as a full refresh stream in `source-shopify-native` that captures Shopify's [`StaffMember`](https://shopify.dev/docs/api/admin-graphql/latest/objects/StaffMember) object.

See individual commits for more details. Best reviewed commit-by-commit.

**Documentation links affected:**

The connector's documentation should be updated to include that we can capture `staff_members` and include the `read_users` scope as required for that stream.

**Notes for reviewers:**

I haven't been able to get the `read_users` scope for my dev Shopify app, so I haven't been able to test out this stream with actual API calls to confirm everything works end-to-end. I'm fairly confident it should ✨ just work ✨ , but there may be some bumps to iron out once the stream gets used in production.
