### PR TITLE
source-shopify-native: don't sort bulk queries to avoid missing data

### DIFF
--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -701,13 +701,23 @@ class ShopifyGraphQLResource(BaseDocument):
             cls._resolve_conditional_fields(capabilities)
         )
 
+        # Don't sort bulk queries. We observed that a bulk query pairing `sortKey: UPDATED_AT`
+        # with an `updated_at` filter omits some records that match the filter. Removing the sortKey
+        # returns those omitted records. To avoid silently omitting records, never use a sortKey
+        # for bulk queries.
+        sort_key_clause = (
+            f"sortKey: {cls.SORT_KEY}"
+            if cls.SORT_KEY and not cls.SHOULD_USE_BULK_QUERIES
+            else ""
+        )
+
         query = f"""
         {{
             {cls.QUERY_ROOT}(
                 query: "updated_at:>='{lower_bound}' AND updated_at:<='{upper_bound}' {
             "AND " + query.strip() if query else ""
         }"
-                {f"sortKey: {cls.SORT_KEY}" if cls.SORT_KEY else ""}
+                {sort_key_clause}
                 {f"first: {first}" if first else ""}
                 {f'after: "{after}"' if after else ""}
             ) {{


### PR DESCRIPTION
**Regression?**

No

**Description:**

We've observed that streams using bulk queries with `sortKey: UPDATED_AT` were missing records. After some investigation, it appears that including `sortKey: UPDATED_AT` in a bulk query causes some records to be omitted from the results returned by Shopify; removing `sortKey: UPDATED_AT` causes the previously omitted records to be included in the query results. (I'm speculating the omissions are due to some stale index on `updatedAt` somewhere in Shopify's internals, but I don't have any evidence that's specifically what's causing the bulk query to omit records.)

Bulk queries already aren't relying on bulk query results being sorted in any particular order, so the fix here is to not include `sortKey` for any bulk queries. This might be a little heavy handed (maybe using `sortKey: CREATED_AT` doesn't cause results to be omitted?) but since the connector currently doesn't need results to be sorted, I wanted to completely eliminate `sortKey` as a suspect for any future missing data investigations.

**Notes for reviewers:**

See this [Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1781705673777699) for more context around the investigation that motivated this PR.

