### PR TITLE
materializations: first round of synchronous StartedCommit

### DIFF
--- a/materialize-azure-fabric-warehouse/transactor.go
+++ b/materialize-azure-fabric-warehouse/transactor.go
@@ -281,83 +281,81 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
 		}
 
-		return nil, m.RunAsyncOperation(func() error {
-			defer t.storeFiles.CleanupCurrentTransaction(ctx)
+		defer t.storeFiles.CleanupCurrentTransaction(ctx)
 
-			db, err := t.cfg.db()
+		db, err := t.cfg.db()
+		if err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("creating db: %w", err))
+		}
+		defer db.Close()
+
+		txn, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("store BeginTx: %w", err))
+		}
+		defer txn.Rollback()
+
+		for idx, b := range t.bindings {
+			if !t.storeFiles.Started(idx) {
+				continue
+			}
+
+			uris, err := t.storeFiles.Flush(idx)
 			if err != nil {
-				return fmt.Errorf("creating db: %w", err)
-			}
-			defer db.Close()
-
-			txn, err := db.BeginTx(ctx, nil)
-			if err != nil {
-				return fmt.Errorf("store BeginTx: %w", err)
-			}
-			defer txn.Rollback()
-
-			for idx, b := range t.bindings {
-				if !t.storeFiles.Started(idx) {
-					continue
-				}
-
-				uris, err := t.storeFiles.Flush(idx)
-				if err != nil {
-					return fmt.Errorf("flushing store file for binding[%d]: %w", idx, err)
-				}
-
-				params := &queryParams{
-					Table:             b.target,
-					URIs:              uris,
-					StorageAccountKey: t.cfg.StorageAccountKey,
-					Bounds:            b.store.mergeBounds.Build(),
-				}
-
-				t.be.StartedResourceCommit(b.target.Path)
-				if b.store.mustMerge {
-					var mergeQuery strings.Builder
-					if err := t.templates.storeMergeQuery.Execute(&mergeQuery, params); err != nil {
-						return err
-					} else if _, err := txn.ExecContext(ctx, mergeQuery.String()); err != nil {
-						log.WithField(
-							"query", redactedQuery(mergeQuery, t.cfg.StorageAccountKey),
-						).Error("merge query failed")
-						return fmt.Errorf("executing store merge query for binding[%d]: %w", idx, err)
-					}
-				} else {
-					var copyIntoQuery strings.Builder
-					tpl := t.templates.storeCopyIntoDirectQuery
-					if b.hasBinaryColumns {
-						tpl = t.templates.storeCopyIntoFromStagedQuery
-					}
-
-					if err := tpl.Execute(&copyIntoQuery, params); err != nil {
-						return err
-					} else if _, err := txn.ExecContext(ctx, copyIntoQuery.String()); err != nil {
-						log.WithField(
-							"query", redactedQuery(copyIntoQuery, t.cfg.StorageAccountKey),
-						).Error("copy into query failed")
-						return fmt.Errorf("executing store copy into query for binding[%d]: %w", idx, err)
-					}
-				}
-				t.be.FinishedResourceCommit(b.target.Path)
-				b.store.mustMerge = false
+				return nil, m.FinishedOperation(fmt.Errorf("flushing store file for binding[%d]: %w", idx, err))
 			}
 
-			if res, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
-				return fmt.Errorf("updating checkpoints: %w", err)
-			} else if rows, err := res.RowsAffected(); err != nil {
-				return fmt.Errorf("getting fence update rows affected: %w", err)
-			} else if rows != 1 {
-				return fmt.Errorf("this instance was fenced off by another")
-			} else if err := txn.Commit(); err != nil {
-				return fmt.Errorf("committing store transaction: %w", err)
-			} else if err := t.storeFiles.CleanupCurrentTransaction(ctx); err != nil {
-				return fmt.Errorf("cleaning up temporary object files: %w", err)
+			params := &queryParams{
+				Table:             b.target,
+				URIs:              uris,
+				StorageAccountKey: t.cfg.StorageAccountKey,
+				Bounds:            b.store.mergeBounds.Build(),
 			}
 
-			return nil
-		})
+			t.be.StartedResourceCommit(b.target.Path)
+			if b.store.mustMerge {
+				var mergeQuery strings.Builder
+				if err := t.templates.storeMergeQuery.Execute(&mergeQuery, params); err != nil {
+					return nil, m.FinishedOperation(err)
+				} else if _, err := txn.ExecContext(ctx, mergeQuery.String()); err != nil {
+					log.WithField(
+						"query", redactedQuery(mergeQuery, t.cfg.StorageAccountKey),
+					).Error("merge query failed")
+					return nil, m.FinishedOperation(fmt.Errorf("executing store merge query for binding[%d]: %w", idx, err))
+				}
+			} else {
+				var copyIntoQuery strings.Builder
+				tpl := t.templates.storeCopyIntoDirectQuery
+				if b.hasBinaryColumns {
+					tpl = t.templates.storeCopyIntoFromStagedQuery
+				}
+
+				if err := tpl.Execute(&copyIntoQuery, params); err != nil {
+					return nil, m.FinishedOperation(err)
+				} else if _, err := txn.ExecContext(ctx, copyIntoQuery.String()); err != nil {
+					log.WithField(
+						"query", redactedQuery(copyIntoQuery, t.cfg.StorageAccountKey),
+					).Error("copy into query failed")
+					return nil, m.FinishedOperation(fmt.Errorf("executing store copy into query for binding[%d]: %w", idx, err))
+				}
+			}
+			t.be.FinishedResourceCommit(b.target.Path)
+			b.store.mustMerge = false
+		}
+
+		if res, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating checkpoints: %w", err))
+		} else if rows, err := res.RowsAffected(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("getting fence update rows affected: %w", err))
+		} else if rows != 1 {
+			return nil, m.FinishedOperation(fmt.Errorf("this instance was fenced off by another"))
+		} else if err := txn.Commit(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("committing store transaction: %w", err))
+		} else if err := t.storeFiles.CleanupCurrentTransaction(ctx); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("cleaning up temporary object files: %w", err))
+		}
+
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-bigtable/transactor.go
+++ b/materialize-bigtable/transactor.go
@@ -289,14 +289,12 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		return nil, fmt.Errorf("marshalling state: %w", err)
 	}
 
-	return func(_ context.Context, _ *pc.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return &pf.ConnectorState{UpdatedJson: newState}, m.RunAsyncOperation(func() error {
-			if err := group.Wait(); err != nil {
-				return fmt.Errorf("draining store workers: %w", err)
-			}
+	if err := group.Wait(); err != nil {
+		return nil, fmt.Errorf("draining store workers: %w", err)
+	}
 
-			return nil
-		})
+	return func(_ context.Context, _ *pc.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
+		return &pf.ConnectorState{UpdatedJson: newState}, nil
 	}, nil
 }
 

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -855,61 +855,59 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	defuser.Defuse()
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return nil, m.RunAsyncOperation(func() error {
-			defer txn.Rollback()
+		defer txn.Rollback()
 
-			for _, b := range d.bindings {
-				d.be.StartedResourceCommit(b.target.Path)
-				if b.mustDelete {
-					// Apply any deletions
-					if _, err := txn.ExecContext(ctx, b.deleteQuerySQL); err != nil {
-						return fmt.Errorf("running DELETE USING for %q: %w", b.target.Identifier, err)
-					} else if _, err := txn.ExecContext(ctx, b.deleteTruncateSQL); err != nil {
-						return fmt.Errorf("truncating delete table for %q: %w", b.target.Identifier, err)
-					}
-
-					b.mustDelete = false
+		for _, b := range d.bindings {
+			d.be.StartedResourceCommit(b.target.Path)
+			if b.mustDelete {
+				// Apply any deletions
+				if _, err := txn.ExecContext(ctx, b.deleteQuerySQL); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("running DELETE USING for %q: %w", b.target.Identifier, err))
+				} else if _, err := txn.ExecContext(ctx, b.deleteTruncateSQL); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("truncating delete table for %q: %w", b.target.Identifier, err))
 				}
 
-				if b.mustMerge {
-					// Merge data from the temporary staging table into the target table, replacing keys
-					// that already exist.
-					if _, err := txn.ExecContext(ctx, b.updateReplaceSQL); err != nil {
-						return fmt.Errorf("running REPLACE INTO for %q: %w", b.target.Identifier, err)
-					} else if _, err := txn.ExecContext(ctx, b.updateTruncateSQL); err != nil {
-						return fmt.Errorf("truncating update table for %q: %w", b.target.Identifier, err)
-					}
+				b.mustDelete = false
+			}
 
-					// Reset for the next round.
-					b.mustMerge = false
+			if b.mustMerge {
+				// Merge data from the temporary staging table into the target table, replacing keys
+				// that already exist.
+				if _, err := txn.ExecContext(ctx, b.updateReplaceSQL); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("running REPLACE INTO for %q: %w", b.target.Identifier, err))
+				} else if _, err := txn.ExecContext(ctx, b.updateTruncateSQL); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("truncating update table for %q: %w", b.target.Identifier, err))
 				}
-				d.be.FinishedResourceCommit(b.target.Path)
-			}
 
-			var err error
-			if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
-				return fmt.Errorf("marshalling checkpoint: %w", err)
+				// Reset for the next round.
+				b.mustMerge = false
 			}
+			d.be.FinishedResourceCommit(b.target.Path)
+		}
 
-			var fenceUpdate strings.Builder
-			if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
-				return fmt.Errorf("evaluating fence template: %w", err)
-			}
+		var err error
+		if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
+		}
 
-			if results, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
-				return fmt.Errorf("updating flow checkpoint: %w", err)
-			} else if rowsAffected, err := results.RowsAffected(); err != nil {
-				return fmt.Errorf("updating flow checkpoint (rows affected): %w", err)
-			} else if rowsAffected < 1 {
-				return fmt.Errorf("This instance was fenced off by another")
-			}
+		var fenceUpdate strings.Builder
+		if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
+		}
 
-			if err := txn.Commit(); err != nil {
-				return fmt.Errorf("committing Store transaction: %w", err)
-			}
+		if results, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint: %w", err))
+		} else if rowsAffected, err := results.RowsAffected(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint (rows affected): %w", err))
+		} else if rowsAffected < 1 {
+			return nil, m.FinishedOperation(fmt.Errorf("This instance was fenced off by another"))
+		}
 
-			return nil
-		})
+		if err := txn.Commit(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("committing Store transaction: %w", err))
+		}
+
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -984,69 +984,67 @@ func (t *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	// Return the StartCommit function
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return nil, m.RunAsyncOperation(func() error {
-			commitStart := time.Now()
-			var commitDuration time.Duration
+		commitStart := time.Now()
+		var commitDuration time.Duration
 
-			defer func() {
-				storeDuration := time.Since(storeStart)
-				commitDuration = time.Since(commitStart)
+		defer func() {
+			storeDuration := time.Since(storeStart)
+			commitDuration = time.Since(commitStart)
 
-				log.WithFields(log.Fields{
-					"totalDuration":       storeDuration.Seconds(),
-					"storePhaseDuration":  (storeDuration - commitDuration).Seconds(),
-					"commitPhaseDuration": commitDuration.Seconds(),
-					"storeCount":          storeCount,
-					"storeBytes":          storeBytes,
-					"numBatches":          flusher.getBatchCount(),
-				}).Info("store: phase complete")
-			}()
+			log.WithFields(log.Fields{
+				"totalDuration":       storeDuration.Seconds(),
+				"storePhaseDuration":  (storeDuration - commitDuration).Seconds(),
+				"commitPhaseDuration": commitDuration.Seconds(),
+				"storeCount":          storeCount,
+				"storeBytes":          storeBytes,
+				"numBatches":          flusher.getBatchCount(),
+			}).Info("store: phase complete")
+		}()
 
-			// Marshal the checkpoint
-			checkpointBytes, err := runtimeCheckpoint.Marshal()
-			if err != nil {
-				return fmt.Errorf("marshalling checkpoint: %w", err)
-			}
+		// Marshal the checkpoint
+		checkpointBytes, err := runtimeCheckpoint.Marshal()
+		if err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
+		}
 
-			// Update the fence checkpoint
-			t.fence.Checkpoint = checkpointBytes
+		// Update the fence checkpoint
+		t.fence.Checkpoint = checkpointBytes
 
-			// Add fence update mutation to the current batch
-			// Use the standard checkpoint table name
-			fenceValues := []interface{}{
-				t.fence.Materialization.String(),
-				int64(t.fence.KeyBegin), // Convert uint32 to int64
-				int64(t.fence.KeyEnd),   // Convert uint32 to int64
-				int64(t.fence.Fence),    // Convert uint64 to int64
-				base64.StdEncoding.EncodeToString(checkpointBytes),
-			}
-			fenceMutation := spanner.InsertOrUpdate(
-				sql.DefaultFlowCheckpoints,
-				[]string{"materialization", "key_begin", "key_end", "fence", "checkpoint"},
-				fenceValues,
-			)
+		// Add fence update mutation to the current batch
+		// Use the standard checkpoint table name
+		fenceValues := []interface{}{
+			t.fence.Materialization.String(),
+			int64(t.fence.KeyBegin), // Convert uint32 to int64
+			int64(t.fence.KeyEnd),   // Convert uint32 to int64
+			int64(t.fence.Fence),    // Convert uint64 to int64
+			base64.StdEncoding.EncodeToString(checkpointBytes),
+		}
+		fenceMutation := spanner.InsertOrUpdate(
+			sql.DefaultFlowCheckpoints,
+			[]string{"materialization", "key_begin", "key_end", "fence", "checkpoint"},
+			fenceValues,
+		)
 
-			// Flush all data partitions first (before fence)
-			nonEmptyPartitions := flusher.partitionedBatch.getNonEmptyPartitions()
-			if err := flusher.flushPartitionsAsync(nonEmptyPartitions); err != nil {
-				return fmt.Errorf("flushing remaining partitions during commit: %w", err)
-			}
+		// Flush all data partitions first (before fence)
+		nonEmptyPartitions := flusher.partitionedBatch.getNonEmptyPartitions()
+		if err := flusher.flushPartitionsAsync(nonEmptyPartitions); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("flushing remaining partitions during commit: %w", err))
+		}
 
-			// Wait for all data flushes to complete
-			if err := flusher.wait(); err != nil {
-				return fmt.Errorf("flushing data mutations: %w", err)
-			}
+		// Wait for all data flushes to complete
+		if err := flusher.wait(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("flushing data mutations: %w", err))
+		}
 
-			// Apply fence mutation separately after all data succeeds
-			// This ensures data is never committed without the checkpoint update
-			if _, _, err := t.timedSpannerApply(ctx, []*spanner.Mutation{fenceMutation}, "store-fence"); err != nil {
-				return fmt.Errorf("applying fence checkpoint: %w", err)
-			}
+		// Apply fence mutation separately after all data succeeds
+		// This ensures data is never committed without the checkpoint update
+		if _, _, err := t.timedSpannerApply(ctx, []*spanner.Mutation{fenceMutation}, "store-fence"); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("applying fence checkpoint: %w", err))
+		}
 
-			log.WithField("batches", flusher.getBatchCount()).Info("store: completed all mutation batches")
+		log.WithField("batches", flusher.getBatchCount()).Info("store: completed all mutation batches")
 
-			return nil
-		})
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -384,14 +384,12 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 	}
 
-	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return nil, m.RunAsyncOperation(func() error {
-			if err = txn.Commit(); err != nil {
-				return fmt.Errorf("commit transaction: %w", err)
-			}
+	if err := txn.Commit(); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
 
-			return nil
-		})
+	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -697,59 +697,57 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 	defuser.Defuse()
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return nil, m.RunAsyncOperation(func() error {
-			defer txn.Rollback()
+		defer txn.Rollback()
 
-			for _, b := range d.bindings {
-				if !b.hasData {
-					continue
+		for _, b := range d.bindings {
+			if !b.hasData {
+				continue
+			}
+
+			d.be.StartedResourceCommit(b.target.Path)
+			if b.needsMerge {
+				if _, err := txn.ExecContext(ctx, b.mergeInto); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("store batch merge on %q: %w", b.target.Identifier, err))
 				}
-
-				d.be.StartedResourceCommit(b.target.Path)
-				if b.needsMerge {
-					if _, err := txn.ExecContext(ctx, b.mergeInto); err != nil {
-						return fmt.Errorf("store batch merge on %q: %w", b.target.Identifier, err)
-					}
-				} else {
-					if _, err := txn.ExecContext(ctx, b.directCopy); err != nil {
-						return fmt.Errorf("store batch direct insert on %q: %w", b.target.Identifier, err)
-					}
+			} else {
+				if _, err := txn.ExecContext(ctx, b.directCopy); err != nil {
+					return nil, m.FinishedOperation(fmt.Errorf("store batch direct insert on %q: %w", b.target.Identifier, err))
 				}
-
-				if _, err = txn.ExecContext(ctx, b.tempStoreTruncate); err != nil {
-					return fmt.Errorf("truncating store table: %w", err)
-				}
-				d.be.FinishedResourceCommit(b.target.Path)
-
-				// reset the value for next transaction
-				b.needsMerge = false
-				b.hasData = false
 			}
 
-			var err error
-			if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
-				return fmt.Errorf("marshalling checkpoint: %w", err)
+			if _, err = txn.ExecContext(ctx, b.tempStoreTruncate); err != nil {
+				return nil, m.FinishedOperation(fmt.Errorf("truncating store table: %w", err))
 			}
+			d.be.FinishedResourceCommit(b.target.Path)
 
-			var fenceUpdate strings.Builder
-			if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
-				return fmt.Errorf("evaluating fence template: %w", err)
-			}
+			// reset the value for next transaction
+			b.needsMerge = false
+			b.hasData = false
+		}
 
-			if results, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
-				return fmt.Errorf("updating flow checkpoint: %w", err)
-			} else if rowsAffected, err := results.RowsAffected(); err != nil {
-				return fmt.Errorf("updating flow checkpoint (rows affected): %w", err)
-			} else if rowsAffected < 1 {
-				return fmt.Errorf("This instance was fenced off by another")
-			}
+		var err error
+		if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
+		}
 
-			if err := txn.Commit(); err != nil {
-				return fmt.Errorf("committing Store transaction: %w", err)
-			}
+		var fenceUpdate strings.Builder
+		if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
+		}
 
-			return nil
-		})
+		if results, err := txn.ExecContext(ctx, fenceUpdate.String()); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint: %w", err))
+		} else if rowsAffected, err := results.RowsAffected(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint (rows affected): %w", err))
+		} else if rowsAffected < 1 {
+			return nil, m.FinishedOperation(fmt.Errorf("This instance was fenced off by another"))
+		}
+
+		if err := txn.Commit(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("committing Store transaction: %w", err))
+		}
+
+		return nil, nil
 	}, nil
 }
 


### PR DESCRIPTION
**Description:**

For compatibility with the V2 runtime, materialization connectors must ensure all of the effects of the current transaction are durable before their `StartCommit` function returns.

Connectors that follow the post-commit apply pattern already do this naturally, since they stage files and reference them in their returned checkpoints.

However, remote-authoritative materializations must be modified to finish their commits in the destination system before returning from `StartCommit`, rather than as an asynchronous operation.

There are throughput and latency implications to this change for these connectors, since it means they cannot read the Load requests for the next transaction while waiting for the current one to finish. Some remote-authoritative connectors like `materialize-postgres` will be relatively unaffected, since they already do most of the work while reading `Store` requests. Others, like `materialize-motherduck` and `materialize-redshift`, which do comparatively lightweight staging of files during `Store` and then run the data-storing queries in the asynchronous function returned from `StartCommit`, will be more impacted. That said, it may end up being a wash or even a net benefit, since the V2 runtime is generally more performant.

In the future we may convert `materialize-redshift`, `materialize-motherduck`, and `materialize-azure-fabric-warehouse` to something more like a post-commit apply strategy, both to improve transaction pipelining and to enable scale-out.

This is an initial round of changes that includes a handful of lesser-used connectors. Because the change is mechanical, I don't think there's much risk in doing them all at once, but it can't hurt to split them up a little. Subsequent PRs will modify the remaining connectors that still need updating (motherduck, postgres, and redshift), and will eventually simplify the `StartCommit` function signature to drop the `OpFuture` return value that is no longer needed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

