### PR TITLE
source-sqlserver-ct: Detect replicas and incoherent CT metadata

### DIFF
--- a/source-sqlserver-ct/prerequisites.go
+++ b/source-sqlserver-ct/prerequisites.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/estuary/connectors/go/capture/sqlserver/backfill"
 	"github.com/estuary/connectors/go/capture/sqlserver/version"
@@ -19,6 +20,7 @@ func (db *sqlserverDatabase) SetupPrerequisites(ctx context.Context) []error {
 	}
 
 	var checks = []func(ctx context.Context) error{
+		db.prerequisiteWritableDatabase,
 		db.prerequisiteCTEnabled,
 		db.prerequisiteConnectionEncryption,
 	}
@@ -82,6 +84,22 @@ func isCTEnabled(ctx context.Context, conn *sql.DB) (bool, error) {
 		return false, fmt.Errorf("unable to query Change Tracking status: %w", err)
 	}
 	return version.Valid, nil
+}
+
+// prerequisiteWritableDatabase verifies that the connector is not connected to a read-only
+// database. Change Tracking data must always be captured from the primary replica, and the
+// Change Tracking metadata can be incoherent on a secondary.
+func (db *sqlserverDatabase) prerequisiteWritableDatabase(ctx context.Context) error {
+	var updateability sql.NullString
+	const query = `SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Updateability') AS NVARCHAR(128));`
+	if err := db.conn.QueryRowContext(ctx, query).Scan(&updateability); err != nil {
+		log.WithField("err", err).Warn("unable to query database updateability")
+		return nil
+	}
+	if updateability.Valid && strings.EqualFold(strings.TrimSpace(updateability.String), "READ_ONLY") {
+		return fmt.Errorf("Change Tracking captures must target the primary writable database instance, but database %q is read-only", db.config.Database)
+	}
+	return nil
 }
 
 func (db *sqlserverDatabase) prerequisiteConnectionEncryption(ctx context.Context) error {

--- a/source-sqlserver-ct/replication.go
+++ b/source-sqlserver-ct/replication.go
@@ -251,10 +251,21 @@ func (rs *sqlserverCTReplicationStream) pollChanges(ctx context.Context, toVersi
 	var tablesToPoll []*ctTablePollInfo
 	for streamID, info := range rs.tables {
 		fromVersion := rs.tableVersions[streamID]
+		minValid, ctEnabled := minValidVersions[streamID]
+
+		// Sanity check that the table's minValid < toVersion. This should always hold on a
+		// healthy primary since changes cannot be cleaned up before they exist and toVersion
+		// is just a recent `CHANGE_TRACKING_CURRENT_VERSION()`.
+		//
+		// A violation means we're trying to capture from some sort of incoherent replica
+		// setup which our prerequisites failed to catch.
+		if ctEnabled && toVersion < minValid {
+			return fmt.Errorf("inconsistent change tracking metadata for table %q: current version %d is below min valid version %d, which should be impossible on the primary database", streamID, toVersion, minValid)
+		}
 
 		// Check that the table still has change tracking enabled and data hasn't expired
 		var invalidCause error
-		if minValid, ok := minValidVersions[streamID]; !ok {
+		if !ctEnabled {
 			invalidCause = fmt.Errorf("change tracking no longer enabled for table %q", streamID)
 		} else if fromVersion < minValid {
 			invalidCause = fmt.Errorf("change tracking data expired for table %q (version %d < min valid %d)", streamID, fromVersion, minValid)


### PR DESCRIPTION
**Description:**

Change Tracking must be captured from the primary writable database. I was under the impression that our existing prerequisites ought to error out on a replica but apparently they don't, and actually trying to capture from a replica leads to pain as the version metadata is incoherent in a way which resulted in repeatedly backfilling all tables over and over.

Adds a prerequisite check that fails when DATABASEPROPERTYEX reports the database is read-only, so the misconfiguration is reported to the user up front.

Also adds an internal sanity check in pollChanges that errors out if the current version is below any table's min valid version, so that any future cases of incoherent replicas not caught by the prerequisite check might fail cleanly instead of repeatedly backfilling.

**Documentation links affected:**

We need to update the SQL Server CT documentation to note the primary-DB requirement but that isn't really affected by this, that was always the requirement.
