### PR TITLE
materialize-mongodb: retry transient per-item bulk write errors

### DIFF
--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	m "github.com/estuary/connectors/go/materialize"
 	pf "github.com/estuary/flow/go/protocols/flow"
@@ -32,7 +34,31 @@ const (
 	// The default batchWriteLimit is 100,000 documents. Practically speaking we will be limited to
 	// less than that to keep connector memory usage reasonable.
 	storeBatchSize = 10_000
+
+	// maxStoreRetries bounds how many times a bulk write is attempted when items
+	// fail with a transient (retryable) write error.
+	maxStoreRetries = 5
 )
+
+// retryableWriteErrorCodes are MongoDB write error codes that are transient and
+// safe to retry by re-sending the affected models. Taken from the mongo-driver's
+// own retryableCodes set (x/mongo/driver/errors.go). Note that 11000 (E11000
+// duplicate key) is deliberately absent: a strict InsertOneModel on a !Exists
+// store is a tripwire, and a duplicate key must fail fast rather than retry.
+var retryableWriteErrorCodes = map[int]bool{
+	11600: true, // InterruptedAtShutdown
+	11602: true, // InterruptedDueToReplStateChange
+	10107: true, // NotWritablePrimary
+	13435: true, // NotPrimaryNoSecondaryOk
+	13436: true, // NotPrimaryOrSecondary
+	189:   true, // PrimarySteppedDown
+	91:    true, // ShutdownInProgress
+	7:     true, // HostNotFound
+	6:     true, // HostUnreachable
+	89:    true, // NetworkTimeout
+	9001:  true, // SocketException
+	262:   true, // ExceededTimeLimit
+}
 
 type transactor struct {
 	cfg      *config
@@ -293,7 +319,14 @@ func (t *transactor) storeWorker(
 
 			// Ordered operations are not needed since each key can only be seen a single time in a
 			// Flow transaction. Turning this off supposedly allows for optimizations by the server.
-			res, err := collection.BulkWrite(ctx, batch.models, options.BulkWrite().SetOrdered(false))
+			// Transient per-item write errors (e.g. a primary stepdown) are retried by re-sending
+			// only the failed models; a duplicate-key (E11000) is terminal and fails fast.
+			res, err := storeBulkWithRetry(ctx, batch.models, maxStoreRetries,
+				func(models []mongo.WriteModel) (*mongo.BulkWriteResult, error) {
+					return collection.BulkWrite(ctx, models, options.BulkWrite().SetOrdered(false))
+				},
+				storeRetryDelay,
+			)
 			if err != nil {
 				return fmt.Errorf("bulk write for collection %s: %w", collection.Name(), err)
 			}
@@ -328,6 +361,103 @@ func (t *transactor) storeWorker(
 				)
 			}
 		}
+	}
+}
+
+// classifyBulkErr inspects a BulkWrite error. It returns the first terminal
+// (non-retryable) error, if any, and the indices of models that failed with a
+// retryable write error. A terminal error takes precedence: when one is present
+// the caller should fail rather than retry. A non-BulkWriteException error
+// (transport/command level, which the driver has already retried per its own
+// retryable-write logic) and a write-concern error are both treated as terminal.
+func classifyBulkErr(err error) (terminal error, retryable []int) {
+	if err == nil {
+		return nil, nil
+	}
+
+	var bwe mongo.BulkWriteException
+	if !errors.As(err, &bwe) {
+		return err, nil
+	}
+	if bwe.WriteConcernError != nil {
+		return bwe, nil
+	}
+
+	for _, we := range bwe.WriteErrors {
+		if retryableWriteErrorCodes[we.Code] {
+			retryable = append(retryable, we.Index)
+		} else {
+			// First non-retryable item error (including E11000) wins.
+			return bwe, nil
+		}
+	}
+
+	return nil, retryable
+}
+
+// storeBulkWithRetry sends models via send and, if any models fail with a
+// retryable per-item write error, re-sends only those models after a delay, up
+// to maxAttempts times. Re-sending only the failed models is safe: a failed
+// model did not land, so it is never duplicated, and models that succeeded are
+// never re-sent. BulkWriteResult counts are accumulated across attempts so the
+// caller's sanity check sees the totals across the whole batch.
+func storeBulkWithRetry(
+	ctx context.Context,
+	models []mongo.WriteModel,
+	maxAttempts int,
+	send func(models []mongo.WriteModel) (*mongo.BulkWriteResult, error),
+	delay func(ctx context.Context, attempt int) error,
+) (*mongo.BulkWriteResult, error) {
+	pending := models
+	total := &mongo.BulkWriteResult{}
+
+	for attempt := 0; ; attempt++ {
+		res, err := send(pending)
+		if res != nil {
+			total.InsertedCount += res.InsertedCount
+			total.MatchedCount += res.MatchedCount
+			total.ModifiedCount += res.ModifiedCount
+			total.DeletedCount += res.DeletedCount
+			total.UpsertedCount += res.UpsertedCount
+		}
+
+		terminal, retryable := classifyBulkErr(err)
+		if terminal != nil {
+			return total, terminal
+		}
+		if len(retryable) == 0 {
+			return total, nil
+		}
+		if attempt+1 >= maxAttempts {
+			return total, fmt.Errorf("%d write models still failing after %d attempts: %w", len(retryable), attempt+1, err)
+		}
+
+		next := make([]mongo.WriteModel, len(retryable))
+		for i, idx := range retryable {
+			next[i] = pending[idx]
+		}
+		pending = next
+
+		if err := delay(ctx, attempt); err != nil {
+			return total, err
+		}
+	}
+}
+
+// storeRetryDelay waits before re-sending failed models, with exponential
+// backoff capped at 5s.
+func storeRetryDelay(ctx context.Context, attempt int) error {
+	d := time.Duration(1<<attempt) * time.Second
+	if d > 5*time.Second {
+		d = 5 * time.Second
+	}
+	logrus.WithFields(logrus.Fields{"attempt": attempt, "delay": d.String()}).
+		Info("waiting to retry transient bulk write error")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
 	}
 }
 

--- a/materialize-mongodb/transactor_unit_test.go
+++ b/materialize-mongodb/transactor_unit_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// bulkErr builds a mongo.BulkWriteException with one per-item WriteError per
+// entry in codeByIndex (index -> MongoDB error code). It is returned by value,
+// which satisfies the error interface.
+func bulkErr(codeByIndex map[int]int) mongo.BulkWriteException {
+	var bwe mongo.BulkWriteException
+	for idx, code := range codeByIndex {
+		bwe.WriteErrors = append(bwe.WriteErrors, mongo.BulkWriteError{
+			WriteError: mongo.WriteError{Index: idx, Code: code, Message: fmt.Sprintf("code %d", code)},
+		})
+	}
+	return bwe
+}
+
+func model(id string) mongo.WriteModel {
+	return &mongo.InsertOneModel{Document: bson.M{idField: id}}
+}
+
+func noDelay(context.Context, int) error { return nil }
+
+// TestStoreBulkRetryResendsOnlyFailedModels is the regression test for transient
+// per-item bulk write errors: a retryable per-item error (e.g. PrimarySteppedDown,
+// code 189) must be retried by re-sending only the failed model, not surfaced as
+// fatal. Counts from each attempt accumulate so the caller's sanity check holds.
+func TestStoreBulkRetryResendsOnlyFailedModels(t *testing.T) {
+	models := []mongo.WriteModel{model("A"), model("B"), model("C")}
+
+	responses := []struct {
+		res *mongo.BulkWriteResult
+		err error
+	}{
+		{&mongo.BulkWriteResult{InsertedCount: 2}, bulkErr(map[int]int{1: 189})}, // B fails transiently
+		{&mongo.BulkWriteResult{MatchedCount: 1}, nil},                           // resent B succeeds
+	}
+	var sent [][]mongo.WriteModel
+	send := func(models []mongo.WriteModel) (*mongo.BulkWriteResult, error) {
+		sent = append(sent, models)
+		r := responses[0]
+		responses = responses[1:]
+		return r.res, r.err
+	}
+
+	res, err := storeBulkWithRetry(context.Background(), models, maxStoreRetries, send, noDelay)
+	require.NoError(t, err)
+	require.Len(t, sent, 2, "should send the initial batch then a retry")
+	require.Len(t, sent[0], 3, "first send is the whole batch")
+	require.Len(t, sent[1], 1, "retry re-sends only the failed model")
+	require.Same(t, models[1], sent[1][0], "retry re-sends exactly the failed model")
+	require.Equal(t, int64(2), res.InsertedCount, "counts accumulate across attempts")
+	require.Equal(t, int64(1), res.MatchedCount, "counts accumulate across attempts")
+}
+
+// TestStoreBulkRetryFailsFastOnDuplicateKey guards the strict-insert tripwire: an
+// E11000 duplicate-key (code 11000) is non-retryable and must be returned
+// immediately without retrying.
+func TestStoreBulkRetryFailsFastOnDuplicateKey(t *testing.T) {
+	models := []mongo.WriteModel{model("A")}
+
+	var sends int
+	send := func(models []mongo.WriteModel) (*mongo.BulkWriteResult, error) {
+		sends++
+		return &mongo.BulkWriteResult{}, bulkErr(map[int]int{0: 11000})
+	}
+
+	_, err := storeBulkWithRetry(context.Background(), models, maxStoreRetries, send, noDelay)
+	require.Error(t, err)
+	require.Equal(t, 1, sends, "a duplicate-key error must not be retried")
+	var bwe mongo.BulkWriteException
+	require.True(t, errors.As(err, &bwe), "terminal error should be the BulkWriteException")
+	require.Equal(t, 11000, bwe.WriteErrors[0].Code)
+}
+
+// TestStoreBulkRetryExhaustsAttempts guards that a persistently retryable error
+// gives up after maxAttempts rather than looping forever, surfacing the
+// underlying error.
+func TestStoreBulkRetryExhaustsAttempts(t *testing.T) {
+	models := []mongo.WriteModel{model("A")}
+
+	var sends int
+	send := func(models []mongo.WriteModel) (*mongo.BulkWriteResult, error) {
+		sends++
+		return &mongo.BulkWriteResult{}, bulkErr(map[int]int{0: 10107}) // NotWritablePrimary
+	}
+
+	_, err := storeBulkWithRetry(context.Background(), models, 3 /* maxAttempts */, send, noDelay)
+	require.Error(t, err)
+	require.Equal(t, 3, sends, "should attempt exactly maxAttempts times")
+}


### PR DESCRIPTION
**Description:**

Adds a transient per-item bulk-write retry to `materialize-mongodb`. On a retryable write error (primary stepdown, not-writable-primary, network timeout, shutdown-in-progress), `storeBulkWithRetry` re-sends only the failed model indices with bounded exponential backoff (max 5 attempts; 1s/2s/4s/5s), accumulating `BulkWriteResult` counts across attempts so the existing count sanity check still holds.

`E11000` (duplicate key) is deliberately NOT retryable — the strict `InsertOneModel` on a `!Exists` store is a tripwire and must fail fast. Mirrors the merged scope of #4678 (materialize-elasticsearch).

**Workflow steps:**

Behavior-only; no config/API change. Standard materializations ride out momentary destination blips instead of crash-looping the shard.

**Notes for reviewers:**

- Retryable codes mirror the mongo-driver `retryableCodes` set; `11000` is intentionally excluded.
- Retry logic is unit-tested via an injected `send` func (no live MongoDB), TDD: failing-test commit then fix commit.
- Out of scope: the backfill duplicate-key crash (strict insert onto a non-empty collection) is left to be handled operationally; this PR only adds transient-error resilience.
