### PR TITLE
source-*-batch: Guard against nil ScanType() in column type logging

### DIFF
--- a/source-db2-batch/driver.go
+++ b/source-db2-batch/driver.go
@@ -572,10 +572,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		return fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -479,10 +479,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		return fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -626,10 +626,16 @@ func (c *capture) pollCustomQuery(ctx context.Context, binding *bindingInfo) err
 		return fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 
@@ -965,10 +971,16 @@ func (c *capture) pollIncrementalChunk(ctx context.Context, chunk *incrementalCh
 		return 0, fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 	var columnIndices = make(map[string]int)

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -489,10 +489,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo, tmpl *template
 		return fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -532,10 +532,16 @@ func (c *capture) poll(ctx context.Context, binding *bindingInfo) error {
 		return fmt.Errorf("error processing query result: %w", err)
 	}
 	for i, columnType := range columnTypes {
+		// ScanType() returns a nil reflect.Type for column types the driver has
+		// no Go mapping for, so guard against it to avoid a nil dereference.
+		var scanTypeName string
+		if scanType := columnType.ScanType(); scanType != nil {
+			scanTypeName = scanType.Name()
+		}
 		log.WithFields(log.Fields{
 			"idx":          i,
 			"name":         columnType.DatabaseTypeName(),
-			"scanTypeName": columnType.ScanType().Name(),
+			"scanTypeName": scanTypeName,
 		}).Debug("column type")
 	}
 


### PR DESCRIPTION
**Description:**

ColumnType.ScanType() returns a nil reflect.Type for column types the driver has no Go mapping for, and the debug log line called .Name() on it unconditionally, panicking with a nil dereference before any rows were processed. Guard the call so the scan type name degrades to an empty string instead.

This may or may not just push the failure down a couple lines to the point of actually trying to scan result rows, but at least in that case we can enable debug logging to see the offending column type(s).