### PR TITLE
materialize-iceberg: fix Glue optimizer region for IAM auth

### DIFF
--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -641,7 +641,7 @@ func (c config) toGlueClient(ctx context.Context) (*glue.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		region = catalogAuth.AWSRegion
+		region = catalogAuth.IAMConfig.AWSRegion
 	default:
 		return nil, fmt.Errorf("Glue optimizers require AWS credentials (SigV4 or IAM), not %q", catalogAuth.AuthType)
 	}


### PR DESCRIPTION
**Description:**

This only surfaced for configs with Glue table optimizers enabled. toGlueClient is the only AWS client built from the catalog credentials, and it read the region via the bare catalogAuth.AWSRegion selector. Because catalogAuthConfig embeds both the SigV4 and IAM config structs (which each carry an aws_region field), that selector resolves to the SigV4 field, which is never populated under IAM auth. The Glue client was therefore built without a region and GetTableOptimizer failed with "Missing Region". Read the region from the IAM config explicitly, matching what toCatalog already does.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

