### PR TITLE
source-salesforce-native: accept ISO 8601 duration time windows

### DIFF
--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -17,6 +17,7 @@ from .bulk_job_manager import (
 from .rest_query_manager import RestQueryManager
 from .shared import dt_to_str, str_to_dt, now, should_retry, VERSION
 from .models import (
+    MIN_INCREMENTAL_WINDOW_SIZE,
     FieldDetails,
     FieldDetailsDict,
     SalesforceRecord,
@@ -35,7 +36,6 @@ BULK_CHECKPOINT_INTERVAL = MAX_BULK_QUERY_SET_SIZE
 # but it's a simple fix that easily rolled back if we come up with a better solution. The default
 # interval is already 5 minutes, so the connector is not really "real-time" anyway.
 LAG = timedelta(minutes=5)
-MIN_INCREMENTAL_WINDOW_SIZE = timedelta(minutes=1)
 
 
 def _determine_cursor_field(
@@ -162,7 +162,7 @@ async def backfill_incremental_resources(
     name: str,
     fields: FieldDetailsDict,
     model_cls: type[SalesforceRecord],
-    window_size: int,
+    window_size: timedelta,
     start_date: datetime,
     log: Logger,
     page: PageCursor | None,
@@ -184,7 +184,7 @@ async def backfill_incremental_resources(
         })
         return
 
-    max_window_size = min(timedelta(days=window_size), cutoff - start)
+    max_window_size = min(window_size, cutoff - start)
     end = min(cutoff, start + max_window_size)
 
     cursor_field = _determine_cursor_field(fields)
@@ -257,15 +257,14 @@ async def fetch_incremental_resources(
     rest_query_manager: RestQueryManager,
     instance_url: str,
     name: str,
-    window_size: int,
+    window_size: timedelta,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[SalesforceRecord | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    max_window_size = timedelta(days=window_size)
     max_end = now() - LAG
-    end = min(max_end, log_cursor + max_window_size)
+    end = min(max_end, log_cursor + window_size)
 
     # Return early and sleep if the end date is before the start date or if the date window is too small.
     # This is done to prevent repeatedly sending API requests for tiny date windows.
@@ -297,7 +296,7 @@ async def fetch_incremental_resources(
         end,
     )
 
-    async for record_or_dt in _execution_wrapper(gen, cursor_field, log_cursor, end, max_window_size, REST_CHECKPOINT_INTERVAL):
+    async for record_or_dt in _execution_wrapper(gen, cursor_field, log_cursor, end, window_size, REST_CHECKPOINT_INTERVAL):
         yield record_or_dt
 
     log.debug("Finished fetching incremental changes.", {

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -1,10 +1,11 @@
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from enum import StrEnum
-from typing import Any, Iterator, Annotated, ClassVar
+from typing import Any, Iterator, ClassVar, Literal
 
 from pydantic import (
     AwareDatetime,
     BaseModel,
+    ConfigDict,
     Field,
     ValidationInfo,
     create_model,
@@ -28,6 +29,7 @@ EARLIEST_VALID_DATE_IN_SALESFORCE = datetime(1700, 1, 1, tzinfo=UTC)
 # Salesforce was founded on 03FEB1999. As long as cursor values aren't backdated before this date (which only seems possible
 # for a select few of them), Salesforce's founding date should be a good start date for most users.
 SALESFORCE_FOUNDING_DATE = datetime(1999, 2, 3, tzinfo=UTC)
+MIN_INCREMENTAL_WINDOW_SIZE = timedelta(minutes=1)
 
 
 class SalesforceResourceConfigWithSchedule(ResourceConfigWithSchedule):
@@ -41,6 +43,44 @@ class SalesforceResourceConfigWithSchedule(ResourceConfigWithSchedule):
 
 def default_start_date():
     return SALESFORCE_FOUNDING_DATE
+
+
+class WindowSizeInDays(BaseModel):
+    model_config = ConfigDict(title="Days")
+
+    window_type: Literal["days"] = Field(
+        default="days",
+        json_schema_extra={"type": "string", "order": 0},
+    )
+    days: int = Field(
+        title="Days",
+        description="Window size as a whole number of days.",
+        gt=0,
+        json_schema_extra={"order": 1},
+    )
+
+    @property
+    def as_timedelta(self) -> timedelta:
+        return timedelta(days=self.days)
+
+
+class WindowSizeAsInterval(BaseModel):
+    model_config = ConfigDict(title="Interval")
+
+    window_type: Literal["interval"] = Field(
+        default="interval",
+        json_schema_extra={"type": "string", "order": 0},
+    )
+    interval: timedelta = Field(
+        title="Interval",
+        description="Window size as an ISO 8601 duration, e.g. PT1H for one hour.",
+        gt=MIN_INCREMENTAL_WINDOW_SIZE,
+        json_schema_extra={"order": 1},
+    )
+
+    @property
+    def as_timedelta(self) -> timedelta:
+        return self.interval
 
 
 class EndpointConfig(BaseModel):
@@ -86,19 +126,30 @@ class EndpointConfig(BaseModel):
         return self
 
     class Advanced(BaseModel):
-        window_size: Annotated[int, Field(
-            description="Date window size for Bulk API 2.0 queries (in days). Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+        window_size: WindowSizeAsInterval | WindowSizeInDays = Field(
+            description="Date window size for Bulk API 2.0 queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
             title="Window size",
-            default=18250,
-            gt=0,
-        )]
+            default_factory=lambda: WindowSizeInDays(days=18250),
+            discriminator="window_type",
+        )
+
+        @model_validator(mode="before")
+        @classmethod
+        def _coerce_legacy_window_size(cls, data: Any) -> Any:
+            # Older configs stored window_size as a bare integer count of days, before it became a
+            # discriminated union. Wrap that legacy form so running captures keep working without the
+            # user re-saving their config.
+            if isinstance(data, dict) and isinstance(data.get("window_size"), int):
+                return {**data, "window_size": {"window_type": "days", "days": data["window_size"]}}
+            return data
 
     advanced: Advanced = Field(
-        default_factory=Advanced, #type: ignore
+        default_factory=Advanced,  # type: ignore
         title="Advanced Config",
         description="Advanced settings for the connector.",
         json_schema_extra={"advanced": True},
     )
+
 
 ConnectorState = GenericConnectorState[ResourceState]
 

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -171,7 +171,7 @@ def incremental_resource(
                 name,
                 fields,
                 model_cls,
-                config.advanced.window_size,
+                config.advanced.window_size.as_timedelta,
                 config.start_date,
             ),
             fetch_changes=functools.partial(
@@ -182,7 +182,7 @@ def incremental_resource(
                 rest_query_manager,
                 instance_url,
                 name,
-                config.advanced.window_size,
+                config.advanced.window_size.as_timedelta,
             ),
         )
 

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,11 +6,23 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "default": 18250,
-              "description": "Date window size for Bulk API 2.0 queries (in days). Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
-              "exclusiveMinimum": 0,
-              "title": "Window size",
-              "type": "integer"
+              "description": "Date window size for Bulk API 2.0 queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+              "discriminator": {
+                "mapping": {
+                  "days": "#/$defs/WindowSizeInDays",
+                  "interval": "#/$defs/WindowSizeAsInterval"
+                },
+                "propertyName": "window_type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/WindowSizeAsInterval"
+                },
+                {
+                  "$ref": "#/$defs/WindowSizeInDays"
+                }
+              ],
+              "title": "Window size"
             }
           },
           "title": "Advanced",
@@ -80,6 +92,52 @@
             "security_token"
           ],
           "title": "UserPass",
+          "type": "object"
+        },
+        "WindowSizeAsInterval": {
+          "properties": {
+            "window_type": {
+              "const": "interval",
+              "default": "interval",
+              "order": 0,
+              "title": "Window Type",
+              "type": "string"
+            },
+            "interval": {
+              "description": "Window size as an ISO 8601 duration, e.g. PT1H for one hour.",
+              "format": "duration",
+              "order": 1,
+              "title": "Interval",
+              "type": "string"
+            }
+          },
+          "required": [
+            "interval"
+          ],
+          "title": "Interval",
+          "type": "object"
+        },
+        "WindowSizeInDays": {
+          "properties": {
+            "window_type": {
+              "const": "days",
+              "default": "days",
+              "order": 0,
+              "title": "Window Type",
+              "type": "string"
+            },
+            "days": {
+              "description": "Window size as a whole number of days.",
+              "exclusiveMinimum": 0,
+              "order": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "days"
+          ],
+          "title": "Days",
           "type": "object"
         },
         "_OAuth2Credentials": {


### PR DESCRIPTION
**Description:**

Adds support for ISO 8601 duration time windows. Bare integers are interpreted as days to preserve the existing behaviour.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

