### PR TITLE
source-impact-native: avoid eventually consistent results by lagging incremental replication behind by an hour

### DIFF
--- a/source-impact-native/source_impact_native/api.py
+++ b/source-impact-native/source_impact_native/api.py
@@ -15,6 +15,15 @@ from source_impact_native.models import ActionInquiries, Actions
 API = "https://api.impact.com"
 API_CATALOG = "Advertisers"
 
+# Impact's endpoints are eventually consistent.A record can become
+# queryable minutes after its timestamp, after the connector has
+# already seen records with later timestamps. Since the incremental
+# cursor is a high-water mark, anything that surfaces below it would
+# be filtered out and lost forever. To avoid that, we never advance
+# the cursor over records younger than INCREMENTAL_LAG, giving late
+# arrivals time to appear before the cursor moves past their timestamp.
+INCREMENTAL_LAG = timedelta(hours=1)
+
 async def fetch_incremental(
     cls,
     account_sid,
@@ -38,13 +47,14 @@ async def fetch_incremental(
     if _cls.START_DATE_INCREMENTAL:
         parameters = {f"{_cls.START_DATE_INCREMENTAL}": _cursor_dt(_cls.NAME, log_cursor)}
     max_ts = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
 
     while iterating:
         result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
         for results in result[f"{_cls.NAME}"]:
             ts = _s_to_dt(results[f"{_cls.REP_KEY}"])
-            if ts >= log_cursor:
+            if log_cursor <= ts < horizon:
                 max_ts = max(max_ts, ts)
                 doc = _cls.model_validate_json(json.dumps(results))
                 yield doc
@@ -132,6 +142,7 @@ async def fetch_incremental_actions(
         campaign_list.add(campaign.Id)
 
     max_ts = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
 
     for campaign in campaign_list:
 
@@ -146,7 +157,8 @@ async def fetch_incremental_actions(
             result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
             for results in result[f"{cls.NAME}"]:
-                if _s_to_dt(results["CreationDate"]) >= log_cursor:
+                ts = _s_to_dt(results["CreationDate"])
+                if log_cursor <= ts < horizon:
                     doc = _cls.model_validate_json(json.dumps(results))
                     max_ts = max(max_ts, doc.CreationDate)
                     yield doc
@@ -287,6 +299,7 @@ async def fetch_incremental_child(
         campaign_list.add(campaign.Id)
 
     max_ts = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
 
     for campaign in campaign_list:
         iterating = True
@@ -303,12 +316,13 @@ async def fetch_incremental_child(
             result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
             for results in result[f"{_cls.NAME}"]:
-                if _s_to_dt(results[f"{_cls.REP_KEY}"]) >= log_cursor:
-                    max_ts = max(max_ts, _s_to_dt(results[f"{_cls.REP_KEY}"]))
+                ts = _s_to_dt(results[f"{_cls.REP_KEY}"])
+                if log_cursor <= ts < horizon:
+                    max_ts = max(max_ts, ts)
                     doc = _cls.model_validate_json(json.dumps(results))
                     yield doc
 
-                elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < log_cursor:
+                elif ts < log_cursor:
                     iterating = False
                     break
             if result.get("@nextpageuri"):

--- a/source-impact-native/source_impact_native/api.py
+++ b/source-impact-native/source_impact_native/api.py
@@ -26,6 +26,7 @@ async def fetch_incremental(
     This method has the basic behaviour of querying data after the logcursor, comparing and yielding
     records accorrding.
     """
+    assert isinstance(log_cursor, datetime)
     _cls: Any = cls  # Silence mypy false-positive
     
     iterating = True
@@ -42,12 +43,13 @@ async def fetch_incremental(
         result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
         for results in result[f"{_cls.NAME}"]:
-            if _s_to_dt(results[f"{_cls.REP_KEY}"]) >= log_cursor:
-                max_ts = max(max_ts, _s_to_dt(results[f"{_cls.REP_KEY}"]))
+            ts = _s_to_dt(results[f"{_cls.REP_KEY}"])
+            if ts >= log_cursor:
+                max_ts = max(max_ts, ts)
                 doc = _cls.model_validate_json(json.dumps(results))
                 yield doc
 
-            elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < log_cursor:
+            elif ts < log_cursor:
                 iterating = False
                 break
         if result.get("@nextpageuri"):
@@ -61,22 +63,23 @@ async def fetch_incremental(
 async def fetch_backfill(
     cls,
     config_start_date: datetime,
-    account_sid,
+    account_sid: str,
     http: HTTPSession,
     log: Logger,
-    page: str | None,
-    cutoff: datetime,
+    page: PageCursor,
+    cutoff: LogCursor,
 )-> AsyncGenerator:
     """Fetch backfill is the default FetchPagesFn handler for source-impact-native
     This method has the basic behaviour of backfilling data and (when possible) query data from
     specific ranges. Its page_cursor is already the full URI for the next page
     """
-
+    assert isinstance(cutoff, datetime)
     _cls: Any = cls
     headers = {'Accept': 'application/json'}
     parameters = None
 
     if page:
+        assert isinstance(page, str)
         url = API + page
     
     else:
@@ -87,12 +90,13 @@ async def fetch_backfill(
     result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
     for results in result[f"{_cls.NAME}"]:
-        if _s_to_dt(results[f"{_cls.REP_KEY}"]) == config_start_date:
+        ts = _s_to_dt(results[f"{_cls.REP_KEY}"])
+        if ts == config_start_date:
             doc = _cls.model_validate_json(json.dumps(results))
             yield doc
-        elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < config_start_date:
+        elif ts < config_start_date:
             return
-        elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < cutoff:
+        elif ts < cutoff:
             doc = _cls.model_validate_json(json.dumps(results))
             yield doc
 
@@ -160,11 +164,11 @@ async def fetch_backfill_actions(
     cls_parent,
     cls,
     config_start_date: datetime,
-    account_sid,
+    account_sid: str,
     http: HTTPSession,
     log: Logger,
-    page: str | None,
-    cutoff: datetime,
+    page: PageCursor,
+    cutoff: LogCursor,
 )-> AsyncGenerator:
     """Fetch backfill actions is the default FetchPageFn handler for Actions Streams
     This method requires CampaignIds to query for actions data.
@@ -175,6 +179,7 @@ async def fetch_backfill_actions(
     start_date and end_date cant be set more than 45 days apart.
     
     """
+    assert isinstance(cutoff, datetime)
     headers = {'Accept': 'application/json'}
     parameters = {}
 
@@ -232,7 +237,7 @@ async def fetch_backfill_actions(
 
 async def fetch_snapshot(
     cls,
-    account_sid,
+    account_sid: str,
     http: HTTPSession,
     log: Logger,
 ) -> AsyncGenerator:
@@ -272,7 +277,7 @@ async def fetch_incremental_child(
     
     This method requires CampaignId values from the Campaigns stream.
     """
-
+    assert isinstance(log_cursor, datetime)
     _cls: Any = cls  # Silence mypy false-positive
 
     campaign_list = set()
@@ -318,11 +323,11 @@ async def fetch_backfill_child(
     cls_parent,
     cls,
     config_start_date: datetime,
-    account_sid,
+    account_sid: str,
     http: HTTPSession,
     log: Logger,
-    page: str | None,
-    cutoff: datetime,
+    page: PageCursor,
+    cutoff: LogCursor,
 )-> AsyncGenerator:
     """_Fetch backfill child is the default FetchPagesFn handler for source-impact-native child streams.
     This method has the basic behaviour of backfilling data and (when possible) query data from
@@ -331,7 +336,7 @@ async def fetch_backfill_child(
     
     This method requires CampaignId values from the Campaigns stream.
     """
-
+    assert isinstance(cutoff, datetime)
     _cls: Any = cls
     headers = {'Accept': 'application/json'}
     parameters = None
@@ -356,14 +361,14 @@ async def fetch_backfill_child(
             result = json.loads(await http.request(log, url, method="GET", params=parameters, headers=headers))
 
             for results in result[f"{_cls.NAME}"]:
-                if _s_to_dt(results[f"{_cls.REP_KEY}"]) == config_start_date:
+                ts = _s_to_dt(results[f"{_cls.REP_KEY}"])
+                if ts == config_start_date:
                     doc = _cls.model_validate_json(json.dumps(results))
                     yield doc
-
-                elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < config_start_date:
+                elif ts < config_start_date:
                     iterating = False
                     break
-                elif _s_to_dt(results[f"{_cls.REP_KEY}"]) < cutoff:
+                elif ts < cutoff:
                     doc = _cls.model_validate_json(json.dumps(results))
                     yield doc
             if result.get("@nextpageuri"):
@@ -376,7 +381,7 @@ async def fetch_backfill_child(
 async def fetch_snapshot_child(
     cls_parent,
     cls,
-    account_sid,
+    account_sid: str,
     http: HTTPSession,
     log: Logger,
 ) -> AsyncGenerator:
@@ -389,10 +394,7 @@ async def fetch_snapshot_child(
     async for campaign in campaigns:
         campaign_list.add(campaign.Id)
 
-    
-
     for campaign in campaign_list:
-    
         iterating = True
 
         url = f"{API}/{API_CATALOG}/{account_sid}/Campaigns/{campaign}/{cls.NAME}"
@@ -416,15 +418,15 @@ async def fetch_snapshot_child(
 def _s_to_dt(date: str) -> datetime:
     return datetime.fromisoformat(date)
 
-def _cursor_dt(name, logcursor):
+def _cursor_dt(name: str, logcursor: datetime) -> str:
     new_logcursor = logcursor.strftime("%Y-%m-%dT%H:%M:%S%z")
     if name == "PhoneNumbers" or name == "Jobs":
         new_logcursor = logcursor.strftime("%Y-%m-%d")
     return new_logcursor
 
-def get_date_ranges(start_date, end_date, step=40):
+def get_date_ranges(start_date: datetime, end_date: datetime, step: int = 40) -> list[tuple[datetime, datetime]]:
     current_start = start_date
-    date_ranges = []
+    date_ranges: list[tuple[datetime, datetime]] = []
 
     while current_start < end_date:
         current_end = min(current_start + timedelta(days=step), end_date)

--- a/source-impact-native/source_impact_native/models.py
+++ b/source-impact-native/source_impact_native/models.py
@@ -45,7 +45,7 @@ class EndpointConfig(BaseModel, extra="allow"):
 class Actions(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Actions"
     START_DATE: ClassVar[str] = ""
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
     PRIMARY_KEY: ClassVar[str] = "/Id"
@@ -56,7 +56,7 @@ class Actions(BaseDocument, extra="allow"):
 class ActionInquiries(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "ActionInquiries"
     START_DATE: ClassVar[str] = "StartDate"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     END_DATE: ClassVar[str] = "EndDate"
     REP_KEY: ClassVar[str] = "CreationDate"
     PRIMARY_KEY: ClassVar[str] = "/Id"
@@ -67,7 +67,7 @@ class ActionInquiries(BaseDocument, extra="allow"):
 class Ads(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Ads"
     START_DATE: ClassVar[str] = ""
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
     PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
@@ -75,7 +75,7 @@ class Ads(BaseDocument, extra="allow"):
 class Catalogs(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Catalogs"
     START_DATE: ClassVar[str] = ""
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
     PRIMARY_KEY: ClassVar[str] = "/_meta/row_id"
@@ -92,7 +92,7 @@ class Invoices(BaseDocument, extra="allow"):
 
 class Deals(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "Deals"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "StartDate"
@@ -102,7 +102,7 @@ class Deals(BaseDocument, extra="allow"):
 
 class TrackingValueRequests(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "TrackingValueRequests"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "DatePlaced"
@@ -112,7 +112,7 @@ class TrackingValueRequests(BaseDocument, extra="allow"):
 
 class ExceptionLists(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "ExceptionLists"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "CreatedDate"
@@ -134,7 +134,7 @@ class Jobs(BaseDocument, extra="allow"):
 class Campaigns(BaseDocument, extra="allow"):
     # No query parameters available, and no date replication key
     # will probably need to use snapshot
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     NAME: ClassVar[str] = "Campaigns"
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
@@ -146,7 +146,7 @@ class Reports(BaseDocument, extra="allow"):
     # No query parameters available, and no date replication key
     # will probably need to use snapshot
     NAME: ClassVar[str] = "Reports"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""
@@ -154,7 +154,7 @@ class Reports(BaseDocument, extra="allow"):
 
 class UniqueUrls(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "UniqueUrls"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "DateCreated"
@@ -164,7 +164,7 @@ class UniqueUrls(BaseDocument, extra="allow"):
 
 class PhoneNumbers(BaseDocument, extra="allow"):
     NAME: ClassVar[str] = "PhoneNumbers"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "DateCreated"
@@ -189,7 +189,7 @@ class Tasks(BaseDocument, extra="allow"):
     # URI example
     # https://api.impact.com/Advertisers/<AccountSID>/Programs/1000/Tasks
     NAME: ClassVar[str] = "Tasks"
-    START_DATE_INCREMENTAL: ClassVar[str]  = None
+    START_DATE_INCREMENTAL: ClassVar[str | None]  = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = "DateCreated"
@@ -213,7 +213,7 @@ class BlockRedirectRules(BaseDocument, extra="allow"):
 class MediaPartnerGroups(BaseDocument, extra="allow"):
 
     NAME: ClassVar[str] = "MediaPartnerGroups"
-    START_DATE_INCREMENTAL: ClassVar[str] = None
+    START_DATE_INCREMENTAL: ClassVar[str | None] = None
     START_DATE: ClassVar[str] = ""
     END_DATE: ClassVar[str] = ""
     REP_KEY: ClassVar[str] = ""

--- a/source-impact-native/source_impact_native/resources.py
+++ b/source-impact-native/source_impact_native/resources.py
@@ -82,7 +82,7 @@ async def all_resources(
 
 
 def base_object(
-    cls, http: HTTPSession, stop_date: datetime, account_sid
+    cls, http: HTTPSession, stop_date: datetime, account_sid: str
 ) -> Resource:
     """Base Object is the standard object for source-impact-native
     """
@@ -120,7 +120,7 @@ def base_object(
 
 
 def action_object(
-    cls_parent, cls, http: HTTPSession, stop_date: datetime, account_sid
+    cls_parent, cls, http: HTTPSession, stop_date: datetime, account_sid: str
 ) -> Resource:
     """Action Object is the standard method for Actions and ActionsInquires streams.
     Actions endpoints require a really specific set of parameters to work, and also requires
@@ -159,7 +159,7 @@ def action_object(
     )
 
 def snapshot_object(
-    cls, http: HTTPSession, stop_date: datetime, account_sid
+    cls, http: HTTPSession, stop_date: datetime, account_sid: str
 ) -> Resource:
     """Snapshot Object handles the stream cases were we dont have any valid replication keys
     to use. Some streams have valid Ids being returned by the API, others depend on flow's _meta/id
@@ -192,7 +192,7 @@ def snapshot_object(
     )
 
 def child_object(
-    cls_parent, cls, http: HTTPSession, stop_date: datetime, account_sid
+    cls_parent, cls, http: HTTPSession, stop_date: datetime, account_sid: str
 ) -> Resource:
     """Child Object handles the default parent/child streams. As of now, the only possible parent stream to exist is the
     Campaigns stream.


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've observed Impact's API be eventually consistent, meaning a record can become queryable via the API after its timestamp cursor. When that happens, the connector has already seen records with later timestamps & progressed its cursor past the record affected by eventual consistency, so that record gets missed.

This PR adds an `INCREMENTAL_LAG` to hopefully combat the Impact API's eventual consistency. All incremental `fetch_changes` functions ignore any records with cursor timestamps more recent than `now - INCREMENTAL_LAG`. Ideally, this gives the Impact API enough time to return consistent results over the time range we care about & keeps the connector out of eventual consistency territory.

We may need to update this connector to use a real-time and delayed stream strategy if a 1 hour lag is unacceptable for users, but that'll require some more work. We'd ideally polish up the connector at the same time so it uses the same patterns & conventions we've been using in more recent connectors too.

**Notes for reviewers:**

Pylance was flagging a lot of errors due to incorrect / missing type hints, so I fixed a lot of those complaints in the first commit. There are still a handful of type related complaints, but addressing those will require more involved refactoring of classes in `models.py` than I wanted to tackle right now.

Best reviewed commit-by-commit.
