### PR TITLE
materializations: second round of synchronous StartedCommit

### DIFF
--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -342,7 +342,11 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
 		}
 
-		return nil, m.RunAsyncOperation(func() error { return d.commit(ctx, fenceUpdate.String()) })
+		if err := d.commit(ctx, fenceUpdate.String()); err != nil {
+			return nil, m.FinishedOperation(err)
+		}
+
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -665,46 +665,44 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 	defuser.Defuse()
 	return func(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (*pf.ConnectorState, m.OpFuture) {
-		return nil, m.RunAsyncOperation(func() error {
-			defer txn.Rollback(ctx)
+		defer txn.Rollback(ctx)
 
-			var err error
-			if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
-				return fmt.Errorf("marshalling checkpoint: %w", err)
-			}
+		var err error
+		if d.store.fence.Checkpoint, err = runtimeCheckpoint.Marshal(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
+		}
 
-			var fenceUpdate strings.Builder
-			if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
-				return fmt.Errorf("evaluating fence template: %w", err)
-			}
+		var fenceUpdate strings.Builder
+		if err := d.templates.updateFence.Execute(&fenceUpdate, d.store.fence); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
+		}
 
-			// Add the update to the fence as the last statement in the batch.
-			batch.Queue(fenceUpdate.String())
+		// Add the update to the fence as the last statement in the batch.
+		batch.Queue(fenceUpdate.String())
 
-			results := txn.SendBatch(ctx, &batch)
+		results := txn.SendBatch(ctx, &batch)
 
-			// Execute all remaining doc inserts & updates.
-			for i := 0; i < batch.Len()-1; i++ {
-				if _, err := results.Exec(); err != nil {
-					return fmt.Errorf("store at index %d: %w", i, err)
-				}
-			}
-
-			// The fence update is always the last operation in the batch.
+		// Execute all remaining doc inserts & updates.
+		for i := 0; i < batch.Len()-1; i++ {
 			if _, err := results.Exec(); err != nil {
-				return fmt.Errorf("updating flow checkpoint: %w", err)
-			} else if err = results.Close(); err != nil {
-				return fmt.Errorf("results.Close(): %w", err)
+				return nil, m.FinishedOperation(fmt.Errorf("store at index %d: %w", i, err))
 			}
+		}
 
-			commitCtx, cancel := ctxWithQueryTimeout(ctx)
-			defer cancel()
-			if err := txn.Commit(commitCtx); err != nil {
-				return fmt.Errorf("committing Store transaction: %w", err)
-			}
+		// The fence update is always the last operation in the batch.
+		if _, err := results.Exec(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint: %w", err))
+		} else if err = results.Close(); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("results.Close(): %w", err))
+		}
 
-			return nil
-		})
+		commitCtx, cancel := ctxWithQueryTimeout(ctx)
+		defer cancel()
+		if err := txn.Commit(commitCtx); err != nil {
+			return nil, m.FinishedOperation(fmt.Errorf("committing Store transaction: %w", err))
+		}
+
+		return nil, nil
 	}, nil
 }
 

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -767,7 +767,11 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil, m.FinishedOperation(fmt.Errorf("marshalling checkpoint: %w", err))
 		}
 
-		return nil, pf.RunAsyncOperation(func() error { return d.commit(ctx, varcharColumnUpdates) })
+		if err := d.commit(ctx, varcharColumnUpdates); err != nil {
+			return nil, pf.FinishedOperation(err)
+		}
+
+		return nil, nil
 	}, nil
 }
 


### PR DESCRIPTION
**Description:**

This covers the remaining remote-authoritative connectors: `materialize-postgres`, `materialize-motherduck`, and `materialize-redshift`. They were held back from the first round as the more heavily used of the affected connectors, so they could land on their own.

See: https://github.com/estuary/connectors/pull/4659

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

