### PR TITLE
materialize-clickhouse: tolerate a missing store table during recovery

### DIFF
--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
@@ -639,10 +642,26 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				// A committed-but-unacknowledged transaction has rows staged
 				// in this binding's store table. Move them; never truncate or
 				// re-create a stage table holding pending rows.
-				if err := t.moveStorePartitionsToTarget(ctx, b, si, true); err != nil {
+				err := t.moveStorePartitionsToTarget(ctx, b, si, true)
+				if err == nil {
+					continue
+				}
+				if !isUnknownTableErr(err) {
 					return nil, fmt.Errorf("recovering stage to target %s: %w", b.target.Identifier, err)
 				}
-			} else if err := t.ensureTempTables(ctx, b); err != nil {
+				// The store table was lost out-of-band (e.g. dropped) while the
+				// connector state still recorded a pending commit referencing
+				// it. No staged rows remain to recover -- the same situation as
+				// a commit that fully completed before the previous process
+				// exited -- so fall through to (re-)create the temp tables for
+				// the next transaction instead of crash-looping forever on the
+				// missing table. The pending transaction's rows are
+				// unrecoverable regardless; ReplacingMergeTree lets later
+				// transactions refresh them.
+				log.WithField("target", b.target.Identifier).Warn(
+					"store table missing during recovery; nothing to recover, re-creating temp tables")
+			}
+			if err := t.ensureTempTables(ctx, b); err != nil {
 				return nil, fmt.Errorf("ensuring temp tables of %s: %w", b.target.Identifier, err)
 			}
 		}
@@ -685,6 +704,14 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	}
 
 	return &pf.ConnectorState{UpdatedJson: checkpointJSON, MergePatch: true}, nil
+}
+
+// isUnknownTableErr reports whether err (anywhere in its chain) is a ClickHouse
+// "unknown table" exception (code 60), raised when a query references a table
+// that does not exist.
+func isUnknownTableErr(err error) bool {
+	var exc *clickhouseproto.Exception
+	return errors.As(err, &exc) && exc.Code == int32(chproto.ErrUnknownTable)
 }
 
 // moveStorePartitionsToTarget commits a transaction's staged rows by moving

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -1210,6 +1210,30 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_partial")))
 	})
 
+	t.Run("pending state with a missing store table recovers as a no-op", func(t *testing.T) {
+		tr, b := newTestTransactor(t, ctx, "test_recovery_missing_store")
+		// The store table was lost out-of-band (e.g. dropped) while the
+		// connector state still records a pending commit referencing it. There
+		// are no staged rows left to recover, so Acknowledge must not crash on
+		// the missing table -- it must treat it as nothing to recover, clear
+		// the pending state, and (re-)create the temp table so the next
+		// transaction can stage into it.
+		require.NoError(t, tr.store.conn.Exec(ctx, b.store.dropTableSQL))
+
+		tr.ensured = false
+		tr.recovery = true
+		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
+		_, err := tr.Acknowledge(ctx)
+		require.NoError(t, err)
+		require.Empty(t, tr.state)
+
+		// The store table is back, empty, and ready for the next round's store.
+		stageName := tr.dialect.Identifier(storeTableName(b.target, 0))
+		require.EqualValues(t, 0, countTable(t, ctx, tr, stageName))
+		stageTestRows(t, ctx, tr, b, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
+		require.EqualValues(t, 1, countTable(t, ctx, tr, stageName))
+	})
+
 	t.Run("leftover rows of an uncommitted transaction are truncated", func(t *testing.T) {
 		tr, b := newTestTransactor(t, ctx, "test_recovery_leftovers")
 		require.NoError(t, tr.ensureTempTables(ctx, b))


### PR DESCRIPTION
**Description:**

`materialize-clickhouse` crash-loops during recovery when a binding's store stage table (`flow_temp_store_<rangeKey>_<table>`) is missing while the connector state still records a pending commit for it. `Acknowledge` queries the stage table's partitions; against a missing table ClickHouse returns code 60 (`Unknown table`), the shard fails, and the durable pending state makes every restart fail identically.

Observed on `Briostack/mysql-cdc-prod/clickhouse-direct` (binding `customer_service_category_addon`): no data movement for days, ~85 identical recovery failures per 30 min.

Recovery already treats an *empty* stage table as a no-op (commit completed before the prior process exited). A *missing* table is the same case — nothing left to recover. This detects code 60 in the recovery path, treats it as nothing-to-recover, recreates the temp tables, and clears the pending state. Gated to `recovery == true`; the normal commit path keeps a missing store table fatal.

**Workflow steps:**

No user-facing change. Affected tasks self-heal on the next restart after this release.

**Notes for reviewers:**

- We don't yet know what dropped the store table — the connector never drops a pending binding's stage table itself, so something external removed it. This fix is resilient regardless; if it recurs, the disappearing table warrants separate investigation.
- Commit 1 is the failing regression test (reproduces code 60); commit 2 is the fix.
