### PR TITLE
source-shopify-native: add `staffMember.id` field to `orders` stream

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -23,6 +23,7 @@ class Orders(ShopifyGraphQLResource):
         id
         name
     }
+    # {{ staffMember }}
     billingAddress {
         id
         address1
@@ -370,6 +371,17 @@ class Orders(ShopifyGraphQLResource):
         id
     }""",
             is_available=requires_any_scope("read_locations"),
+        ),
+        # staffMember requires the read_users scope, which is only grantable on
+        # Shopify Plus / Advanced stores or finance embedded apps. Both the
+        # scope and the plan tier must be present.
+        ConditionalField(
+            placeholder="# {{ staffMember }}",
+            fields="""staffMember {
+        id
+    }""",
+            is_available=lambda caps: "read_users" in caps.scopes
+            and caps.is_plus_or_advanced,
         ),
     ]
 

--- a/source-shopify-native/tests/test_conditional_fields.py
+++ b/source-shopify-native/tests/test_conditional_fields.py
@@ -37,8 +37,10 @@ def test_orders_missing_capabilities_omits_conditional_fields():
     query = Orders.build_query(START, END)
 
     assert "retailLocation" not in query
+    assert "staffMember" not in query
     # The placeholder itself must not leak into the emitted query.
     assert "{{ retailLocation }}" not in query
+    assert "{{ staffMember }}" not in query
 
 
 def test_placeholder_substituted_at_any_depth():


### PR DESCRIPTION
**Regression?**

No

**Description:**

Reading `staffMember` requires a Shopify Plus/Advanced store or a finance embedded app _plus_ the `read_users` scope, so we only include the `staffMember.id` field in `orders` queries when those conditions are met. Only the `id` field of `staffMember` is captured; to get other `staffMember` related details, users can join on the soon-to-be-added `staff_members` stream.

**Notes for reviewers:**

Similar to https://github.com/estuary/connectors/pull/4647, I couldn't get the `read_users` scope for my dev Shopify account, so I haven't tested this change out with actual API queries. But it should work since it aligns with [Shopify's documentation](https://shopify.dev/docs/api/admin-graphql/2026-01/objects/Order#field-Order.fields.staffMember) on how to query this field.

Also, the `read_users` scope isn't added to the list of scopes in the connector in this PR because https://github.com/estuary/connectors/pull/4647 is adding it.

