### PR TITLE
"observable" logs for backfills and column migrations

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -21,6 +21,7 @@ from typing_extensions import override
 from pydantic import AwareDatetime, BaseModel, Field, NonNegativeInt
 
 from ..cron import next_fire
+from ..logger import OBSERVABLE_FIELD
 from ..flow import (
     AccessToken,
     AuthorizationCodeFlowOAuth2Credentials,
@@ -1113,7 +1114,12 @@ async def _binding_backfill_task(
     if state.next_page is not None:
         task.log.info("resuming backfill", {"state": state, "subtask_id": subtask_id})
     else:
-        task.log.info("beginning backfill", {"state": state, "subtask_id": subtask_id})
+        # Marked observable so backfill activity can be aggregated fleet-wide.
+        task.log.info(
+            "beginning backfill",
+            {"state": state, "subtask_id": subtask_id},
+            extra={OBSERVABLE_FIELD: True},
+        )
 
     while True:
         # Yield to the event loop to prevent starvation.

--- a/estuary-cdk/estuary_cdk/logger.py
+++ b/estuary-cdk/estuary_cdk/logger.py
@@ -40,6 +40,14 @@ class LogFormatter(logging.Formatter):
         return OpsLog(level=record.levelname, msg=record.msg, fields=fields).model_dump_json()
 
 
+# Boolean log field set to True on log lines we aggregate across the whole
+# connector fleet as health indicators (e.g. backfills triggered). An observable
+# log line is an otherwise-normal log line that additionally carries this field,
+# so that downstream aggregation can select observable logs without matching on
+# free-form messages. Go connectors set the same "observable" field directly.
+OBSERVABLE_FIELD = "observable"
+
+
 class EventLogger:
     def __init__(self, logger: logging.Logger):
         self._logger = logger

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -538,6 +538,16 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 			return nil, err
 		}
 
+		// Observable log for fleet-wide aggregation of backfill activity. Each
+		// binding in backfillBindings is having its backfill counter incremented,
+		// which triggers a backfill of that resource.
+		log.WithFields(log.Fields{
+			"observable":      true,
+			"materialization": req.Materialization.Name.String(),
+			"resource_path":   strings.Join(req.Materialization.Bindings[bindingIdx].ResourcePath, "."),
+			"backfill":        req.Materialization.Bindings[bindingIdx].Backfill,
+		}).Info("backfill triggered")
+
 		// If the existing resource is compatible with the proposed binding spec
 		// without incrementing the backfill counter, it only needs to be
 		// truncated rather than fully dropping and re-creating the table.
@@ -659,6 +669,15 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 					From: *existingField,
 					To:   p,
 				})
+				// Observable log for fleet-wide aggregation of column migrations by type.
+				log.WithFields(log.Fields{
+					"observable":      true,
+					"materialization": req.Materialization.Name.String(),
+					"resource_path":   strings.Join(mb.ResourcePath, "."),
+					"field":           p.Field,
+					"fromType":        existingField.Type,
+					"toType":          p.Mapped.String(),
+				}).Info("migrating column type")
 			} else if !p.Mapped.Compatible(*existingField) {
 				// This is mostly a sanity check that some other process (user
 				// modifications, perhaps) didn't change the type of a column in

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -484,6 +484,21 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 			return fmt.Errorf("invalid backfill mode %q for stream %q", binding.Resource.Mode, streamID)
 		}
 
+		// Emit an observable log whenever a stream enters a backfilling state.
+		// This only runs for streams currently in the Pending state, so it fires
+		// once when a backfill begins — both for newly-added streams and for
+		// streams whose state was reset to re-trigger a backfill. Observable logs
+		// are otherwise-normal log lines carrying "observable": true, used for
+		// fleet-wide aggregation of backfill activity.
+		switch state.Mode {
+		case TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill:
+			log.WithFields(log.Fields{
+				"observable": true,
+				"stream":     streamID.String(),
+				"mode":       string(binding.Resource.Mode),
+			}).Info("backfill triggered")
+		}
+
 		// Log an informational notice if the key we'll be using for a backfill differs from
 		// the discovered primary key of a table.
 		if state.Mode == TableStatePreciseBackfill || state.Mode == TableStateUnfilteredBackfill {


### PR DESCRIPTION
**Description:**

- add a few observable logs to begin with: backfills and column migrations. This allows us to get a sense of how many backfills and column migrations we are running, and from the task name we can infer the connector to see if a specific connector is doing it too much. We can create dashboards for these in Grafana.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

