### PR TITLE
materialize-boilerplate: set multiple constraints for projections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954
+	github.com/estuary/flow v0.6.10
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.9
+	github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954 h1:lXUHH6uyXGX/l3ph+yfoZ8Rv3tHs3rInVUoH23w6nX4=
-github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.10 h1:Z+zM5Qct0aR5EQAhfHmi4bR3jZPDpNwK0R5KPlZz/Wc=
+github.com/estuary/flow v0.6.10/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=

--- a/go.sum
+++ b/go.sum
@@ -417,12 +417,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
-github.com/estuary/flow v0.6.8 h1:HK9zYKV2HvF6jPI8eSDGdLy4nVUW2FWB+CA37PyuPLI=
-github.com/estuary/flow v0.6.8/go.mod h1:SYiOTbPZ0ZlCh8qNVARPMjRF6/aVWY7xQuHFK9BSELk=
-github.com/estuary/flow v0.6.9-0.20260520113844-a3d8595811ed h1:+pm+QyY8+bhC2gxJdRa735NX+QawxO0Piuv5c1CUj0w=
-github.com/estuary/flow v0.6.9-0.20260520113844-a3d8595811ed/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
-github.com/estuary/flow v0.6.9 h1:1cGdwmlB4UxNhRnvujTDGwmx1ABvBS9iqWYIIStRaRI=
-github.com/estuary/flow v0.6.9/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954 h1:lXUHH6uyXGX/l3ph+yfoZ8Rv3tHs3rInVUoH23w6nX4=
+github.com/estuary/flow v0.6.10-0.20260605161557-1013f9821954/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=

--- a/materialize-bigquery/.snapshots/TestIntegration-apply
+++ b/materialize-bigquery/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'INTEGER' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'JSON' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'INTEGER' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta_flow_truncated","Nullable":false,"Type":"BOOLEAN"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"________-_problematicValue_______","Nullable":true,"Type":"STRING"}
 {"Name":"_dollar_signs","Nullable":true,"Type":"STRING"}
 {"Name":"_id","Nullable":false,"Type":"STRING"}
+{"Name":"_meta_flow_truncated","Nullable":false,"Type":"BOOLEAN"}
 {"Name":"a_string_with_quote_characters","Nullable":true,"Type":"STRING"}
 {"Name":"flow_document","Nullable":false,"Type":"JSON"}
 {"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}

--- a/materialize-bigtable/.snapshots/TestIntegration-apply
+++ b/materialize-bigtable/.snapshots/TestIntegration-apply
@@ -40,7 +40,7 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
 {"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
@@ -50,7 +50,7 @@ Big Schema Re-validated Constraints:
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"nullField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
@@ -79,15 +79,15 @@ Big Schema Re-validated Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Metadata fields are able to be materialized"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
 {"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"key","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Primary key locations are required"}
 {"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
-{"Field":"nullField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}
 {"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This field is able to be materialized"}

--- a/materialize-boilerplate/.snapshots/TestValidate
+++ b/materialize-boilerplate/.snapshots/TestValidate
@@ -14,14 +14,14 @@ new materialization - standard updates:
 same binding again - standard updates:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 new materialization - delta updates:
@@ -39,63 +39,63 @@ new materialization - delta updates:
 
 same binding again - delta updates:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 
 binding update with incompatible changes:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nonScalarValue","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'nonScalarValue' is already being materialized as endpoint type 'OBJECT' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"scalarValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 fields exist in destination but not in collection:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 change root document projection for standard updates:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized for standard updates"}
 {"Field":"second_root","Type":6,"TypeString":"INCOMPATIBLE","Reason":"The root document must be materialized as field 'flow_document'"}
 
 change root document projection for delta updates:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The root document should usually be materialized"}
 
 increment backfill counter:
@@ -127,26 +127,26 @@ increment backfill counter for disabled -> enabled binding:
 table already exists with identical spec:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 table already exists with incompatible proposed spec:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nonScalarValue","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'nonScalarValue' is already being materialized as endpoint type 'OBJECT' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"scalarValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
@@ -154,14 +154,14 @@ table already exists with incompatible root document column:
 {"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document is required for a standard updates materialization"}
 {"Field":"flow_document","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'flow_document' is already being materialized as endpoint type 'STRING' but endpoint type 'OBJECT' is required by its schema '{ type: [object] }'"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multiple","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
-{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numericString","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 field names over the length limit are forbidden:

--- a/materialize-boilerplate/.snapshots/TestValidate
+++ b/materialize-boilerplate/.snapshots/TestValidate
@@ -83,6 +83,7 @@ change root document projection for standard updates:
 {"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"second_root","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized for standard updates"}
 {"Field":"second_root","Type":6,"TypeString":"INCOMPATIBLE","Reason":"The root document must be materialized as field 'flow_document'"}
 
 change root document projection for delta updates:
@@ -147,6 +148,20 @@ table already exists with incompatible proposed spec:
 {"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"scalarValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
+{"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
+
+table already exists with incompatible root document column:
+{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
+{"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document is required for a standard updates materialization"}
+{"Field":"flow_document","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'flow_document' is already being materialized as endpoint type 'STRING' but endpoint type 'OBJECT' is required by its schema '{ type: [object] }'"}
+{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
+{"Field":"multiple","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nonScalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"nullValue","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize this field"}
+{"Field":"numericString","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"optional","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"scalarValue","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
 {"Field":"second_root","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize root document projection 'second_root' because field 'flow_document' is already being materialized as the document"}
 
 field names over the length limit are forbidden:

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -402,7 +402,7 @@ func RunValidate[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT
 		} else {
 			out = append(out, &pm.Response_Validated_Binding{
 				CaseInsensitiveFields: materializer.Config().CaseInsensitiveFields,
-				Constraints:           constraints,
+				ProjectionConstraints: ValidatedConstraints(constraints),
 				DeltaUpdates:          delta,
 				ResourcePath:          path,
 				SerPolicy:             mCfg.SerPolicy,

--- a/materialize-boilerplate/testutil/field_selection_test.go
+++ b/materialize-boilerplate/testutil/field_selection_test.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"testing"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSelectedFields covers how the harness emulates control-plane field
+// selection from a binding's projection_constraints, including multiple
+// constraints per field. Notably a field that is INCOMPATIBLE but also required
+// is still selected (presuming a backfill), matching build_selection in flow's
+// field_selection.rs.
+func TestSelectedFields(t *testing.T) {
+	c := func(typ pm.Response_Validated_Constraint_Type) *pm.Response_Validated_Constraint {
+		return &pm.Response_Validated_Constraint{Type: typ}
+	}
+
+	// Projections must be sorted by field for CollectionSpec.GetProjection.
+	collection := pf.CollectionSpec{
+		Projections: []pf.Projection{
+			{Field: "bare_incompat", Ptr: "/bare_incompat"},
+			{Field: "doc", Ptr: ""}, // root document projection
+			{Field: "forbidden", Ptr: "/forbidden"},
+			{Field: "id", Ptr: "/id", IsPrimaryKey: true},
+			{Field: "opt", Ptr: "/opt"},
+			{Field: "recommended", Ptr: "/recommended"},
+		},
+	}
+
+	binding := &pm.Response_Validated_Binding{
+		ProjectionConstraints: []*pm.Response_Validated_ProjectionConstraint{
+			{Field: "id", Constraint: c(pm.Response_Validated_Constraint_LOCATION_REQUIRED)},
+			// Required AND incompatible: must still be selected as the document.
+			{Field: "doc", Constraint: c(pm.Response_Validated_Constraint_LOCATION_REQUIRED)},
+			{Field: "doc", Constraint: c(pm.Response_Validated_Constraint_INCOMPATIBLE)},
+			{Field: "recommended", Constraint: c(pm.Response_Validated_Constraint_LOCATION_RECOMMENDED)},
+			{Field: "opt", Constraint: c(pm.Response_Validated_Constraint_FIELD_OPTIONAL)},
+			{Field: "forbidden", Constraint: c(pm.Response_Validated_Constraint_FIELD_FORBIDDEN)},
+			// Incompatible with no accompanying requirement: dropped.
+			{Field: "bare_incompat", Constraint: c(pm.Response_Validated_Constraint_INCOMPATIBLE)},
+		},
+	}
+
+	t.Run("without optionals", func(t *testing.T) {
+		got := selectedFields(binding, collection, false)
+		require.Equal(t, []string{"id"}, got.Keys)
+		require.Equal(t, "doc", got.Document)
+		require.Equal(t, []string{"recommended"}, got.Values)
+	})
+
+	t.Run("with optionals", func(t *testing.T) {
+		got := selectedFields(binding, collection, true)
+		require.Equal(t, []string{"id"}, got.Keys)
+		require.Equal(t, "doc", got.Document)
+		require.Equal(t, []string{"opt", "recommended"}, got.Values)
+	})
+}

--- a/materialize-boilerplate/testutil/field_selection_test.go
+++ b/materialize-boilerplate/testutil/field_selection_test.go
@@ -45,16 +45,29 @@ func TestSelectedFields(t *testing.T) {
 	}
 
 	t.Run("without optionals", func(t *testing.T) {
-		got := selectedFields(binding, collection, false)
+		// LOCATION_RECOMMENDED is equivalent to FIELD_OPTIONAL and carries no
+		// selection signal: without optionals only the key and document (hard
+		// wants) are selected.
+		got := selectedFields(binding, collection, pf.FieldSelection{}, false)
 		require.Equal(t, []string{"id"}, got.Keys)
 		require.Equal(t, "doc", got.Document)
-		require.Equal(t, []string{"recommended"}, got.Values)
+		require.Empty(t, got.Values)
 	})
 
 	t.Run("with optionals", func(t *testing.T) {
-		got := selectedFields(binding, collection, true)
+		got := selectedFields(binding, collection, pf.FieldSelection{}, true)
 		require.Equal(t, []string{"id"}, got.Keys)
 		require.Equal(t, "doc", got.Document)
 		require.Equal(t, []string{"opt", "recommended"}, got.Values)
+	})
+
+	t.Run("live selection keeps recommended without optionals", func(t *testing.T) {
+		// A field carried in the prior selection stays selected even without
+		// optionals, emulating the control plane's stability preference.
+		live := pf.FieldSelection{Keys: []string{"id"}, Document: "doc", Values: []string{"recommended"}}
+		got := selectedFields(binding, collection, live, false)
+		require.Equal(t, []string{"id"}, got.Keys)
+		require.Equal(t, "doc", got.Document)
+		require.Equal(t, []string{"recommended"}, got.Values)
 	})
 }

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -699,11 +699,12 @@ func runChallengingNamesApplyTests[EC boilerplate.EndpointConfiger, FC boilerpla
 
 	// Validate and apply twice to make sure that a re-application does not attempt to re-create
 	// any columns. This makes sure we are able to read back the schema we have created
-	// correctly.
+	// correctly. Optionals are included so the challenging-named fields are
+	// materialized: recommended/optional fields are not selected by name alone.
 	for range 2 {
 		validateRes, err := driver.Validate(ctx, validateReq(fixture, nil, configJson, resourceConfigJson))
 		require.NoError(t, err)
-		_, err = driver.Apply(ctx, applyReq(fixture, nil, configJson, resourceConfigJson, validateRes, false))
+		_, err = driver.Apply(ctx, applyReq(fixture, nil, configJson, resourceConfigJson, validateRes, true))
 		require.NoError(t, err)
 	}
 
@@ -829,7 +830,14 @@ func applyReq(spec *pf.MaterializationSpec, lastSpec *pf.MaterializationSpec, co
 	spec.Bindings[0].ResourceConfigJson = resourceConfig
 	spec.Bindings[0].ResourcePath = validateRes.Bindings[0].ResourcePath
 	spec.Bindings[0].DeltaUpdates = validateRes.Bindings[0].DeltaUpdates
-	spec.Bindings[0].FieldSelection = selectedFields(validateRes.Bindings[0], spec.Bindings[0].Collection, includeOptional)
+
+	// The live (prior) field selection keeps previously materialized fields
+	// selected, just as the control plane does.
+	var live pf.FieldSelection
+	if lastSpec != nil && len(lastSpec.Bindings) > 0 {
+		live = lastSpec.Bindings[0].FieldSelection
+	}
+	spec.Bindings[0].FieldSelection = selectedFields(validateRes.Bindings[0], spec.Bindings[0].Collection, live, includeOptional)
 
 	req := &pm.Request_Apply{
 		Materialization:     spec,
@@ -840,13 +848,23 @@ func applyReq(spec *pf.MaterializationSpec, lastSpec *pf.MaterializationSpec, co
 	return req
 }
 
-// selectedFields creates a field selection that includes all possible fields.
-// A field may carry multiple projection_constraints; a field is selected when
-// some constraint wants it (required, recommended, or optional when optionals
-// are included) and none forbids it. An INCOMPATIBLE constraint does not by
-// itself exclude a wanted field: the control plane selects it presuming a
-// backfill (see build_selection in flow's field_selection.rs).
-func selectedFields(binding *pm.Response_Validated_Binding, collection pf.CollectionSpec, includeOptional bool) pf.FieldSelection {
+// selectedFields emulates the control plane's field selection from a binding's
+// projection_constraints, mirroring extract_constraints and build_selection in
+// flow's field_selection.rs. A field is selected when something wants it and
+// nothing fatally rejects it.
+//
+// Wants that are independent of the connector's "optional" opinion ("hard"
+// wants) are: group-by keys and the root document (always selected); the live
+// (prior) field selection, which keeps previously materialized fields stable;
+// and a connector FIELD_REQUIRED or LOCATION_REQUIRED constraint. When
+// includeOptional is set, every other non-rejected field is wanted too,
+// emulating a `recommended` selection depth.
+//
+// Per flow, LOCATION_RECOMMENDED and FIELD_OPTIONAL are equivalent and carry no
+// selection signal on their own. FIELD_FORBIDDEN always rejects. INCOMPATIBLE
+// rejects a field unless it is independently (hard-)wanted, in which case the
+// field is selected presuming a backfill.
+func selectedFields(binding *pm.Response_Validated_Binding, collection pf.CollectionSpec, live pf.FieldSelection, includeOptional bool) pf.FieldSelection {
 	out := pf.FieldSelection{}
 
 	// Group the binding's projection_constraints by field, preserving order so
@@ -861,27 +879,51 @@ func selectedFields(binding *pm.Response_Validated_Binding, collection pf.Collec
 		byField[pc.Field] = append(byField[pc.Field], pc.Constraint)
 	}
 
+	liveFields := make(map[string]struct{})
+	for _, f := range live.AllFields() {
+		liveFields[f] = struct{}{}
+	}
+
 	var foldedFieldMap = make(map[string]struct{})
 
 	for _, field := range fieldOrder {
 		constraints := byField[field]
 
-		var wanted, forbidden bool
+		var forbidden, incompatible, required bool
 		for _, c := range constraints {
 			switch c.Type {
 			case pm.Response_Validated_Constraint_FIELD_FORBIDDEN:
 				forbidden = true
+			case pm.Response_Validated_Constraint_INCOMPATIBLE,
+				pm.Response_Validated_Constraint_UNSATISFIABLE:
+				incompatible = true
 			case pm.Response_Validated_Constraint_FIELD_REQUIRED,
-				pm.Response_Validated_Constraint_LOCATION_REQUIRED,
-				pm.Response_Validated_Constraint_LOCATION_RECOMMENDED:
-				wanted = true
-			case pm.Response_Validated_Constraint_FIELD_OPTIONAL:
-				if includeOptional {
-					wanted = true
-				}
+				pm.Response_Validated_Constraint_LOCATION_REQUIRED:
+				required = true
+			case pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
+				pm.Response_Validated_Constraint_FIELD_OPTIONAL:
+				// Neither selected nor rejected by the connector; selection
+				// depends on includeOptional below.
 			}
 		}
-		if !wanted || forbidden {
+
+		proj := collection.GetProjection(field)
+		_, inLive := liveFields[field]
+		isKey := proj != nil && proj.IsPrimaryKey
+		isDoc := proj != nil && proj.IsRootDocumentProjection()
+		hardWanted := required || isKey || isDoc || inLive
+
+		switch {
+		case forbidden:
+			continue
+		case hardWanted:
+			// Selected even if also INCOMPATIBLE: presumes a backfill.
+		case incompatible:
+			// A bare incompatible field with no independent want is dropped.
+			continue
+		case includeOptional:
+			// Recommended/optional field selected at this depth.
+		default:
 			continue
 		}
 
@@ -897,10 +939,10 @@ func selectedFields(binding *pm.Response_Validated_Binding, collection pf.Collec
 		}
 		foldedFieldMap[foldedField] = struct{}{}
 
-		proj := collection.GetProjection(field)
-		if proj.IsPrimaryKey {
+		switch {
+		case isKey:
 			out.Keys = append(out.Keys, field)
-		} else if proj.IsRootDocumentProjection() {
+		case isDoc:
 			if out.Document == "" {
 				out.Document = field
 			} else {
@@ -908,7 +950,7 @@ func selectedFields(binding *pm.Response_Validated_Binding, collection pf.Collec
 				// one is the document, and the rest are materialized as values.
 				out.Values = append(out.Values, field)
 			}
-		} else {
+		default:
 			out.Values = append(out.Values, field)
 		}
 	}

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -563,7 +564,7 @@ func runBigSchemaApplyTests[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 	require.NoError(t, err)
 
 	snap.WriteString("Big Schema Initial Constraints:\n")
-	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].Constraints))
+	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].ProjectionConstraints))
 
 	// Initial apply with no previously existing table.
 	_, err = driver.Apply(ctx, applyReq(fixture, nil, configJson, resourceConfigJson, validateRes, true))
@@ -576,7 +577,7 @@ func runBigSchemaApplyTests[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 	require.NoError(t, err)
 
 	snap.WriteString("\nBig Schema Re-validated Constraints:\n")
-	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].Constraints))
+	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].ProjectionConstraints))
 
 	// Apply again - this should be a no-op.
 	_, err = driver.Apply(ctx, applyReq(fixture, fixture, configJson, resourceConfigJson, validateRes, true))
@@ -589,7 +590,7 @@ func runBigSchemaApplyTests[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 	require.NoError(t, err)
 
 	snap.WriteString("\nBig Schema Changed Types Constraints:\n")
-	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].Constraints))
+	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].ProjectionConstraints))
 
 	snap.WriteString("\nBig Schema Materialized Resource Schema With All Fields Required:\n")
 	snap.WriteString(sch)
@@ -618,7 +619,7 @@ func runBigSchemaApplyTests[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 	require.NoError(t, err)
 
 	snap.WriteString("\nBig Schema Changed Types With Backfill Constraints:\n")
-	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].Constraints))
+	snap.WriteString(snapshotConstraints(t, validateRes.Bindings[0].ProjectionConstraints))
 
 	_, err = driver.Apply(ctx, applyReq(changed, nullable, configJson, resourceConfigJson, validateRes, true))
 	require.NoError(t, err)
@@ -840,19 +841,53 @@ func applyReq(spec *pf.MaterializationSpec, lastSpec *pf.MaterializationSpec, co
 }
 
 // selectedFields creates a field selection that includes all possible fields.
+// A field may carry multiple projection_constraints; a field is selected when
+// some constraint wants it (required, recommended, or optional when optionals
+// are included) and none forbids it. An INCOMPATIBLE constraint does not by
+// itself exclude a wanted field: the control plane selects it presuming a
+// backfill (see build_selection in flow's field_selection.rs).
 func selectedFields(binding *pm.Response_Validated_Binding, collection pf.CollectionSpec, includeOptional bool) pf.FieldSelection {
 	out := pf.FieldSelection{}
 
+	// Group the binding's projection_constraints by field, preserving order so
+	// the folded field is taken from the first constraint, as the control plane
+	// does.
+	byField := make(map[string][]*pm.Response_Validated_Constraint)
+	var fieldOrder []string
+	for _, pc := range binding.ProjectionConstraints {
+		if _, ok := byField[pc.Field]; !ok {
+			fieldOrder = append(fieldOrder, pc.Field)
+		}
+		byField[pc.Field] = append(byField[pc.Field], pc.Constraint)
+	}
+
 	var foldedFieldMap = make(map[string]struct{})
 
-	for field, constraint := range binding.Constraints {
-		if constraint.Type.IsForbidden() || !includeOptional && constraint.Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL {
+	for _, field := range fieldOrder {
+		constraints := byField[field]
+
+		var wanted, forbidden bool
+		for _, c := range constraints {
+			switch c.Type {
+			case pm.Response_Validated_Constraint_FIELD_FORBIDDEN:
+				forbidden = true
+			case pm.Response_Validated_Constraint_FIELD_REQUIRED,
+				pm.Response_Validated_Constraint_LOCATION_REQUIRED,
+				pm.Response_Validated_Constraint_LOCATION_RECOMMENDED:
+				wanted = true
+			case pm.Response_Validated_Constraint_FIELD_OPTIONAL:
+				if includeOptional {
+					wanted = true
+				}
+			}
+		}
+		if !wanted || forbidden {
 			continue
 		}
 
 		var foldedField = field
-		if constraint.FoldedField != "" {
-			foldedField = constraint.FoldedField
+		if constraints[0].FoldedField != "" {
+			foldedField = constraints[0].FoldedField
 		}
 
 		// The runtime only keeps one of the fields which have equal FoldedFields. We replicate
@@ -884,9 +919,10 @@ func selectedFields(binding *pm.Response_Validated_Binding, collection pf.Collec
 	return out
 }
 
-// snapshotConstraints makes a compact string representation of a set of constraints, with one
-// constraint printed per line.
-func snapshotConstraints(t *testing.T, cs map[string]*pm.Response_Validated_Constraint) string {
+// snapshotConstraints makes a compact string representation of a binding's
+// projection_constraints, with one constraint printed per line. A field may
+// carry multiple constraints, each of which is printed.
+func snapshotConstraints(t *testing.T, pcs []*pm.Response_Validated_ProjectionConstraint) string {
 	t.Helper()
 
 	type constraintRow struct {
@@ -896,18 +932,18 @@ func snapshotConstraints(t *testing.T, cs map[string]*pm.Response_Validated_Cons
 		Reason     string
 	}
 
-	rows := make([]constraintRow, 0, len(cs))
-	for f, c := range cs {
+	rows := make([]constraintRow, 0, len(pcs))
+	for _, pc := range pcs {
 		rows = append(rows, constraintRow{
-			Field:      f,
-			Type:       int(c.Type),
-			TypeString: c.Type.String(),
-			Reason:     c.Reason,
+			Field:      pc.Field,
+			Type:       int(pc.Constraint.Type),
+			TypeString: pc.Constraint.Type.String(),
+			Reason:     pc.Constraint.Reason,
 		})
 	}
 
 	slices.SortFunc(rows, func(i, j constraintRow) int {
-		return strings.Compare(i.Field, j.Field)
+		return cmp.Or(strings.Compare(i.Field, j.Field), cmp.Compare(i.Type, j.Type))
 	})
 
 	var out strings.Builder

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -3,6 +3,7 @@ package boilerplate
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -62,6 +63,10 @@ func NewValidator(
 }
 
 // ValidateBinding calculates the constraints for a new binding or a change to an existing binding.
+// Each field may have more than one constraint: notably, a required field whose existing
+// materialized column is incompatible with the proposed projection carries both the requiredness
+// constraint and the INCOMPATIBLE constraint, so that the control plane fails the build with a
+// clear error.
 func (v Validator) ValidateBinding(
 	path []string,
 	deltaUpdates bool,
@@ -69,7 +74,7 @@ func (v Validator) ValidateBinding(
 	boundCollection pf.CollectionSpec,
 	fieldConfigJsonMap map[string]json.RawMessage,
 	lastSpec *pf.MaterializationSpec,
-) (map[string]*pm.Response_Validated_Constraint, error) {
+) (map[string][]*pm.Response_Validated_Constraint, error) {
 	lastBinding := findLastBinding(path, lastSpec)
 	existingResource := v.is.GetResource(path)
 
@@ -105,13 +110,18 @@ func (v Validator) ValidateBinding(
 	}
 
 	var err error
-	var constraints map[string]*pm.Response_Validated_Constraint
+	var constraints map[string][]*pm.Response_Validated_Constraint
 	if existingResource == nil || (lastBinding != nil && backfill != lastBinding.Backfill) {
 		// Always validate as a new table if the existing table doesn't exist, since there is no
 		// existing table to be incompatible with. Also validate as a new table if we are going to
 		// be replacing the table.
-		if constraints, err = v.validateNewBinding(boundCollection, deltaUpdates, fieldConfigJsonMap); err != nil {
+		newConstraints, err := v.validateNewBinding(boundCollection, deltaUpdates, fieldConfigJsonMap)
+		if err != nil {
 			return nil, err
+		}
+		constraints = make(map[string][]*pm.Response_Validated_Constraint, len(newConstraints))
+		for field, c := range newConstraints {
+			constraints[field] = []*pm.Response_Validated_Constraint{c}
 		}
 	} else {
 		if lastBinding != nil && lastBinding.DeltaUpdates && !deltaUpdates {
@@ -125,14 +135,34 @@ func (v Validator) ValidateBinding(
 	}
 
 	// Set folded field for each constraint where field translation changes the field name.
-	// This applies to both new and existing fields, ensuring complete coverage.
-	for field, constraint := range constraints {
+	// This applies to both new and existing fields, ensuring complete coverage. All
+	// constraints of a field must agree on the folded field, per the protocol.
+	for field, cs := range constraints {
 		if t := v.is.translateField(field); t != field {
-			constraint.FoldedField = t
+			for _, constraint := range cs {
+				constraint.FoldedField = t
+			}
 		}
 	}
 
 	return forbidLongFields(v.maxFieldLength, boundCollection, constraints)
+}
+
+// ValidatedConstraints flattens per-field constraint lists into the Validated
+// response's projection_constraints representation, which can express multiple
+// constraints per field.
+func ValidatedConstraints(
+	constraints map[string][]*pm.Response_Validated_Constraint,
+) []*pm.Response_Validated_ProjectionConstraint {
+	list := make([]*pm.Response_Validated_ProjectionConstraint, 0, len(constraints))
+
+	for _, field := range slices.Sorted(maps.Keys(constraints)) {
+		for _, c := range constraints[field] {
+			list = append(list, &pm.Response_Validated_ProjectionConstraint{Field: field, Constraint: c})
+		}
+	}
+
+	return list
 }
 
 func (v Validator) validateNewBinding(
@@ -183,8 +213,8 @@ func (v Validator) validateMatchesExistingResource(
 	boundCollection pf.CollectionSpec,
 	deltaUpdates bool,
 	fieldConfigJsonMap map[string]json.RawMessage,
-) (map[string]*pm.Response_Validated_Constraint, error) {
-	constraints := make(map[string]*pm.Response_Validated_Constraint)
+) (map[string][]*pm.Response_Validated_Constraint, error) {
+	constraints := make(map[string][]*pm.Response_Validated_Constraint)
 
 	docFields := []string{}
 	for _, p := range boundCollection.Projections {
@@ -196,6 +226,19 @@ func (v Validator) validateMatchesExistingResource(
 			return nil, err
 		}
 
+		// baseRequired reports whether the connector's base constraint requires
+		// the projection (LOCATION_REQUIRED or FIELD_REQUIRED). When a required
+		// projection turns out to be incompatible, c is left as this base
+		// constraint and paired with the incompatibility below, so the control
+		// plane surfaces a clear error rather than dropping a lone INCOMPATIBLE.
+		baseRequired := c.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED ||
+			c.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED
+
+		// incompatible is an optional INCOMPATIBLE constraint paired with c; it is
+		// set only when a required projection's existing column is incompatible.
+		// Otherwise the field gets the single constraint c.
+		var incompatible *pm.Response_Validated_Constraint
+
 		if c.Type == pm.Response_Validated_Constraint_FIELD_FORBIDDEN {
 			// Is the proposed type completely disallowed by the materialization? This differs from
 			// being INCOMPATIBLE, which implies that re-creating the materialization could resolve
@@ -206,24 +249,36 @@ func (v Validator) validateMatchesExistingResource(
 			// changes to a standard updates materialization. If there is no previously persisted
 			// spec, the first root document projection is selected as the root document.
 			if (lastBinding != nil && p.Field == lastBinding.FieldSelection.Document) || (lastBinding == nil && len(docFields) == 1) {
-				c = &pm.Response_Validated_Constraint{
+				docConstraint := &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "This field is the document in the current materialization",
 				}
 
-				// Do not allow incompatible type changes to the root document
-				// field if it has already been materialized.
-				if existingField := existingResource.GetField(p.Field); existingField != nil {
-					if constraintFromExisting, err := v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap); err != nil {
-						return nil, err
-					} else if constraintFromExisting.Type.IsForbidden() {
-						c = constraintFromExisting
-					}
+				// Mark this field as the document, unless it is already materialized
+				// with an incompatible type. In that case keep the base constraint c
+				// when it's required and pair it with the incompatibility; otherwise
+				// report only the incompatibility.
+				if existingField := existingResource.GetField(p.Field); existingField == nil {
+					c = docConstraint
+				} else if constraintFromExisting, err := v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap); err != nil {
+					return nil, err
+				} else if !constraintFromExisting.Type.IsForbidden() {
+					c = docConstraint
+				} else if baseRequired {
+					incompatible = constraintFromExisting
+				} else {
+					c = constraintFromExisting
 				}
 			} else if lastBinding != nil && lastBinding.FieldSelection.Document == "" {
-				c = &pm.Response_Validated_Constraint{
+				addDocIncompatible := &pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
 					Reason: "Cannot add a new root document projection to materialization without backfilling",
+				}
+				if baseRequired {
+					// Keep the base (required) constraint in c and pair it with the incompatibility.
+					incompatible = addDocIncompatible
+				} else {
+					c = addDocIncompatible
 				}
 			} else {
 				c = &pm.Response_Validated_Constraint{
@@ -272,6 +327,7 @@ func (v Validator) validateMatchesExistingResource(
 		// not have "columns" that can be inspected, but still support field selection (ex:
 		// materialize-dynamodb), so that selected fields can continue to be recommended.
 		if lastBinding != nil &&
+			incompatible == nil &&
 			c.Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL &&
 			slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
 			c = &pm.Response_Validated_Constraint{
@@ -280,19 +336,32 @@ func (v Validator) validateMatchesExistingResource(
 			}
 		}
 
-		constraints[p.Field] = c
+		// A required projection with an incompatible existing column carries both
+		// constraints; every other field carries the single constraint c.
+		if incompatible != nil {
+			constraints[p.Field] = []*pm.Response_Validated_Constraint{c, incompatible}
+		} else {
+			constraints[p.Field] = []*pm.Response_Validated_Constraint{c}
+		}
 	}
 
 	if lastBinding != nil && !deltaUpdates && lastBinding.FieldSelection.Document != "" && !slices.Contains(docFields, lastBinding.FieldSelection.Document) {
 		// For standard updates, the proposed binding must still have the original document field
 		// from a prior specification, if that's known. If it doesn't, make sure to fail the build
-		// with a constraint on a root document projection that it does have.
-		constraints[docFields[0]] = &pm.Response_Validated_Constraint{
-			Type: pm.Response_Validated_Constraint_INCOMPATIBLE,
-			Reason: fmt.Sprintf(
-				"The root document must be materialized as field '%s'",
-				lastBinding.FieldSelection.Document,
-			),
+		// with a constraint on a root document projection that it does have. The paired
+		// LOCATION_REQUIRED constraint guarantees the conflict is surfaced as a clean error.
+		constraints[docFields[0]] = []*pm.Response_Validated_Constraint{
+			{
+				Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
+				Reason: "The root document must be materialized for standard updates",
+			},
+			{
+				Type: pm.Response_Validated_Constraint_INCOMPATIBLE,
+				Reason: fmt.Sprintf(
+					"The root document must be materialized as field '%s'",
+					lastBinding.FieldSelection.Document,
+				),
+			},
 		}
 	}
 
@@ -381,18 +450,24 @@ func findLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *p
 // if all of the projections of a location that is required have names that are too long - at least
 // one of the projections of a required location must be able to be materialized. If maxLength is 0
 // no restrictions are enforced.
-func forbidLongFields(maxLength int, collection pf.CollectionSpec, constraints map[string]*pm.Response_Validated_Constraint) (map[string]*pm.Response_Validated_Constraint, error) {
+func forbidLongFields(maxLength int, collection pf.CollectionSpec, constraints map[string][]*pm.Response_Validated_Constraint) (map[string][]*pm.Response_Validated_Constraint, error) {
 	if maxLength == 0 {
 		return constraints, nil
 	}
 
+	hasType := func(cs []*pm.Response_Validated_Constraint, t pm.Response_Validated_Constraint_Type) bool {
+		return slices.ContainsFunc(cs, func(c *pm.Response_Validated_Constraint) bool {
+			return c.Type == t
+		})
+	}
+
 	requiredLocations := make(map[string]bool)
-	for field, constraint := range constraints {
+	for field, cs := range constraints {
 		tooLong := len([]rune(field)) > maxLength
 
 		p := collection.GetProjection(field)
 
-		if constraint.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED {
+		if hasType(cs, pm.Response_Validated_Constraint_LOCATION_REQUIRED) {
 			if _, ok := requiredLocations[p.Ptr]; !ok {
 				requiredLocations[p.Ptr] = false
 			}
@@ -406,7 +481,7 @@ func forbidLongFields(maxLength int, collection pf.CollectionSpec, constraints m
 			continue
 		}
 
-		if constraint.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED {
+		if hasType(cs, pm.Response_Validated_Constraint_FIELD_REQUIRED) {
 			return nil, fmt.Errorf(
 				"field '%s' is required to be materialized but has a length of %d which exceeds the maximum length allowable by the destination of %d",
 				field,
@@ -415,13 +490,16 @@ func forbidLongFields(maxLength int, collection pf.CollectionSpec, constraints m
 			)
 		}
 
-		constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
-		constraint.Reason = fmt.Sprintf(
-			"Field '%s' has a length of %d which exceeds the maximum length allowable by the destination of %d. Use an alternate projection with a shorter name to materialize this location",
-			field,
-			len(field),
-			maxLength,
-		)
+		constraints[field] = []*pm.Response_Validated_Constraint{{
+			Type: pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
+			Reason: fmt.Sprintf(
+				"Field '%s' has a length of %d which exceeds the maximum length allowable by the destination of %d. Use an alternate projection with a shorter name to materialize this location",
+				field,
+				len(field),
+				maxLength,
+			),
+			FoldedField: cs[0].FoldedField,
+		}}
 	}
 
 	for location, hasAllowable := range requiredLocations {

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -237,19 +237,6 @@ func (v Validator) validateMatchesExistingResource(
 			return nil, err
 		}
 
-		// Continue to recommend an optional field that was part of a prior
-		// selection, even when the destination doesn't report it as an existing
-		// column (e.g. materialize-dynamodb), so that it stays selected.
-		if lastBinding != nil &&
-			len(cs) == 1 &&
-			cs[0].Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL &&
-			slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
-			cs = []*pm.Response_Validated_Constraint{{
-				Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
-				Reason: "This location is part of the current materialization",
-			}}
-		}
-
 		constraints[p.Field] = cs
 	}
 

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -214,135 +214,36 @@ func (v Validator) validateMatchesExistingResource(
 	deltaUpdates bool,
 	fieldConfigJsonMap map[string]json.RawMessage,
 ) (map[string][]*pm.Response_Validated_Constraint, error) {
-	constraints := make(map[string][]*pm.Response_Validated_Constraint)
-
-	docFields := []string{}
+	// Root document projections, in projection order. The first one is the
+	// document when there is no prior selection to defer to.
+	var docFields []string
 	for _, p := range boundCollection.Projections {
-		// Base constraint used for all new projections of the binding. This may be re-evaluated
-		// below, depending on the details of the projection and any pre-existing materialization of
-		// it.
-		c, err := v.c.NewConstraints(&p, deltaUpdates, fieldConfigJsonMap[p.Field])
+		if p.IsRootDocumentProjection() {
+			docFields = append(docFields, p.Field)
+		}
+	}
+
+	constraints := make(map[string][]*pm.Response_Validated_Constraint)
+	for _, p := range boundCollection.Projections {
+		cs, err := v.projectionConstraints(p, existingResource, lastBinding, boundCollection, deltaUpdates, docFields, fieldConfigJsonMap)
 		if err != nil {
 			return nil, err
 		}
 
-		// baseRequired reports whether the connector's base constraint requires
-		// the projection (LOCATION_REQUIRED or FIELD_REQUIRED). When a required
-		// projection turns out to be incompatible, c is left as this base
-		// constraint and paired with the incompatibility below, so the control
-		// plane surfaces a clear error rather than dropping a lone INCOMPATIBLE.
-		baseRequired := c.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED ||
-			c.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED
-
-		// incompatible is an optional INCOMPATIBLE constraint paired with c; it is
-		// set only when a required projection's existing column is incompatible.
-		// Otherwise the field gets the single constraint c.
-		var incompatible *pm.Response_Validated_Constraint
-
-		if c.Type == pm.Response_Validated_Constraint_FIELD_FORBIDDEN {
-			// Is the proposed type completely disallowed by the materialization? This differs from
-			// being INCOMPATIBLE, which implies that re-creating the materialization could resolve
-			// the difference.
-		} else if !deltaUpdates && p.IsRootDocumentProjection() {
-			docFields = append(docFields, p.Field)
-			// Only the originally selected root document projection is allowed to be selected for
-			// changes to a standard updates materialization. If there is no previously persisted
-			// spec, the first root document projection is selected as the root document.
-			if (lastBinding != nil && p.Field == lastBinding.FieldSelection.Document) || (lastBinding == nil && len(docFields) == 1) {
-				docConstraint := &pm.Response_Validated_Constraint{
-					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
-					Reason: "This field is the document in the current materialization",
-				}
-
-				// Mark this field as the document, unless it is already materialized
-				// with an incompatible type. In that case keep the base constraint c
-				// when it's required and pair it with the incompatibility; otherwise
-				// report only the incompatibility.
-				if existingField := existingResource.GetField(p.Field); existingField == nil {
-					c = docConstraint
-				} else if constraintFromExisting, err := v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap); err != nil {
-					return nil, err
-				} else if !constraintFromExisting.Type.IsForbidden() {
-					c = docConstraint
-				} else if baseRequired {
-					incompatible = constraintFromExisting
-				} else {
-					c = constraintFromExisting
-				}
-			} else if lastBinding != nil && lastBinding.FieldSelection.Document == "" {
-				addDocIncompatible := &pm.Response_Validated_Constraint{
-					Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
-					Reason: "Cannot add a new root document projection to materialization without backfilling",
-				}
-				if baseRequired {
-					// Keep the base (required) constraint in c and pair it with the incompatibility.
-					incompatible = addDocIncompatible
-				} else {
-					c = addDocIncompatible
-				}
-			} else {
-				c = &pm.Response_Validated_Constraint{
-					Type: pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
-					Reason: fmt.Sprintf(
-						"Cannot materialize root document projection '%s' because field '%s' is already being materialized as the document",
-						p.Field,
-						func() string {
-							if lastBinding != nil {
-								return lastBinding.FieldSelection.Document
-							} else {
-								return docFields[0]
-							}
-						}(),
-					),
-				}
-			}
-		} else if !deltaUpdates && p.IsPrimaryKey && lastBinding != nil && !slices.Contains(lastBinding.FieldSelection.Keys, p.Field) {
-			// Locations that are part of the primary key may not be added without backfilling the binding
-			c = &pm.Response_Validated_Constraint{
-				Type:   pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
-				Reason: "Cannot add a new key location to the field selection of an existing non-delta-updates materialization without backfilling",
-			}
-			if lastBinding != nil && slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
-				if existingField := existingResource.GetField(p.Field); existingField != nil {
-					if c, err = v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap); err != nil {
-						return nil, fmt.Errorf("evaluating constraint for existing field: %w", err)
-					}
-				} else {
-					c = &pm.Response_Validated_Constraint{
-						Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
-						Reason: "This location is part of the current materialization",
-					}
-				}
-			}
-		} else if existingField := existingResource.GetField(p.Field); existingField != nil {
-			// All other fields that are already being materialized.
-			if c, err = v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap); err != nil {
-				return nil, err
-			}
-		}
-
-		// Continue to recommended any optional fields that were included in a prior spec's
-		// field selection, even if the materialized field is not reported to exist in the
-		// destination. This is primarily to produce more useful constraints for systems that do
-		// not have "columns" that can be inspected, but still support field selection (ex:
-		// materialize-dynamodb), so that selected fields can continue to be recommended.
+		// Continue to recommend an optional field that was part of a prior
+		// selection, even when the destination doesn't report it as an existing
+		// column (e.g. materialize-dynamodb), so that it stays selected.
 		if lastBinding != nil &&
-			incompatible == nil &&
-			c.Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL &&
+			len(cs) == 1 &&
+			cs[0].Type == pm.Response_Validated_Constraint_FIELD_OPTIONAL &&
 			slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
-			c = &pm.Response_Validated_Constraint{
+			cs = []*pm.Response_Validated_Constraint{{
 				Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
 				Reason: "This location is part of the current materialization",
-			}
+			}}
 		}
 
-		// A required projection with an incompatible existing column carries both
-		// constraints; every other field carries the single constraint c.
-		if incompatible != nil {
-			constraints[p.Field] = []*pm.Response_Validated_Constraint{c, incompatible}
-		} else {
-			constraints[p.Field] = []*pm.Response_Validated_Constraint{c}
-		}
+		constraints[p.Field] = cs
 	}
 
 	if lastBinding != nil && !deltaUpdates && lastBinding.FieldSelection.Document != "" && !slices.Contains(docFields, lastBinding.FieldSelection.Document) {
@@ -366,6 +267,160 @@ func (v Validator) validateMatchesExistingResource(
 	}
 
 	return constraints, nil
+}
+
+// projectionConstraints computes the validation constraint(s) for a single
+// projection of a binding that updates an existing resource. A field carries a
+// single constraint in the common case; a required projection whose existing
+// column is incompatible carries both the requiredness and an INCOMPATIBLE
+// constraint, so the control plane surfaces a clear conflict.
+func (v Validator) projectionConstraints(
+	p pf.Projection,
+	existingResource ExistingResource,
+	lastBinding *pf.MaterializationSpec_Binding,
+	boundCollection pf.CollectionSpec,
+	deltaUpdates bool,
+	docFields []string,
+	fieldConfigJsonMap map[string]json.RawMessage,
+) ([]*pm.Response_Validated_Constraint, error) {
+	// Base constraint, the connector's opinion of the projection on its own.
+	base, err := v.c.NewConstraints(&p, deltaUpdates, fieldConfigJsonMap[p.Field])
+	if err != nil {
+		return nil, err
+	}
+
+	// withIncompatibility pairs an INCOMPATIBLE constraint with the base
+	// requiredness when the base requires the projection, so the control plane
+	// surfaces a clear conflict; for a non-required projection it returns only
+	// the incompatibility, which the control plane drops.
+	withIncompatibility := func(incompatible *pm.Response_Validated_Constraint) []*pm.Response_Validated_Constraint {
+		if base.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED ||
+			base.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED {
+			return []*pm.Response_Validated_Constraint{base, incompatible}
+		}
+		return []*pm.Response_Validated_Constraint{incompatible}
+	}
+
+	switch {
+	case base.Type == pm.Response_Validated_Constraint_FIELD_FORBIDDEN:
+		// The proposed type is completely disallowed by the materialization. This
+		// differs from INCOMPATIBLE, which re-creating the materialization could
+		// resolve.
+		return []*pm.Response_Validated_Constraint{base}, nil
+
+	case !deltaUpdates && p.IsRootDocumentProjection():
+		return v.rootDocumentConstraints(p, withIncompatibility, existingResource, lastBinding, boundCollection, docFields, fieldConfigJsonMap)
+
+	case !deltaUpdates && p.IsPrimaryKey && lastBinding != nil && !slices.Contains(lastBinding.FieldSelection.Keys, p.Field):
+		return v.addedKeyConstraints(p, existingResource, lastBinding, boundCollection, fieldConfigJsonMap)
+
+	case existingResource.GetField(p.Field) != nil:
+		// An already-materialized field: validate against its existing column.
+		c, err := v.constraintForExistingField(boundCollection, p, *existingResource.GetField(p.Field), fieldConfigJsonMap)
+		if err != nil {
+			return nil, err
+		}
+		return []*pm.Response_Validated_Constraint{c}, nil
+
+	default:
+		return []*pm.Response_Validated_Constraint{base}, nil
+	}
+}
+
+// rootDocumentConstraints computes the constraint(s) for a root document
+// projection of a standard-updates binding.
+func (v Validator) rootDocumentConstraints(
+	p pf.Projection,
+	withIncompatibility func(*pm.Response_Validated_Constraint) []*pm.Response_Validated_Constraint,
+	existingResource ExistingResource,
+	lastBinding *pf.MaterializationSpec_Binding,
+	boundCollection pf.CollectionSpec,
+	docFields []string,
+	fieldConfigJsonMap map[string]json.RawMessage,
+) ([]*pm.Response_Validated_Constraint, error) {
+	// Only the originally selected root document projection is allowed to be
+	// selected. If there is no prior spec, the first root document projection is
+	// the document.
+	selectedDoc := (lastBinding != nil && p.Field == lastBinding.FieldSelection.Document) ||
+		(lastBinding == nil && p.Field == docFields[0])
+
+	switch {
+	case selectedDoc:
+		docConstraint := &pm.Response_Validated_Constraint{
+			Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
+			Reason: "This field is the document in the current materialization",
+		}
+
+		// Mark this field as the document, unless it is already materialized with
+		// an incompatible type, in which case surface the incompatibility.
+		existingField := existingResource.GetField(p.Field)
+		if existingField == nil {
+			return []*pm.Response_Validated_Constraint{docConstraint}, nil
+		}
+		c, err := v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap)
+		if err != nil {
+			return nil, err
+		}
+		if !c.Type.IsForbidden() {
+			return []*pm.Response_Validated_Constraint{docConstraint}, nil
+		}
+		return withIncompatibility(c), nil
+
+	case lastBinding != nil && lastBinding.FieldSelection.Document == "":
+		return withIncompatibility(&pm.Response_Validated_Constraint{
+			Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
+			Reason: "Cannot add a new root document projection to materialization without backfilling",
+		}), nil
+
+	default:
+		// Another root document projection when one is already materialized.
+		materializedAs := docFields[0]
+		if lastBinding != nil {
+			materializedAs = lastBinding.FieldSelection.Document
+		}
+		return []*pm.Response_Validated_Constraint{{
+			Type: pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
+			Reason: fmt.Sprintf(
+				"Cannot materialize root document projection '%s' because field '%s' is already being materialized as the document",
+				p.Field,
+				materializedAs,
+			),
+		}}, nil
+	}
+}
+
+// addedKeyConstraints computes the constraint(s) for a primary key projection
+// that is not part of the existing binding's key, which cannot be added to a
+// standard-updates materialization without backfilling.
+func (v Validator) addedKeyConstraints(
+	p pf.Projection,
+	existingResource ExistingResource,
+	lastBinding *pf.MaterializationSpec_Binding,
+	boundCollection pf.CollectionSpec,
+	fieldConfigJsonMap map[string]json.RawMessage,
+) ([]*pm.Response_Validated_Constraint, error) {
+	if !slices.Contains(lastBinding.FieldSelection.AllFields(), p.Field) {
+		return []*pm.Response_Validated_Constraint{{
+			Type:   pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
+			Reason: "Cannot add a new key location to the field selection of an existing non-delta-updates materialization without backfilling",
+		}}, nil
+	}
+
+	// The key location was already part of the selection: validate it against
+	// its existing column, or recommend it if the destination doesn't report
+	// columns.
+	existingField := existingResource.GetField(p.Field)
+	if existingField == nil {
+		return []*pm.Response_Validated_Constraint{{
+			Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
+			Reason: "This location is part of the current materialization",
+		}}, nil
+	}
+	c, err := v.constraintForExistingField(boundCollection, p, *existingField, fieldConfigJsonMap)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating constraint for existing field: %w", err)
+	}
+	return []*pm.Response_Validated_Constraint{c}, nil
 }
 
 func (v Validator) constraintForExistingField(

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -223,6 +223,13 @@ func (v Validator) validateMatchesExistingResource(
 		}
 	}
 
+	// Standard updates require a root document projection: docFields[0] is
+	// dereferenced below as the fallback document field, and the protocol does
+	// not guarantee its presence.
+	if !deltaUpdates && len(docFields) == 0 {
+		return nil, fmt.Errorf("collection %q has no root document projection, which is required for a standard-updates materialization", boundCollection.Name.String())
+	}
+
 	constraints := make(map[string][]*pm.Response_Validated_Constraint)
 	for _, p := range boundCollection.Projections {
 		cs, err := v.projectionConstraints(p, existingResource, lastBinding, boundCollection, deltaUpdates, docFields, fieldConfigJsonMap)

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -401,12 +401,12 @@ func (v Validator) addedKeyConstraints(
 	}
 
 	// The key location was already part of the selection: validate it against
-	// its existing column, or recommend it if the destination doesn't report
+	// its existing column, or mark it optional if the destination doesn't report
 	// columns.
 	existingField := existingResource.GetField(p.Field)
 	if existingField == nil {
 		return []*pm.Response_Validated_Constraint{{
-			Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
+			Type:   pm.Response_Validated_Constraint_FIELD_OPTIONAL,
 			Reason: "This location is part of the current materialization",
 		}}, nil
 	}
@@ -435,11 +435,8 @@ func (v Validator) constraintForExistingField(
 				Reason: "This field is a key in the current materialization",
 			}
 		} else {
-			// TODO(whb): Really this should be "FIELD_RECOMMENDED", but that is not a
-			// constraint that has been implemented currently. This would be an issue if there
-			// are multiple projections of the same location.
 			out = &pm.Response_Validated_Constraint{
-				Type:   pm.Response_Validated_Constraint_LOCATION_RECOMMENDED,
+				Type:   pm.Response_Validated_Constraint_FIELD_OPTIONAL,
 				Reason: "This location is part of the current materialization",
 			}
 		}

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -296,18 +296,6 @@ func (v Validator) projectionConstraints(
 		return nil, err
 	}
 
-	// withIncompatibility pairs an INCOMPATIBLE constraint with the base
-	// requiredness when the base requires the projection, so the control plane
-	// surfaces a clear conflict; for a non-required projection it returns only
-	// the incompatibility, which the control plane drops.
-	withIncompatibility := func(incompatible *pm.Response_Validated_Constraint) []*pm.Response_Validated_Constraint {
-		if base.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED ||
-			base.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED {
-			return []*pm.Response_Validated_Constraint{base, incompatible}
-		}
-		return []*pm.Response_Validated_Constraint{incompatible}
-	}
-
 	switch {
 	case base.Type == pm.Response_Validated_Constraint_FIELD_FORBIDDEN:
 		// The proposed type is completely disallowed by the materialization. This
@@ -316,7 +304,7 @@ func (v Validator) projectionConstraints(
 		return []*pm.Response_Validated_Constraint{base}, nil
 
 	case !deltaUpdates && p.IsRootDocumentProjection():
-		return v.rootDocumentConstraints(p, withIncompatibility, existingResource, lastBinding, boundCollection, docFields, fieldConfigJsonMap)
+		return v.rootDocumentConstraints(p, base, existingResource, lastBinding, boundCollection, docFields, fieldConfigJsonMap)
 
 	case !deltaUpdates && p.IsPrimaryKey && lastBinding != nil && !slices.Contains(lastBinding.FieldSelection.Keys, p.Field):
 		return v.addedKeyConstraints(p, existingResource, lastBinding, boundCollection, fieldConfigJsonMap)
@@ -334,11 +322,23 @@ func (v Validator) projectionConstraints(
 	}
 }
 
+// withIncompatibility pairs an INCOMPATIBLE constraint with the base
+// requiredness when the base requires the projection, so the control plane
+// surfaces a clear conflict; for a non-required projection it returns only the
+// incompatibility, which the control plane drops.
+func withIncompatibility(base, incompatible *pm.Response_Validated_Constraint) []*pm.Response_Validated_Constraint {
+	if base.Type == pm.Response_Validated_Constraint_LOCATION_REQUIRED ||
+		base.Type == pm.Response_Validated_Constraint_FIELD_REQUIRED {
+		return []*pm.Response_Validated_Constraint{base, incompatible}
+	}
+	return []*pm.Response_Validated_Constraint{incompatible}
+}
+
 // rootDocumentConstraints computes the constraint(s) for a root document
 // projection of a standard-updates binding.
 func (v Validator) rootDocumentConstraints(
 	p pf.Projection,
-	withIncompatibility func(*pm.Response_Validated_Constraint) []*pm.Response_Validated_Constraint,
+	base *pm.Response_Validated_Constraint,
 	existingResource ExistingResource,
 	lastBinding *pf.MaterializationSpec_Binding,
 	boundCollection pf.CollectionSpec,
@@ -371,10 +371,10 @@ func (v Validator) rootDocumentConstraints(
 		if !c.Type.IsForbidden() {
 			return []*pm.Response_Validated_Constraint{docConstraint}, nil
 		}
-		return withIncompatibility(c), nil
+		return withIncompatibility(base, c), nil
 
 	case lastBinding != nil && lastBinding.FieldSelection.Document == "":
-		return withIncompatibility(&pm.Response_Validated_Constraint{
+		return withIncompatibility(base, &pm.Response_Validated_Constraint{
 			Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
 			Reason: "Cannot add a new root document projection to materialization without backfilling",
 		}), nil

--- a/materialize-boilerplate/validate_test.go
+++ b/materialize-boilerplate/validate_test.go
@@ -3,6 +3,7 @@ package boilerplate
 import (
 	"embed"
 	"encoding/json"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -174,6 +175,16 @@ func TestValidate(t *testing.T) {
 			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "retain_existing_data_on_backfill": false},
 		},
 		{
+			name:               "table already exists with incompatible root document column",
+			deltaUpdates:       false,
+			specForInfoSchema:  specWithDocColumnType(loadValidateSpec(t, "base.flow.proto"), "string"),
+			existingSpec:       nil,
+			proposedSpec:       loadValidateSpec(t, "base.flow.proto"),
+			fieldNameTransform: simpleTestTransform,
+			maxFieldLength:     0,
+			featureFlags:       map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "retain_existing_data_on_backfill": false},
+		},
+		{
 			name:               "field names over the length limit are forbidden",
 			deltaUpdates:       false,
 			specForInfoSchema:  nil,
@@ -284,11 +295,13 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that folded fields are set for all constraints
-		for field, constraint := range cs {
-			// simpleTestTransform adds "_transformed" to all field names
-			expectedFolded := field + "_transformed"
-			require.Equal(t, expectedFolded, constraint.FoldedField,
-				"FoldedField should be set to the transformed field name for field %q", field)
+		for field, constraints := range cs {
+			for _, constraint := range constraints {
+				// simpleTestTransform adds "_transformed" to all field names
+				expectedFolded := field + "_transformed"
+				require.Equal(t, expectedFolded, constraint.FoldedField,
+					"FoldedField should be set to the transformed field name for field %q", field)
+			}
 		}
 	})
 
@@ -312,9 +325,11 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that folded fields are empty when no transformation occurs
-		for field, constraint := range cs {
-			require.Empty(t, constraint.FoldedField,
-				"FoldedField should be empty when field name is unchanged for field %q", field)
+		for field, constraints := range cs {
+			for _, constraint := range constraints {
+				require.Empty(t, constraint.FoldedField,
+					"FoldedField should be empty when field name is unchanged for field %q", field)
+			}
 		}
 	})
 
@@ -485,15 +500,94 @@ func TestValidate(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		// The INCOMPATIBLE constraint is paired with the connector's own LOCATION_REQUIRED
+		// constraint, so the control plane fails the build with a clear error.
 		for _, documentField := range []string{"flow_document", "second_root"} {
 			require.Equal(t, constraints[documentField],
-				&pm.Response_Validated_Constraint{
-					Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
-					Reason: "Cannot add a new root document projection to materialization without backfilling",
+				[]*pm.Response_Validated_Constraint{
+					{
+						Type:   pm.Response_Validated_Constraint_LOCATION_REQUIRED,
+						Reason: "The root document is required for a standard updates materialization",
+					},
+					{
+						Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
+						Reason: "Cannot add a new root document projection to materialization without backfilling",
+					},
 				},
 			)
 		}
 	})
+
+	t.Run("new binding to existing table with incompatible document column", func(t *testing.T) {
+		// A new binding attached to an existing table whose document column has an
+		// incompatible type reports both LOCATION_REQUIRED and INCOMPATIBLE for the
+		// document field, so the control plane fails the build with a clear error.
+		identityTransform := func(s string) string { return s }
+		is := testInfoSchemaFromSpec(t, specWithDocColumnType(loadValidateSpec(t, "base.flow.proto"), "string"), identityTransform)
+		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": true, "retain_existing_data_on_backfill": false}
+		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
+
+		proposed := loadValidateSpec(t, "base.flow.proto")
+		cs, err := validator.ValidateBinding(
+			[]string{"key_value"},
+			false,
+			proposed.Bindings[0].Backfill,
+			proposed.Bindings[0].Collection,
+			proposed.Bindings[0].FieldSelection.FieldConfigJsonMap,
+			nil, // No existing spec (new binding)
+		)
+		require.NoError(t, err)
+
+		require.Len(t, cs["flow_document"], 2)
+		require.Equal(t, pm.Response_Validated_Constraint_LOCATION_REQUIRED, cs["flow_document"][0].Type)
+		require.Equal(t, pm.Response_Validated_Constraint_INCOMPATIBLE, cs["flow_document"][1].Type)
+		require.Contains(t, cs["flow_document"][1].Reason, "already being materialized as endpoint type 'STRING'")
+
+		// projection_constraints carries both entries for the field.
+		list := ValidatedConstraints(cs)
+
+		var docConstraints []*pm.Response_Validated_Constraint
+		for _, pc := range list {
+			require.NotEmpty(t, pc.Field)
+			require.NotNil(t, pc.Constraint)
+			if pc.Field == "flow_document" {
+				docConstraints = append(docConstraints, pc.Constraint)
+			}
+		}
+		require.Equal(t, cs["flow_document"], docConstraints)
+	})
+
+	t.Run("new binding to existing table with incompatible document column in document-less mode", func(t *testing.T) {
+		// When the connector reports the root document projection as optional (e.g. the
+		// no_flow_document mode), an incompatible document column remains a lone INCOMPATIBLE
+		// constraint: the materialization legitimately proceeds without the document field.
+		identityTransform := func(s string) string { return s }
+		is := testInfoSchemaFromSpec(t, specWithDocColumnType(loadValidateSpec(t, "base.flow.proto"), "string"), identityTransform)
+		featureFlags := map[string]bool{"allow_existing_tables_for_new_bindings": true, "flow_document": false, "retain_existing_data_on_backfill": false}
+		validator := NewValidator(testConstrainter{featureFlags: featureFlags}, is, 0, true, featureFlags)
+
+		proposed := loadValidateSpec(t, "base.flow.proto")
+		cs, err := validator.ValidateBinding(
+			[]string{"key_value"},
+			false,
+			proposed.Bindings[0].Backfill,
+			proposed.Bindings[0].Collection,
+			proposed.Bindings[0].FieldSelection.FieldConfigJsonMap,
+			nil, // No existing spec (new binding)
+		)
+		require.NoError(t, err)
+
+		require.Len(t, cs["flow_document"], 1)
+		require.Equal(t, pm.Response_Validated_Constraint_INCOMPATIBLE, cs["flow_document"][0].Type)
+	})
+}
+
+// specWithDocColumnType simulates an existing table whose root document column has the given
+// type, by mutating the inference types of the flow_document projection used to build the
+// InfoSchema fixture.
+func specWithDocColumnType(spec *pf.MaterializationSpec, typ string) *pf.MaterializationSpec {
+	spec.Bindings[0].Collection.GetProjection("flow_document").Inference.Types = []string{typ}
+	return spec
 }
 
 type testConstrainter struct {
@@ -622,7 +716,7 @@ func TestFlowDocumentFeatureFlag(t *testing.T) {
 	})
 }
 
-func snapshotConstraints(t *testing.T, cs map[string]*pm.Response_Validated_Constraint) string {
+func snapshotConstraints(t *testing.T, cs map[string][]*pm.Response_Validated_Constraint) string {
 	t.Helper()
 
 	type constraintRow struct {
@@ -632,24 +726,17 @@ func snapshotConstraints(t *testing.T, cs map[string]*pm.Response_Validated_Cons
 		Reason     string
 	}
 
-	rows := make([]constraintRow, 0, len(cs))
-	for f, c := range cs {
-		rows = append(rows, constraintRow{
-			Field:      f,
-			Type:       int(c.Type),
-			TypeString: c.Type.String(),
-			Reason:     c.Reason,
-		})
-	}
-
-	slices.SortFunc(rows, func(i, j constraintRow) int {
-		return strings.Compare(i.Field, j.Field)
-	})
-
 	var out strings.Builder
 	enc := json.NewEncoder(&out)
-	for _, r := range rows {
-		require.NoError(t, enc.Encode(r))
+	for _, f := range slices.Sorted(maps.Keys(cs)) {
+		for _, c := range cs[f] {
+			require.NoError(t, enc.Encode(constraintRow{
+				Field:      f,
+				Type:       int(c.Type),
+				TypeString: c.Type.String(),
+				Reason:     c.Reason,
+			}))
+		}
 	}
 
 	return out.String()

--- a/materialize-clickhouse/.snapshots/TestIntegration-apply
+++ b/materialize-clickhouse/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOL' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT64' but endpoint type 'BOOL' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"Bool"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"String"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"String"}
 {"Name":"_id","Nullable":false,"Type":"String"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"Bool"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"String"}
 {"Name":"flow_document","Nullable":false,"Type":"String"}
 {"Name":"flow_published_at","Nullable":false,"Type":"DateTime64(6, 'UTC')"}

--- a/materialize-databricks/.snapshots/TestIntegration-apply
+++ b/materialize-databricks/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"BOOLEAN"}
@@ -337,8 +337,9 @@ Challenging Field Names Materialized Columns:
 {"Name":"_______.-_problematicKey_�_𐀀_嶲_","Nullable":false,"Type":"STRING"}
 {"Name":"_______.-_problematicValue_�_𐀀_嶲_","Nullable":true,"Type":"STRING"}
 {"Name":"_id","Nullable":false,"Type":"STRING"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"BOOLEAN"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"STRING"}
-{"Name":"flow_document","Nullable":true,"Type":"STRING"}
+{"Name":"flow_document","Nullable":false,"Type":"STRING"}
 {"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}
 {"Name":"value-with-separated-words","Nullable":true,"Type":"STRING"}
 {"Name":"value.with-separated_words","Nullable":true,"Type":"STRING"}

--- a/materialize-dynamodb/.snapshots/TestIntegration-apply
+++ b/materialize-dynamodb/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nullField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"nullField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This field is able to be materialized"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"key","Nullable":false,"Type":"S"}

--- a/materialize-elasticsearch/.snapshots/TestIntegration-apply
+++ b/materialize-elasticsearch/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"intField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'intField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'FLATTENED' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateTimeField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'TEXT' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringIntegerField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv4Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv4Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv6Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv6Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringNumberField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringUint32Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringUint64Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"text"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"text"}
 {"Name":"_id_flow","Nullable":true,"Type":"keyword"}
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"text"}
 {"Name":"flow_document","Nullable":true,"Type":"flattened"}
 {"Name":"flow_published_at","Nullable":true,"Type":"date"}

--- a/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-apply
+++ b/materialize-elasticsearch/.snapshots/TestIntegration-opensearch-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"intField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'intField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'FLAT_OBJECT' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateTimeField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'DATE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'TEXT' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringIntegerField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv4Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv4Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv6Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv6Field' is already being materialized as endpoint type 'IP' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringNumberField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringUint32Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringUint64Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'LONG' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"text"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"text"}
 {"Name":"_id_flow","Nullable":true,"Type":"keyword"}
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"text"}
 {"Name":"flow_document","Nullable":true,"Type":"flat_object"}
 {"Name":"flow_published_at","Nullable":true,"Type":"date"}

--- a/materialize-eventbridge/.snapshots/TestIntegration-apply
+++ b/materialize-eventbridge/.snapshots/TestIntegration-apply
@@ -46,7 +46,7 @@ Big Schema Re-validated Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"intField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
-{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"EventBridge ignores keys; including them in the payload is optional"}
 {"Field":"multipleField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"numField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
@@ -85,7 +85,7 @@ Big Schema Changed Types Constraints:
 {"Field":"flow_document","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"The root document must be materialized"}
 {"Field":"flow_published_at","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"intField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
-{"Field":"key","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"key","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"EventBridge ignores keys; including them in the payload is optional"}
 {"Field":"multipleField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}
 {"Field":"numField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"EventBridge only materializes the full document"}

--- a/materialize-iceberg/.snapshots/TestIntegration-apply
+++ b/materialize-iceberg/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"string"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"string"}
 {"Name":"_id","Nullable":false,"Type":"string"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"string"}
 {"Name":"flow_document","Nullable":false,"Type":"string"}
 {"Name":"flow_published_at","Nullable":false,"Type":"timestamptz"}

--- a/materialize-motherduck/.snapshots/TestIntegration-apply
+++ b/materialize-motherduck/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'JSON' but endpoint type 'VARCHAR' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'VARCHAR' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"BOOLEAN"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"VARCHAR"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"VARCHAR"}
 {"Name":"_id","Nullable":false,"Type":"VARCHAR"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"BOOLEAN"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"VARCHAR"}
 {"Name":"flow_document","Nullable":false,"Type":"JSON"}
 {"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP WITH TIME ZONE"}

--- a/materialize-mysql/.snapshots/TestIntegration-apply
+++ b/materialize-mysql/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'TINYINT' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'LONGTEXT(4294967295)' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"tinyint"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"longtext"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"longtext"}
 {"Name":"_id","Nullable":false,"Type":"varchar"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"tinyint"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"longtext"}
 {"Name":"flow_document","Nullable":false,"Type":"longtext"}
 {"Name":"flow_published_at","Nullable":false,"Type":"datetime"}
@@ -387,82 +388,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'TINYINT' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'JSON' but endpoint type 'LONGTEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'LONGTEXT(4294967295)' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"tinyint"}
@@ -684,6 +685,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"longtext"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"longtext"}
 {"Name":"_id","Nullable":false,"Type":"varchar"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"tinyint"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"longtext"}
 {"Name":"flow_document","Nullable":false,"Type":"json"}
 {"Name":"flow_published_at","Nullable":false,"Type":"datetime"}

--- a/materialize-postgres/.snapshots/TestIntegration-apply
+++ b/materialize-postgres/.snapshots/TestIntegration-apply
@@ -40,81 +40,81 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE PRECISION' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'JSON' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringDurationField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDurationField' is already being materialized as endpoint type 'INTERVAL' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'TEXT' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringIpv4Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv4Field' is already being materialized as endpoint type 'CIDR' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringIpv6Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIpv6Field' is already being materialized as endpoint type 'CIDR' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringMacAddr8Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringMacAddr8Field' is already being materialized as endpoint type 'MACADDR8' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 {"Field":"stringMacAddrField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringMacAddrField' is already being materialized as endpoint type 'MACADDR' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringUuidField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUuidField' is already being materialized as endpoint type 'UUID' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"text"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"text"}
 {"Name":"_id","Nullable":false,"Type":"text"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"text"}
 {"Name":"flow_document","Nullable":false,"Type":"json"}
 {"Name":"flow_published_at","Nullable":false,"Type":"timestamp with time zone"}

--- a/materialize-redshift/.snapshots/TestIntegration-apply
+++ b/materialize-redshift/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE PRECISION' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'SUPER' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'CHARACTER VARYING(256)' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"character varying"}
 {"Name":"123startswithdigits","Nullable":true,"Type":"character varying"}
 {"Name":"_id","Nullable":true,"Type":"character varying"}
+{"Name":"_meta/flow_truncated","Nullable":true,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"character varying"}
 {"Name":"flow_document","Nullable":true,"Type":"super"}
 {"Name":"flow_published_at","Nullable":true,"Type":"timestamp with time zone"}

--- a/materialize-s3-iceberg/.snapshots/TestIntegration-apply
+++ b/materialize-s3-iceberg/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"flow_document","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_document","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"intField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'intField' is already being materialized as endpoint type 'LONG' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringDateField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateField' is already being materialized as endpoint type 'DATE' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"stringDateTimeField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringDateTimeField' is already being materialized as endpoint type 'TIMESTAMPTZ' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING' but endpoint type 'LONG' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringIntegerField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringIntegerField' is already being materialized as endpoint type 'LONG' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringNumberField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringNumberField' is already being materialized as endpoint type 'DOUBLE' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringUint32Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint32Field' is already being materialized as endpoint type 'LONG' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
 {"Field":"stringUint64Field","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUint64Field' is already being materialized as endpoint type 'LONG' but endpoint type 'STRING' is required by its schema '{ type: [string] }'"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
@@ -341,6 +341,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"string"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"string"}
 {"Name":"_id","Nullable":false,"Type":"string"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"string"}
 {"Name":"flow_document","Nullable":false,"Type":"string"}
 {"Name":"flow_published_at","Nullable":false,"Type":"timestamptz"}

--- a/materialize-snowflake/.snapshots/TestIntegration-apply
+++ b/materialize-snowflake/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOLEAN' but endpoint type 'INTEGER' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'REAL' but endpoint type 'BOOLEAN' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'VARIANT' but endpoint type 'TEXT' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'TEXT(16777216)' but endpoint type 'INTEGER' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"ARRAYFIELD","Nullable":false,"Type":"VARIANT"}
@@ -340,6 +340,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"FLOW_PUBLISHED_AT","Nullable":false,"Type":"TIMESTAMP_LTZ"}
 {"Name":"VALUE_WITH_SEPARATED_WORDS","Nullable":true,"Type":"TEXT"}
 {"Name":"_ID","Nullable":false,"Type":"TEXT"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"BOOLEAN"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"TEXT"}
 {"Name":"value with separated words","Nullable":true,"Type":"TEXT"}
 {"Name":"value-with-separated-words","Nullable":true,"Type":"TEXT"}

--- a/materialize-spanner/.snapshots/TestIntegration-apply
+++ b/materialize-spanner/.snapshots/TestIntegration-apply
@@ -40,81 +40,81 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BOOL' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":2,"TypeString":"LOCATION_REQUIRED","Reason":"Required root-level properties must be present when flow_document is disabled"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT64' but endpoint type 'BOOL' is required by its schema '{ type: [boolean] }'"}
 {"Field":"objField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'objField' is already being materialized as endpoint type 'JSON' but endpoint type 'STRING(MAX)' is required by its schema '{ type: [string] }'"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'STRING(MAX)' but endpoint type 'INT64' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringUuidField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringUuidField' is already being materialized as endpoint type 'STRING(36)' but endpoint type 'STRING(MAX)' is required by its schema '{ type: [string] }'"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
@@ -340,7 +340,8 @@ Challenging Field Names Materialized Columns:
 {"Name":"c___________problematicValue_______","Nullable":true,"Type":"STRING(MAX)"}
 {"Name":"c__dollar_signs","Nullable":true,"Type":"STRING(MAX)"}
 {"Name":"c__id","Nullable":false,"Type":"STRING(MAX)"}
-{"Name":"flow_document","Nullable":true,"Type":"JSON"}
+{"Name":"c__meta_flow_truncated","Nullable":false,"Type":"BOOL"}
+{"Name":"flow_document","Nullable":false,"Type":"JSON"}
 {"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}
 {"Name":"value_with_separated_words","Nullable":true,"Type":"STRING(MAX)"}
 

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -203,17 +203,17 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 			reqBinding := req.Bindings[idx]
 			for _, p := range reqBinding.Collection.Projections {
 				if p.IsPrimaryKey {
-					if binding.Constraints == nil {
-						binding.Constraints = make(map[string]*pm.Response_Validated_Constraint)
-					}
 					log.WithFields(log.Fields{
 						"binding": idx,
 						"field":   p.Field,
 					}).Info("adding INCOMPATIBLE constraint for key field due to key distribution optimization change")
-					binding.Constraints[p.Field] = &pm.Response_Validated_Constraint{
-						Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
-						Reason: "The 'disable_key_distribution_optimization' setting has changed. This changes the table's primary key structure (flow_key_hash column is added or removed) and requires re-creating all tables. Backfill all bindings to proceed.",
-					}
+					binding.ProjectionConstraints = append(binding.ProjectionConstraints, &pm.Response_Validated_ProjectionConstraint{
+						Field: p.Field,
+						Constraint: &pm.Response_Validated_Constraint{
+							Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
+							Reason: "The 'disable_key_distribution_optimization' setting has changed. This changes the table's primary key structure (flow_key_hash column is added or removed) and requires re-creating all tables. Backfill all bindings to proceed.",
+						},
+					})
 				}
 			}
 		}

--- a/materialize-sqlserver/.snapshots/TestIntegration-apply
+++ b/materialize-sqlserver/.snapshots/TestIntegration-apply
@@ -40,82 +40,82 @@ Big Schema Initial Constraints:
 {"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"The projection has a single scalar type"}
 
 Big Schema Re-validated Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"boolField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"boolField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":5,"TypeString":"FIELD_FORBIDDEN","Reason":"Cannot materialize a field where the only possible type is 'null'"}
-{"Field":"numField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"numField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Changed Types Constraints:
-{"Field":"_meta/flow_truncated","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"arrayField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"_meta/flow_truncated","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"arrayField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"boolField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'boolField' is already being materialized as endpoint type 'BIT' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
 {"Field":"flow_document","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is the document in the current materialization"}
-{"Field":"flow_published_at","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"intField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"flow_published_at","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"intField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"key","Type":1,"TypeString":"FIELD_REQUIRED","Reason":"This field is a key in the current materialization"}
-{"Field":"multipleField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"multipleField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"nullField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"Object fields may be materialized"}
 {"Field":"numField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'numField' is already being materialized as endpoint type 'FLOAT' but endpoint type 'BIT' is required by its schema '{ type: [boolean] }'"}
-{"Field":"objField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDateTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringDurationField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"objField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDateTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringDurationField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 {"Field":"stringField","Type":6,"TypeString":"INCOMPATIBLE","Reason":"Field 'stringField' is already being materialized as endpoint type 'VARCHAR' but endpoint type 'BIGINT' is required by its schema '{ type: [integer] }'"}
-{"Field":"stringHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnEmailField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIdnHostnameField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIntegerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv4Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIpv6Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringIriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddr8Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringMacAddrField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringNumberField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRegexField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringRelativeJsonPointerField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringTimeField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint32Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUint64Field","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriReferenceField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUriTemplateField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
-{"Field":"stringUuidField","Type":3,"TypeString":"LOCATION_RECOMMENDED","Reason":"This location is part of the current materialization"}
+{"Field":"stringHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnEmailField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIdnHostnameField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIntegerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv4Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIpv6Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringIriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddr8Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringMacAddrField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringNumberField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRegexField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringRelativeJsonPointerField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringTimeField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint32Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUint64Field","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriReferenceField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUriTemplateField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
+{"Field":"stringUuidField","Type":4,"TypeString":"FIELD_OPTIONAL","Reason":"This location is part of the current materialization"}
 
 Big Schema Materialized Resource Schema With All Fields Required:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"bit"}
@@ -337,6 +337,7 @@ Challenging Field Names Materialized Columns:
 {"Name":"123","Nullable":true,"Type":"varchar"}
 {"Name":"123startsWithDigits","Nullable":true,"Type":"varchar"}
 {"Name":"_id","Nullable":false,"Type":"varchar"}
+{"Name":"_meta/flow_truncated","Nullable":false,"Type":"bit"}
 {"Name":"a\"string`with`quote'characters","Nullable":true,"Type":"varchar"}
 {"Name":"flow_document","Nullable":false,"Type":"varchar"}
 {"Name":"flow_published_at","Nullable":false,"Type":"datetime2"}


### PR DESCRIPTION
**Description:**

- Fixes the bug where a flow_document projection may already exist and be incompatible, while at the same time being required
- Did a refactor of `validateMatchesExistingResource` -- it was too hard to follow specially after adding the new logic. It is a separate commit

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

