### PR TITLE
source-shopify-native: resolve nested connections in non-bulk queries

### DIFF
--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -1,7 +1,8 @@
+import asyncio
 import time
 from datetime import UTC, datetime, timedelta
 from logging import Logger
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from estuary_cdk.capture.common import (
     LogCursor,
@@ -19,6 +20,7 @@ from source_shopify_native.models import (
 )
 
 from .graphql.client import ShopifyGraphQLClient
+from .graphql.nested_resolver import NESTED_CONNECTION_CONCURRENCY, resolve_document
 from .utils import dt_to_str, str_to_dt
 
 CHECKPOINT_INTERVAL = 1_000
@@ -97,19 +99,26 @@ async def _paginate_through_resources(
 ) -> AsyncGenerator[TShopifyGraphQLResource, None]:
     after: str | None = None
     ctx = StoreValidationContext(store=store)
+    # Shared across all pages of this fetch so total concurrent nested re-queries stay bounded.
+    nested_sem = asyncio.Semaphore(NESTED_CONNECTION_CONCURRENCY)
+    # Streams that inline nested connections use a smaller page to keep per-query cost in budget.
+    page_size = model.OUTER_PAGE_SIZE or PAGE_SIZE
 
     while True:
         query = model.build_query(
             start=start,
             end=end,
-            first=PAGE_SIZE,
+            first=page_size,
             after=after,
             capabilities=capabilities,
         )
 
         data = await client.request(query, data_model, log, context=ctx)
 
-        for doc in data.nodes:
+        docs = data.nodes
+        if model.NESTED_CONNECTIONS:
+            await _stitch_nested_connections(client, model, docs, nested_sem, log)
+        for doc in docs:
             yield doc
 
         page_info = data.page_info
@@ -117,6 +126,39 @@ async def _paginate_through_resources(
             return
 
         after = page_info.endCursor
+
+
+async def _stitch_nested_connections(
+    client: ShopifyGraphQLClient,
+    model: type[TShopifyGraphQLResource],
+    nodes: list[TShopifyGraphQLResource],
+    sem: asyncio.Semaphore,
+    log: Logger,
+) -> None:
+    """Resolve each node's nested connections in place, draining overflow under the passed-in semaphore.
+
+    Per node, we pass the resolver a `document` view - the node's `id` plus the fields its
+    connections' paths start from - referencing those fields rather than copying them. So when the
+    resolver flattens a connection in place, the change lands on the node itself.
+    """
+
+    async def stitch(node: TShopifyGraphQLResource) -> None:
+        # `document` carries the node's id plus the field each connection's path starts from.
+        document: dict[str, Any] = {"id": getattr(node, "id", None)}
+        for connection in model.NESTED_CONNECTIONS:
+            key = connection.parent_path[0] if connection.parent_path else connection.field_name
+            document[key] = getattr(node, key, None)
+
+        await resolve_document(client, document, model.NESTED_CONNECTIONS, log, sem)
+
+        # Only root connections (an empty parent_path) need this reassignment with setattr.
+        # The resolver reassigned them on `document` instead of mutating a shared object,
+        # so the node still holds the pre-resolved value.
+        for connection in model.NESTED_CONNECTIONS:
+            if not connection.parent_path:
+                setattr(node, connection.field_name, document[connection.field_name])
+
+    await asyncio.gather(*[stitch(node) for node in nodes])
 
 
 async def fetch_snapshot(

--- a/source-shopify-native/source_shopify_native/graphql/README.md
+++ b/source-shopify-native/source_shopify_native/graphql/README.md
@@ -1,6 +1,6 @@
 # GraphQL
 
-This subpackage provides the `BulkJobManager` for [executing bulk query jobs](https://shopify.dev/docs/api/usage/bulk-operations/queries) via Shopify's GraphQL API.
+This subpackage handles GraphQL access to Shopify's Admin API: [bulk query jobs](https://shopify.dev/docs/api/usage/bulk-operations/queries) via the `BulkJobManager`, and standard queries via the `ShopifyGraphQLClient`.
 
 ## `BulkJobManager`
 
@@ -14,3 +14,15 @@ Since fields must be explicitly specific in GraphQL queries, each stream has a d
 Shopify places [restrictions](https://shopify.dev/docs/api/usage/bulk-operations/queries#operation-restrictions) on bulk queries. Consult Shopify's API documentation to determine what fields are available for a specific stream. Bulk job errors are not extremely specific, so testing a query before trying to execute it via the bulk API is recommended.
 
 Shopify places query results into a [JSONL file](https://shopify.dev/docs/api/usage/bulk-operations/queries#the-jsonl-data-format), and nested connections (ex: variants of a product) appear on separate lines after their parents. Result parsing functions read the JSONL file one line at a time and rely on the order of nested connections to build up records before yielding them.
+
+
+## Nested connection resolution
+
+Bulk operations reject a connection nested inside a list, so a `Refund`'s `refundLineItems` (under the `Order.refunds` list) or a `Fulfillment`'s `fulfillmentLineItems` (under `Order.fulfillments`) can't be captured in bulk. Streams that need such connections run on the non-bulk path and declare them as `NESTED_CONNECTIONS` on their Pydantic model, resolved by `nested_resolver.py`:
+
+- The connection's first page is spliced inline into the outer query, at a `# {{ field }}` placeholder in the stream's `QUERY` (or, for a connection nested inside another, in that connection's `node_selection`). Empirical testing has shown a list-nested connection's `first` isn't multiplied across the outer page, so this is somewhat cheap - most parents have few children and are captured fully inline with no extra requests. Streams lower `OUTER_PAGE_SIZE` to keep the inline query's cost under Shopify's per-query ceiling.
+- Only when a parent's inline page reports `hasNextPage` does the resolver page the remainder, via focused `node(id:)` re-queries seeded from the inline cursor (`overflow_page_size` sizes these independently of the inline page).
+
+The resolver flattens each connection into a plain list under the field name, stripping all `edges`/`pageInfo`/cursor metadata, and mutates the parent documents in place.
+
+Each `NestedConnection` declares a `parent_path` locating the parent object(s) carrying it, so a connection anywhere in the document can be resolved. For example, `["refunds"]` is each object in the `refunds` list, `[]` is the document node itself, and a multi-step path descends fields, fanning out over any list it meets. Two rules follow from the `node(id:)` drain: every parent must be a `Node` with an `id` and connections resolve in declaration order - resolving one flattens it to a list, so a connection nested inside another must be declared after the connection it sits within.

--- a/source-shopify-native/source_shopify_native/graphql/nested_resolver.py
+++ b/source-shopify-native/source_shopify_native/graphql/nested_resolver.py
@@ -1,0 +1,210 @@
+"""Resolver for GraphQL connections nested inside a parent document.
+
+Shopify exposes some connections only beneath a list field (e.g. a Refund's `refundLineItems`
+lives under `Order.refunds`, a list). Bulk operations reject a connection nested in a list, so
+these must be captured with the standard, non-bulk API. Ideally, most parents have few children
+and are fully captured inline with zero extra requests.
+
+Only when a parent's inline page reports `hasNextPage` do we fall back to `drain_connection`,
+which pages the remainder with focused `node(id: ...)` re-queries seeded from the inline cursor.
+This keeps the common case at one request per outer page while still capturing parents with large
+connections without truncation.
+
+Resolved nodes are stitched into the parent document as a plain list under the connection's field
+name, with all pagination metadata (`edges`/`pageInfo`/cursors) stripped.
+"""
+
+import asyncio
+from logging import Logger
+from typing import Any
+
+from pydantic import BaseModel
+
+from ..models import NestedConnection, PageInfo
+from .client import ShopifyGraphQLClient
+
+# Bound on concurrent nested-connection re-queries in flight at once. Keeps the connector from
+# flooding the API and its cost budget while still overlapping requests across a fetched page.
+NESTED_CONNECTION_CONCURRENCY = 5
+
+
+class _NodeResponse(BaseModel, extra="allow"):
+    """Data model for a `{ node(id: ...) { ... } }` response.
+
+    `node` is kept as a raw dict because the connection field name is dynamic. The resolved node
+    dicts are the payloads we stitch into the document.
+    """
+
+    node: dict[str, Any] | None = None
+
+
+def _build_node_query(parent_id: str, connection: NestedConnection, after: str | None) -> str:
+    after_arg = f', after: "{after}"' if after else ""
+    first = connection.overflow_page_size or connection.page_size
+    query = f"""
+    {{
+        node(id: "{parent_id}") {{
+            ... on {connection.parent_typename} {{
+                {connection.field_name}(first: {first}{after_arg}) {{
+                    edges {{
+                        node {{
+                            {connection.node_selection}
+                        }}
+                    }}
+                    pageInfo {{
+                        hasNextPage
+                        endCursor
+                    }}
+                }}
+            }}
+        }}
+    }}
+    """
+
+    for fragment in connection.fragments:
+        query += fragment
+
+    return query
+
+
+async def drain_connection(
+    client: ShopifyGraphQLClient,
+    parent_id: str,
+    connection: NestedConnection,
+    log: Logger,
+    after: str | None = None,
+) -> list[dict[str, Any]]:
+    """Page the remainder of a parent's connection from `after`, returning the node dicts.
+
+    Called only for overflow when the inline first page reported `hasNextPage`, seeded with the inline
+    page's end cursor.
+    """
+    nodes: list[dict[str, Any]] = []
+
+    while True:
+        query = _build_node_query(parent_id, connection, after)
+        data = await client.request(query, _NodeResponse, log)
+
+        if data.node is None:
+            # The parent disappeared between the outer query and this re-query (e.g. deleted).
+            # Treat as no nested data rather than failing the whole fetch.
+            log.warning(
+                "Parent node not found while resolving nested connection.",
+                {"parent_id": parent_id, "field": connection.field_name},
+            )
+            break
+
+        # `node` is present, so the connection we queried under it must be too.
+        page = data.node.get(connection.field_name)
+        if not isinstance(page, dict):
+            raise TypeError(
+                f"Parent {parent_id!r} is missing its {connection.field_name!r} connection "
+                f"(expected an object, got {type(page).__name__})."
+            )
+        nodes.extend(edge["node"] for edge in page.get("edges", []))
+
+        page_info = PageInfo.model_validate(page.get("pageInfo") or {})
+        if not page_info.hasNextPage or not page_info.endCursor:
+            break
+
+        after = page_info.endCursor
+
+    return nodes
+
+
+def _navigate_to_parents(document: dict[str, Any], parent_path: list[str]) -> list[dict[str, Any]]:
+    """Resolve `parent_path` from `document` to the parent object(s) containing the connection.
+
+    An empty path yields the document node itself. Otherwise each step descends one field, fanning
+    out over any list it lands on. The fields/lists along the path should always be selected in the outer
+    query, so an absent/scalar value where the path keeps going, or a non-object parent,
+    can't arise from valid data - it's a query-building bug or an API contract breach, and we raise
+    rather than silently resolve nothing.
+    """
+    current: list[Any] = [document]
+    for step in parent_path:
+        next: list[Any] = []
+        for obj in current:
+            if not isinstance(obj, dict):
+                raise TypeError(
+                    f"Cannot descend {step!r} while navigating {parent_path}: expected an object, "
+                    f"got {type(obj).__name__}."
+                )
+            value = obj.get(step)
+            next.extend(value) if isinstance(value, list) else next.append(value)
+        current = next
+
+    for parent in current:
+        if not isinstance(parent, dict):
+            raise TypeError(
+                f"Nested-connection parent at path {parent_path} must be an object, "
+                f"got {type(parent).__name__}."
+            )
+
+    return current
+
+
+async def _resolve_parent(
+    client: ShopifyGraphQLClient,
+    parent: dict[str, Any],
+    connection: NestedConnection,
+    log: Logger,
+    sem: asyncio.Semaphore,
+) -> None:
+    """Replace one parent's inline connection with a flat list of its nodes, draining any overflow.
+
+    The parent already carries the connection's first page inline (`{edges, pageInfo}`). We flatten
+    those edges and, only if the page reports more, append the remainder via `drain_connection`.
+    The result is written back under the connection's field name, so the parent
+    ends up with a plain list in place of the `{edges, pageInfo}` wrapper.
+    """
+    # The connection is always selected inline in the outer query, so a parent that lacks it
+    # or carries a non-object is a query bug or API contract violation.
+    inline = parent.get(connection.field_name)
+    if not isinstance(inline, dict):
+        raise TypeError(
+            f"Parent {parent.get('id')!r} is missing its inlined {connection.field_name!r} "
+            f"connection (expected an object, got {type(inline).__name__})."
+        )
+
+    nodes = [edge["node"] for edge in inline.get("edges", [])]
+    page_info = PageInfo.model_validate(inline.get("pageInfo") or {})
+
+    if page_info.hasNextPage and page_info.endCursor:
+        # Draining needs the parent's id for the `node(id:)` re-query. `id` is always selected
+        # and non-null, so a parent that overflows without one is a query bug or API contract violation.
+        parent_id = parent.get("id")
+        if not parent_id:
+            raise ValueError(
+                f"Parent for {connection.field_name!r} ({connection.parent_typename}) reports "
+                f"more pages but has no id to fetch them."
+            )
+
+        async with sem:
+            nodes.extend(
+                await drain_connection(
+                    client, parent_id, connection, log, after=page_info.endCursor
+                )
+            )
+
+    parent[connection.field_name] = nodes
+
+
+async def resolve_document(
+    client: ShopifyGraphQLClient,
+    document: dict[str, Any],
+    connections: list[NestedConnection],
+    log: Logger,
+    sem: asyncio.Semaphore,
+) -> None:
+    """Resolve every connection in `document` in place, draining overflow under `sem`.
+
+    Connections resolve in declaration order - resolving one flattens it to a plain list, so a
+    connection nested inside another can navigate to it. Within a connection, its parents resolve
+    concurrently. The ordering only serializes across connections, not within one.
+    """
+    for connection in connections:
+        parents = _navigate_to_parents(document, connection.parent_path)
+        await asyncio.gather(
+            *[_resolve_parent(client, parent, connection, log, sem) for parent in parents]
+        )

--- a/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/fulfillments.py
@@ -2,7 +2,28 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
-from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
+from ..common import money_bag_fragment
+from ...models import (
+    NestedConnection,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+)
+
+
+_FULFILLMENT_LINE_ITEM_SELECTION = """
+id
+quantity
+discountedTotalSet {
+    ..._MoneyBagFields
+}
+originalTotalSet {
+    ..._MoneyBagFields
+}
+lineItem {
+    id
+}
+"""
 
 
 class Fulfillments(ShopifyGraphQLResource):
@@ -65,8 +86,21 @@ class Fulfillments(ShopifyGraphQLResource):
             number
             url
         }
+        # {{ fulfillmentLineItems }}
     }
     """
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=["fulfillments"],
+            parent_typename="Fulfillment",
+            field_name="fulfillmentLineItems",
+            node_selection=_FULFILLMENT_LINE_ITEM_SELECTION,
+            page_size=100,
+            overflow_page_size=250,
+            fragments=[money_bag_fragment],
+        ),
+    ]
+    OUTER_PAGE_SIZE = 100
 
     @staticmethod
     def build_query(

--- a/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/refunds.py
@@ -3,7 +3,35 @@ from logging import Logger
 from typing import AsyncGenerator
 
 from ..common import money_bag_fragment
-from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
+from ...models import (
+    NestedConnection,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+)
+
+
+_REFUND_LINE_ITEM_SELECTION = """
+id
+location {
+    id
+}
+priceSet {
+    ..._MoneyBagFields
+}
+quantity
+restocked
+restockType
+subtotalSet {
+    ..._MoneyBagFields
+}
+totalTaxSet {
+    ..._MoneyBagFields
+}
+lineItem {
+    id
+}
+"""
 
 
 class OrderRefunds(ShopifyGraphQLResource):
@@ -50,10 +78,23 @@ class OrderRefunds(ShopifyGraphQLResource):
         totalRefundedSet {
             ..._MoneyBagFields
         }
+        # {{ refundLineItems }}
     }
     """
 
     FRAGMENTS = [money_bag_fragment]
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=["refunds"],
+            parent_typename="Refund",
+            field_name="refundLineItems",
+            node_selection=_REFUND_LINE_ITEM_SELECTION,
+            page_size=10,
+            overflow_page_size=250,
+            fragments=[money_bag_fragment],
+        ),
+    ]
+    OUTER_PAGE_SIZE = 100
 
     @staticmethod
     def build_query(

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -1,6 +1,6 @@
 import json
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from logging import Logger
@@ -465,6 +465,57 @@ def requires_any_scope(*scopes: str) -> Callable[["StoreCapabilities"], bool]:
     return lambda capabilities: not required.isdisjoint(capabilities.scopes)
 
 
+@dataclass(frozen=True, slots=True)
+class NestedConnection:
+    """Describes a connection nested somewhere in a document.
+
+    Its first page is spliced inline into the outer query at `placeholder`; after that query, the
+    resolver descends `parent_path` to the parents, flattens each inline page into a plain list, and
+    drains any overflow with `node(id:)` re-queries.
+
+    Every parent must be a Node with an `id`, and connections resolve in declaration order -
+    resolving one flattens it to a list, so a connection nested inside another must be declared
+    after it.
+    """
+
+    # Path from the document root to the parent object(s) containing the connection. [] means the document
+    # node itself; ["refunds"] means each object in document["refunds"]; a multi-step path descends
+    # fields, fanning out to the elements of any list a step lands on.
+    parent_path: list[str]
+    # The parent object's GraphQL type, used in the `... on <typename>` inline fragment.
+    parent_typename: str
+    # The connection field name. Also the key the resolved list is written back under.
+    field_name: str
+    # GraphQL fields selected for each node. It should contain no edges/pageInfo wrapping.
+    node_selection: str
+    # The inline `first:` argument, spliced into the outer query. Sized to keep that outer query
+    # under Shopify's per-query cost ceiling.
+    page_size: int
+    # `first:` for the overflow queries. Defaults to `page_size`. The overflow query is 
+    # cheaper than the outer query, so this can be raised to drain large parents in
+    # fewer round trips.
+    overflow_page_size: int | None = None
+    # Fragment definitions referenced by node_selection, appended to the query.
+    fragments: list[str] = field(default_factory=list)
+
+    @property
+    def placeholder(self) -> str:
+        """The marker in the resource's QUERY where the inline connection block is spliced.
+
+        Written as a GraphQL comment so an unsubstituted marker degrades to a no-op.
+        """
+        return f"# {{{{ {self.field_name} }}}}"
+
+    def inline_block(self) -> str:
+        """The connection selection spliced into the outer query to fetch the first page inline."""
+        return (
+            f"{self.field_name}(first: {self.page_size}) {{\n"
+            f"    edges {{ node {{ {self.node_selection} }} }}\n"
+            f"    pageInfo {{ hasNextPage endCursor }}\n"
+            f"}}"
+        )
+
+
 class ShopifyGraphQLResource(BaseDocument):
     QUERY: ClassVar[str] = ""
     QUERY_ROOT: ClassVar[str] = ""
@@ -481,6 +532,13 @@ class ShopifyGraphQLResource(BaseDocument):
     # Fields included in the query only when the store's capabilities allow it. See
     # ConditionalField for placeholder/substitution semantics.
     CONDITIONAL_FIELDS: ClassVar[list[ConditionalField]] = []
+    # Connections nested under a list field. Their first page is spliced inline into the outer query
+    # at each connection's placeholder; overflow is paged separately. See graphql/nested_resolver.py.
+    # Only used on the non-bulk fetch path.
+    NESTED_CONNECTIONS: ClassVar[list[NestedConnection]] = []
+    # Outer-connection page size override. Streams that inline nested connections lower this to keep
+    # the per-query cost comfortably under Shopify's ceiling (with headroom for more connections).
+    OUTER_PAGE_SIZE: ClassVar[int | None] = None
 
     model_config = ConfigDict(extra="allow", validate_assignment=True)
 
@@ -495,6 +553,18 @@ class ShopifyGraphQLResource(BaseDocument):
                     f"{cls.__name__} declares a ConditionalField with placeholder "
                     f"{field.placeholder!r}, but that marker is not present in its QUERY. "
                     f"Embed the placeholder verbatim where the field belongs."
+                )
+        # A nested connection's placeholder lives in the QUERY, or — for a connection nested inside
+        # another — in that other connection's node_selection. Check both, so a missing marker
+        # (silently dropped during substitution) is rejected at class-definition time.
+        templates = [cls.QUERY, *(c.node_selection for c in cls.NESTED_CONNECTIONS)]
+        for connection in cls.NESTED_CONNECTIONS:
+            if cls.QUERY and not any(connection.placeholder in t for t in templates):
+                raise ValueError(
+                    f"{cls.__name__} declares a NestedConnection {connection.field_name!r}, but its "
+                    f"placeholder {connection.placeholder!r} is not present in its QUERY (or in "
+                    f"another connection's node_selection). Embed the placeholder verbatim where the "
+                    f"connection belongs."
                 )
 
     class Meta(BaseDocument.Meta):
@@ -602,6 +672,17 @@ class ShopifyGraphQLResource(BaseDocument):
         return body
 
     @classmethod
+    def _resolve_nested_connections(cls, body: str) -> str:
+        """Splice each NESTED_CONNECTIONS inline block into `body` at its placeholder.
+
+        Splicing happens in declaration order, so a connection whose inline block embeds another
+        connection's placeholder (a connection nested inside another) must be declared first.
+        """
+        for connection in cls.NESTED_CONNECTIONS:
+            body = body.replace(connection.placeholder, connection.inline_block())
+        return body
+
+    @classmethod
     def build_query_with_fragment(
         cls,
         start: datetime,
@@ -616,7 +697,9 @@ class ShopifyGraphQLResource(BaseDocument):
     ) -> str:
         lower_bound = dt_to_str(start)
         upper_bound = dt_to_str(end)
-        query_body = cls._resolve_conditional_fields(capabilities)
+        query_body = cls._resolve_nested_connections(
+            cls._resolve_conditional_fields(capabilities)
+        )
 
         query = f"""
         {{
@@ -649,7 +732,15 @@ class ShopifyGraphQLResource(BaseDocument):
         }}
         """
 
-        for fragment in cls.FRAGMENTS:
+        # Inline nested connections reuse fragments. We dedupe so each fragment
+        # is defined exactly once in the query.
+        fragments = list(
+            dict.fromkeys(
+                cls.FRAGMENTS
+                + [f for connection in cls.NESTED_CONNECTIONS for f in connection.fragments]
+            )
+        )
+        for fragment in fragments:
             query += fragment
 
         return query

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -659,6 +659,35 @@
           "deliveredAt": null,
           "displayStatus": "FULFILLED",
           "estimatedDeliveryAt": null,
+          "fulfillmentLineItems": [
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "885.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "885.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18219383717933",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50353178017837"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "885.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "885.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 1
+            }
+          ],
           "id": "gid://shopify/Fulfillment/7089298964525",
           "inTransitAt": null,
           "legacyResourceId": "7089298964525",
@@ -695,6 +724,278 @@
           "deliveredAt": "2026-06-15T13:19:16Z",
           "displayStatus": "DELIVERED",
           "estimatedDeliveryAt": null,
+          "fulfillmentLineItems": [
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "8600.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "8600.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166932996141",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "8600.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "8600.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "120000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "120000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933028909",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "120000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "120000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933061677",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933094445",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933127213",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933159981",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933192749",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933225517",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933258285",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            },
+            {
+              "discountedTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "id": "gid://shopify/FulfillmentLineItem/18166933291053",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "originalTotalSet": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 200
+            }
+          ],
           "id": "gid://shopify/Fulfillment/7059371851821",
           "inTransitAt": null,
           "legacyResourceId": "7059371851821",

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -4843,6 +4843,428 @@
             "id": "gid://shopify/Order/18697849798701",
             "legacyResourceId": "18697849798701"
           },
+          "refundLineItems": [
+            {
+              "id": "gid://shopify/RefundLineItem/743490748461",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "4300.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "4300.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490781229",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "60000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "60000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490813997",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "74995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "74995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490846765",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "102500.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "102500.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490879533",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "78595.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "78595.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490912301",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490945069",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743490977837",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491010605",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491043373",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 100,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ],
           "totalRefundedSet": {
             "presentmentMoney": {
               "amount": "670365.0",
@@ -4865,6 +5287,428 @@
             "id": "gid://shopify/Order/18697849798701",
             "legacyResourceId": "18697849798701"
           },
+          "refundLineItems": [
+            {
+              "id": "gid://shopify/RefundLineItem/743491305517",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "215.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "215.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491338285",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491371053",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3749.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3749.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491403821",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "5125.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "5125.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491436589",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3929.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3929.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491469357",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491502125",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491534893",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491567661",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/743491600429",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ],
           "totalRefundedSet": {
             "presentmentMoney": {
               "amount": "33518.25",
@@ -4887,6 +5731,428 @@
             "id": "gid://shopify/Order/18697849798701",
             "legacyResourceId": "18697849798701"
           },
+          "refundLineItems": [
+            {
+              "id": "gid://shopify/RefundLineItem/744073855021",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "43.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "215.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "215.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744073887789",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "600.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744073920557",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "749.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3749.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3749.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744073953325",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "1025.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "5125.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "5125.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744073986093",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "785.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3929.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3929.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744074018861",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744074051629",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744074084397",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744074117165",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "id": "gid://shopify/RefundLineItem/744074149933",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "location": {
+                "id": "gid://shopify/Location/73871392813"
+              },
+              "priceSet": {
+                "presentmentMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "699.95",
+                  "currencyCode": "USD"
+                }
+              },
+              "quantity": 5,
+              "restockType": "RETURN",
+              "restocked": true,
+              "subtotalSet": {
+                "presentmentMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxSet": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ],
           "totalRefundedSet": {
             "presentmentMoney": {
               "amount": "32632.3",

--- a/source-shopify-native/tests/test_nested_connection_shapes.py
+++ b/source-shopify-native/tests/test_nested_connection_shapes.py
@@ -1,0 +1,317 @@
+"""End-to-end tests for every connection shape `NestedConnection` supports.
+
+These drive the `ShopifyGraphQLClient` and the `_paginate_through_resources` flow
+(query build -> HTTP POST -> response validation -> inline stitch -> overflow drain). Only the HTTP
+transport is mocked, so each test shows the actual `{"data": ...}` envelope Shopify would return for
+a given connection shape and verifies the document the connector emits after stitching.
+
+Supported shapes exercised here (declared via `NestedConnection.parent_path`):
+  - `["refunds"]`            connection on each element of a top-level list   (OrderRefunds, real)
+  - `[]`                     connection directly on the document node
+  - `["wrapper", "things"]`  connection on each element of a list nested under an object
+  - `["agreements"]`         connection nested inside another connection (resolved in order)
+"""
+
+import json
+import re
+from datetime import UTC, datetime
+from logging import Logger
+from unittest.mock import MagicMock
+
+import pytest
+
+from source_shopify_native.api import _paginate_through_resources
+from source_shopify_native.graphql.client import ShopifyGraphQLClient
+from source_shopify_native.graphql.orders.refunds import OrderRefunds
+from source_shopify_native.models import (
+    NestedConnection,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+    create_response_data_model,
+)
+
+START = datetime(2024, 1, 1, tzinfo=UTC)
+END = datetime(2024, 2, 1, tzinfo=UTC)
+STORE = "teststore"
+CAPS = StoreCapabilities(scopes=frozenset())
+
+
+class MockHTTP:
+    """Stands in for estuary_cdk's HTTPSession, returning canned GraphQL JSON bodies.
+
+    Routes by query shape: a `node(id: "<id>")` overflow re-query returns the next queued page for
+    that parent id; any other query (an outer connection page) returns the next queued outer page.
+    Bodies are the full `{"data": ...}` envelope Shopify returns, so the real ShopifyGraphQLClient
+    parses, validates, and stitches them exactly as it would in production.
+    """
+
+    def __init__(
+        self,
+        outer_pages: list[dict],
+        node_pages: dict[str, list[dict]] | None = None,
+    ):
+        self._outer = list(outer_pages)
+        self._node = {pid: list(pages) for pid, pages in (node_pages or {}).items()}
+        self.queries: list[str] = []
+
+    async def request(self, log, url, method="GET", **kwargs) -> bytes:
+        query = (kwargs.get("json") or {}).get("query", "")
+        self.queries.append(query)
+        match = re.search(r'node\(id: "([^"]+)"', query)
+        page = self._node[match.group(1)].pop(0) if match else self._outer.pop(0)
+        return json.dumps({"data": page}).encode()
+
+
+def _conn(nodes: list[dict], has_next: bool = False, end_cursor: str | None = None) -> dict:
+    """The `{edges, pageInfo}` shape a connection takes in a response (inline or in a node re-query)."""
+    return {
+        "edges": [{"node": n} for n in nodes],
+        "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+    }
+
+
+def _outer_page(query_root: str, nodes: list[dict], has_next: bool = False, end_cursor: str | None = None) -> dict:
+    """An outer-query response body: `{ <query_root>: { edges, pageInfo } }`."""
+    return {
+        query_root: {
+            "edges": [{"node": n} for n in nodes],
+            "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+        }
+    }
+
+
+def _node_page(field: str, nodes: list[dict], has_next: bool = False, end_cursor: str | None = None) -> dict:
+    """A `node(id:){ ... }` overflow response body: `{ node: { <field>: { edges, pageInfo } } }`."""
+    return {"node": {field: _conn(nodes, has_next, end_cursor)}}
+
+
+async def _capture(model: type[ShopifyGraphQLResource], http: MockHTTP, log: Logger) -> list:
+    """Run a single non-bulk fetch through the real client + paginate flow, collecting documents."""
+    client = ShopifyGraphQLClient(http, STORE)  # type: ignore[arg-type]
+    data_model = create_response_data_model(model)
+    return [
+        doc
+        async for doc in _paginate_through_resources(
+            client, model, data_model, START, END, STORE, CAPS, log
+        )
+    ]
+
+
+# Test-only models for the shapes that no shipping stream uses yet. Each is a real
+# ShopifyGraphQLResource subclass, so it goes through class-definition validation and the actual
+# query builder.
+
+
+class _NodeConnectionModel(ShopifyGraphQLResource):
+    """A connection directly on the node (`parent_path=[]`)."""
+
+    NAME = "node_conn"
+    QUERY_ROOT = "orders"
+    SORT_KEY = SortKey.UPDATED_AT
+    SHOULD_USE_BULK_QUERIES = False
+    QUERY = "# {{ agreements }}"
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=[],
+            parent_typename="Order",
+            field_name="agreements",
+            node_selection="id",
+            page_size=2,
+        ),
+    ]
+
+    @staticmethod
+    def build_query(start, end, first=None, after=None, capabilities=None):
+        return _NodeConnectionModel.build_query_with_fragment(
+            start, end, first=first, after=after, capabilities=capabilities
+        )
+
+
+class _NestedListModel(ShopifyGraphQLResource):
+    """A connection on each element of a list nested under an object (`parent_path=["wrapper", "things"]`)."""
+
+    NAME = "nested_list"
+    QUERY_ROOT = "orders"
+    SORT_KEY = SortKey.UPDATED_AT
+    SHOULD_USE_BULK_QUERIES = False
+    QUERY = "wrapper { things { id # {{ widgets }} } }"
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=["wrapper", "things"],
+            parent_typename="Thing",
+            field_name="widgets",
+            node_selection="id",
+            page_size=2,
+        ),
+    ]
+
+    @staticmethod
+    def build_query(start, end, first=None, after=None, capabilities=None):
+        return _NestedListModel.build_query_with_fragment(
+            start, end, first=first, after=after, capabilities=capabilities
+        )
+
+
+class _ConnectionInConnectionModel(ShopifyGraphQLResource):
+    """A connection nested inside another connection; the outer must be declared first."""
+
+    NAME = "conn_in_conn"
+    QUERY_ROOT = "orders"
+    SORT_KEY = SortKey.UPDATED_AT
+    SHOULD_USE_BULK_QUERIES = False
+    QUERY = "# {{ agreements }}"
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=[],
+            parent_typename="Order",
+            field_name="agreements",
+            node_selection="id\n# {{ sales }}",
+            page_size=2,
+        ),
+        NestedConnection(
+            parent_path=["agreements"],
+            parent_typename="SalesAgreement",
+            field_name="sales",
+            node_selection="id",
+            page_size=2,
+        ),
+    ]
+
+    @staticmethod
+    def build_query(start, end, first=None, after=None, capabilities=None):
+        return _ConnectionInConnectionModel.build_query_with_fragment(
+            start, end, first=first, after=after, capabilities=capabilities
+        )
+
+
+@pytest.fixture
+def log():
+    return MagicMock(spec=Logger)
+
+
+# --- ["refunds"]: connection on each element of a top-level list (real stream) --------------------
+
+
+@pytest.mark.asyncio
+async def test_top_level_list_inline(log):
+    """A refund whose inline page is complete is flattened with no extra request."""
+    order = {
+        "id": "gid://shopify/Order/1",
+        "refunds": [
+            {"id": "gid://shopify/Refund/1", "refundLineItems": _conn([{"id": "a"}, {"id": "b"}])},
+        ],
+    }
+    http = MockHTTP(outer_pages=[_outer_page("orders", [order])])
+
+    docs = await _capture(OrderRefunds, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["refunds"][0]["refundLineItems"] == [{"id": "a"}, {"id": "b"}]
+    assert len(http.queries) == 1  # outer query only
+
+
+@pytest.mark.asyncio
+async def test_top_level_list_overflow_drains(log):
+    """A refund whose inline page reports hasNextPage drains the rest via node(id: <refund>)."""
+    order = {
+        "id": "gid://shopify/Order/1",
+        "refunds": [
+            {
+                "id": "gid://shopify/Refund/1",
+                "refundLineItems": _conn([{"id": "a"}], has_next=True, end_cursor="C1"),
+            },
+        ],
+    }
+    http = MockHTTP(
+        outer_pages=[_outer_page("orders", [order])],
+        node_pages={"gid://shopify/Refund/1": [_node_page("refundLineItems", [{"id": "b"}])]},
+    )
+
+    docs = await _capture(OrderRefunds, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["refunds"][0]["refundLineItems"] == [{"id": "a"}, {"id": "b"}]
+    assert any('node(id: "gid://shopify/Refund/1"' in q for q in http.queries)
+
+
+# --- []: connection directly on the node ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_on_node_inline(log):
+    """A connection on the node itself is flattened in place (the node is the parent)."""
+    order = {"id": "gid://shopify/Order/1", "agreements": _conn([{"id": "ag1"}, {"id": "ag2"}])}
+    http = MockHTTP(outer_pages=[_outer_page("orders", [order])])
+
+    docs = await _capture(_NodeConnectionModel, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["agreements"] == [{"id": "ag1"}, {"id": "ag2"}]
+    assert len(http.queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_connection_on_node_overflow_drains(log):
+    """An overflowing connection on the node drains via node(id: <the node's own id>)."""
+    order = {
+        "id": "gid://shopify/Order/1",
+        "agreements": _conn([{"id": "ag1"}], has_next=True, end_cursor="C1"),
+    }
+    http = MockHTTP(
+        outer_pages=[_outer_page("orders", [order])],
+        node_pages={"gid://shopify/Order/1": [_node_page("agreements", [{"id": "ag2"}])]},
+    )
+
+    docs = await _capture(_NodeConnectionModel, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["agreements"] == [{"id": "ag1"}, {"id": "ag2"}]
+    assert any('node(id: "gid://shopify/Order/1"' in q for q in http.queries)
+
+
+# --- ["wrapper", "things"]: connection on a list nested under an object ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_nested_list_path_fans_out(log):
+    """A multi-step path descends an object, then resolves the connection on each list element."""
+    order = {
+        "id": "gid://shopify/Order/1",
+        "wrapper": {
+            "things": [
+                {"id": "t1", "widgets": _conn([{"id": "w1"}])},
+                {"id": "t2", "widgets": _conn([{"id": "w2"}])},
+            ]
+        },
+    }
+    http = MockHTTP(outer_pages=[_outer_page("orders", [order])])
+
+    docs = await _capture(_NestedListModel, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["wrapper"]["things"][0]["widgets"] == [{"id": "w1"}]
+    assert dumped["wrapper"]["things"][1]["widgets"] == [{"id": "w2"}]
+    assert len(http.queries) == 1
+
+
+# --- ["agreements"]: connection nested inside another connection ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_in_connection_resolves_both(log):
+    """The outer connection is flattened first, so the inner one can be resolved on each parent."""
+    order = {
+        "id": "gid://shopify/Order/1",
+        "agreements": _conn(
+            [{"id": "gid://shopify/SalesAgreement/1", "sales": _conn([{"id": "s1"}, {"id": "s2"}])}]
+        ),
+    }
+    http = MockHTTP(outer_pages=[_outer_page("orders", [order])])
+
+    docs = await _capture(_ConnectionInConnectionModel, http, log)
+
+    dumped = docs[0].model_dump(by_alias=True)
+    assert dumped["agreements"][0]["id"] == "gid://shopify/SalesAgreement/1"
+    assert dumped["agreements"][0]["sales"] == [{"id": "s1"}, {"id": "s2"}]
+    assert len(http.queries) == 1  # everything inline, no overflow

--- a/source-shopify-native/tests/test_nested_resolver.py
+++ b/source-shopify-native/tests/test_nested_resolver.py
@@ -1,0 +1,369 @@
+"""
+Tests for the inline-first nested-connection resolver. Each parent carries its connection's first
+page inline from the outer query. The resolver flattens that to a clean list and only issues
+`node(id:)` re-queries to drain overflow when the inline page reports `hasNextPage`.
+"""
+
+import asyncio
+import re
+from logging import Logger
+from unittest.mock import MagicMock
+
+import pytest
+
+from source_shopify_native.graphql.nested_resolver import (
+    _NodeResponse,
+    drain_connection,
+    resolve_document,
+)
+from source_shopify_native.models import NestedConnection
+
+CONNECTION = NestedConnection(
+    parent_path=["refunds"],
+    parent_typename="Refund",
+    field_name="refundLineItems",
+    node_selection="id quantity",
+    page_size=2,
+)
+
+
+def _inline(nodes: list[dict], has_next: bool = False, end_cursor: str | None = None) -> dict:
+    """The inline `{edges, pageInfo}` shape a parent carries from the outer query."""
+    return {
+        "edges": [{"node": n} for n in nodes],
+        "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+    }
+
+
+def _node_page(nodes: list[dict], has_next: bool = False, end_cursor: str | None = None) -> _NodeResponse:
+    """A `node(id:){ ...connection... }` overflow re-query response."""
+    return _NodeResponse(
+        node={CONNECTION.field_name: _inline(nodes, has_next, end_cursor)}
+    )
+
+
+class _MockClient:
+    """Returns queued overflow pages keyed by the parent id parsed out of each `node(id:)` query.
+
+    Keying by parent id (not call order) keeps results correct under the resolver's concurrent
+    gather across parents.
+    """
+
+    def __init__(self, pages_by_parent: dict[str, list[_NodeResponse]]):
+        self._pages = {pid: list(pages) for pid, pages in pages_by_parent.items()}
+        self.queries: list[str] = []
+
+    async def request(self, query, data_model, log, context=None):
+        self.queries.append(query)
+        match = re.search(r'node\(id: "([^"]+)"', query)
+        assert match, query
+        return self._pages[match.group(1)].pop(0)
+
+
+@pytest.fixture
+def log():
+    return MagicMock(spec=Logger)
+
+
+# --- drain_connection: the overflow pager ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_seeds_after_cursor(log):
+    client = _MockClient({"gid://shopify/Refund/1": [_node_page([{"id": "c"}])]})
+
+    nodes = await drain_connection(client, "gid://shopify/Refund/1", CONNECTION, log, after="CUR0")
+
+    assert nodes == [{"id": "c"}]
+    assert 'after: "CUR0"' in client.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_drain_paginates_until_exhausted(log):
+    client = _MockClient(
+        {
+            "gid://shopify/Refund/1": [
+                _node_page([{"id": "c"}], has_next=True, end_cursor="CUR1"),
+                _node_page([{"id": "d"}], has_next=False),
+            ]
+        }
+    )
+
+    nodes = await drain_connection(client, "gid://shopify/Refund/1", CONNECTION, log, after="CUR0")
+
+    assert nodes == [{"id": "c"}, {"id": "d"}]
+    assert len(client.queries) == 2
+    assert 'after: "CUR1"' in client.queries[1]
+
+
+@pytest.mark.asyncio
+async def test_drain_missing_node_returns_empty(log):
+    client = _MockClient({"gid://shopify/Refund/1": [_NodeResponse(node=None)]})
+
+    nodes = await drain_connection(client, "gid://shopify/Refund/1", CONNECTION, log, after="CUR0")
+
+    assert nodes == []
+    log.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_drain_missing_connection_field_raises(log):
+    """A node present but lacking the queried connection field is a wrong-shape breach, not 'no data'."""
+    client = _MockClient({"gid://shopify/Refund/1": [_NodeResponse(node={})]})
+
+    with pytest.raises(TypeError):
+        await drain_connection(client, "gid://shopify/Refund/1", CONNECTION, log, after="CUR0")
+
+
+@pytest.mark.asyncio
+async def test_overflow_page_size_sets_drain_first(log):
+    """drain_connection uses overflow_page_size for its `first:`, independent of the inline page_size."""
+    connection = NestedConnection(
+        parent_path=["refunds"],
+        parent_typename="Refund",
+        field_name="refundLineItems",
+        node_selection="id",
+        page_size=2,
+        overflow_page_size=50,
+    )
+    client = _MockClient({"gid://shopify/Refund/1": [_node_page([{"id": "a"}])]})
+
+    await drain_connection(client, "gid://shopify/Refund/1", connection, log, after="CUR0")
+
+    assert "first: 50" in client.queries[0]
+    assert "first: 2" not in client.queries[0]
+
+
+# --- resolve_document: inline-first stitching -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inline_only_makes_no_request(log):
+    """A parent whose inline page is complete is flattened with zero extra requests."""
+    document = {
+        "id": "gid://shopify/Order/9",
+        "refunds": [{"id": "gid://shopify/Refund/1", "refundLineItems": _inline([{"id": "a"}, {"id": "b"}])}],
+    }
+    client = _MockClient({})
+
+    await resolve_document(client, document, [CONNECTION], log, asyncio.Semaphore(5))
+
+    assert document["refunds"][0]["refundLineItems"] == [{"id": "a"}, {"id": "b"}]
+    assert client.queries == []
+
+
+@pytest.mark.asyncio
+async def test_overflow_drains_remainder(log):
+    """When the inline page reports hasNextPage, the rest is drained and appended."""
+    document = {
+        "id": "gid://shopify/Order/9",
+        "refunds": [
+            {"id": "gid://shopify/Refund/1", "refundLineItems": _inline([{"id": "a"}], has_next=True, end_cursor="CUR1")},
+        ],
+    }
+    client = _MockClient({"gid://shopify/Refund/1": [_node_page([{"id": "b"}, {"id": "c"}])]})
+
+    await resolve_document(client, document, [CONNECTION], log, asyncio.Semaphore(5))
+
+    assert document["refunds"][0]["refundLineItems"] == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    assert 'after: "CUR1"' in client.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_mixed_parents_only_overflow_requeries(log):
+    document = {
+        "id": "gid://shopify/Order/9",
+        "refunds": [
+            {"id": "gid://shopify/Refund/1", "refundLineItems": _inline([{"id": "a"}])},
+            {"id": "gid://shopify/Refund/2", "refundLineItems": _inline([{"id": "b"}], has_next=True, end_cursor="C")},
+        ],
+    }
+    client = _MockClient({"gid://shopify/Refund/2": [_node_page([{"id": "c"}])]})
+
+    await resolve_document(client, document, [CONNECTION], log, asyncio.Semaphore(5))
+
+    assert document["refunds"][0]["refundLineItems"] == [{"id": "a"}]
+    assert document["refunds"][1]["refundLineItems"] == [{"id": "b"}, {"id": "c"}]
+    # Only the overflowing parent triggered a request.
+    assert len(client.queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_overflow_missing_id_raises(log):
+    """hasNextPage but no parent id can't happen with valid data (id is always selected), so it raises."""
+    document = {
+        "id": "gid://shopify/Order/9",
+        "refunds": [{"refundLineItems": _inline([{"id": "a"}], has_next=True, end_cursor="C")}],
+    }
+
+    with pytest.raises(ValueError):
+        await resolve_document(_MockClient({}), document, [CONNECTION], log, asyncio.Semaphore(5))
+
+
+@pytest.mark.asyncio
+async def test_empty_inline_yields_empty_list(log):
+    document = {"id": "gid://shopify/Order/9", "refunds": [{"id": "gid://shopify/Refund/1", "refundLineItems": _inline([])}]}
+    client = _MockClient({})
+
+    await resolve_document(client, document, [CONNECTION], log, asyncio.Semaphore(5))
+
+    assert document["refunds"][0]["refundLineItems"] == []
+    assert client.queries == []
+
+
+@pytest.mark.asyncio
+async def test_no_parents_makes_no_requests(log):
+    document = {"id": "gid://shopify/Order/9", "refunds": []}
+    client = _MockClient({})
+
+    await resolve_document(client, document, [CONNECTION], log, asyncio.Semaphore(5))
+
+    assert document["refunds"] == []
+    assert client.queries == []
+
+
+# --- shape enforcement: empty list is a no-op, absent/wrong shape raises -------------------------
+
+
+@pytest.mark.asyncio
+async def test_absent_parent_field_raises(log):
+    """The parent field is always selected and non-null, so an absent field signals a bug."""
+    document = {"id": "gid://shopify/Order/9"}
+
+    with pytest.raises(TypeError):
+        await resolve_document(_MockClient({}), document, [CONNECTION], log, asyncio.Semaphore(5))
+
+
+@pytest.mark.asyncio
+async def test_scalar_parent_raises(log):
+    """A path landing on a scalar (not an object) can't be a parent, so the navigator raises."""
+    document = {"id": "gid://shopify/Order/9", "refunds": "not-an-object"}
+
+    with pytest.raises(TypeError):
+        await resolve_document(_MockClient({}), document, [CONNECTION], log, asyncio.Semaphore(5))
+
+
+@pytest.mark.asyncio
+async def test_parent_missing_connection_raises(log):
+    """A parent lacking the inlined connection we always query signals a bug, so it raises."""
+    document = {"id": "gid://shopify/Order/9", "refunds": [{"id": "gid://shopify/Refund/1"}]}
+
+    with pytest.raises(TypeError):
+        await resolve_document(_MockClient({}), document, [CONNECTION], log, asyncio.Semaphore(5))
+
+
+# --- parent_path: empty / multi-step / connection-in-connection ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_path_resolves_connection_on_node(log):
+    """An empty path treats the document node itself as the parent (a connection directly on it)."""
+    connection = NestedConnection(
+        parent_path=[],
+        parent_typename="Order",
+        field_name="agreements",
+        node_selection="id",
+        page_size=2,
+    )
+    document = {"id": "gid://shopify/Order/9", "agreements": _inline([{"id": "a"}, {"id": "b"}])}
+
+    await resolve_document(_MockClient({}), document, [connection], log, asyncio.Semaphore(5))
+
+    assert document["agreements"] == [{"id": "a"}, {"id": "b"}]
+
+
+@pytest.mark.asyncio
+async def test_empty_path_drains_via_node_id(log):
+    """An overflowing connection on the node drains via node(id: <the node's own id>)."""
+    connection = NestedConnection(
+        parent_path=[],
+        parent_typename="Order",
+        field_name="agreements",
+        node_selection="id",
+        page_size=2,
+    )
+    document = {
+        "id": "gid://shopify/Order/9",
+        "agreements": _inline([{"id": "a"}], has_next=True, end_cursor="C"),
+    }
+    client = _MockClient(
+        {"gid://shopify/Order/9": [_NodeResponse(node={"agreements": _inline([{"id": "b"}])})]}
+    )
+
+    await resolve_document(client, document, [connection], log, asyncio.Semaphore(5))
+
+    assert document["agreements"] == [{"id": "a"}, {"id": "b"}]
+    assert 'node(id: "gid://shopify/Order/9"' in client.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_multi_step_path_fans_out(log):
+    """A multi-step path descends an object, then fans out over a nested list of parents."""
+    connection = NestedConnection(
+        parent_path=["wrapper", "refunds"],
+        parent_typename="Refund",
+        field_name="refundLineItems",
+        node_selection="id",
+        page_size=2,
+    )
+    document = {
+        "id": "gid://shopify/Order/9",
+        "wrapper": {
+            "refunds": [
+                {"id": "gid://shopify/Refund/1", "refundLineItems": _inline([{"id": "a"}])},
+                {"id": "gid://shopify/Refund/2", "refundLineItems": _inline([{"id": "b"}])},
+            ]
+        },
+    }
+
+    await resolve_document(_MockClient({}), document, [connection], log, asyncio.Semaphore(5))
+
+    assert document["wrapper"]["refunds"][0]["refundLineItems"] == [{"id": "a"}]
+    assert document["wrapper"]["refunds"][1]["refundLineItems"] == [{"id": "b"}]
+
+
+@pytest.mark.asyncio
+async def test_connection_in_connection_resolves_in_order(log):
+    """Resolving the outer connection flattens it, so the inner connection's path can navigate it."""
+    agreements = NestedConnection(
+        parent_path=[],
+        parent_typename="Order",
+        field_name="agreements",
+        node_selection="id",
+        page_size=2,
+    )
+    sales = NestedConnection(
+        parent_path=["agreements"],
+        parent_typename="SalesAgreement",
+        field_name="sales",
+        node_selection="id",
+        page_size=2,
+    )
+    document = {
+        "id": "gid://shopify/Order/9",
+        "agreements": _inline(
+            [{"id": "gid://shopify/SalesAgreement/1", "sales": _inline([{"id": "s1"}])}]
+        ),
+    }
+
+    await resolve_document(_MockClient({}), document, [agreements, sales], log, asyncio.Semaphore(5))
+
+    # Outer flattened to a list, and the inner connection on each agreement flattened too.
+    assert document["agreements"][0]["id"] == "gid://shopify/SalesAgreement/1"
+    assert document["agreements"][0]["sales"] == [{"id": "s1"}]
+
+
+@pytest.mark.asyncio
+async def test_descend_into_non_object_raises(log):
+    """A path that tries to descend through a non-object raises rather than resolve nothing."""
+    connection = NestedConnection(
+        parent_path=["wrapper", "refunds"],
+        parent_typename="Refund",
+        field_name="refundLineItems",
+        node_selection="id",
+        page_size=2,
+    )
+    document = {"id": "gid://shopify/Order/9", "wrapper": "not-an-object"}
+
+    with pytest.raises(TypeError):
+        await resolve_document(_MockClient({}), document, [connection], log, asyncio.Semaphore(5))


### PR DESCRIPTION
**Regression?**

No

**Description:**

Some Shopify fields are GraphQL connections nested under a list. For example, a refund's `refundLineItems` lives under `Order.refunds`, and a fulfillment's `fulfillmentLineItems` under `Order.fulfillments`. Bulk operations reject a connection nested inside a list, and the connector's non-bulk path queries didn't support nested connections (mainly because paginating through nested connections is complex & we hadn't needed to tackle that complexity since bulk queries are likely more efficient when queries contain connections), so these fields couldn't be captured with the existing functionality.

This PR addresses this by adding a `NestedConnection` resolver for non-bulk queries. The strategy for resolving a `NestedConnection` is:
1. Inline the first page into the outer query. In the common case where a parent has few children, no extra HTTP requests are made to paginate through the connection.
2. Drain the remaining records only when the first page reports there are more records via the `pageInfo`. The remaining records are fetched via `node(parent_id:)` queries.
3. Flatten the result into a list under the field name, dropping the `edges`/`pageInfo` wrapper that's only used to paginate through a connection.

The new `NestedConnection` resolver is used for adding the `refundLineItems` field to the `order_refunds` stream & the `fulfillmentLineItems` field to the `fulfillments` stream.

Capture snapshot changes are expected. I did a lot of modifications & tweaking in the dev Shopify account we use for snapshot tests, so the baseline changed quite a bit in the first commit. The remaining snapshot changes are expected due to the addition of the new fields.

**Notes for reviewers:**

Tested with `flowctl preview`. Confirmed the `NestedConnection` is drained by artificially setting the page size to `1` in order to for the additional records to be fetched via follow up queries.

I put a little bit of effort into making `NestedConnection` & the resolver logic somewhat general purpose, although they're still pretty specific to Shopify's GraphQL API due to the specific pagination fields. If we need to resolve connections for other GraphQL APIs in the future, we _may_ be able to polish the `NestedConnection` infrastructure in this connector so it's fit for use in any connector hitting a GraphQL API then pull it into the CDK.