### PR TITLE
source-stripe-native: stop logging the expected 404 in access checks

### DIFF
--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -56,6 +56,7 @@ from .priority_capture import (
 DEFAULT_SCHEDULE = "0 0 * * *"
 
 DISABLED_MESSAGE_REGEX = r"Your account is not set up to use"
+ENABLED_RESOURCE_EXPECTED_ERROR_REGEX = r"No such .*: 'invalid_id'"
 
 
 async def check_accessibility(
@@ -82,8 +83,15 @@ async def check_accessibility(
         is_disabled = err.code == 400 and bool(
             re.search(DISABLED_MESSAGE_REGEX, err.message)
         )
+        # A "No such ...: 'invalid_id'" response means the resource is reachable —
+        # we probed it with a placeholder ID on purpose. We deliberately do not let
+        # this affect `is_accessible` to preserve the existing behavior
+        can_search_for_ids = re.search(
+            ENABLED_RESOURCE_EXPECTED_ERROR_REGEX, err.message
+        )
         is_accessible = not is_permission_blocked and not is_disabled
 
+        warning_msg = None
         if is_permission_blocked:
             warning_msg = (
                 f"Removing inaccessible resource for {url} due to missing API key permissions. "
@@ -93,12 +101,13 @@ async def check_accessibility(
             warning_msg = (
                 f"Removing resource the account is not configured to use: {url}."
             )
-        else:
+        elif not can_search_for_ids:
             warning_msg = (
                 f"Encountered HTTP error while checking accessibility for {url}"
             )
 
-        log.warning(warning_msg, {"err.code": err.code, "err.message": err.message})
+        if warning_msg:
+            log.warning(warning_msg, {"err.code": err.code, "err.message": err.message})
 
     return is_accessible
 


### PR DESCRIPTION
**Regression?**

https://github.com/estuary/connectors/pull/4625 (the impact was some false positive warnings getting printed, still a regression)

**Description:**

A recent change logged a warning for every HTTP error encountered during resource access checks, ignoring that we deliberately queried for a placeholder id to verify if id lookups were allowed. This commit only raises warnings if the expected pattern does not match.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

