### PR TITLE
source-{misc. CDK captures}: start backfills with `next_page=None` so observable logs are more accurate

### DIFF
--- a/source-braintree-native/source_braintree_native/api/__init__.py
+++ b/source-braintree-native/source_braintree_native/api/__init__.py
@@ -135,14 +135,18 @@ async def backfill_transactions(
     base_url: str,
     braintree_gateway: BraintreeGateway,
     window_size: int,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[IncrementalResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = _str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = _str_to_dt(page)
 
     initial_end = min(
         start + timedelta(hours=window_size),
@@ -238,14 +242,18 @@ async def backfill_incremental_resources(
     braintree_gateway: BraintreeGateway,
     braintree_class: IncrementalResourceBraintreeClass,
     window_size: int,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor
 ) -> AsyncGenerator[IncrementalResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = _str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = _str_to_dt(page)
 
     initial_end = min(
         start + timedelta(hours=window_size),
@@ -317,14 +325,18 @@ async def backfill_disputes(
     http: HTTPSession,
     base_url: str,
     window_size: int,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[IncrementalResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = _str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = _str_to_dt(page)
 
     window_end = start + timedelta(hours=max(window_size, MIN_DISPUTES_WINDOW_SIZE))
     end = min(window_end, cutoff).replace(microsecond=0)

--- a/source-braintree-native/source_braintree_native/resources.py
+++ b/source-braintree-native/source_braintree_native/resources.py
@@ -30,7 +30,6 @@ from .models import (
 )
 
 from .api import (
-    dt_to_str,
     fetch_transactions,
     backfill_transactions,
     fetch_incremental_resources,
@@ -236,6 +235,7 @@ def incremental_resources(
                 gateway,
                 braintree_class,
                 window_size,
+                config.start_date,
             )
         )
 
@@ -249,7 +249,7 @@ def incremental_resources(
             open=functools.partial(open, path, response_model, _create_gateway(config), braintree_class, config.advanced.window_size),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(next_page=dt_to_str(config.start_date), cutoff=cutoff)
+                backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
             ),
             initial_config=ResourceConfigWithSchedule(
                 name=name, interval=timedelta(minutes=5), schedule="0 20 * * 5",
@@ -291,6 +291,7 @@ def transactions(
                 base_url,
                 gateway,
                 window_size,
+                config.start_date,
             )
         )
 
@@ -303,7 +304,7 @@ def transactions(
         open=functools.partial(open, _create_gateway(config), config.advanced.window_size),
         initial_state=ResourceState(
             inc=ResourceState.Incremental(cursor=cutoff),
-            backfill=ResourceState.Backfill(next_page=dt_to_str(config.start_date), cutoff=cutoff)
+            backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
         ),
         initial_config=ResourceConfigWithSchedule(
             name='transactions', interval=timedelta(minutes=5)
@@ -339,6 +340,7 @@ def disputes(
                 http,
                 base_url,
                 window_size,
+                config.start_date,
             )
         )
 
@@ -351,7 +353,7 @@ def disputes(
         open=functools.partial(open, config.advanced.window_size),
         initial_state=ResourceState(
             inc=ResourceState.Incremental(cursor=cutoff),
-            backfill=ResourceState.Backfill(next_page=dt_to_str(config.start_date), cutoff=cutoff)
+            backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
         ),
         initial_config=ResourceConfigWithSchedule(
             name='disputes', interval=timedelta(minutes=5)

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/api.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/api.py
@@ -213,13 +213,18 @@ async def backfill_report(
     property_id: str,
     report_doc_model: type[ReportDocument],
     report: Report,
+    start_date: datetime,
     log: Logger,
-    page: PageCursor,
+    page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[ReportDocument | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
-    start = str_to_dt(page)
+
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
 
     # The incremental task will capture records for the cutoff day.
     if start >= cutoff or _are_same_day(start, cutoff):

--- a/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
+++ b/source-google-analytics-data-api-native/source_google_analytics_data_api_native/resources.py
@@ -28,10 +28,6 @@ from .models import (
     Report,
     ReportDocument,
 )
-from .utils import (
-    dt_to_str,
-)
-
 from .default_reports import DEFAULT_REPORTS
 
 
@@ -183,6 +179,7 @@ def reports(
                 config.property_id,
                 model,
                 report,
+                start,
             )
         )
 
@@ -206,7 +203,7 @@ def reports(
             open=functools.partial(open, model, report),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
             ),
             initial_config=ResourceConfig(
                 name=report.name, interval=timedelta(hours=12)

--- a/source-google-play/source_google_play/api.py
+++ b/source-google-play/source_google_play/api.py
@@ -72,13 +72,18 @@ async def fetch_reviews(
 async def backfill_resources(
     gcs_client: GCSClient,
     model: type[GooglePlayRow],
+    start: str,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[GooglePlayRow | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
-    cursor_month = str_to_dt(page)
+
+    if page is None:
+        cursor_month = str_to_dt(start)
+    else:
+        assert isinstance(page, str)
+        cursor_month = str_to_dt(page)
 
     if cursor_month >= cutoff:
         return

--- a/source-google-play/source_google_play/resources.py
+++ b/source-google-play/source_google_play/resources.py
@@ -84,6 +84,7 @@ def resources(
                 backfill_resources,
                 gcs_client,
                 model,
+                start,
             )
         )
 
@@ -100,7 +101,7 @@ def resources(
             open=functools.partial(open, model),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=start)
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
             ),
             initial_config=ResourceConfig(
                 name=model.name, interval=timedelta(minutes=60)

--- a/source-jira-native/source_jira_native/api.py
+++ b/source-jira-native/source_jira_native/api.py
@@ -1071,14 +1071,19 @@ async def backfill_issues(
     domain: str,
     timezone: ZoneInfo,
     projects: str | None,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[JiraResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
+
     last_seen = start
 
     count = 0
@@ -1280,14 +1285,19 @@ async def backfill_issues_child_resources(
     timezone: ZoneInfo,
     projects: str | None,
     stream: type[IssueChildStream],
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[IssueChildResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
+
     last_seen = start
 
     count = 0

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -47,7 +47,6 @@ from .models import (
 from .api import (
     backfill_issues,
     backfill_issues_child_resources,
-    dt_to_str,
     fetch_issues,
     fetch_issues_child_resources,
     fetch_timezone,
@@ -368,6 +367,7 @@ def issues(
                 config.domain,
                 timezone,
                 config.advanced.projects,
+                start,
             )
         )
 
@@ -386,7 +386,7 @@ def issues(
                 REALTIME: ResourceState.Incremental(cursor=cutoff),
                 LOOKBACK: ResourceState.Incremental(cursor=cutoff - ISSUE_SEARCH_EVENTUAL_CONSISTENCY_HORIZON),
             },
-            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
+            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
         ),
         initial_config=ResourceConfigWithSchedule(
             name="issues", interval=timedelta(minutes=5)
@@ -432,6 +432,7 @@ def issue_child_resources(
                 timezone,
                 config.advanced.projects,
                 stream,
+                start,
             )
         )
 
@@ -454,7 +455,7 @@ def issue_child_resources(
                         REALTIME: ResourceState.Incremental(cursor=cutoff),
                         LOOKBACK: ResourceState.Incremental(cursor=cutoff - ISSUE_SEARCH_EVENTUAL_CONSISTENCY_HORIZON),
                     },
-                    backfill=ResourceState.Backfill(cutoff=cutoff, next_page=dt_to_str(start))
+                    backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
                 ),
                 initial_config=ResourceConfigWithSchedule(
                     name=stream.name, interval=timedelta(minutes=5)

--- a/source-klaviyo-native/source_klaviyo_native/api/common.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/common.py
@@ -250,14 +250,18 @@ async def fetch_incremental_resources(
 async def backfill_incremental_resources(
     http: HTTPSession,
     model: type[IncrementalStream],
+    start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[IncrementalStream | PageCursor, None]:
     assert isinstance(cutoff, datetime)
-    assert isinstance(page, str)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
 
     if start >= cutoff:
         return

--- a/source-klaviyo-native/source_klaviyo_native/api/events.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/events.py
@@ -383,14 +383,19 @@ async def subdivision_worker(
 async def backfill_events(
     http: HTTPSession,
     window_size: timedelta,
+    start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[IncrementalStream | PageCursor, None]:
     assert isinstance(cutoff, datetime)
-    assert isinstance(page, str)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
+
     if start >= cutoff:
         return
 

--- a/source-klaviyo-native/source_klaviyo_native/resources.py
+++ b/source-klaviyo-native/source_klaviyo_native/resources.py
@@ -34,7 +34,6 @@ from .models import (
     SmsCampaigns,
     SmsCampaignsArchived,
 )
-from .shared import dt_to_str
 
 # Klaviyo doesn't use the standard "Bearer" token type in the Authorization
 # header. Instead, it uses "Klaviyo-API-Key" as the token type.
@@ -138,11 +137,12 @@ def incremental_resources(
                 backfill_incremental_resources,
                 http,
                 model,
+                start,
             )
         )
 
     cutoff = datetime.now(tz=UTC)
-    start = dt_to_str(config.start_date - timedelta(seconds=1))
+    start = config.start_date - timedelta(seconds=1)
 
     resources = [
             common.Resource(
@@ -152,7 +152,7 @@ def incremental_resources(
             open=functools.partial(open, model),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=start)
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
             ),
             initial_config=ResourceConfig(
                 name=model.name, interval=timedelta(minutes=5)
@@ -208,28 +208,28 @@ def campaigns(
             },
             fetch_page={
                 "email": functools.partial(
-                    backfill_incremental_resources, http, EmailCampaigns,
+                    backfill_incremental_resources, http, EmailCampaigns, start,
                 ),
                 "archived_email": functools.partial(
-                    backfill_incremental_resources, http, EmailCampaignsArchived,
+                    backfill_incremental_resources, http, EmailCampaignsArchived, start,
                 ),
                 "sms": functools.partial(
-                    backfill_incremental_resources, http, SmsCampaigns,
+                    backfill_incremental_resources, http, SmsCampaigns, start,
                 ),
                 "archived_sms": functools.partial(
-                    backfill_incremental_resources, http, SmsCampaignsArchived,
+                    backfill_incremental_resources, http, SmsCampaignsArchived, start,
                 ),
                 "mobile_push": functools.partial(
-                    backfill_incremental_resources, http, MobilePushCampaigns,
+                    backfill_incremental_resources, http, MobilePushCampaigns, start,
                 ),
                 "archived_mobile_push": functools.partial(
-                    backfill_incremental_resources, http, MobilePushCampaignsArchived,
+                    backfill_incremental_resources, http, MobilePushCampaignsArchived, start,
                 ),
             }
         )
 
     cutoff = datetime.now(tz=UTC)
-    start = dt_to_str(config.start_date - timedelta(seconds=1))
+    start = config.start_date - timedelta(seconds=1)
 
     return common.Resource(
         name=Campaigns.name,
@@ -246,12 +246,12 @@ def campaigns(
                 "archived_mobile_push": ResourceState.Incremental(cursor=cutoff),
             },
             backfill={
-                "email": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "archived_email": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "sms": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "archived_sms": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "mobile_push": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "archived_mobile_push": ResourceState.Backfill(cutoff=cutoff, next_page=start),
+                "email": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "archived_email": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "sms": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "archived_sms": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "mobile_push": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "archived_mobile_push": ResourceState.Backfill(cutoff=cutoff, next_page=None),
             }
         ),
         initial_config=ResourceConfig(
@@ -290,16 +290,16 @@ def flows(
             },
             fetch_page={
                 "active": functools.partial(
-                    backfill_incremental_resources, http, Flows,
+                    backfill_incremental_resources, http, Flows, start,
                 ),
                 "archived": functools.partial(
-                    backfill_incremental_resources, http, FlowsArchived,
+                    backfill_incremental_resources, http, FlowsArchived, start,
                 ),
             }
         )
 
     cutoff = datetime.now(tz=UTC)
-    start = dt_to_str(config.start_date - timedelta(seconds=1))
+    start = config.start_date - timedelta(seconds=1)
 
     return common.Resource(
         name=Flows.name,
@@ -312,8 +312,8 @@ def flows(
                 "archived": ResourceState.Incremental(cursor=cutoff),
             },
             backfill={
-                "active": ResourceState.Backfill(cutoff=cutoff, next_page=start),
-                "archived": ResourceState.Backfill(cutoff=cutoff, next_page=start),
+                "active": ResourceState.Backfill(cutoff=cutoff, next_page=None),
+                "archived": ResourceState.Backfill(cutoff=cutoff, next_page=None),
             }
         ),
         initial_config=ResourceConfig(
@@ -350,11 +350,11 @@ def events(
                     fetch_incremental_resources, http, Events, EVENTS_EVENTUAL_CONSISTENCY_HORIZON,
                 ),
             },
-            fetch_page=functools.partial(backfill_events, http, config.advanced.window_size)
+            fetch_page=functools.partial(backfill_events, http, config.advanced.window_size, start)
         )
 
     cutoff = datetime.now(tz=UTC)
-    start = dt_to_str(config.start_date - timedelta(seconds=1))
+    start = config.start_date - timedelta(seconds=1)
 
     return common.Resource(
         name=Events.name,
@@ -366,7 +366,7 @@ def events(
                 "realtime": ResourceState.Incremental(cursor=cutoff),
                 "lookback": ResourceState.Incremental(cursor=cutoff - EVENTS_EVENTUAL_CONSISTENCY_HORIZON),
             },
-            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=start)
+            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
         ),
         initial_config=ResourceConfig(
             name=Events.name, interval=timedelta(minutes=5)

--- a/source-pendo/source_pendo/api.py
+++ b/source-pendo/source_pendo/api.py
@@ -454,13 +454,19 @@ async def backfill_events(
         model: type[Event],
         identifying_field: str,
         limit: int,
+        start_ms: int,
         log: Logger,
         page_cursor: PageCursor | None,
         cutoff: LogCursor,
 ) -> AsyncGenerator[Event | PageCursor, None]:
-    assert isinstance(page_cursor, int)
     assert isinstance(cutoff, datetime)
-    last_dt = _ms_to_dt(page_cursor)
+    if page_cursor is None:
+        start = start_ms
+    else:
+        assert isinstance(page_cursor, int)
+        start = page_cursor
+
+    last_dt = _ms_to_dt(start)
     upper_bound_dt = last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS)
 
     # If we've reached or exceeded the cutoff date, stop backfilling.
@@ -486,7 +492,7 @@ async def backfill_events(
     if count == 0:
         # If there were no documents, we need to move the cursor forward to slide forward our date window.
         yield _dt_to_ms(last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS))
-    elif last_dt > _ms_to_dt(page_cursor):
+    elif last_dt > _ms_to_dt(start):
         # If there were documents and the last one has a later timestamp than our cursor,
         # then update the cursor to the later timestamp.
         yield _dt_to_ms(last_dt)
@@ -640,13 +646,19 @@ async def backfill_aggregated_events(
         model: type[EventAggregate],
         identifying_field: str,
         limit: int,
+        start_ms: int,
         log: Logger,
         page_cursor: PageCursor | None,
         cutoff: LogCursor,
 ) -> AsyncGenerator[EventAggregate | PageCursor, None]:
-    assert isinstance(page_cursor, int)
     assert isinstance(cutoff, datetime)
-    last_dt = _ms_to_dt(page_cursor)
+    if page_cursor is None:
+        start = start_ms
+    else:
+        assert isinstance(page_cursor, int)
+        start = page_cursor
+
+    last_dt = _ms_to_dt(start)
     upper_bound_dt = last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS)
 
     # If we've reached or exceeded the cutoff date, stop backfilling.
@@ -672,7 +684,7 @@ async def backfill_aggregated_events(
     if count == 0:
         # If there were no documents, we need to move the cursor forward to slide forward our date window.
         yield _dt_to_ms(last_dt + timedelta(days=EVENT_DATE_WINDOW_SIZE_IN_DAYS))
-    elif last_dt > _ms_to_dt(page_cursor):
+    elif last_dt > _ms_to_dt(start):
         # If there were documents and the last one has a later
         # timestamp than our cursor, update the cursor.
         yield _dt_to_ms(last_dt)
@@ -844,13 +856,19 @@ async def backfill_resources(
         updated_at_field: str,
         identifying_field: str,
         limit: int,
+        start_ms: int,
         log: Logger,
         page_cursor: PageCursor | None,
         cutoff: LogCursor,
 ) -> AsyncGenerator[IncrementalResource | PageCursor, None]:
-    assert isinstance(page_cursor, int)
     assert isinstance(cutoff, datetime)
-    last_dt = _ms_to_dt(page_cursor)
+    if page_cursor is None:
+        start = start_ms
+    else:
+        assert isinstance(page_cursor, int)
+        start = page_cursor
+
+    last_dt = _ms_to_dt(start)
     upper_bound_dt = last_dt + timedelta(days=RESOURCE_DATE_WINDOW_SIZE_IN_DAYS)
 
     # If we've reached or exceeded the cutoff date, stop backfilling.
@@ -877,7 +895,7 @@ async def backfill_resources(
     if count == 0:
         # If there were no documents, we need to move the cursor forward to slide forward our date window.
         yield _dt_to_ms(last_dt + timedelta(days=RESOURCE_DATE_WINDOW_SIZE_IN_DAYS))
-    elif last_dt > _ms_to_dt(page_cursor):
+    elif last_dt > _ms_to_dt(start):
         # If there were documents and the last one has a later
         # timestamp than our cursor, update the cursor.
         yield _dt_to_ms(last_dt)

--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -138,6 +138,7 @@ def incremental_resources(
                 updated_at_field,
                 identifying_field,
                 config.advanced.backfill_limit,
+                backfill_start_ts,
             )
         )
 
@@ -152,7 +153,7 @@ def incremental_resources(
             open=functools.partial(open, stream.entity_name, stream, stream.cursor_field, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)
+                backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
             ),
             initial_config=ResourceConfig(
                 name=stream.resource_name, interval=timedelta(minutes=5)
@@ -244,6 +245,7 @@ def events(
                 model,
                 identifying_field,
                 config.advanced.backfill_limit,
+                backfill_start_ts,
             )
         )
 
@@ -268,7 +270,7 @@ def events(
             open=functools.partial(open, stream.entity_name, stream, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)
+                backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
             ),
             initial_config=ResourceConfig(
                 name=stream.resource_name, interval=timedelta(minutes=5)
@@ -316,11 +318,12 @@ def aggregated_events(
                 model,
                 identifying_field,
                 config.advanced.backfill_limit,
+                backfill_start_ts,
             )
         )
 
     backfill_start_ts = _dt_to_ms(datetime.fromisoformat(config.startDate))
-    cutoff = datetime.now(tz=UTC) - API_EVENT_LAG 
+    cutoff = datetime.now(tz=UTC) - API_EVENT_LAG
 
     shared_keys = [
         "/accountId",
@@ -341,7 +344,7 @@ def aggregated_events(
             open=functools.partial(open, stream.entity_name, stream, stream.identifying_field),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(next_page=backfill_start_ts, cutoff=cutoff)
+                backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
             ),
             initial_config=ResourceConfig(
                 name=stream.resource_name, interval=timedelta(minutes=5)

--- a/source-quickbooks/source_quickbooks/api.py
+++ b/source-quickbooks/source_quickbooks/api.py
@@ -79,14 +79,19 @@ async def backfill_entity(
     http: HTTPSession,
     base_url: str,
     realm_id: str,
+    start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[T | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    page_ts = datetime.fromisoformat(page)
+    if page is None:
+        page_ts = start_date
+    else:
+        assert isinstance(page, str)
+        page_ts = datetime.fromisoformat(page)
+
     timeout = datetime.now(tz=UTC) + TARGET_FETCH_PAGE_INVOCATION_RUN_TIME
     timeout_checkpoint = None
 

--- a/source-quickbooks/source_quickbooks/resources.py
+++ b/source-quickbooks/source_quickbooks/resources.py
@@ -100,6 +100,7 @@ async def all_resources(
                 http,
                 base_url,
                 config.realm_id,
+                start_date,
             ),
         )
 
@@ -111,7 +112,7 @@ async def all_resources(
             open=functools.partial(open_all_bindings, resource),
             initial_state=ResourceState(
                 backfill=ResourceState.Backfill(
-                    cutoff=cutoff, next_page=start_date.isoformat(timespec="seconds")
+                    cutoff=cutoff, next_page=None
                 ),
                 inc=ResourceState.Incremental(cursor=cutoff),
             ),

--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -163,15 +163,19 @@ async def backfill_incremental_resources(
     fields: FieldDetailsDict,
     model_cls: type[SalesforceRecord],
     window_size: int,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
     is_connector_initiated: bool,
 ) -> AsyncGenerator[SalesforceRecord | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
 
     if start >= cutoff:
         log.debug("Page cursor is after cutoff, indicating backfill is complete.", {

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -17,7 +17,7 @@ from .supported_standard_objects import (
 
 from .bulk_job_manager import BulkJobManager
 from .rest_query_manager import RestQueryManager
-from .shared import dt_to_str, now, VERSION
+from .shared import now, VERSION
 
 from .models import (
     EndpointConfig,
@@ -171,7 +171,8 @@ def incremental_resource(
                 name,
                 fields,
                 model_cls,
-                config.advanced.window_size
+                config.advanced.window_size,
+                config.start_date,
             ),
             fetch_changes=functools.partial(
                 fetch_incremental_resources,
@@ -194,7 +195,7 @@ def incremental_resource(
         open=open,
         initial_state=ResourceState(
             inc=ResourceState.Incremental(cursor=cutoff),
-            backfill=ResourceState.Backfill(next_page=dt_to_str(config.start_date), cutoff=cutoff)
+            backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
         ),
         initial_config=SalesforceResourceConfigWithSchedule(
             name=name,

--- a/source-sentry/source_sentry/api.py
+++ b/source-sentry/source_sentry/api.py
@@ -101,14 +101,19 @@ async def backfill_issues(
     http: HTTPSession,
     organization: str,
     window_size: timedelta,
+    start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[Issue | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    page_ts = datetime.fromisoformat(page)
+    if page is None:
+        page_ts = start_date
+    else:
+        assert isinstance(page, str)
+        page_ts = datetime.fromisoformat(page)
+
     max_date_to_fetch = min(page_ts + window_size, cutoff)
 
     log.info(
@@ -400,6 +405,7 @@ async def backfill_explore_query(
     http: HTTPSession,
     organization: str,
     explore_query: ExploreQuery,
+    start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
@@ -407,10 +413,14 @@ async def backfill_explore_query(
     """Backfill the pre-30d tail (older than the rolling full-fidelity window)
     one explicit start/end window at a time. errors/transactions are full;
     spans are sampled (Sentry downsamples on explicit ranges)."""
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    page_ts = datetime.fromisoformat(page)
+    if page is None:
+        page_ts = start_date
+    else:
+        assert isinstance(page, str)
+        page_ts = datetime.fromisoformat(page)
+
     if page_ts >= cutoff:
         return
 

--- a/source-sentry/source_sentry/resources.py
+++ b/source-sentry/source_sentry/resources.py
@@ -121,7 +121,11 @@ async def all_resources(
             task,
             fetch_changes=functools.partial(fetch_issues, http, config.organization),
             fetch_page=functools.partial(
-                backfill_issues, http, config.organization, config.advanced.window_size
+                backfill_issues,
+                http,
+                config.organization,
+                config.advanced.window_size,
+                start_date,
             ),
         )
 
@@ -142,7 +146,7 @@ async def all_resources(
                 fetch_explore_query, http, config.organization, explore_query
             ),
             fetch_page=functools.partial(
-                backfill_explore_query, http, config.organization, explore_query
+                backfill_explore_query, http, config.organization, explore_query, start_date
             ),
         )
 
@@ -172,7 +176,7 @@ async def all_resources(
             initial_state=ResourceState(
                 backfill=ResourceState.Backfill(
                     cutoff=cutoff,
-                    next_page=start_date.isoformat(),
+                    next_page=None,
                 ),
                 inc=common.ResourceState.Incremental(
                     cursor=cutoff - timedelta(seconds=1)  # Time bounds are exclusive
@@ -190,7 +194,7 @@ async def all_resources(
             initial_state=ResourceState(
                 backfill=ResourceState.Backfill(
                     cutoff=explore_cutoff,
-                    next_page=start_date.isoformat(),
+                    next_page=None,
                 ),
                 inc=common.ResourceState.Incremental(
                     # Time bounds are exclusive; start incremental at the later of

--- a/source-shopify-native/source_shopify_native/api.py
+++ b/source-shopify-native/source_shopify_native/api.py
@@ -266,14 +266,18 @@ async def backfill_incremental(
     data_model: type[BaseResponseData[TShopifyGraphQLResource]],
     store: str,
     capabilities: StoreCapabilities,
+    start_date: datetime,
     log: Logger,
     page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[TShopifyGraphQLResource | PageCursor, None]:
-    assert isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    start = str_to_dt(page)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, str)
+        start = str_to_dt(page)
 
     last_seen_dt = start
     count = 0

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -35,7 +35,6 @@ from .api import (
     fetch_incremental_unsorted,
     fetch_snapshot,
 )
-from .utils import dt_to_str
 from .models import (
     AccessScopes,
     ConnectorState,
@@ -254,7 +253,6 @@ def _create_initial_state(
     store_ids: list[str],
     start_date: AwareDatetime,
     use_backfill: bool,
-    is_unsorted: bool = False,
 ) -> ResourceState:
     """Create initial state for a resource.
 
@@ -267,16 +265,14 @@ def _create_initial_state(
         store_ids: List of store IDs to create state for.
         start_date: The start date for data replication.
         use_backfill: Whether to create backfill state (for non-bulk queries).
-        is_unsorted: Whether this is an unsorted (no sortKey) stream.
     """
     cutoff = datetime.now(tz=UTC)
 
     if use_backfill:
-        next_page = None if is_unsorted else dt_to_str(start_date)
         return ResourceState(
             inc={sid: ResourceState.Incremental(cursor=cutoff) for sid in store_ids},
             backfill={
-                sid: ResourceState.Backfill(next_page=next_page, cutoff=cutoff)
+                sid: ResourceState.Backfill(next_page=None, cutoff=cutoff)
                 for sid in store_ids
             },
         )
@@ -547,9 +543,8 @@ async def all_resources(
             continue
 
         use_backfill = not model.SHOULD_USE_BULK_QUERIES
-        is_unsorted = model.SORT_KEY is None
         initial_state = _create_initial_state(
-            stores_with_access, config.start_date, use_backfill, is_unsorted
+            stores_with_access, config.start_date, use_backfill
         )
         legacy_store_id = config._legacy_store or config.stores[0].store
 
@@ -647,6 +642,7 @@ async def all_resources(
                             data_model,
                             store_id,
                             ctx.capabilities,
+                            config.start_date,
                         )
 
                 open_binding(

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -411,23 +411,29 @@ async def fetch_satisfaction_ratings(
 async def backfill_satisfaction_ratings(
     http: HTTPSession,
     subdomain: str,
+    start_date: datetime,
     log: Logger,
-    page: PageCursor,
+    page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[ZendeskResource | PageCursor, None]:
-    assert isinstance(page, int)
     assert isinstance(cutoff, datetime)
     cutoff_ts = _dt_to_s(cutoff)
 
-    if page >= cutoff_ts:
+    if page is None:
+        start = _dt_to_s(start_date)
+    else:
+        assert isinstance(page, int)
+        start = page
+
+    if start >= cutoff_ts:
         return
 
-    end = min(cutoff_ts, page + int(MAX_SATISFACTION_RATINGS_WINDOW_SIZE.total_seconds()))
+    end = min(cutoff_ts, start + int(MAX_SATISFACTION_RATINGS_WINDOW_SIZE.total_seconds()))
 
     generator = _fetch_satisfaction_ratings_between(
         http=http,
         subdomain=subdomain,
-        start=page,
+        start=start,
         end=end,
         log=log,
     )
@@ -538,14 +544,20 @@ async def backfill_incremental_time_export_resources(
     name: str,
     path: str,
     response_model: type[IncrementalTimeExportResponse],
+    start_date: datetime,
     log: Logger,
-    page: PageCursor,
+    page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | PageCursor, None]:
-    assert isinstance(page, int)
     assert isinstance(cutoff, datetime)
 
-    generator = _fetch_incremental_time_export_resources(http, subdomain, name, path, response_model, _s_to_dt(page), log)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, int)
+        start = _s_to_dt(page)
+
+    generator = _fetch_incremental_time_export_resources(http, subdomain, name, path, response_model, start, log)
 
     async for result in generator:
         if isinstance(result, datetime):
@@ -661,14 +673,20 @@ async def backfill_talk_incremental_export_resources(
     name: str,
     path: str,
     response_model: type[TalkIncrementalExportResponse],
+    start_date: datetime,
     log: Logger,
-    page: PageCursor,
+    page: PageCursor | None,
     cutoff: LogCursor,
 ) -> AsyncGenerator[TimestampedResource | PageCursor, None]:
-    assert isinstance(page, int)
     assert isinstance(cutoff, datetime)
 
-    generator = _fetch_talk_incremental_export_resources(http, subdomain, name, path, response_model, _s_to_dt(page), log)
+    if page is None:
+        start = start_date
+    else:
+        assert isinstance(page, int)
+        start = _s_to_dt(page)
+
+    generator = _fetch_talk_incremental_export_resources(http, subdomain, name, path, response_model, start, log)
 
     async for result in generator:
         if isinstance(result, datetime):

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -534,6 +534,7 @@ def satisfaction_ratings(
                 backfill_satisfaction_ratings,
                 http,
                 config.subdomain,
+                config.start_date,
             )
         )
 
@@ -546,7 +547,7 @@ def satisfaction_ratings(
         open=open,
         initial_state=ResourceState(
             inc=ResourceState.Incremental(cursor=cutoff),
-            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=_dt_to_s(config.start_date))
+            backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
         ),
         initial_config=ResourceConfig(
             name="satisfaction_ratings", interval=timedelta(minutes=5)
@@ -653,6 +654,7 @@ def incremental_time_export_resources(
                 name,
                 path,
                 response_model,
+                config.start_date,
             )
         )
 
@@ -666,7 +668,7 @@ def incremental_time_export_resources(
             open=functools.partial(open, name, path, response_model),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=_dt_to_s(config.start_date))
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
             ),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5)
@@ -713,6 +715,7 @@ def talk_incremental_export_resources(
                 name,
                 path,
                 response_model,
+                config.start_date,
             )
         )
 
@@ -726,7 +729,7 @@ def talk_incremental_export_resources(
             open=functools.partial(open, name, path, response_model),
             initial_state=ResourceState(
                 inc=ResourceState.Incremental(cursor=cutoff),
-                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=_dt_to_s(config.start_date))
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None)
             ),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5)


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Some connectors have been seeding their initial backfill state with non-`None` `next_page` values. Functionally, that's perfectly fine, but it prevents the CDK from determining between a freshly started backfill & an ongoing backfill. We've recently made the `beginning backfill` log in the CDK an [observable log](https://github.com/estuary/connectors/pull/4656) so we can track which connectors are performing backfills & how frequently. It'd be nicer if as many CDK based connectors as possible didn't seed their backfills' initial `next_page`s with non-`None` values so those observable logs were more accurate / useful.

This PR updates many of the CDK connectors to stop seeding `next_page` with non-`None` values so fresh backfills trigger the `beginning backfill` log. There are still some more improvements we can make to certain connectors so these diagnostic logs are even more accurate to reality (ex: updating `source-shopify-native` to have distinct backfill / `fetch_page` tasks for incremental streams using bulk queries), but the current PR scope felt fairly well scoped by itself & tackled enough of the low hanging fruit for now.

**Notes for reviewers:**

No functional changes. They're all pretty mechanical changes of pushing the initial `page` determination from the `Resource` construction flow down into each `fetch_page` function.

