### PR TITLE
source-shopify-native: add `disputes` and `order_returns` streams

### DIFF
--- a/source-shopify-native/acmeCo/disputes.schema.yaml
+++ b/source-shopify-native/acmeCo/disputes.schema.yaml
@@ -1,0 +1,37 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+  id:
+    title: Id
+    type: string
+required:
+- id
+title: ShopifyGraphQLResource
+type: object
+x-infer-schema: true

--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -19,6 +19,10 @@ collections:
     schema: customers.schema.yaml
     key:
     - /id
+  acmeCo/disputes:
+    schema: disputes.schema.yaml
+    key:
+    - /id
   acmeCo/fulfillment_orders:
     schema: fulfillment_orders.schema.yaml
     key:

--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -59,6 +59,10 @@ collections:
     schema: order_refunds.schema.yaml
     key:
     - /id
+  acmeCo/order_returns:
+    schema: order_returns.schema.yaml
+    key:
+    - /id
   acmeCo/order_risks:
     schema: order_risks.schema.yaml
     key:

--- a/source-shopify-native/acmeCo/order_returns.schema.yaml
+++ b/source-shopify-native/acmeCo/order_returns.schema.yaml
@@ -1,0 +1,37 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+  id:
+    title: Id
+    type: string
+required:
+- id
+title: ShopifyGraphQLResource
+type: object
+x-infer-schema: true

--- a/source-shopify-native/source_shopify_native/__init__.py
+++ b/source-shopify-native/source_shopify_native/__init__.py
@@ -8,7 +8,7 @@ from estuary_cdk.capture import (
     request,
     response,
 )
-from estuary_cdk.capture.common import ResourceConfig
+from estuary_cdk.capture.common import ResourceConfigWithSchedule
 from estuary_cdk.flow import (
     ConnectorSpec,
     ValidationError,
@@ -23,7 +23,7 @@ from .resources import all_resources, validate_credentials
 
 
 def _validate_config(
-    validate_req: request.Validate[EndpointConfig, ResourceConfig],
+    validate_req: request.Validate[EndpointConfig, ResourceConfigWithSchedule],
 ) -> None:
     """Validate config constraints around composite keys and multi-store.
 
@@ -119,30 +119,30 @@ def _validate_config(
 
 
 class Connector(
-    BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
+    BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
 ):
     def request_class(self):
-        return Request[EndpointConfig, ResourceConfig, ConnectorState]
+        return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]
 
     async def spec(self, log: FlowLogger, _: request.Spec) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
             oauth2=None,
             documentationUrl="https://go.estuary.dev/source-shopify-native",
-            resourceConfigSchema=ResourceConfig.model_json_schema(),
-            resourcePathPointers=ResourceConfig.PATH_POINTERS,
+            resourceConfigSchema=ResourceConfigWithSchedule.model_json_schema(),
+            resourcePathPointers=ResourceConfigWithSchedule.PATH_POINTERS,
         )
 
     async def discover(
         self, log: FlowLogger, discover: request.Discover[EndpointConfig]
-    ) -> response.Discovered[ResourceConfig]:
+    ) -> response.Discovered[ResourceConfigWithSchedule]:
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
     async def validate(
         self,
         log: FlowLogger,
-        validate: request.Validate[EndpointConfig, ResourceConfig],
+        validate: request.Validate[EndpointConfig, ResourceConfigWithSchedule],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
         _validate_config(validate)
@@ -163,7 +163,7 @@ class Connector(
     async def open(
         self,
         log: FlowLogger,
-        open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
+        open: request.Open[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
         config = open.capture.config
 

--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -113,7 +113,7 @@ async def _paginate_through_resources(
             yield doc
 
         page_info = data.page_info
-        if not page_info.hasNextPage or not page_info.endCursor:
+        if not page_info.hasNextPage:
             return
 
         after = page_info.endCursor

--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -265,3 +265,38 @@ async def backfill_incremental(
         yield doc
         count += 1
         last_seen_dt = cursor_value
+
+
+async def backfill_incremental_unsorted(
+    client: ShopifyGraphQLClient,
+    model: type[TShopifyGraphQLResource],
+    data_model: type[BaseResponseData[TShopifyGraphQLResource]],
+    store: str,
+    capabilities: StoreCapabilities,
+    start_date: datetime,
+    log: Logger,
+    page: PageCursor | None,
+    cutoff: LogCursor,
+) -> AsyncGenerator[TShopifyGraphQLResource | PageCursor, None]:
+    assert isinstance(cutoff, datetime)
+
+    if page is not None:
+        assert isinstance(page, str)
+
+    query = model.build_query(
+        start_date,
+        cutoff,
+        first=PAGE_SIZE,
+        after=page,
+        capabilities=capabilities,
+    )
+    data = await client.request(
+        query, data_model, log, context=StoreValidationContext(store=store)
+    )
+
+    for doc in data.nodes:
+        yield doc
+
+    page_info = data.page_info
+    if page_info.hasNextPage:
+        yield page_info.endCursor

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -26,6 +26,7 @@ from .orders.risks import OrderRisks
 from .orders.transactions import OrderTransactions
 from .subscriptions.subscription_contracts import SubscriptionContracts
 from .staff_members import StaffMembers
+from .disputes import Disputes
 
 
 __all__ = [
@@ -55,5 +56,6 @@ __all__ = [
     "OrderRefunds",
     "OrderRisks",
     "OrderTransactions",
+    "Disputes",
     "SubscriptionContracts",
 ]

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -22,6 +22,7 @@ from .orders.fulfillments import Fulfillments
 from .orders.metafields import OrderMetafields
 from .orders.orders import Orders
 from .orders.refunds import OrderRefunds
+from .orders.returns import OrderReturns
 from .orders.risks import OrderRisks
 from .orders.transactions import OrderTransactions
 from .subscriptions.subscription_contracts import SubscriptionContracts
@@ -54,6 +55,7 @@ __all__ = [
     "Orders",
     "OrderMetafields",
     "OrderRefunds",
+    "OrderReturns",
     "OrderRisks",
     "OrderTransactions",
     "Disputes",

--- a/source-shopify-native/source_shopify_native/graphql/disputes.py
+++ b/source-shopify-native/source_shopify_native/graphql/disputes.py
@@ -1,0 +1,196 @@
+from datetime import datetime
+
+from pydantic import AwareDatetime
+
+from ..models import ShopifyGraphQLResource, StoreCapabilities
+from ..utils import dt_to_str, str_to_dt
+
+
+class Disputes(ShopifyGraphQLResource):
+    NAME = "disputes"
+    QUERY_ROOT = "disputes"
+    SHOULD_USE_BULK_QUERIES = False
+    # The disputes query offers no datetime sortKey, so the connector routes
+    # this stream to the unsorted incremental path.
+    SORT_KEY = None
+    QUALIFYING_SCOPES = {"read_shopify_payments_disputes"}
+    # Disputes are filtered based off of the initiatedAt field, which lets the
+    # connector incrementally capture creations of new records but miss updates
+    # to older records. To capture updates, we re-backfill the binding every day.
+    BACKFILL_SCHEDULE = "55 23 * * *"
+    QUERY = """
+    id
+    legacyResourceId
+    amount {
+        amount
+        currencyCode
+    }
+    reasonDetails {
+        reason
+        networkReasonCode
+    }
+    status
+    type
+    initiatedAt
+    evidenceDueBy
+    evidenceSentOn
+    finalizedOn
+    order {
+        id
+        legacyResourceId
+    }
+    disputeEvidence {
+        id
+        accessActivityLog
+        cancellationPolicyDisclosure
+        cancellationRebuttal
+        customerEmailAddress
+        customerFirstName
+        customerLastName
+        customerPurchaseIp
+        productDescription
+        refundPolicyDisclosure
+        refundRefusalExplanation
+        submitted
+        uncategorizedText
+        billingAddress {
+            address1
+            address2
+            city
+            company
+            country
+            countryCodeV2
+            firstName
+            lastName
+            latitude
+            longitude
+            name
+            phone
+            province
+            provinceCode
+            zip
+        }
+        shippingAddress {
+            address1
+            address2
+            city
+            company
+            country
+            countryCodeV2
+            firstName
+            lastName
+            latitude
+            longitude
+            name
+            phone
+            province
+            provinceCode
+            zip
+        }
+        cancellationPolicyFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        customerCommunicationFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        refundPolicyFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        serviceDocumentationFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        shippingDocumentationFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        uncategorizedFile {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        disputeFileUploads {
+            id
+            fileType
+            fileSize
+            url
+            originalFileName
+            disputeEvidenceType
+        }
+        fulfillments {
+            id
+            shippingCarrier
+            shippingDate
+            shippingTrackingNumber
+        }
+    }
+    """
+
+    def get_cursor_value(self) -> AwareDatetime:
+        raw_value = getattr(self, "initiatedAt")
+
+        if isinstance(raw_value, str):
+            return str_to_dt(raw_value)
+        elif isinstance(raw_value, datetime):
+            return raw_value
+        else:
+            raise ValueError(f"Expected datetime string, got {type(raw_value)}")
+
+    # Since disputes are filtered based off of the unique initiatedAt field, we can't reuse
+    # ShopifyGraphQLResource's build_query_with_fragment method that filters based off
+    # of the updatedAt field.
+    @staticmethod
+    def build_query(
+        start: datetime,
+        end: datetime,
+        first: int | None = None,
+        after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
+    ) -> str:
+        lower_bound = dt_to_str(start)
+        upper_bound = dt_to_str(end)
+        return f"""
+        {{
+            disputes(
+                query: "initiated_at:>='{lower_bound}' AND initiated_at:<='{upper_bound}'"
+                {f"first: {first}" if first else ""}
+                {f'after: "{after}"' if after else ""}
+            ) {{
+                edges {{
+                    node {{
+                        {Disputes.QUERY}
+                    }}
+                }}
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+            }}
+        }}
+        """

--- a/source-shopify-native/source_shopify_native/graphql/orders/returns.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/returns.py
@@ -1,0 +1,208 @@
+import json
+from datetime import datetime
+from logging import Logger
+from typing import AsyncGenerator, Any
+
+from ...models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+)
+
+
+class OrderReturns(ShopifyGraphQLResource):
+    NAME = "order_returns"
+    QUERY_ROOT = "orders"
+    SORT_KEY = SortKey.UPDATED_AT
+    QUALIFYING_SCOPES = {"read_returns", "read_marketplace_returns"}
+    QUERY = """
+    returns {
+        edges {
+            node {
+                id
+                name
+                status
+                totalQuantity
+                closedAt
+                createdAt
+                decline {
+                    note
+                    reason
+                }
+                # {{ staffMember }}
+                returnLineItems {
+                    edges {
+                        node {
+                            id
+                            customerNote
+                            quantity
+                            refundedQuantity
+                            returnReasonNote
+                            returnReasonDefinition {
+                                id
+                                deleted
+                                handle
+                                name
+                            }
+                        }
+                    }
+                }
+                exchangeLineItems {
+                    edges {
+                        node {
+                            id
+                            quantity
+                            processableQuantity
+                            processedQuantity
+                            variantId
+                        }
+                    }
+                }
+                refunds {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    CONDITIONAL_FIELDS = [
+        # staffMember requires the read_users scope, which is only grantable on
+        # Shopify Plus / Advanced stores or finance embedded apps.
+        ConditionalField(
+            placeholder="# {{ staffMember }}",
+            fields="""staffMember {
+                    id
+                }""",
+            is_available=lambda caps: "read_users" in caps.scopes
+            and caps.is_plus_or_advanced,
+        ),
+    ]
+
+    @staticmethod
+    def build_query(
+        start: datetime,
+        end: datetime,
+        first: int | None = None,
+        after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
+    ) -> str:
+        return OrderReturns.build_query_with_fragment(
+            start,
+            end,
+            first=first,
+            after=after,
+            capabilities=capabilities,
+        )
+
+    @staticmethod
+    async def process_result(
+        log: Logger, lines: AsyncGenerator[bytes, None]
+    ) -> AsyncGenerator[dict, None]:
+        RETURNS_KEY = "returns"
+        RETURN_LINE_ITEMS_KEY = "returnLineItems"
+        EXCHANGE_LINE_ITEMS_KEY = "exchangeLineItems"
+        REFUNDS_KEY = "refunds"
+
+        current_order = None
+
+        def find_parent_return(parent_id: str) -> dict[str, Any] | None:
+            if not current_order:
+                return None
+            for ret in current_order[RETURNS_KEY]:
+                if ret.get("id", "") == parent_id:
+                    return ret
+            return None
+
+        async for line in lines:
+            record: dict[str, Any] = json.loads(line)
+            id: str = record.get("id", "")
+
+            if "gid://shopify/Order/" in id:
+                if current_order:
+                    yield current_order
+
+                current_order = record
+                current_order[RETURNS_KEY] = []
+
+            elif "gid://shopify/ReturnLineItem/" in id:
+                parent_id = record.get("__parentId", "")
+                parent_return = find_parent_return(parent_id)
+                if not parent_return:
+                    log.error(
+                        "Could not find parent return for return line item.",
+                        {
+                            "returnLineItem.id": id,
+                            "returnLineItem.__parentId": parent_id,
+                            "current_order.id": current_order.get("id")
+                            if current_order
+                            else None,
+                        },
+                    )
+                    raise RuntimeError()
+                parent_return[RETURN_LINE_ITEMS_KEY].append(record)
+
+            elif "gid://shopify/ExchangeLineItem/" in id:
+                parent_id = record.get("__parentId", "")
+                parent_return = find_parent_return(parent_id)
+                if not parent_return:
+                    log.error(
+                        "Could not find parent return for exchange line item.",
+                        {
+                            "exchangeLineItem.id": id,
+                            "exchangeLineItem.__parentId": parent_id,
+                            "current_order.id": current_order.get("id")
+                            if current_order
+                            else None,
+                        },
+                    )
+                    raise RuntimeError()
+                parent_return[EXCHANGE_LINE_ITEMS_KEY].append(record)
+
+            elif "gid://shopify/Refund/" in id:
+                parent_id = record.get("__parentId", "")
+                parent_return = find_parent_return(parent_id)
+                if not parent_return:
+                    log.error(
+                        "Could not find parent return for refund.",
+                        {
+                            "refund.id": id,
+                            "refund.__parentId": parent_id,
+                            "current_order.id": current_order.get("id")
+                            if current_order
+                            else None,
+                        },
+                    )
+                    raise RuntimeError()
+                parent_return[REFUNDS_KEY].append(record)
+
+            elif "gid://shopify/Return/" in id:
+                if not current_order:
+                    log.error("Found a return before finding an order.")
+                    raise RuntimeError()
+                elif record.get("__parentId", "") != current_order.get("id", ""):
+                    log.error(
+                        "Return's parent id does not match the current order's id. Check if the JSONL response from Shopify is not ordered correctly.",
+                        {
+                            "return.id": id,
+                            "return.__parentId": record.get("__parentId"),
+                            "current_order.id": current_order.get("id"),
+                        },
+                    )
+                    raise RuntimeError()
+
+                record[RETURN_LINE_ITEMS_KEY] = []
+                record[EXCHANGE_LINE_ITEMS_KEY] = []
+                record[REFUNDS_KEY] = []
+                current_order[RETURNS_KEY].append(record)
+
+            else:
+                log.error("Unidentified line in JSONL response.", record)
+                raise RuntimeError()
+
+        if current_order:
+            yield current_order

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -656,6 +656,17 @@ class PageInfo(BaseModel):
     endCursor: str | None = None
     hasNextPage: bool = False
 
+    @model_validator(mode="after")
+    def _require_end_cursor_when_more_pages(self) -> "PageInfo":
+        # A Relay connection that reports another page must also return the cursor to
+        # fetch it. hasNextPage without an endCursor would otherwise silently truncate
+        # pagination, so reject it at validation time and fail loudly.
+        if self.hasNextPage and not self.endCursor:
+            raise ValueError(
+                "PageInfo reported hasNextPage but no endCursor to fetch the next page."
+            )
+        return self
+
 
 class Edge(BaseModel, Generic[TShopifyGraphQLResource]):
     node: TShopifyGraphQLResource

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -48,6 +48,7 @@ scopes = [
     "read_customers",  # Customers
     "read_own_subscription_contracts",  # SubscriptionContracts
     "read_users", # StaffMembers
+    "read_returns",  # OrderReturns
     "read_shopify_payments_disputes",  # Disputes
     # FulfillmentOrder requires one of the following 4 scopes (not read_fulfillments).
     # See: https://shopify.dev/docs/api/admin-graphql/latest/objects/FulfillmentOrder

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -470,6 +470,8 @@ class ShopifyGraphQLResource(BaseDocument):
     SORT_KEY: ClassVar[SortKey | None] = None
     SHOULD_USE_BULK_QUERIES: ClassVar[bool] = True
     QUALIFYING_SCOPES: ClassVar[set[str]] = set()
+    # Cron expression driving a periodic re-initialization of this stream's binding.
+    BACKFILL_SCHEDULE: ClassVar[str] = ""
     # Some resources are only queryable on Shopify Plus / Advanced plans or
     # partner dev stores regardless of granted scopes.
     REQUIRES_PLUS_OR_ADVANCED_PLAN: ClassVar[bool] = False

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -48,6 +48,7 @@ scopes = [
     "read_customers",  # Customers
     "read_own_subscription_contracts",  # SubscriptionContracts
     "read_users", # StaffMembers
+    "read_shopify_payments_disputes",  # Disputes
     # FulfillmentOrder requires one of the following 4 scopes (not read_fulfillments).
     # See: https://shopify.dev/docs/api/admin-graphql/latest/objects/FulfillmentOrder
     "read_assigned_fulfillment_orders",

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -9,6 +9,7 @@ from estuary_cdk.capture import Task
 from estuary_cdk.capture.common import (
     Resource,
     ResourceConfig,
+    ResourceConfigWithSchedule,
     ResourceState,
     SnapshotResource,
     open_binding,
@@ -655,8 +656,10 @@ async def all_resources(
                 ),
                 initial_state=initial_state,
                 schema_inference=True,
-                initial_config=ResourceConfig(
-                    name=model.NAME, interval=timedelta(minutes=5)
+                initial_config=ResourceConfigWithSchedule(
+                    name=model.NAME,
+                    interval=timedelta(minutes=5),
+                    schedule=model.BACKFILL_SCHEDULE,
                 ),
             )
         )
@@ -734,8 +737,9 @@ async def all_resources(
                 name=model.NAME,
                 key=snapshot_key,
                 open=create_snapshot_open_fn(model, stores_with_access),
-                initial_config=ResourceConfig(
-                    name=model.NAME, interval=timedelta(minutes=15)
+                initial_config=ResourceConfigWithSchedule(
+                    name=model.NAME,
+                    interval=timedelta(minutes=15)
                 ),
             )
         )

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -151,6 +151,7 @@ INCREMENTAL_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.OrderMetafields,
     gql.OrderTransactions,
     gql.OrderRefunds,
+    gql.OrderReturns,
     gql.OrderRisks,
     gql.InventoryItems,
     gql.InventoryLevels,

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -161,6 +161,7 @@ INCREMENTAL_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.Locations,
     gql.LocationMetafields,
     gql.SubscriptionContracts,
+    gql.Disputes,
 ]
 
 PII_RESOURCES: set[type[ShopifyGraphQLResource]] = {

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -28,6 +28,7 @@ from .graphql.bulk_job_manager import BulkJobManager
 
 from .api import (
     backfill_incremental,
+    backfill_incremental_unsorted,
     bulk_fetch_incremental,
     bulk_fetch_snapshot,
     fetch_incremental,
@@ -251,6 +252,7 @@ def _create_initial_state(
     store_ids: list[str],
     start_date: AwareDatetime,
     use_backfill: bool,
+    is_unsorted: bool = False,
 ) -> ResourceState:
     """Create initial state for a resource.
 
@@ -262,17 +264,17 @@ def _create_initial_state(
     Args:
         store_ids: List of store IDs to create state for.
         start_date: The start date for data replication.
-        use_backfill: Whether to create backfill state (for non-bulk queries with SORT_KEY).
+        use_backfill: Whether to create backfill state (for non-bulk queries).
+        is_unsorted: Whether this is an unsorted (no sortKey) stream.
     """
     cutoff = datetime.now(tz=UTC)
 
     if use_backfill:
+        next_page = None if is_unsorted else dt_to_str(start_date)
         return ResourceState(
             inc={sid: ResourceState.Incremental(cursor=cutoff) for sid in store_ids},
             backfill={
-                sid: ResourceState.Backfill(
-                    next_page=dt_to_str(start_date), cutoff=cutoff
-                )
+                sid: ResourceState.Backfill(next_page=next_page, cutoff=cutoff)
                 for sid in store_ids
             },
         )
@@ -542,9 +544,10 @@ async def all_resources(
         if not stores_with_access:
             continue
 
-        use_backfill = not model.SHOULD_USE_BULK_QUERIES and model.SORT_KEY is not None
+        use_backfill = not model.SHOULD_USE_BULK_QUERIES
+        is_unsorted = model.SORT_KEY is None
         initial_state = _create_initial_state(
-            stores_with_access, config.start_date, use_backfill
+            stores_with_access, config.start_date, use_backfill, is_unsorted
         )
         legacy_store_id = config._legacy_store or config.stores[0].store
 
@@ -616,6 +619,15 @@ async def all_resources(
                             data_model,
                             store_id,
                             ctx.capabilities,
+                        )
+                        fetch_page[store_id] = functools.partial(
+                            backfill_incremental_unsorted,
+                            ctx.client,
+                            model,
+                            data_model,
+                            store_id,
+                            ctx.capabilities,
+                            config.start_date,
                         )
                     else:
                         fetch_changes[store_id] = functools.partial(

--- a/source-shopify-native/test.flow.yaml
+++ b/source-shopify-native/test.flow.yaml
@@ -73,6 +73,10 @@ captures:
         interval: PT5M
       target: acmeCo/order_refunds
     - resource:
+        name: order_returns
+        interval: PT5M
+      target: acmeCo/order_returns
+    - resource:
         name: order_risks
         interval: PT5M
       target: acmeCo/order_risks

--- a/source-shopify-native/test.flow.yaml
+++ b/source-shopify-native/test.flow.yaml
@@ -108,3 +108,7 @@ captures:
         name: location_metafields
         interval: PT5M
       target: acmeCo/location_metafields
+    - resource:
+        name: disputes
+        interval: PT5M
+      target: acmeCo/disputes

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -4603,6 +4603,189 @@
     }
   ],
   [
+    "acmeCo/order_returns",
+    {
+      "_meta": {
+        "store": "estuary-alex-testing",
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "createdAt": "2026-06-11T17:33:51Z",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
+      "returns": [
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "closedAt": "2026-06-15T13:21:46Z",
+          "createdAt": "2026-06-15T13:20:39Z",
+          "decline": null,
+          "exchangeLineItems": [
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "id": "gid://shopify/ExchangeLineItem/964526125",
+              "processableQuantity": 0,
+              "processedQuantity": 1,
+              "quantity": 1,
+              "variantId": "gid://shopify/ProductVariant/43217823891501"
+            }
+          ],
+          "id": "gid://shopify/Return/18804736045",
+          "name": "#1007-R1",
+          "refunds": [
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "id": "gid://shopify/Refund/1100817530925"
+            }
+          ],
+          "returnLineItems": [
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27743977517",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "too-long",
+                "id": "gid://shopify/ReturnReasonDefinition/254",
+                "name": "Too long"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744010285",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "too-short",
+                "id": "gid://shopify/ReturnReasonDefinition/261",
+                "name": "Too short"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744043053",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "color",
+                "id": "gid://shopify/ReturnReasonDefinition/10",
+                "name": "Color"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744075821",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "flex",
+                "id": "gid://shopify/ReturnReasonDefinition/106",
+                "name": "Flex"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744108589",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "changed-my-mind",
+                "id": "gid://shopify/ReturnReasonDefinition/2",
+                "name": "Changed my mind"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744141357",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "item-not-as-described",
+                "id": "gid://shopify/ReturnReasonDefinition/3",
+                "name": "Item not as described"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744174125",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "received-the-wrong-item",
+                "id": "gid://shopify/ReturnReasonDefinition/4",
+                "name": "Received the wrong item"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744206893",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "damaged-or-defective",
+                "id": "gid://shopify/ReturnReasonDefinition/6",
+                "name": "Damaged or defective"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744239661",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "unknown",
+                "id": "gid://shopify/ReturnReasonDefinition/1",
+                "name": "Unknown"
+              },
+              "returnReasonNote": ""
+            },
+            {
+              "__parentId": "gid://shopify/Return/18804736045",
+              "customerNote": null,
+              "id": "gid://shopify/ReturnLineItem/27744272429",
+              "quantity": 5,
+              "refundedQuantity": 5,
+              "returnReasonDefinition": {
+                "deleted": false,
+                "handle": "other-reason",
+                "id": "gid://shopify/ReturnReasonDefinition/5",
+                "name": "Other"
+              },
+              "returnReasonNote": "test reason"
+            }
+          ],
+          "status": "CLOSED",
+          "totalQuantity": 50
+        }
+      ],
+      "updatedAt": "redacted"
+    }
+  ],
+  [
     "acmeCo/order_risks",
     {
       "_meta": {

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -324,10 +324,10 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
+      "createdAt": "2026-06-11T17:33:51Z",
       "fulfillmentOrders": [
         {
-          "__parentId": "gid://shopify/Order/5714619858989",
+          "__parentId": "gid://shopify/Order/18697849798701",
           "__typename": "FulfillmentOrder",
           "assignedLocation": {
             "address1": null,
@@ -344,81 +344,304 @@
             "zip": null
           },
           "channelId": null,
-          "createdAt": "2025-04-10T17:42:58Z",
+          "createdAt": "2026-06-11T17:33:52Z",
           "deliveryMethod": {
-            "id": "gid://shopify/DeliveryMethod/1234789171245",
+            "id": "gid://shopify/DeliveryMethod/16175942959149",
             "maxDeliveryDateTime": null,
-            "methodType": "NONE",
+            "methodType": "SHIPPING",
             "minDeliveryDateTime": null
           },
           "destination": {
-            "address1": null,
+            "address1": "",
             "address2": null,
-            "city": null,
+            "city": "",
             "company": null,
-            "countryCode": null,
-            "email": "ayumu.hirano@example.com",
-            "firstName": null,
-            "id": "gid://shopify/FulfillmentOrderDestination/6991280111661",
-            "lastName": null,
+            "countryCode": "US",
+            "email": "test@example.com",
+            "firstName": "Test",
+            "id": "gid://shopify/FulfillmentOrderDestination/21536448479277",
+            "lastName": "McTesterson",
             "phone": null,
             "province": null,
             "zip": null
           },
-          "fulfillAt": "2025-04-10T17:00:00Z",
+          "fulfillAt": "2026-06-11T17:00:00Z",
           "fulfillBy": null,
           "fulfillmentHolds": [],
-          "id": "gid://shopify/FulfillmentOrder/6720249167917",
+          "id": "gid://shopify/FulfillmentOrder/21899296014381",
           "internationalDuties": null,
           "lineItems": [
             {
-              "__parentId": "gid://shopify/FulfillmentOrder/6720249167917",
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
               "__typename": "FulfillmentOrderLineItem",
-              "id": "gid://shopify/FulfillmentOrderLineItem/14276053729325",
-              "inventoryItemId": "gid://shopify/InventoryItem/45258935009325",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498265645",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935926829",
               "lineItem": {
-                "currentQuantity": 1,
-                "fulfillableQuantity": 1,
-                "id": "gid://shopify/LineItem/14150963134509",
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223512109",
                 "product": {
-                  "id": "gid://shopify/Product/8086707830829",
-                  "legacyResourceId": "8086707830829"
+                  "id": "gid://shopify/Product/8086708453421",
+                  "legacyResourceId": "8086708453421"
                 },
                 "variant": {
-                  "id": "gid://shopify/ProductVariant/43217823367213",
-                  "legacyResourceId": "43217823367213"
+                  "id": "gid://shopify/ProductVariant/43217824284717",
+                  "legacyResourceId": "43217824284717"
                 }
               }
             },
             {
-              "__parentId": "gid://shopify/FulfillmentOrder/6720249167917",
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
               "__typename": "FulfillmentOrderLineItem",
-              "id": "gid://shopify/FulfillmentOrderLineItem/14276053762093",
-              "inventoryItemId": "gid://shopify/InventoryItem/45258935042093",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498298413",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935500845",
               "lineItem": {
-                "currentQuantity": 1,
-                "fulfillableQuantity": 1,
-                "id": "gid://shopify/LineItem/14150963167277",
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223544877",
                 "product": {
-                  "id": "gid://shopify/Product/8086707830829",
-                  "legacyResourceId": "8086707830829"
+                  "id": "gid://shopify/Product/8086708191277",
+                  "legacyResourceId": "8086708191277"
                 },
                 "variant": {
-                  "id": "gid://shopify/ProductVariant/43217823399981",
-                  "legacyResourceId": "43217823399981"
+                  "id": "gid://shopify/ProductVariant/43217823858733",
+                  "legacyResourceId": "43217823858733"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498331181",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935795757",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223577645",
+                "product": {
+                  "id": "gid://shopify/Product/8086708355117",
+                  "legacyResourceId": "8086708355117"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217824153645",
+                  "legacyResourceId": "43217824153645"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498363949",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935664685",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223610413",
+                "product": {
+                  "id": "gid://shopify/Product/8086708224045",
+                  "legacyResourceId": "8086708224045"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217824022573",
+                  "legacyResourceId": "43217824022573"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498396717",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935271469",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223643181",
+                "product": {
+                  "id": "gid://shopify/Product/8086708125741",
+                  "legacyResourceId": "8086708125741"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823760429",
+                  "legacyResourceId": "43217823760429"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498429485",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935337005",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223675949",
+                "product": {
+                  "id": "gid://shopify/Product/8086707994669",
+                  "legacyResourceId": "8086707994669"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823596589",
+                  "legacyResourceId": "43217823596589"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498462253",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935369773",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223708717",
+                "product": {
+                  "id": "gid://shopify/Product/8086707994669",
+                  "legacyResourceId": "8086707994669"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823629357",
+                  "legacyResourceId": "43217823629357"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498495021",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935402541",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223741485",
+                "product": {
+                  "id": "gid://shopify/Product/8086707994669",
+                  "legacyResourceId": "8086707994669"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823662125",
+                  "legacyResourceId": "43217823662125"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498527789",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935435309",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223774253",
+                "product": {
+                  "id": "gid://shopify/Product/8086707994669",
+                  "legacyResourceId": "8086707994669"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823694893",
+                  "legacyResourceId": "43217823694893"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21899296014381",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50325498560557",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935468077",
+              "lineItem": {
+                "currentQuantity": 90,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50297223807021",
+                "product": {
+                  "id": "gid://shopify/Product/8086707994669",
+                  "legacyResourceId": "8086707994669"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823727661",
+                  "legacyResourceId": "43217823727661"
                 }
               }
             }
           ],
           "merchantRequests": [],
           "requestStatus": "UNSUBMITTED",
-          "status": "OPEN",
+          "status": "CLOSED",
           "supportedActions": [],
-          "updatedAt": "2025-04-10T17:42:58Z"
+          "updatedAt": "2026-06-11T17:35:16Z"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "__typename": "FulfillmentOrder",
+          "assignedLocation": {
+            "address1": null,
+            "address2": null,
+            "city": null,
+            "countryCode": "US",
+            "location": {
+              "id": "gid://shopify/Location/73871392813",
+              "legacyResourceId": "73871392813"
+            },
+            "name": "Shop location",
+            "phone": null,
+            "province": null,
+            "zip": null
+          },
+          "channelId": null,
+          "createdAt": "2026-06-15T13:21:45Z",
+          "deliveryMethod": {
+            "id": "gid://shopify/DeliveryMethod/16207704457261",
+            "maxDeliveryDateTime": null,
+            "methodType": "SHIPPING",
+            "minDeliveryDateTime": null
+          },
+          "destination": {
+            "address1": "",
+            "address2": null,
+            "city": "",
+            "company": null,
+            "countryCode": "US",
+            "email": "test@example.com",
+            "firstName": "Test",
+            "id": "gid://shopify/FulfillmentOrderDestination/21567918112813",
+            "lastName": "McTesterson",
+            "phone": null,
+            "province": null,
+            "zip": null
+          },
+          "fulfillAt": "2026-06-15T13:00:00Z",
+          "fulfillBy": null,
+          "fulfillmentHolds": [],
+          "id": "gid://shopify/FulfillmentOrder/21931063640109",
+          "internationalDuties": null,
+          "lineItems": [
+            {
+              "__parentId": "gid://shopify/FulfillmentOrder/21931063640109",
+              "__typename": "FulfillmentOrderLineItem",
+              "id": "gid://shopify/FulfillmentOrderLineItem/50381491863597",
+              "inventoryItemId": "gid://shopify/InventoryItem/45258935304237",
+              "lineItem": {
+                "currentQuantity": 1,
+                "fulfillableQuantity": 0,
+                "id": "gid://shopify/LineItem/50353178017837",
+                "product": {
+                  "id": "gid://shopify/Product/8086708060205",
+                  "legacyResourceId": "8086708060205"
+                },
+                "variant": {
+                  "id": "gid://shopify/ProductVariant/43217823891501",
+                  "legacyResourceId": "43217823891501"
+                }
+              }
+            }
+          ],
+          "merchantRequests": [],
+          "requestStatus": "UNSUBMITTED",
+          "status": "CLOSED",
+          "supportedActions": [],
+          "updatedAt": "2026-06-15T13:21:56Z"
         }
       ],
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "updatedAt": "redacted"
     }
   ],
@@ -429,10 +652,83 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
-      "fulfillments": [],
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "createdAt": "2026-06-11T17:33:51Z",
+      "fulfillments": [
+        {
+          "createdAt": "2026-06-15T13:21:56Z",
+          "deliveredAt": null,
+          "displayStatus": "FULFILLED",
+          "estimatedDeliveryAt": null,
+          "id": "gid://shopify/Fulfillment/7089298964525",
+          "inTransitAt": null,
+          "legacyResourceId": "7089298964525",
+          "location": {
+            "id": "gid://shopify/Location/73871392813",
+            "legacyResourceId": "73871392813"
+          },
+          "name": "#1007-F2",
+          "order": {
+            "id": "gid://shopify/Order/18697849798701",
+            "legacyResourceId": "18697849798701"
+          },
+          "originAddress": null,
+          "requiresShipping": true,
+          "service": {
+            "handle": "manual",
+            "id": "gid://shopify/FulfillmentService/manual",
+            "inventoryManagement": false,
+            "location": {
+              "id": "gid://shopify/Location/73871392813",
+              "legacyResourceId": "73871392813"
+            },
+            "serviceName": "Manual",
+            "trackingSupport": false,
+            "type": "MANUAL"
+          },
+          "status": "SUCCESS",
+          "totalQuantity": 1,
+          "trackingInfo": [],
+          "updatedAt": "2026-06-15T13:21:56Z"
+        },
+        {
+          "createdAt": "2026-06-11T17:35:15Z",
+          "deliveredAt": "2026-06-15T13:19:16Z",
+          "displayStatus": "DELIVERED",
+          "estimatedDeliveryAt": null,
+          "id": "gid://shopify/Fulfillment/7059371851821",
+          "inTransitAt": null,
+          "legacyResourceId": "7059371851821",
+          "location": {
+            "id": "gid://shopify/Location/73871392813",
+            "legacyResourceId": "73871392813"
+          },
+          "name": "#1007-F1",
+          "order": {
+            "id": "gid://shopify/Order/18697849798701",
+            "legacyResourceId": "18697849798701"
+          },
+          "originAddress": null,
+          "requiresShipping": true,
+          "service": {
+            "handle": "manual",
+            "id": "gid://shopify/FulfillmentService/manual",
+            "inventoryManagement": false,
+            "location": {
+              "id": "gid://shopify/Location/73871392813",
+              "legacyResourceId": "73871392813"
+            },
+            "serviceName": "Manual",
+            "trackingSupport": false,
+            "type": "MANUAL"
+          },
+          "status": "SUCCESS",
+          "totalQuantity": 2000,
+          "trackingInfo": [],
+          "updatedAt": "2026-06-15T13:19:16Z"
+        }
+      ],
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "updatedAt": "redacted"
     }
   ],
@@ -447,22 +743,39 @@
         "id": "gid://shopify/App/1354745",
         "name": "Draft Orders"
       },
-      "billingAddress": null,
+      "billingAddress": {
+        "address1": "",
+        "address2": null,
+        "city": "",
+        "company": null,
+        "country": "United States",
+        "countryCodeV2": "US",
+        "firstName": "Test",
+        "id": "gid://shopify/MailingAddress/40831289622573?model_name=Address",
+        "lastName": "McTesterson",
+        "latitude": null,
+        "longitude": null,
+        "name": "Test McTesterson",
+        "phone": null,
+        "province": null,
+        "provinceCode": null,
+        "zip": null
+      },
       "cancelReason": null,
       "cancelledAt": null,
-      "clientIp": "209.25.185.18",
-      "closedAt": "2025-04-10T17:54:23Z",
-      "confirmationNumber": "WIEXW87LG",
+      "clientIp": "76.182.0.22",
+      "closedAt": "2026-06-15T13:21:57Z",
+      "confirmationNumber": "ULEG58LMN",
       "confirmed": true,
-      "createdAt": "2025-04-10T17:42:58Z",
+      "createdAt": "2026-06-11T17:33:51Z",
       "currencyCode": "USD",
       "currentSubtotalPriceSet": {
         "presentmentMoney": {
-          "amount": "75.0",
+          "amount": "604214.45",
           "currencyCode": "USD"
         },
         "shopMoney": {
-          "amount": "75.0",
+          "amount": "604214.45",
           "currencyCode": "USD"
         }
       },
@@ -480,11 +793,11 @@
       "currentTotalDutiesSet": null,
       "currentTotalPriceSet": {
         "presentmentMoney": {
-          "amount": "75.0",
+          "amount": "604214.45",
           "currencyCode": "USD"
         },
         "shopMoney": {
-          "amount": "75.0",
+          "amount": "604214.45",
           "currencyCode": "USD"
         }
       },
@@ -500,8 +813,8 @@
       },
       "customAttributes": [],
       "customer": {
-        "id": "gid://shopify/Customer/7609762938925",
-        "legacyResourceId": "7609762938925"
+        "id": "gid://shopify/Customer/30911737757741",
+        "legacyResourceId": "30911737757741"
       },
       "customerAcceptsMarketing": false,
       "customerJourneySummary": {
@@ -519,87 +832,87 @@
       "discountApplications": [],
       "discountCode": null,
       "discountCodes": [],
-      "displayFinancialStatus": "PENDING",
-      "displayFulfillmentStatus": "UNFULFILLED",
-      "email": "ayumu.hirano@example.com",
+      "displayFinancialStatus": "PARTIALLY_REFUNDED",
+      "displayFulfillmentStatus": "FULFILLED",
+      "email": "test@example.com",
       "estimatedTaxes": false,
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "lineItems": [
         {
-          "__parentId": "gid://shopify/Order/5714619858989",
-          "currentQuantity": 1,
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
           "customAttributes": [],
           "discountAllocations": [],
           "discountedTotalSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "8600.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "8600.0",
               "currencyCode": "USD"
             }
           },
           "discountedUnitPriceAfterAllDiscountsSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             }
           },
           "discountedUnitPriceSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             }
           },
           "duties": [],
-          "id": "gid://shopify/LineItem/14150963134509",
+          "id": "gid://shopify/LineItem/50297223512109",
           "image": {
-            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/gift_card.png?v=1736867416"
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_b13ad453-477c-4ed1-9b43-81f3345adfd6.jpg?v=1736867416"
           },
-          "isGiftCard": true,
+          "isGiftCard": false,
           "lineItemGroup": null,
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "8600.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "8600.0",
               "currencyCode": "USD"
             }
           },
           "originalUnitPriceSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "43.0",
               "currencyCode": "USD"
             }
           },
           "product": {
-            "id": "gid://shopify/Product/8086707830829",
-            "legacyResourceId": "8086707830829"
+            "id": "gid://shopify/Product/8086708453421",
+            "legacyResourceId": "8086708453421"
           },
-          "quantity": 1,
-          "refundableQuantity": 1,
-          "requiresShipping": false,
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
           "sellingPlan": null,
-          "sku": null,
+          "sku": "123456789",
           "taxLines": [],
-          "taxable": false,
+          "taxable": true,
           "totalDiscountSet": {
             "presentmentMoney": {
               "amount": "0.0",
@@ -612,106 +925,666 @@
           },
           "unfulfilledDiscountedTotalSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             }
           },
           "unfulfilledOriginalTotalSet": {
             "presentmentMoney": {
-              "amount": "25.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "25.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             }
           },
-          "unfulfilledQuantity": 1,
+          "unfulfilledQuantity": 0,
           "variant": {
-            "id": "gid://shopify/ProductVariant/43217823367213",
-            "legacyResourceId": "43217823367213",
+            "id": "gid://shopify/ProductVariant/43217824284717",
+            "legacyResourceId": "43217824284717",
+            "sku": "123456789"
+          },
+          "vendor": "estuary-alex-testing"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "120000.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "120000.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223544877",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_0a40b01b-5021-48c1-80d1-aa8ab4876d3d.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "120000.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "120000.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "600.0",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086708191277",
+            "legacyResourceId": "8086708191277"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823858733",
+            "legacyResourceId": "43217823858733",
+            "sku": null
+          },
+          "vendor": "Hydrogen Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "149990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "149990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223577645",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_b13ad453-477c-4ed1-9b43-81f3345adfd6.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "149990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "149990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "749.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086708355117",
+            "legacyResourceId": "8086708355117"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217824153645",
+            "legacyResourceId": "43217824153645",
+            "sku": null
+          },
+          "vendor": "Hydrogen Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "205000.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "205000.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223610413",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_d624f226-0a89-4fe1-b333-0d1548b43c06.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "205000.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "205000.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "1025.0",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086708224045",
+            "legacyResourceId": "8086708224045"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217824022573",
+            "legacyResourceId": "43217824022573",
+            "sku": null
+          },
+          "vendor": "Hydrogen Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "157190.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "157190.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223643181",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/snowboard_sky.png?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "157190.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "157190.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "785.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086708125741",
+            "legacyResourceId": "8086708125741"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823760429",
+            "legacyResourceId": "43217823760429",
+            "sku": null
+          },
+          "vendor": "estuary-alex-testing"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223675949",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707994669",
+            "legacyResourceId": "8086707994669"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823596589",
+            "legacyResourceId": "43217823596589",
             "sku": null
           },
           "vendor": "Snowboard Vendor"
         },
         {
-          "__parentId": "gid://shopify/Order/5714619858989",
-          "currentQuantity": 1,
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
           "customAttributes": [],
           "discountAllocations": [],
           "discountedTotalSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "139990.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "139990.0",
               "currencyCode": "USD"
             }
           },
           "discountedUnitPriceAfterAllDiscountsSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             }
           },
           "discountedUnitPriceSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             }
           },
           "duties": [],
-          "id": "gid://shopify/LineItem/14150963167277",
+          "id": "gid://shopify/LineItem/50297223708717",
           "image": {
-            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/gift_card.png?v=1736867416"
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1736867416"
           },
-          "isGiftCard": true,
+          "isGiftCard": false,
           "lineItemGroup": null,
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "139990.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "139990.0",
               "currencyCode": "USD"
             }
           },
           "originalUnitPriceSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "699.95",
               "currencyCode": "USD"
             }
           },
           "product": {
-            "id": "gid://shopify/Product/8086707830829",
-            "legacyResourceId": "8086707830829"
+            "id": "gid://shopify/Product/8086707994669",
+            "legacyResourceId": "8086707994669"
           },
-          "quantity": 1,
-          "refundableQuantity": 1,
-          "requiresShipping": false,
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
           "sellingPlan": null,
           "sku": null,
           "taxLines": [],
-          "taxable": false,
+          "taxable": true,
           "totalDiscountSet": {
             "presentmentMoney": {
               "amount": "0.0",
@@ -724,79 +1597,558 @@
           },
           "unfulfilledDiscountedTotalSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             }
           },
           "unfulfilledOriginalTotalSet": {
             "presentmentMoney": {
-              "amount": "50.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             },
             "shopMoney": {
-              "amount": "50.0",
+              "amount": "0.0",
               "currencyCode": "USD"
             }
           },
-          "unfulfilledQuantity": 1,
+          "unfulfilledQuantity": 0,
           "variant": {
-            "id": "gid://shopify/ProductVariant/43217823399981",
-            "legacyResourceId": "43217823399981",
+            "id": "gid://shopify/ProductVariant/43217823629357",
+            "legacyResourceId": "43217823629357",
             "sku": null
           },
           "vendor": "Snowboard Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223741485",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707994669",
+            "legacyResourceId": "8086707994669"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823662125",
+            "legacyResourceId": "43217823662125",
+            "sku": null
+          },
+          "vendor": "Snowboard Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223774253",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707994669",
+            "legacyResourceId": "8086707994669"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823694893",
+            "legacyResourceId": "43217823694893",
+            "sku": null
+          },
+          "vendor": "Snowboard Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 90,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50297223807021",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "139990.0",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "699.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086707994669",
+            "legacyResourceId": "8086707994669"
+          },
+          "quantity": 200,
+          "refundableQuantity": 90,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823727661",
+            "legacyResourceId": "43217823727661",
+            "sku": null
+          },
+          "vendor": "Snowboard Vendor"
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "currentQuantity": 1,
+          "customAttributes": [],
+          "discountAllocations": [],
+          "discountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceAfterAllDiscountsSet": {
+            "presentmentMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            }
+          },
+          "discountedUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            }
+          },
+          "duties": [],
+          "id": "gid://shopify/LineItem/50353178017837",
+          "image": {
+            "originalSrc": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/Main.jpg?v=1736867416"
+          },
+          "isGiftCard": false,
+          "lineItemGroup": null,
+          "nonFulfillableQuantity": 0,
+          "originalTotalSet": {
+            "presentmentMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            }
+          },
+          "originalUnitPriceSet": {
+            "presentmentMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "885.95",
+              "currencyCode": "USD"
+            }
+          },
+          "product": {
+            "id": "gid://shopify/Product/8086708060205",
+            "legacyResourceId": "8086708060205"
+          },
+          "quantity": 1,
+          "refundableQuantity": 1,
+          "requiresShipping": true,
+          "sellingPlan": null,
+          "sku": null,
+          "taxLines": [],
+          "taxable": true,
+          "totalDiscountSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledDiscountedTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledOriginalTotalSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          },
+          "unfulfilledQuantity": 0,
+          "variant": {
+            "id": "gid://shopify/ProductVariant/43217823891501",
+            "legacyResourceId": "43217823891501",
+            "sku": null
+          },
+          "vendor": "estuary-alex-testing"
         }
       ],
       "merchantOfRecordApp": null,
-      "name": "#1001",
-      "note": "Testing a note.",
+      "name": "#1007",
+      "note": null,
       "originalTotalAdditionalFeesSet": null,
       "originalTotalDutiesSet": null,
-      "paymentGatewayNames": [],
+      "paymentGatewayNames": [
+        "manual"
+      ],
       "paymentTerms": {
-        "dueInDays": 7,
-        "id": "gid://shopify/PaymentTerms/22703865901",
+        "dueInDays": null,
+        "id": "gid://shopify/PaymentTerms/40743305261",
         "overdue": true,
         "paymentSchedules": [
           {
-            "__parentId": "gid://shopify/Order/5714619858989",
+            "__parentId": "gid://shopify/Order/18697849798701",
+            "completedAt": "2026-06-11T17:35:21Z",
+            "dueAt": "2026-06-11T17:35:16Z",
+            "id": "gid://shopify/PaymentSchedule/40764047405",
+            "issuedAt": null
+          },
+          {
+            "__parentId": "gid://shopify/Order/18697849798701",
+            "completedAt": "2026-06-11T17:35:24Z",
+            "dueAt": "2026-06-11T17:35:24Z",
+            "id": "gid://shopify/PaymentSchedule/40764080173",
+            "issuedAt": null
+          },
+          {
+            "__parentId": "gid://shopify/Order/18697849798701",
             "completedAt": null,
-            "dueAt": "2025-04-17T17:40:19Z",
-            "id": "gid://shopify/PaymentSchedule/22655238189",
-            "issuedAt": "2025-04-10T17:40:19Z"
+            "dueAt": "2026-06-15T13:21:57Z",
+            "id": "gid://shopify/PaymentSchedule/40868446253",
+            "issuedAt": null
           }
         ],
-        "paymentTermsName": "Net 7",
-        "paymentTermsType": "NET"
+        "paymentTermsName": "Due on fulfillment",
+        "paymentTermsType": "FULFILLMENT"
       },
-      "phone": "+16135550127",
+      "phone": null,
       "poNumber": null,
       "presentmentCurrencyCode": "USD",
-      "processedAt": "2025-04-10T17:42:57Z",
+      "processedAt": "2026-06-11T17:33:51Z",
       "purchasingEntity": {
         "__typename": "Customer"
       },
       "referrerUrl": null,
       "registeredSourceUrl": null,
-      "retailLocation": {
-        "id": "gid://shopify/Location/73871392813"
+      "retailLocation": null,
+      "shippingAddress": {
+        "address1": "",
+        "address2": null,
+        "city": "",
+        "company": null,
+        "country": "United States",
+        "countryCodeV2": "US",
+        "firstName": "Test",
+        "id": "gid://shopify/MailingAddress/40831289589805?model_name=Address",
+        "lastName": "McTesterson",
+        "latitude": null,
+        "longitude": null,
+        "name": "Test McTesterson",
+        "phone": null,
+        "province": null,
+        "provinceCode": null,
+        "zip": null
       },
-      "shippingAddress": null,
       "sourceIdentifier": null,
       "sourceName": "shopify_draft_order",
-      "statusPageUrl": "https://estuary-alex-testing.myshopify.com/66340061229/orders/cec7ba12de8a68ac88469d6418753eb4/authenticate?key=7d63fdde023ada08f12771dfd7d82cdc",
-      "subtotalPrice": "75.00",
+      "statusPageUrl": "https://estuary-alex-testing.myshopify.com/66340061229/orders/9333c6f05c84d01e195bd80f8f18a024/authenticate?key=bb96e7dd8892e40557312ce13d13f605",
+      "subtotalPrice": "1341615.95",
       "subtotalPriceSet": {
         "presentmentMoney": {
-          "amount": "75.0",
+          "amount": "1341615.95",
           "currencyCode": "USD"
         },
         "shopMoney": {
-          "amount": "75.0",
+          "amount": "1341615.95",
           "currencyCode": "USD"
         }
       },
@@ -817,21 +2169,21 @@
       },
       "totalOutstandingSet": {
         "presentmentMoney": {
-          "amount": "75.0",
+          "amount": "0.0",
           "currencyCode": "USD"
         },
         "shopMoney": {
-          "amount": "75.0",
+          "amount": "0.0",
           "currencyCode": "USD"
         }
       },
       "totalPriceSet": {
         "presentmentMoney": {
-          "amount": "75.0",
+          "amount": "1341615.95",
           "currencyCode": "USD"
         },
         "shopMoney": {
-          "amount": "75.0",
+          "amount": "1341615.95",
           "currencyCode": "USD"
         }
       },
@@ -865,7 +2217,7 @@
           "currencyCode": "USD"
         }
       },
-      "totalWeight": "0",
+      "totalWeight": "4541593",
       "updatedAt": "redacted"
     }
   ],
@@ -878,24 +2230,27 @@
       },
       "agreements": [
         {
-          "__parentId": "gid://shopify/Order/5714619858989",
-          "happenedAt": "2025-04-10T17:42:57Z",
-          "id": "gid://shopify/SalesAgreement/6106772504621",
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "happenedAt": "2026-06-11T17:33:51Z",
+          "id": "gid://shopify/SalesAgreement/18948418371629",
           "reason": "ORDER",
           "sales": [
             {
-              "__parentId": "gid://shopify/SalesAgreement/6106772504621",
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
               "actionType": "ORDER",
-              "id": "gid://shopify/Sale/18159734718509",
-              "lineType": "GIFT_CARD",
-              "quantity": 1,
+              "id": "gid://shopify/Sale/68934622412845",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
               "totalAmount": {
                 "presentmentMoney": {
-                  "amount": "25.0",
+                  "amount": "8600.0",
                   "currencyCode": "USD"
                 },
                 "shopMoney": {
-                  "amount": "25.0",
+                  "amount": "8600.0",
                   "currencyCode": "USD"
                 }
               },
@@ -931,18 +2286,1995 @@
               }
             },
             {
-              "__parentId": "gid://shopify/SalesAgreement/6106772504621",
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
               "actionType": "ORDER",
-              "id": "gid://shopify/Sale/18159734751277",
-              "lineType": "GIFT_CARD",
-              "quantity": 1,
+              "id": "gid://shopify/Sale/68934622445613",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
               "totalAmount": {
                 "presentmentMoney": {
-                  "amount": "50.0",
+                  "amount": "120000.0",
                   "currencyCode": "USD"
                 },
                 "shopMoney": {
-                  "amount": "50.0",
+                  "amount": "120000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622478381",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "149990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622511149",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "205000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622543917",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "157190.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622576685",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622609453",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622642221",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622674989",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948418371629",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/68934622707757",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 200,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "139990.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "happenedAt": "2026-06-11T17:35:45Z",
+          "id": "gid://shopify/SalesAgreement/18948422926381",
+          "reason": "REFUND",
+          "sales": [
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633095213",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-4300.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-4300.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633127981",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-60000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-60000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633160749",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-74995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-74995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633193517",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-102500.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-102500.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633226285",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-78595.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-78595.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633259053",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633291821",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633324589",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633357357",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948422926381",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934633390125",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -100,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-69995.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "happenedAt": "2026-06-11T17:37:41Z",
+          "id": "gid://shopify/SalesAgreement/18948427481133",
+          "reason": "REFUND",
+          "sales": [
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934643908653",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-215.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-215.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934643941421",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934643974189",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3749.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3749.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644006957",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-5125.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-5125.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644039725",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3929.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3929.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644072493",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644105261",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644138029",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644170797",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18948427481133",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/68934644203565",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "__parentId": "gid://shopify/Order/18697849798701",
+          "happenedAt": "2026-06-15T13:21:43Z",
+          "id": "gid://shopify/SalesAgreement/18985771270189",
+          "reason": "RETURN",
+          "sales": [
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500442157",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223512109"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-215.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-215.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500474925",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223544877"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3000.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3000.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500507693",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223577645"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3749.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3749.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500540461",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223610413"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-5125.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-5125.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500573229",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223643181"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3929.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3929.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500605997",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223675949"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500638765",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223708717"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500671533",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223741485"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500704301",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223774253"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "RETURN",
+              "id": "gid://shopify/Sale/69014500737069",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50297223807021"
+              },
+              "lineType": "PRODUCT",
+              "quantity": -5,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "-3499.75",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountAfterTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalDiscountAmountBeforeTaxes": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              },
+              "totalTaxAmount": {
+                "presentmentMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "0.0",
+                  "currencyCode": "USD"
+                }
+              }
+            },
+            {
+              "__parentId": "gid://shopify/SalesAgreement/18985771270189",
+              "actionType": "ORDER",
+              "id": "gid://shopify/Sale/69014500769837",
+              "lineItem": {
+                "id": "gid://shopify/LineItem/50353178017837"
+              },
+              "lineType": "PRODUCT",
+              "quantity": 1,
+              "totalAmount": {
+                "presentmentMoney": {
+                  "amount": "885.95",
+                  "currencyCode": "USD"
+                },
+                "shopMoney": {
+                  "amount": "885.95",
                   "currencyCode": "USD"
                 }
               },
@@ -980,9 +4312,9 @@
           ]
         }
       ],
-      "createdAt": "2025-04-10T17:42:58Z",
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "createdAt": "2026-06-11T17:33:51Z",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "updatedAt": "redacted"
     }
   ],
@@ -993,9 +4325,9 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "createdAt": "2026-06-11T17:33:51Z",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "metafields": [],
       "updatedAt": "redacted"
     }
@@ -1007,10 +4339,183 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
-      "transactions": [],
+      "createdAt": "2026-06-11T17:33:51Z",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
+      "transactions": [
+        {
+          "accountNumber": "",
+          "amountRoundingSet": null,
+          "amountSet": {
+            "presentmentMoney": {
+              "amount": "1340730.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "1340730.0",
+              "currencyCode": "USD"
+            }
+          },
+          "authorizationCode": null,
+          "authorizationExpiresAt": null,
+          "createdAt": "2026-06-11T17:35:21Z",
+          "errorCode": null,
+          "formattedGateway": "Manual",
+          "gateway": "manual",
+          "id": "gid://shopify/OrderTransaction/20456462352429",
+          "kind": "SALE",
+          "manualPaymentGateway": true,
+          "manuallyCapturable": false,
+          "multiCapturable": false,
+          "paymentDetails": null,
+          "paymentId": "#1007.1",
+          "processedAt": "2026-06-11T17:35:21Z",
+          "receiptJson": "{}",
+          "settlementCurrency": null,
+          "settlementCurrencyRate": null,
+          "status": "SUCCESS",
+          "test": false,
+          "totalUnsettledSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          }
+        },
+        {
+          "accountNumber": "",
+          "amountRoundingSet": null,
+          "amountSet": {
+            "presentmentMoney": {
+              "amount": "670365.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "670365.0",
+              "currencyCode": "USD"
+            }
+          },
+          "authorizationCode": null,
+          "authorizationExpiresAt": null,
+          "createdAt": "2026-06-11T17:35:45Z",
+          "errorCode": null,
+          "formattedGateway": "Manual",
+          "gateway": "manual",
+          "id": "gid://shopify/OrderTransaction/20456463106093",
+          "kind": "REFUND",
+          "manualPaymentGateway": true,
+          "manuallyCapturable": false,
+          "multiCapturable": false,
+          "paymentDetails": null,
+          "paymentId": "#1007.2",
+          "processedAt": "2026-06-11T17:35:45Z",
+          "receiptJson": "{}",
+          "settlementCurrency": null,
+          "settlementCurrencyRate": null,
+          "status": "SUCCESS",
+          "test": false,
+          "totalUnsettledSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          }
+        },
+        {
+          "accountNumber": "",
+          "amountRoundingSet": null,
+          "amountSet": {
+            "presentmentMoney": {
+              "amount": "33518.25",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "33518.25",
+              "currencyCode": "USD"
+            }
+          },
+          "authorizationCode": null,
+          "authorizationExpiresAt": null,
+          "createdAt": "2026-06-11T17:37:40Z",
+          "errorCode": null,
+          "formattedGateway": "Manual",
+          "gateway": "manual",
+          "id": "gid://shopify/OrderTransaction/20456467365933",
+          "kind": "REFUND",
+          "manualPaymentGateway": true,
+          "manuallyCapturable": false,
+          "multiCapturable": false,
+          "paymentDetails": null,
+          "paymentId": "#1007.3",
+          "processedAt": "2026-06-11T17:37:40Z",
+          "receiptJson": "{}",
+          "settlementCurrency": null,
+          "settlementCurrencyRate": null,
+          "status": "SUCCESS",
+          "test": false,
+          "totalUnsettledSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          }
+        },
+        {
+          "accountNumber": "",
+          "amountRoundingSet": null,
+          "amountSet": {
+            "presentmentMoney": {
+              "amount": "32632.3",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "32632.3",
+              "currencyCode": "USD"
+            }
+          },
+          "authorizationCode": null,
+          "authorizationExpiresAt": null,
+          "createdAt": "2026-06-15T13:21:43Z",
+          "errorCode": null,
+          "formattedGateway": "Manual",
+          "gateway": "manual",
+          "id": "gid://shopify/OrderTransaction/20497063936045",
+          "kind": "REFUND",
+          "manualPaymentGateway": true,
+          "manuallyCapturable": false,
+          "multiCapturable": false,
+          "paymentDetails": null,
+          "paymentId": "#1007.4",
+          "processedAt": "2026-06-15T13:21:43Z",
+          "receiptJson": "{}",
+          "settlementCurrency": null,
+          "settlementCurrencyRate": null,
+          "status": "SUCCESS",
+          "test": false,
+          "totalUnsettledSet": {
+            "presentmentMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "0.0",
+              "currencyCode": "USD"
+            }
+          }
+        }
+      ],
       "updatedAt": "redacted"
     }
   ],
@@ -1021,12 +4526,79 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
-      "displayFinancialStatus": "PENDING",
-      "displayFulfillmentStatus": "UNFULFILLED",
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
-      "refunds": [],
+      "createdAt": "2026-06-11T17:33:51Z",
+      "displayFinancialStatus": "PARTIALLY_REFUNDED",
+      "displayFulfillmentStatus": "FULFILLED",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
+      "refunds": [
+        {
+          "createdAt": "2026-06-11T17:35:45Z",
+          "duties": [],
+          "id": "gid://shopify/Refund/1094845169709",
+          "legacyResourceId": "1094845169709",
+          "note": "",
+          "order": {
+            "id": "gid://shopify/Order/18697849798701",
+            "legacyResourceId": "18697849798701"
+          },
+          "totalRefundedSet": {
+            "presentmentMoney": {
+              "amount": "670365.0",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "670365.0",
+              "currencyCode": "USD"
+            }
+          },
+          "updatedAt": "2026-06-11T17:35:46Z"
+        },
+        {
+          "createdAt": "2026-06-11T17:37:41Z",
+          "duties": [],
+          "id": "gid://shopify/Refund/1094845497389",
+          "legacyResourceId": "1094845497389",
+          "note": "",
+          "order": {
+            "id": "gid://shopify/Order/18697849798701",
+            "legacyResourceId": "18697849798701"
+          },
+          "totalRefundedSet": {
+            "presentmentMoney": {
+              "amount": "33518.25",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "33518.25",
+              "currencyCode": "USD"
+            }
+          },
+          "updatedAt": "2026-06-11T17:37:41Z"
+        },
+        {
+          "createdAt": "2026-06-15T13:21:43Z",
+          "duties": [],
+          "id": "gid://shopify/Refund/1100817530925",
+          "legacyResourceId": "1100817530925",
+          "note": null,
+          "order": {
+            "id": "gid://shopify/Order/18697849798701",
+            "legacyResourceId": "18697849798701"
+          },
+          "totalRefundedSet": {
+            "presentmentMoney": {
+              "amount": "32632.3",
+              "currencyCode": "USD"
+            },
+            "shopMoney": {
+              "amount": "32632.3",
+              "currencyCode": "USD"
+            }
+          },
+          "updatedAt": "2026-06-15T13:21:45Z"
+        }
+      ],
       "updatedAt": "redacted"
     }
   ],
@@ -1037,9 +4609,9 @@
         "store": "estuary-alex-testing",
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
-      "createdAt": "2025-04-10T17:42:58Z",
-      "id": "gid://shopify/Order/5714619858989",
-      "legacyResourceId": "5714619858989",
+      "createdAt": "2026-06-11T17:33:51Z",
+      "id": "gid://shopify/Order/18697849798701",
+      "legacyResourceId": "18697849798701",
       "risk": {
         "assessments": [
           {
@@ -1065,7 +4637,7 @@
                 "sentiment": "NEUTRAL"
               },
               {
-                "description": "Location of IP address used to place the order is Starkville, Mississippi, United States",
+                "description": "Location of IP address used to place the order is Pittsboro, North Carolina, United States",
                 "sentiment": "NEUTRAL"
               },
               {
@@ -1073,8 +4645,8 @@
                 "sentiment": "NEUTRAL"
               },
               {
-                "description": "The billing country or the country of the IP used to place the order isn't available",
-                "sentiment": "NEUTRAL"
+                "description": "Billing country matches the country from which the order was placed",
+                "sentiment": "POSITIVE"
               },
               {
                 "description": "The IP address used to place the order isn't a high risk internet connection (web proxy)",
@@ -1279,6 +4851,11 @@
         },
         {
           "__parentId": "gid://shopify/Collection/295442612269",
+          "id": "gid://shopify/Product/8086708191277",
+          "legacyResourceId": "8086708191277"
+        },
+        {
+          "__parentId": "gid://shopify/Collection/295442612269",
           "id": "gid://shopify/Product/8086708322349",
           "legacyResourceId": "8086708322349"
         },
@@ -1286,11 +4863,6 @@
           "__parentId": "gid://shopify/Collection/295442612269",
           "id": "gid://shopify/Product/8086708256813",
           "legacyResourceId": "8086708256813"
-        },
-        {
-          "__parentId": "gid://shopify/Collection/295442612269",
-          "id": "gid://shopify/Product/8086708191277",
-          "legacyResourceId": "8086708191277"
         },
         {
           "__parentId": "gid://shopify/Collection/295442612269",

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -1275,6 +1275,91 @@
     ]
   },
   {
+    "recommendedName": "order_returns",
+    "resourceConfig": {
+      "name": "order_returns",
+      "interval": "PT5M",
+      "schedule": ""
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ShopifyGraphQLResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/_meta/store",
+      "/id"
+    ]
+  },
+  {
     "recommendedName": "order_risks",
     "resourceConfig": {
       "name": "order_risks",

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2038,5 +2038,90 @@
       "/_meta/store",
       "/id"
     ]
+  },
+  {
+    "recommendedName": "disputes",
+    "resourceConfig": {
+      "name": "disputes",
+      "interval": "PT5M",
+      "schedule": "55 23 * * *"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "ShopifyGraphQLResource",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/_meta/store",
+      "/id"
+    ]
   }
 ]

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,7 +3,8 @@
     "recommendedName": "abandoned_checkouts",
     "resourceConfig": {
       "name": "abandoned_checkouts",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -87,7 +88,8 @@
     "recommendedName": "customers",
     "resourceConfig": {
       "name": "customers",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -171,7 +173,8 @@
     "recommendedName": "customer_metafields",
     "resourceConfig": {
       "name": "customer_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -255,7 +258,8 @@
     "recommendedName": "products",
     "resourceConfig": {
       "name": "products",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -339,7 +343,8 @@
     "recommendedName": "product_media",
     "resourceConfig": {
       "name": "product_media",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -423,7 +428,8 @@
     "recommendedName": "product_metafields",
     "resourceConfig": {
       "name": "product_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -507,7 +513,8 @@
     "recommendedName": "product_variants",
     "resourceConfig": {
       "name": "product_variants",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -591,7 +598,8 @@
     "recommendedName": "product_variant_metafields",
     "resourceConfig": {
       "name": "product_variant_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -675,7 +683,8 @@
     "recommendedName": "fulfillment_orders",
     "resourceConfig": {
       "name": "fulfillment_orders",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -759,7 +768,8 @@
     "recommendedName": "fulfillments",
     "resourceConfig": {
       "name": "fulfillments",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -843,7 +853,8 @@
     "recommendedName": "orders",
     "resourceConfig": {
       "name": "orders",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -927,7 +938,8 @@
     "recommendedName": "order_agreements",
     "resourceConfig": {
       "name": "order_agreements",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1011,7 +1023,8 @@
     "recommendedName": "order_metafields",
     "resourceConfig": {
       "name": "order_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1095,7 +1108,8 @@
     "recommendedName": "order_transactions",
     "resourceConfig": {
       "name": "order_transactions",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1179,7 +1193,8 @@
     "recommendedName": "order_refunds",
     "resourceConfig": {
       "name": "order_refunds",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1263,7 +1278,8 @@
     "recommendedName": "order_risks",
     "resourceConfig": {
       "name": "order_risks",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1347,7 +1363,8 @@
     "recommendedName": "inventory_items",
     "resourceConfig": {
       "name": "inventory_items",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1431,7 +1448,8 @@
     "recommendedName": "inventory_levels",
     "resourceConfig": {
       "name": "inventory_levels",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1515,7 +1533,8 @@
     "recommendedName": "custom_collections",
     "resourceConfig": {
       "name": "custom_collections",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1599,7 +1618,8 @@
     "recommendedName": "smart_collections",
     "resourceConfig": {
       "name": "smart_collections",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1683,7 +1703,8 @@
     "recommendedName": "custom_collection_metafields",
     "resourceConfig": {
       "name": "custom_collection_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1767,7 +1788,8 @@
     "recommendedName": "smart_collection_metafields",
     "resourceConfig": {
       "name": "smart_collection_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1851,7 +1873,8 @@
     "recommendedName": "locations",
     "resourceConfig": {
       "name": "locations",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {
@@ -1935,7 +1958,8 @@
     "recommendedName": "location_metafields",
     "resourceConfig": {
       "name": "location_metafields",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "schedule": ""
     },
     "documentSchema": {
       "$defs": {

--- a/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -136,7 +136,6 @@
     },
     "resourceConfigSchema": {
       "additionalProperties": false,
-      "description": "ResourceConfig is a common resource configuration shape.",
       "properties": {
         "_meta": {
           "anyOf": [
@@ -162,12 +161,19 @@
           "format": "duration",
           "title": "Interval",
           "type": "string"
+        },
+        "schedule": {
+          "default": "",
+          "description": "Schedule to automatically rebackfill this binding. Accepts a cron expression.",
+          "pattern": "^((?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?)(?:,(?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?))*)\\s+((?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?)(?:,(?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?))*)\\s+((?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?)(?:,(?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?))*)\\s+((?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?)(?:,(?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?))*)\\s+((?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?)(?:,(?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?))*)$|^$",
+          "title": "Schedule",
+          "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "title": "ResourceConfig",
+      "title": "ResourceConfigWithSchedule",
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-shopify-native",

--- a/source-shopify-native/tests/test_snapshots.py
+++ b/source-shopify-native/tests/test_snapshots.py
@@ -43,20 +43,35 @@ def test_capture(request, snapshot):
     assert result.returncode == 0
     lines = [json.loads(line) for line in result.stdout.splitlines()]
 
-    unique_stream_lines = []
-    seen = set()
+    # Keep one representative document per stream, preserving first-appearance order.
+    RETURNS_STREAM = "acmeCo/order_returns"
+    chosen: dict[str, list] = {}
+    order: list[str] = []
 
     for line in lines:
         stream, record = line[0], line[1]
-        if stream not in seen:
-            sanitize_tokens(record)
+        if stream not in chosen:
+            chosen[stream] = line
+            order.append(stream)
+        elif (
+            stream == RETURNS_STREAM
+            and not chosen[stream][1].get("returns")
+            and record.get("returns")
+        ):
+            # Prefer the first order that actually has returns so the snapshot
+            # covers the nested return reassembly.
+            chosen[stream] = line
 
-            for field in FIELDS_TO_REDACT:
-                if field in record:
-                    record[field] = "redacted"
+    unique_stream_lines = []
+    for stream in order:
+        record = chosen[stream][1]
+        sanitize_tokens(record)
 
-            unique_stream_lines.append(line)
-            seen.add(stream)
+        for field in FIELDS_TO_REDACT:
+            if field in record:
+                record[field] = "redacted"
+
+        unique_stream_lines.append(chosen[stream])
 
     assert snapshot("capture.stdout.json") == unique_stream_lines
 


### PR DESCRIPTION
**Regression?**

No

**Description:**

This PR's scope includes:
- Updating the capture snapshot with a new baseline because I changed the data in our dev Shopify account used in tests during development of the other features in this PR.
- Preparing for the addition of some new streams. These preparations include:
  - Switching to use `ResourceConfigWithSchedule` so periodic backfills can be scheduled for bindings.
  - Centralizing the sanity check that the API always returns a page cursor when it says there's more pages.
  - Adding a `backfill_incremental_unsorted` function for unsorted incremental streams, like `locations`, `inventory_items`, and `disputes`. This makes it easier for unsorted incremental streams to complete their backfills when they contain lots of records.
- Adding two new streams, including:
  - `disputes`: an unsorted, incremental stream that uses scheduled backfills to capture updates
  - `order_returns`: a sorted, incremental stream that uses bulk queries

Snapshot changes are all expected either due to the re-baselining after changing data in our dev Shopify account, the switch to use `ResourceConfigWithSchedule`, or the addition of the two new streams.

**Documentation links affected:**

The connector's documentation should be updated to reflect:
- The addition of the new `schedule` field for resource configs.
- The two new streams, `disputes` and `order_returns`
- The scopes required to capture data for those two new streams.

**Notes for reviewers:**

I was able to test out that `order_returns` works, and you can see evidence of that in the `order_returns` document included in the capture snapshot. I was unable to create any `disputes` documents in our dev Shopify account, so I was unable to verify this stream works with actual responses from the API. After merging this PR, I plan to keep a close eye on any captures that discover & use the `disputes` stream to ensure it works as anticipated.

Best reviewed commit-by-commit.