### PR TITLE
source-shopify-native: make `disputeEvidence` a `ConditionalField`

### DIFF
--- a/source-shopify-native/source_shopify_native/graphql/disputes.py
+++ b/source-shopify-native/source_shopify_native/graphql/disputes.py
@@ -2,7 +2,12 @@ from datetime import datetime
 
 from pydantic import AwareDatetime
 
-from ..models import ShopifyGraphQLResource, StoreCapabilities
+from ..models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    StoreCapabilities,
+    requires_any_scope,
+)
 from ..utils import dt_to_str, str_to_dt
 
 
@@ -39,7 +44,16 @@ class Disputes(ShopifyGraphQLResource):
         id
         legacyResourceId
     }
-    disputeEvidence {
+    # {{ disputeEvidence }}
+    """
+    # disputeEvidence requires the read_shopify_payments_dispute_evidences scope, which is
+    # distinct from the read_shopify_payments_disputes scope that gates the stream itself. A
+    # store can grant disputes access without granting evidence access, so query this block
+    # only when the evidence scope is present.
+    CONDITIONAL_FIELDS = [
+        ConditionalField(
+            placeholder="# {{ disputeEvidence }}",
+            fields="""disputeEvidence {
         id
         accessActivityLog
         cancellationPolicyDisclosure
@@ -149,8 +163,12 @@ class Disputes(ShopifyGraphQLResource):
             shippingDate
             shippingTrackingNumber
         }
-    }
-    """
+    }""",
+            is_available=requires_any_scope(
+                "read_shopify_payments_dispute_evidences"
+            ),
+        ),
+    ]
 
     def get_cursor_value(self) -> AwareDatetime:
         raw_value = getattr(self, "initiatedAt")
@@ -175,6 +193,7 @@ class Disputes(ShopifyGraphQLResource):
     ) -> str:
         lower_bound = dt_to_str(start)
         upper_bound = dt_to_str(end)
+        query_body = Disputes._resolve_conditional_fields(capabilities)
         return f"""
         {{
             disputes(
@@ -184,7 +203,7 @@ class Disputes(ShopifyGraphQLResource):
             ) {{
                 edges {{
                     node {{
-                        {Disputes.QUERY}
+                        {query_body}
                     }}
                 }}
                 pageInfo {{

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -50,6 +50,7 @@ scopes = [
     "read_users", # StaffMembers
     "read_returns",  # OrderReturns
     "read_shopify_payments_disputes",  # Disputes
+    "read_shopify_payments_dispute_evidences",  # Disputes.disputeEvidence
     # FulfillmentOrder requires one of the following 4 scopes (not read_fulfillments).
     # See: https://shopify.dev/docs/api/admin-graphql/latest/objects/FulfillmentOrder
     "read_assigned_fulfillment_orders",

--- a/source-shopify-native/tests/test_conditional_fields.py
+++ b/source-shopify-native/tests/test_conditional_fields.py
@@ -7,6 +7,7 @@ from datetime import datetime, UTC
 
 import pytest
 
+from source_shopify_native.graphql.disputes import Disputes
 from source_shopify_native.graphql.orders.orders import Orders
 from source_shopify_native.models import (
     ConditionalField,
@@ -114,6 +115,33 @@ def test_non_comment_placeholder_is_rejected():
             fields="retailLocation { id }",
             is_available=requires_any_scope("read_locations"),
         )
+
+
+def test_disputes_evidence_included_only_with_evidence_scope():
+    with_evidence = Disputes.build_query(
+        START,
+        END,
+        capabilities=StoreCapabilities(
+            scopes=frozenset(
+                {
+                    "read_shopify_payments_disputes",
+                    "read_shopify_payments_dispute_evidences",
+                }
+            )
+        ),
+    )
+    without_evidence = Disputes.build_query(
+        START,
+        END,
+        capabilities=StoreCapabilities(
+            scopes=frozenset({"read_shopify_payments_disputes"})
+        ),
+    )
+
+    assert "disputeEvidence" in with_evidence
+    assert "disputeEvidence" not in without_evidence
+    # The placeholder itself must not leak into the emitted query.
+    assert "{{ disputeEvidence }}" not in without_evidence
 
 
 def test_predicate_can_gate_on_plan_tier():


### PR DESCRIPTION
**Regression?**

No

**Description:**

This PR is a fast follow up to https://github.com/estuary/connectors/pull/4654 that introduced the `disputes` stream.

Turns out that `disputeEvidence` can only be queried when the `read_shopify_payments_dispute_evidences` scope is granted. This means this field need to be a `ConditionalField` that's only included in queries when that specific scope is granted.