### PR TITLE
materialize-elasticsearch: retry transient per-item bulk store errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install duckdb
         if: matrix.connector == 'materialize-motherduck' || matrix.connector == 'materialize-s3-iceberg'
-        uses: opt-nc/setup-duckdb-action@v1.0.8
+        uses: opt-nc/setup-duckdb-action@v1.2.9
         with:
           version: v1.3.1
 

--- a/materialize-elasticsearch/transactor.go
+++ b/materialize-elasticsearch/transactor.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/elastic/go-elasticsearch/v8/esutil"
@@ -157,7 +158,11 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	ctx := it.Context()
 
 	type storeBatch struct {
-		buf   []byte
+		// items holds one complete bulk item per element (an action line, plus a
+		// document line for index/create actions, each terminated by '\n').
+		// Keeping items separate rather than as one flat buffer lets doStore
+		// re-send an exact subset of items when only some of them fail.
+		items [][]byte
 		index string
 	}
 
@@ -172,7 +177,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 				case batch, ok := <-batchCh:
 					if !ok {
 						return nil
-					} else if err := t.doStore(groupCtx, batch.buf, batch.index); err != nil {
+					} else if err := t.doStore(groupCtx, batch.items, batch.index); err != nil {
 						return err
 					}
 				}
@@ -180,26 +185,28 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		})
 	}
 
-	sendBatch := func(batch []byte, index string) error {
+	sendBatch := func(items [][]byte, index string) error {
 		select {
 		case <-groupCtx.Done():
 			return group.Wait()
-		case batchCh <- storeBatch{buf: batch, index: index}:
+		case batchCh <- storeBatch{items: items, index: index}:
 			return nil
 		}
 	}
 
-	var batch []byte
+	var batch [][]byte
+	var batchBytes int
 	var lastIndex string
 	// Skip deleted, non-existent documents iff HardDelete is enabled.
 	for it.Next(t.cfg.HardDelete) {
 		b := t.bindings[it.Binding]
 
-		if len(batch) > storeBatchSize || (lastIndex != b.index && lastIndex != "") {
+		if batchBytes > storeBatchSize || (lastIndex != b.index && lastIndex != "") {
 			if err := sendBatch(batch, lastIndex); err != nil {
 				return nil, err
 			}
 			batch = nil
+			batchBytes = 0
 		}
 		lastIndex = b.index
 
@@ -216,41 +223,21 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 
 		if it.Delete && t.cfg.HardDelete && it.Exists {
-			batch = append(batch, []byte(`{"delete":{"_id":"`+id+`"`)...)
+			var item []byte
+			item = append(item, []byte(`{"delete":{"_id":"`+id+`"`)...)
 			if routingVal != nil {
-				batch = append(batch, []byte(`,"routing":`+string(routingVal))...)
+				item = append(item, []byte(`,"routing":`+string(routingVal))...)
 			}
-			batch = append(batch, []byte(`}}`)...)
-			batch = append(batch, '\n')
+			item = append(item, []byte(`}}`)...)
+			item = append(item, '\n')
+			batch = append(batch, item)
+			batchBytes += len(item)
 			continue
 		}
 
-		// The "create" action will fail if an item by the provided ID already exists, and "index"
-		// is like a PUT where it will create or replace. We could just use "index" all the time,
-		// but using "create" when we believe the item does not already exist provides a bit of
-		// extra consistency checking.
-		if it.Exists {
-			batch = append(batch, []byte(`{"index":{"_id":"`+id+`"`)...)
-			if routingVal != nil {
-				batch = append(batch, []byte(`,"routing":`+string(routingVal))...)
-			}
-			batch = append(batch, []byte(`}}`)...)
-		} else if !b.deltaUpdates {
-			batch = append(batch, []byte(`{"create":{"_id":"`+id+`"`)...)
-			if routingVal != nil {
-				batch = append(batch, []byte(`,"routing":`+string(routingVal))...)
-			}
-			batch = append(batch, []byte(`}}`)...)
-		} else {
-			// Leaving the ID blank will cause Elasticsearch to generate one automatically for
-			// delta updates, where we otherwise could not insert multiple rows with the same ID.
-			batch = append(batch, []byte(`{"create":{`)...)
-			if routingVal != nil {
-				batch = append(batch, []byte(`"routing":`+string(routingVal))...)
-			}
-			batch = append(batch, []byte(`}}`)...)
-		}
-		batch = append(batch, '\n')
+		var item []byte
+		item = append(item, storeAction(it.Exists, b.deltaUpdates, id, routingVal)...)
+		item = append(item, '\n')
 
 		doc := make(map[string]any)
 		for idx, v := range append(it.Key, it.Values...) {
@@ -278,8 +265,10 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		if err != nil {
 			return nil, err
 		}
-		batch = append(batch, bodyData...)
-		batch = append(batch, '\n')
+		item = append(item, bodyData...)
+		item = append(item, '\n')
+		batch = append(batch, item)
+		batchBytes += len(item)
 	}
 	if err := it.Err(); err != nil {
 		return nil, err
@@ -296,6 +285,39 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 }
 
 func (t *transactor) Destroy() {}
+
+// storeAction returns the Elasticsearch _bulk action metadata line for storing
+// (not deleting) a single document.
+//
+// The "create" action will fail if an item by the provided ID already exists, and "index"
+// is like a PUT where it will create or replace. We could just use "index" all the time,
+// but using "create" when we believe the item does not already exist provides a bit of
+// extra consistency checking.
+func storeAction(exists, deltaUpdates bool, id string, routingVal []byte) []byte {
+	var line []byte
+	if exists {
+		line = append(line, []byte(`{"index":{"_id":"`+id+`"`)...)
+		if routingVal != nil {
+			line = append(line, []byte(`,"routing":`+string(routingVal))...)
+		}
+		line = append(line, []byte(`}}`)...)
+	} else if !deltaUpdates {
+		line = append(line, []byte(`{"create":{"_id":"`+id+`"`)...)
+		if routingVal != nil {
+			line = append(line, []byte(`,"routing":`+string(routingVal))...)
+		}
+		line = append(line, []byte(`}}`)...)
+	} else {
+		// Leaving the ID blank will cause Elasticsearch to generate one automatically for
+		// delta updates, where we otherwise could not insert multiple rows with the same ID.
+		line = append(line, []byte(`{"create":{`)...)
+		if routingVal != nil {
+			line = append(line, []byte(`"routing":`+string(routingVal))...)
+		}
+		line = append(line, []byte(`}}`)...)
+	}
+	return line
+}
 
 type getDoc struct {
 	Id      string `json:"_id"`
@@ -400,26 +422,67 @@ func (t *transactor) loadDocs(ctx context.Context, getDocs []getDoc, loaded func
 	return nil
 }
 
+const maxStoreRetries = 5
+
+// retryableBulkErrorTypes are Elasticsearch per-item error types that are
+// transient and safe to retry by re-sending only the affected items. They show
+// up inside an HTTP 200 bulk response (the request as a whole succeeded), most
+// commonly when an index's primary shard is briefly unavailable.
+var retryableBulkErrorTypes = map[string]bool{
+	"retry_on_primary_exception":      true,
+	"unavailable_shards_exception":    true,
+	"es_rejected_execution_exception": true,
+}
+
 type bulkResponse struct {
 	Items []map[string]struct {
-		Error struct {
+		Status int `json:"status"`
+		Error  struct {
 			Type   string `json:"type"`
 			Reason string `json:"reason"`
 		} `json:"error"`
 	} `json:"items"`
 }
 
-func (b bulkResponse) firstError() error {
-	for _, item := range b.Items {
-		for action, err := range item {
-			return fmt.Errorf("(%s) %s: %s", action, err.Error.Type, err.Error.Reason)
+// classify inspects the per-item results of a bulk response. Item i corresponds
+// to request item i. It returns the first terminal (non-retryable) item error,
+// if any, and the indices of items that failed with a retryable error. A
+// terminal error takes precedence: when one is present the caller should fail
+// rather than retry.
+func (b bulkResponse) classify() (terminal error, retryableIdx []int) {
+	for i, item := range b.Items {
+		for action, res := range item {
+			if res.Error.Type == "" {
+				continue
+			}
+			if retryableBulkErrorTypes[res.Error.Type] {
+				retryableIdx = append(retryableIdx, i)
+			} else if terminal == nil {
+				terminal = fmt.Errorf("(%s) %s: %s", action, res.Error.Type, res.Error.Reason)
+			}
 		}
 	}
+	return terminal, retryableIdx
+}
 
+// itemError returns the formatted error for the first errored item at one of
+// the given indices, for use when retries are exhausted.
+func (b bulkResponse) itemError(idx []int) error {
+	for _, i := range idx {
+		for action, res := range b.Items[i] {
+			if res.Error.Type != "" {
+				return fmt.Errorf("(%s) %s: %s", action, res.Error.Type, res.Error.Reason)
+			}
+		}
+	}
 	return nil
 }
 
-func (t *transactor) doStore(ctx context.Context, body []byte, index string) error {
+// sendBulk submits a single bulk request and returns the parsed per-item
+// response. A non-nil error indicates a transport- or HTTP-level failure (the
+// go-elasticsearch client has already retried those per its RetryOnStatus
+// config); per-item errors are carried in the returned bulkResponse.
+func (t *transactor) sendBulk(ctx context.Context, body []byte, index string) (*bulkResponse, error) {
 	opts := []func(*esapi.BulkRequest){
 		t.client.es.Bulk.WithContext(ctx),
 		// Request bodies are structured so that all documents belong to the
@@ -427,10 +490,11 @@ func (t *transactor) doStore(ctx context.Context, body []byte, index string) err
 		// rather than on each individual document.
 		t.client.es.Bulk.WithIndex(index),
 		// Without this filter, the response body will contain a bit of metadata
-		// for every single item in the bulk request. We only care if errors
-		// occurred, so this filter reduces the response size drastically in the
-		// most common case of no or few errors.
-		t.client.es.Bulk.WithFilterPath("items.*.error"),
+		// for every single item in the bulk request. We only care about each
+		// item's error and status, which keeps the response small in the common
+		// case of no or few errors while still returning one entry per item (so
+		// response item i aligns with request item i).
+		t.client.es.Bulk.WithFilterPath("items.*.error", "items.*.status"),
 	}
 
 	if !t.isServerless {
@@ -446,18 +510,84 @@ func (t *transactor) doStore(ctx context.Context, body []byte, index string) err
 
 	res, err := t.client.es.Bulk(bytes.NewReader(body), opts...)
 	if err != nil {
-		return fmt.Errorf("bulk request submission failed: %w", err)
+		return nil, fmt.Errorf("bulk request submission failed: %w", err)
 	}
 	defer res.Body.Close()
 
-	var parsed bulkResponse
 	if res.IsError() {
-		return fmt.Errorf("bulk request to index %q failed with status %d: %s", index, res.StatusCode, res.String())
-	} else if err := json.NewDecoder(res.Body).Decode(&parsed); err != nil {
-		return fmt.Errorf("failed to decode bulk response: %w", err)
-	} else if err := parsed.firstError(); err != nil {
-		return fmt.Errorf("bulk request to index %q failed: %w", index, err)
+		return nil, fmt.Errorf("bulk request to index %q failed with status %d: %s", index, res.StatusCode, res.String())
 	}
 
+	var parsed bulkResponse
+	if err := json.NewDecoder(res.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode bulk response: %w", err)
+	}
+	return &parsed, nil
+}
+
+func (t *transactor) doStore(ctx context.Context, items [][]byte, index string) error {
+	if err := retryBulkStore(ctx, items, maxStoreRetries,
+		func(body []byte) (*bulkResponse, error) { return t.sendBulk(ctx, body, index) },
+		storeRetryDelay,
+	); err != nil {
+		return fmt.Errorf("bulk request to index %q failed: %w", index, err)
+	}
 	return nil
+}
+
+// retryBulkStore sends items as a single bulk request and, if any items fail
+// with a retryable per-item error, re-sends only those items after a delay,
+// up to maxAttempts times. Re-sending only the failed items is safe for both
+// standard and delta-updates bindings: a failed item did not land, so it is
+// never duplicated, and items that succeeded are never re-sent.
+func retryBulkStore(
+	ctx context.Context,
+	items [][]byte,
+	maxAttempts int,
+	send func(body []byte) (*bulkResponse, error),
+	delay func(ctx context.Context, attempt int) error,
+) error {
+	pending := items
+	for attempt := 0; ; attempt++ {
+		resp, err := send(bytes.Join(pending, nil))
+		if err != nil {
+			return err
+		}
+
+		terminal, retryableIdx := resp.classify()
+		if terminal != nil {
+			return terminal
+		}
+		if len(retryableIdx) == 0 {
+			return nil
+		}
+		if attempt+1 >= maxAttempts {
+			return fmt.Errorf("%d items still failing after %d attempts: %w",
+				len(retryableIdx), attempt+1, resp.itemError(retryableIdx))
+		}
+
+		next := make([][]byte, len(retryableIdx))
+		for i, idx := range retryableIdx {
+			next[i] = pending[idx]
+		}
+		pending = next
+
+		if err := delay(ctx, attempt); err != nil {
+			return err
+		}
+	}
+}
+
+// storeRetryDelay waits before re-sending failed bulk items, with exponential
+// backoff capped at 5s, mirroring the go-elasticsearch client's RetryBackoff.
+func storeRetryDelay(ctx context.Context, attempt int) error {
+	d := min(time.Duration(1<<attempt)*time.Second, 5*time.Second)
+	log.WithFields(log.Fields{"attempt": attempt, "delay": d.String()}).
+		Info("waiting to retry bulk items on retryable error")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
 }

--- a/materialize-elasticsearch/transactor_unit_test.go
+++ b/materialize-elasticsearch/transactor_unit_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreActionDeltaUsesGeneratedID guards the delta-updates behavior: those
+// stores intentionally use "create" with a blank ID so Elasticsearch generates
+// a unique ID per document and multiple rows with the same key can be inserted.
+func TestStoreActionDeltaUsesGeneratedID(t *testing.T) {
+	line := string(storeAction(false /* exists */, true /* deltaUpdates */, "abc", nil))
+	require.Contains(t, line, `"create"`, "delta-updates store must use the create action, got %q", line)
+	require.NotContains(t, line, `"_id"`, "delta-updates store must use a generated (blank) ID, got %q", line)
+}
+
+// bulkResp builds a parsed bulk response from per-item error types, mirroring
+// the shape Elasticsearch returns under the "items.*.error","items.*.status"
+// filter path. An empty string means the item succeeded.
+func bulkResp(t *testing.T, itemErrTypes ...string) *bulkResponse {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(`{"items":[`)
+	for i, et := range itemErrTypes {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		if et == "" {
+			sb.WriteString(`{"index":{"status":200}}`)
+		} else {
+			sb.WriteString(fmt.Sprintf(`{"index":{"status":429,"error":{"type":%q,"reason":"r"}}}`, et))
+		}
+	}
+	sb.WriteString(`]}`)
+	var r bulkResponse
+	require.NoError(t, json.Unmarshal([]byte(sb.String()), &r))
+	return &r
+}
+
+func TestClassifyBulkResponse(t *testing.T) {
+	const retryable = "retry_on_primary_exception"
+	const terminalType = "mapper_parsing_exception"
+
+	t.Run("clean", func(t *testing.T) {
+		terminal, idx := bulkResp(t, "", "").classify()
+		require.NoError(t, terminal)
+		require.Empty(t, idx)
+	})
+
+	t.Run("all retryable", func(t *testing.T) {
+		terminal, idx := bulkResp(t, retryable, "", retryable).classify()
+		require.NoError(t, terminal)
+		require.Equal(t, []int{0, 2}, idx)
+	})
+
+	t.Run("terminal wins over retryable", func(t *testing.T) {
+		terminal, _ := bulkResp(t, retryable, terminalType).classify()
+		require.Error(t, terminal)
+		require.Contains(t, terminal.Error(), terminalType)
+	})
+
+	t.Run("terminal only", func(t *testing.T) {
+		terminal, idx := bulkResp(t, terminalType).classify()
+		require.Error(t, terminal)
+		require.Empty(t, idx)
+	})
+}
+
+// TestRetryBulkStoreResendsOnlyFailedItems is the regression test for the shard
+// crashes: a transient per-item error (retry_on_primary_exception) in a 200
+// response must be retried by re-sending only the failed item, not surfaced as
+// fatal. Re-sending only the failed item is what makes this safe for delta
+// bindings too (succeeded generated-ID creates are never re-sent).
+func TestRetryBulkStoreResendsOnlyFailedItems(t *testing.T) {
+	items := [][]byte{[]byte("A\n"), []byte("B\n"), []byte("C\n")}
+
+	responses := []*bulkResponse{
+		bulkResp(t, "", "retry_on_primary_exception", ""), // item 1 fails transiently
+		bulkResp(t, ""),                                   // resent item succeeds
+	}
+	var sentBodies [][]byte
+	send := func(body []byte) (*bulkResponse, error) {
+		sentBodies = append(sentBodies, append([]byte(nil), body...))
+		r := responses[0]
+		responses = responses[1:]
+		return r, nil
+	}
+	noDelay := func(context.Context, int) error { return nil }
+
+	err := retryBulkStore(context.Background(), items, maxStoreRetries, send, noDelay)
+	require.NoError(t, err)
+	require.Len(t, sentBodies, 2, "should send the initial batch then a retry")
+	require.Equal(t, []byte("A\nB\nC\n"), sentBodies[0], "first send is the whole batch")
+	require.Equal(t, []byte("B\n"), sentBodies[1], "retry re-sends only the failed item")
+}
+
+// TestRetryBulkStoreFailsFastOnTerminal guards that a non-retryable item error
+// is returned immediately without retrying.
+func TestRetryBulkStoreFailsFastOnTerminal(t *testing.T) {
+	items := [][]byte{[]byte("A\n")}
+
+	var sends int
+	send := func(body []byte) (*bulkResponse, error) {
+		sends++
+		return bulkResp(t, "mapper_parsing_exception"), nil
+	}
+	noDelay := func(context.Context, int) error { return nil }
+
+	err := retryBulkStore(context.Background(), items, maxStoreRetries, send, noDelay)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mapper_parsing_exception")
+	require.Equal(t, 1, sends, "terminal error must not be retried")
+}
+
+// TestRetryBulkStoreExhaustsAttempts guards that a persistently retryable error
+// gives up after maxAttempts (rather than looping forever) and surfaces the
+// underlying error.
+func TestRetryBulkStoreExhaustsAttempts(t *testing.T) {
+	items := [][]byte{[]byte("A\n")}
+
+	var sends int
+	send := func(body []byte) (*bulkResponse, error) {
+		sends++
+		return bulkResp(t, "retry_on_primary_exception"), nil
+	}
+	noDelay := func(context.Context, int) error { return nil }
+
+	err := retryBulkStore(context.Background(), items, 3 /* maxAttempts */, send, noDelay)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "retry_on_primary_exception")
+	require.Equal(t, 3, sends, "should attempt exactly maxAttempts times")
+}


### PR DESCRIPTION
**Description:**

Makes `materialize-elasticsearch` ride out transient destination-cluster blips instead of crashing the shard. When an index's primary shard is briefly unavailable, Elasticsearch returns a retryable per-item error (e.g. `retry_on_primary_exception`) inside an HTTP 200 bulk response. Previously the transactor treated the first item error as fatal and failed the shard; now it re-sends just the affected items with bounded exponential backoff.

Re-sending only the failed items is safe for delta bindings too — items that succeeded (including generated-ID creates) are never re-sent, so no duplicate rows.

**Workflow steps:**

No config/API changes; behavior-only. Tasks stop crash-looping on transient `shard is not in primary mode` errors.

**Notes for reviewers:**

- Scope: only the 200-with-item-errors path. True HTTP 429/5xx are still handled by the existing go-elasticsearch transport retry (`driver.go` `RetryOnStatus`) — not duplicated.
- `firstError()` is replaced by `bulkResponse.classify()` (terminal error → fail; retryable indices → resend); store batches are now `[][]byte` segments so a subset can be re-sent.
- The separate `create`→`index` idempotency change is **split out to a follow-up PR** per review discussion — it would fix the `version_conflict` failures but also removes a consistency tripwire, so it's worth deciding on its own.
- Verified: `go vet` + unit suite, and `TestIntegration` against ES 8.9.0 and OpenSearch 2.13.0 (snapshots unchanged). The retryable-item-error path can't be reproduced in the docker ES, so it's unit-tested via an injected sender.
- Heads-up: an unrelated `.github/workflows/ci.yaml` duckdb chore rode in on this branch.
