### PR TITLE
source-stripe-native: implement API version pinning

### DIFF
--- a/source-stripe-native/source_stripe_native/__init__.py
+++ b/source-stripe-native/source_stripe_native/__init__.py
@@ -14,6 +14,7 @@ from estuary_cdk.flow import ValidationError
 
 from estuary_cdk.capture.common import ResourceConfigWithSchedule
 
+from .http import StripeHTTPMixin
 from .resources import all_resources
 from .models import (
     ConnectorState,
@@ -22,6 +23,7 @@ from .models import (
 
 
 class Connector(
+    StripeHTTPMixin,
     BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
 ):
     def request_class(self):

--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -51,6 +51,25 @@ LAG = timedelta(minutes=1)
 MIN_INCREMENTAL_INTERVAL = timedelta(minutes=1)
 
 
+async def fetch_api_version(http: HTTPSession, log: Logger) -> str:
+    """Return the account's default API version from the `stripe-version` response
+    header. Raises if it's absent."""
+    headers, body = await http.request_stream(log, f"{API}/account")
+    # Drain the body to release the connection.
+    async for _ in body():
+        pass
+
+    api_version = headers.get("stripe-version")
+    if not api_version:
+        raise RuntimeError(
+            (
+                "Stripe did not return a `stripe-version` response header, so the "
+                "account's API version could not be determined."
+            )
+        )
+    return api_version
+
+
 def add_event_types(
     params: dict[str, str | int], event_types: dict[str, Literal["c", "u", "d"]]
 ):

--- a/source-stripe-native/source_stripe_native/http.py
+++ b/source-stripe-native/source_stripe_native/http.py
@@ -1,0 +1,51 @@
+from logging import Logger
+from typing import Any, override
+
+import aiohttp
+
+from estuary_cdk.http import HTTPMixin, ShouldRetryProtocol
+
+
+class StripeHTTPMixin(HTTPMixin):
+    """Pins every request to `pinned_api_version` via the `Stripe-Version` header;
+    None means run at the account's default.
+
+    The injection hooks `_request_stream`, the single chokepoint that `request`,
+    `request_stream`, and `request_lines` all funnel through, so no public entry
+    point can escape the pin."""
+
+    pinned_api_version: str | None = None
+
+    def _with_api_version(
+        self, headers: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if self.pinned_api_version is None:
+            return headers
+        return {**(headers or {}), "Stripe-Version": self.pinned_api_version}
+
+    @override
+    async def _request_stream(
+        self,
+        log: Logger,
+        url: str,
+        method: str,
+        params: dict[str, Any] | None,
+        json: dict[str, Any] | None,
+        form: dict[str, Any] | None,
+        with_token: bool,
+        headers: dict[str, Any] | None = None,
+        should_retry: ShouldRetryProtocol | None = None,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ):
+        return await super()._request_stream(
+            log,
+            url,
+            method,
+            params,
+            json,
+            form,
+            with_token,
+            self._with_api_version(headers),
+            should_retry,
+            timeout,
+        )

--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta, timezone
 from typing import (
     Annotated,
@@ -15,7 +16,18 @@ from estuary_cdk.capture.common import (
 )
 from estuary_cdk.capture.common import ConnectorState as GenericConnectorState
 from estuary_cdk.flow import AccessToken
-from pydantic import AliasChoices, AwareDatetime, BaseModel, Field
+from pydantic import (
+    AliasChoices,
+    AwareDatetime,
+    BaseModel,
+    Field,
+    field_validator,
+)
+
+
+# Stripe API versions are zero-padded dates, optionally with a release codename
+# suffix (e.g. "2024-06-20" or "2026-05-27.dahlia").
+API_VERSION_REGEX = re.compile(r"^\d{4}-\d{2}-\d{2}(\.\w+)?$")
 
 
 def default_start_date():
@@ -35,13 +47,35 @@ class EndpointConfig(BaseModel):
     )
 
     class Advanced(BaseModel):
-        incremental_window_size: Annotated[timedelta, Field(
-            description="Maximum time window to process in a single incremental sweep. This bounds how much catch-up work is done at once and helps prevent the connector from falling behind when there are a large number of changes in a short time frame. Uses ISO 8601 duration format (e.g. PT1H for 1 hour, PT30M for 30 minutes).",
-            title="Max Incremental Window Size",
-            default_factory=lambda: timedelta(days=1),
-            ge=timedelta(minutes=1),
-            le=timedelta(days=30),
-        )]
+        api_version: str | None = Field(
+            description='The Stripe API version to use for all requests, e.g. "2024-06-20". If left blank, the account\'s default API version is used. Streams that require a newer API version than the one in effect are disabled.',
+            title="API Version",
+            default=None,
+        )
+
+        @field_validator("api_version")
+        @classmethod
+        def _validate_api_version(cls, value: str) -> str:
+            if value and not API_VERSION_REGEX.match(value):
+                raise ValueError(
+                    (
+                        f"Invalid API Version {value!r}. Expected a Stripe dated "
+                        'version like "2024-06-20", optionally with a release '
+                        'codename suffix like "2024-06-20.acacia".'
+                    )
+                )
+            return value
+
+        incremental_window_size: Annotated[
+            timedelta,
+            Field(
+                description="Maximum time window to process in a single incremental sweep. This bounds how much catch-up work is done at once and helps prevent the connector from falling behind when there are a large number of changes in a short time frame. Uses ISO 8601 duration format (e.g. PT1H for 1 hour, PT30M for 30 minutes).",
+                title="Max Incremental Window Size",
+                default_factory=lambda: timedelta(days=1),
+                ge=timedelta(minutes=1),
+                le=timedelta(days=30),
+            ),
+        ]
 
     advanced: Advanced = Field(
         default_factory=Advanced,  # type: ignore
@@ -98,6 +132,8 @@ class BaseStripeObject(BaseDocument, extra="allow"):
 
     NAME: ClassVar[str]
     SEARCH_NAME: ClassVar[str]
+    # Oldest Stripe API version this stream can be captured against.
+    MINIMUM_API_VERSION: ClassVar[str | None] = None
 
     id: str
     object: str
@@ -661,9 +697,14 @@ class SetupAttempts(BaseStripeChildObject):
     }
 
 
+# First API version that accepts `status=all` when listing subscriptions.
+SUBSCRIPTIONS_MIN_API_VERSION = "2016-07-06"
+
+
 class Subscriptions(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "Subscriptions"
     SEARCH_NAME: ClassVar[str] = "subscriptions"
+    MINIMUM_API_VERSION: ClassVar[str] = SUBSCRIPTIONS_MIN_API_VERSION
     EVENT_TYPES: ClassVar[dict[str, Literal["c", "u", "d"]]] = {
         "customer.subscription.created": "c",
         "customer.subscription.updated": "u",
@@ -678,6 +719,7 @@ class Subscriptions(BaseStripeObjectWithEvents):
 class SubscriptionItems(BaseStripeObjectWithEvents):
     NAME: ClassVar[str] = "SubscriptionItems"
     SEARCH_NAME: ClassVar[str] = "subscriptions"
+    MINIMUM_API_VERSION: ClassVar[str] = SUBSCRIPTIONS_MIN_API_VERSION
     EVENT_TYPES: ClassVar[dict[str, Literal["c", "u", "d"]]] = {
         "customer.subscription.created": "c",
         "customer.subscription.updated": "u",

--- a/source-stripe-native/source_stripe_native/resources.py
+++ b/source-stripe-native/source_stripe_native/resources.py
@@ -17,11 +17,14 @@ from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.flow import CaptureBinding
 from estuary_cdk.http import HTTPError, HTTPMixin, HTTPSession, TokenSource
 
+from source_stripe_native.http import StripeHTTPMixin
+
 from .protocols import FetchChangesFnFactory, FetchPageFnFactory
 
 from .account_fetcher import fetch_connected_account_ids
 from .api import (
     API,
+    fetch_api_version,
     fetch_backfill,
     fetch_backfill_substreams,
     fetch_backfill_list_items,
@@ -42,6 +45,7 @@ from .models import (
     STREAMS,
     Accounts,
     BaseStripeChildObject,
+    BaseStripeObject,
     BaseStripeObjectNoEvents,
     BaseStripeObjectWithEvents,
     ConnectorState,
@@ -57,6 +61,8 @@ DEFAULT_SCHEDULE = "0 0 * * *"
 
 DISABLED_MESSAGE_REGEX = r"Your account is not set up to use"
 ENABLED_RESOURCE_EXPECTED_ERROR_REGEX = r"No such .*: 'invalid_id'"
+
+StripeResource = Resource[BaseDocument, ResourceConfig, ResourceState]
 
 
 async def check_accessibility(
@@ -176,13 +182,18 @@ async def _reconcile_connector_state(
 
 async def all_resources(
     log: Logger,
-    http: HTTPMixin,
+    http: StripeHTTPMixin,
     config: EndpointConfig,
     should_fetch_connected_accounts: bool = True,
-) -> list[Resource]:
+) -> list[StripeResource]:
     http.token_source = TokenSource(oauth_spec=None, credentials=config.credentials)
+
+    api_version_override = config.advanced.api_version
+    effective_api_version = api_version_override or await fetch_api_version(http, log)
+    http.pinned_api_version = effective_api_version
+
     is_restricted_api_key = config.credentials.access_token.startswith("rk_")
-    all_streams: list[Resource] = []
+    all_streams: list[StripeResource] = []
 
     # If a restricted API key was provided, we have to ensure the /events endpoint is accessible.
     # Almost all streams use this endpoint for incremental replication, so we must be able to access it.
@@ -331,7 +342,36 @@ async def all_resources(
             )
             all_streams.append(resource)
 
+    all_streams = _filter_out_streams_below_min_api_version(
+        all_streams, effective_api_version, log
+    )
+
     return all_streams
+
+
+def _filter_out_streams_below_min_api_version(
+    resources: list[StripeResource],
+    effective_api_version: str,
+    log: Logger,
+) -> list[StripeResource]:
+    kept = []
+
+    for resource in resources:
+        model = resource.model
+        assert isinstance(model, type) and issubclass(model, BaseStripeObject)
+
+        minimum = model.MINIMUM_API_VERSION
+        if minimum and effective_api_version < minimum:
+            log.warning(
+                (
+                    f"Removing stream '{resource.name}': requires Stripe API version "
+                    f"{minimum}+, but the effective version is {effective_api_version}."
+                )
+            )
+            continue
+
+        kept.append(resource)
+    return kept
 
 
 def _create_initial_state(account_ids: str | list[str]) -> ResourceState:
@@ -458,7 +498,7 @@ def _build_resource(
     connected_account_ids: list[str],
     all_account_ids: list[str],
     initial_state: ResourceState,
-) -> Resource[BaseDocument, ResourceConfig, ResourceState]:
+) -> StripeResource:
     """Shared skeleton for every resource builder.
 
     The two factories each map a connected account id (or None for the platform
@@ -754,7 +794,7 @@ def no_events_object(
     connected_account_ids: list[str],
     all_account_ids: list[str],
     initial_state: ResourceState,
-) -> Resource[BaseDocument, ResourceConfig, ResourceState]:
+) -> StripeResource:
     """No Events Object handles a edge-case from source-stripe-native,
     where the given parent stream does not contain a valid Events API type.
     It requires a single, parent stream with a valid list all API endpoint.

--- a/source-stripe-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-stripe-native/tests/snapshots/snapshots__spec__stdout.json
@@ -25,6 +25,12 @@
         },
         "Advanced": {
           "properties": {
+            "api_version": {
+              "default": "",
+              "description": "The Stripe API version to use for all requests, e.g. \"2024-06-20\". If left blank, the account's default API version is used. Streams that require a newer API version than the one in effect are disabled.",
+              "title": "API Version",
+              "type": "string"
+            },
             "incremental_window_size": {
               "description": "Maximum time window to process in a single incremental sweep. This bounds how much catch-up work is done at once and helps prevent the connector from falling behind when there are a large number of changes in a short time frame. Uses ISO 8601 duration format (e.g. PT1H for 1 hour, PT30M for 30 minutes).",
               "format": "duration",

--- a/source-stripe-native/tests/test_version_pin_unit.py
+++ b/source-stripe-native/tests/test_version_pin_unit.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from multidict import CIMultiDict
+from pydantic import ValidationError
+
+from source_stripe_native import Connector
+from source_stripe_native.api import fetch_api_version
+from source_stripe_native.models import (
+    Charges,
+    EndpointConfig,
+    SubscriptionItems,
+    Subscriptions,
+    SUBSCRIPTIONS_MIN_API_VERSION,
+)
+from source_stripe_native.resources import _filter_out_streams_below_min_api_version
+
+
+async def _empty_body():
+    # An empty async generator: fetch_api_version drains the body to release the
+    # connection, so the mock just needs to yield nothing.
+    return
+    yield
+
+
+def _http_returning(headers: CIMultiDict) -> MagicMock:
+    http = MagicMock()
+    http.request_stream = AsyncMock(return_value=(headers, _empty_body))
+    return http
+
+
+def _resource(model: type) -> SimpleNamespace:
+    # Stand-in for estuary_cdk Resource; the helper only reads `name` and `model`.
+    return SimpleNamespace(name=model.NAME, model=model)
+
+
+class TestFetchApiVersion:
+    @pytest.mark.asyncio
+    async def test_returns_header_value_case_insensitively(self):
+        # Capitalized on purpose — the lookup must be case-insensitive.
+        http = _http_returning(CIMultiDict({"Stripe-Version": "2024-06-20"}))
+        assert await fetch_api_version(http, MagicMock()) == "2024-06-20"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_header_missing(self):
+        http = _http_returning(CIMultiDict())
+        with pytest.raises(RuntimeError, match="stripe-version"):
+            _ = await fetch_api_version(http, MagicMock())
+
+
+class TestMinimumApiVersionDeclared:
+    def test_subscription_streams_declare_the_minimum(self):
+        assert Subscriptions.MINIMUM_API_VERSION == SUBSCRIPTIONS_MIN_API_VERSION
+        assert SubscriptionItems.MINIMUM_API_VERSION == SUBSCRIPTIONS_MIN_API_VERSION
+        assert SUBSCRIPTIONS_MIN_API_VERSION == "2016-07-06"
+
+    def test_other_streams_inherit_the_none_default(self):
+        # Streams that don't override it inherit BaseStripeObject's "no minimum".
+        assert Charges.MINIMUM_API_VERSION is None
+
+
+class TestRemoveStreamsBelowMinApiVersion:
+    def test_removes_stream_when_effective_version_is_older(self):
+        for version in ("2014-10-31", "2015-06-15", "2016-07-05"):
+            kept = _filter_out_streams_below_min_api_version(
+                [_resource(Subscriptions)], version, MagicMock()
+            )
+            assert kept == [], version
+
+    def test_keeps_stream_when_effective_version_meets_minimum(self):
+        for version in ("2016-07-06", "2019-03-14", "2026-05-27.dahlia"):
+            resource = _resource(Subscriptions)
+            kept = _filter_out_streams_below_min_api_version(
+                [resource], version, MagicMock()
+            )
+            assert kept == [resource], version
+
+    def test_streams_without_a_minimum_are_kept(self):
+        resource = _resource(Charges)
+        kept = _filter_out_streams_below_min_api_version(
+            [resource], "2010-01-01", MagicMock()
+        )
+        assert kept == [resource]
+
+
+class TestWithApiVersion:
+    """The header-merge that `_request_stream` applies to every call."""
+
+    def test_unpinned_passes_headers_through_unchanged(self):
+        connector = Connector()
+        assert connector.pinned_api_version is None
+        assert connector._with_api_version(None) is None
+        existing = {"Stripe-Account": "acct_1"}
+        assert connector._with_api_version(existing) == existing
+
+    def test_pinned_injects_version_without_dropping_existing_headers(self):
+        connector = Connector()
+        connector.pinned_api_version = "2024-06-20"
+        assert connector._with_api_version(None) == {"Stripe-Version": "2024-06-20"}
+        assert connector._with_api_version({"Stripe-Account": "acct_1"}) == {
+            "Stripe-Account": "acct_1",
+            "Stripe-Version": "2024-06-20",
+        }
+
+
+class TestApiVersionConfigValidation:
+    """The override is validated at config-parse time so a malformed value fails
+    loudly instead of silently mis-sorting in the disable-below-floor gate."""
+
+    def test_accepts_blank_and_well_formed_versions(self):
+        for value in ("", "2024-06-20", "2026-05-27.dahlia"):
+            assert EndpointConfig.Advanced(api_version=value).api_version == value
+
+    def test_rejects_malformed_versions(self):
+        for value in ("2024-6-20", "latest", "2016", "v2024-06-20", "2024/06/20"):
+            with pytest.raises(ValidationError):
+                EndpointConfig.Advanced(api_version=value)


### PR DESCRIPTION
**Description:**

The status=all filter in Subscriptions / SubscriptionItems inadvertently set a hard requirement on how old an API version we can use. This commit adds an API version endpoint config field, falling back to the account's default to preserve the original behavior.

`BaseStripeObject` children can now define a minimum required API version. If any streams fall below the floor they'll be disabled, rather than removed, to handle when an existing capture gets downgraded.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

