### PR TITLE
source-sqlserver{,-ct}: Log backfill queries

### DIFF
--- a/source-sqlserver-ct/backfill.go
+++ b/source-sqlserver-ct/backfill.go
@@ -70,6 +70,9 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 
 	log.WithFields(log.Fields{"query": query, "args": args}).Debug("executing query")
 
+	// If this is the first chunk being backfilled from this table, log the query for debugging.
+	db.logBackfillQuery(streamID, query, args)
+
 	// Set up watchdog timer and run the query
 	var watchdogCtx, cancelWatchdog = context.WithCancel(ctx)
 	defer cancelWatchdog()

--- a/source-sqlserver-ct/diagnostics.go
+++ b/source-sqlserver-ct/diagnostics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/estuary/connectors/sqlcapture"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -61,4 +62,25 @@ func (db *sqlserverDatabase) PeriodicChecks(ctx context.Context) error {
 	// and is called periodically during capture, but Change Tracking does not require
 	// any periodic maintenance or status checks.
 	return nil
+}
+
+// logBackfillQuery logs the backfill query for a table the first time it is scanned during a
+// connector invocation.
+//
+// In other connectors the analogous logic runs an EXPLAIN, and we were going to do the same
+// thing here with `SET SHOWPLAN`, but this was such an absolute pain that we gave up. Turns
+// out that query parameters via go-mssqldb don't play nicely with SHOWPLAN. Also SHOWPLAN
+// requires a special permission which we likely wouldn't have anyway, so it just wasn't
+// worth implementing a workaround at this time.
+func (db *sqlserverDatabase) logBackfillQuery(streamID sqlcapture.StreamID, query string, args []any) {
+	// Only log the backfill query once per table per connector invocation.
+	if db.loggedBackfill == nil {
+		db.loggedBackfill = make(map[sqlcapture.StreamID]struct{})
+	}
+	if _, ok := db.loggedBackfill[streamID]; ok {
+		return
+	}
+	db.loggedBackfill[streamID] = struct{}{}
+
+	log.WithFields(log.Fields{"id": streamID, "query": query, "args": args}).Info("backfill query")
 }

--- a/source-sqlserver-ct/main.go
+++ b/source-sqlserver-ct/main.go
@@ -280,6 +280,7 @@ type sqlserverDatabase struct {
 	datatypesConfig *datatypes.Config // Configuration for datatype handling
 
 	tableStatistics map[sqlcapture.StreamID]*sqlserverTableStatistics // Cached table statistics for backfill progress tracking
+	loggedBackfill  map[sqlcapture.StreamID]struct{}                  // Tracks tables whose backfill query has been logged during this connector invocation
 }
 
 func (db *sqlserverDatabase) HistoryMode() bool {

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -79,6 +79,9 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 
 	log.WithFields(log.Fields{"query": query, "args": args}).Debug("executing query")
 
+	// If this is the first chunk being backfilled from this table, log the query for debugging.
+	db.logBackfillQuery(streamID, query, args)
+
 	// Set up watchdog timer and run the query
 	var watchdogCtx, cancelWatchdog = context.WithCancel(ctx)
 	defer cancelWatchdog()

--- a/source-sqlserver/diagnostics.go
+++ b/source-sqlserver/diagnostics.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/estuary/connectors/sqlcapture"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -59,4 +60,25 @@ func (db *sqlserverDatabase) ReplicationDiagnostics(ctx context.Context) error {
 
 func (db *sqlserverDatabase) PeriodicChecks(ctx context.Context) error {
 	return nil
+}
+
+// logBackfillQuery logs the backfill query for a table the first time it is scanned during a
+// connector invocation.
+//
+// In other connectors the analogous logic runs an EXPLAIN, and we were going to do the same
+// thing here with `SET SHOWPLAN`, but this was such an absolute pain that we gave up. Turns
+// out that query parameters via go-mssqldb don't play nicely with SHOWPLAN. Also SHOWPLAN
+// requires a special permission which we likely wouldn't have anyway, so it just wasn't
+// worth implementing a workaround at this time.
+func (db *sqlserverDatabase) logBackfillQuery(streamID sqlcapture.StreamID, query string, args []any) {
+	// Only log the backfill query once per table per connector invocation.
+	if db.loggedBackfill == nil {
+		db.loggedBackfill = make(map[sqlcapture.StreamID]struct{})
+	}
+	if _, ok := db.loggedBackfill[streamID]; ok {
+		return
+	}
+	db.loggedBackfill[streamID] = struct{}{}
+
+	log.WithFields(log.Fields{"id": streamID, "query": query, "args": args}).Info("backfill query")
 }

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -301,6 +301,7 @@ type sqlserverDatabase struct {
 	datatypesConfig *datatypes.Config // Configuration for datatype handling
 
 	tableStatistics map[sqlcapture.StreamID]*sqlserverTableStatistics // Cached table statistics for backfill progress tracking
+	loggedBackfill  map[sqlcapture.StreamID]struct{}                  // Tracks tables whose backfill query has been logged during this connector invocation
 }
 
 func (db *sqlserverDatabase) HistoryMode() bool {


### PR DESCRIPTION
**Description:**

Adds logic to log the backfill query for a table the first time it is scanned during a connector invocation.

In other connectors the analogous logic runs an EXPLAIN, and I was going to do the same thing here with `SET SHOWPLAN`, but this was such an absolute pain that I gave up. Turns out that query parameters via go-mssqldb don't play nicely with SHOWPLAN. Also SHOWPLAN requires a special permission which we likely wouldn't have anyway, so it just wasn't worth implementing a workaround at this time.