### PR TITLE
ci: prompt-cache the delayed-tag roll-forward check

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -514,34 +514,47 @@ def fetch_pr_details(
     return f'{meta.strip()}\n\n--- diff ---\n{diff}'
 
 
-def build_claude_prompt(
+# Static task framing. Deliberately free of any per-connector specifics (no
+# image name, PR numbers, or diffs) so it is byte-identical across every call
+# in a run and sits at the front of the cacheable prefix.
+_VERDICT_INSTRUCTIONS = (
+    "You are auditing a release pipeline for the Estuary connectors monorepo.\n"
+    "We promote one connector image to the ':delayed' tag, pinned to a CHOSEN\n"
+    "pull request. Determine whether any LATER PR is a roll-forward fix of the\n"
+    "CHOSEN PR — i.e. patches a bug or regression introduced BY the CHOSEN PR. A\n"
+    "feature addition, refactor, dependency bump, test addition, or unrelated\n"
+    "bugfix is NOT a roll-forward fix. Only flag PRs that exist because the\n"
+    "CHOSEN PR was buggy. Note that PR descriptions may explicitly include a link\n"
+    "to the pull-request causing the regression being fixed, however you cannot\n"
+    "take this explicit statement of regression as granted. It is possible that\n"
+    "no such explicit mention of a regression is there, but the pull-request is\n"
+    "still a roll-forward fix of a previous PR. Use the explicit statement as\n"
+    "additional information and not as the sole source of truth.\n\n"
+    "Note: this repo uses rebase-and-merge, so each PR's commits land on main as\n"
+    "a linear sequence — judge PRs as units, not individual commits."
+)
+
+
+def _later_section(later_pr_bodies: list) -> str:
+    """Render the LATER-PR block, sorted by PR number so that two connectors
+    sharing the same set of LATER PRs produce byte-identical text (and thus a
+    shared cache prefix)."""
+    return '\n\n'.join(
+        f'=== LATER: PR #{num} ===\n{body}' for num, body in sorted(later_pr_bodies)
+    )
+
+
+def _chosen_section(
     image_name: str,
     source_dir: str,
     chosen_pr_num: int,
     chosen_pr_body: str,
-    later_pr_bodies: list,  # [(pr_num, body_text), ...]
 ) -> str:
-    later_sections = '\n\n'.join(
-        f'=== LATER: PR #{num} ===\n{body}' for num, body in later_pr_bodies
-    )
+    """The per-connector tail: the CHOSEN PR plus the response instruction."""
     return (
-        f"You are auditing a release pipeline for the Estuary connectors monorepo.\n"
-        f"We are about to promote image '{image_name}' (source dir '{source_dir}/') to\n"
-        f"the ':delayed' tag, pinned to PR #{chosen_pr_num}.\n\n"
-        f"Determine whether any LATER PR is a roll-forward fix of the CHOSEN PR —\n"
-        f"i.e. patches a bug or regression introduced BY the CHOSEN PR. A feature\n"
-        f"addition, refactor, dependency bump, test addition, or unrelated bugfix\n"
-        f"is NOT a roll-forward fix. Only flag PRs that exist because the CHOSEN\n"
-        f"PR was buggy. Note that PR descriptions may explicitly include a link\n"
-        f"to the pull-request causing the regression being fixed, however you cannot\n"
-        f"take this explicit statement of regression as granted. It is possible that\n"
-        f"no such explicit mention of a regression is there, but the pull-request is still\n"
-        f"a roll-forward fix of a previous PR. Use the explicit statement as additional\n"
-        f"information and not as the sole source of truth.\n\n"
-        f"Note: this repo uses rebase-and-merge, so each PR's commits land on main\n"
-        f"as a linear sequence — judge PRs as units, not individual commits.\n\n"
+        f"We are about to promote image '{image_name}' (source dir "
+        f"'{source_dir}/') to the ':delayed' tag, pinned to PR #{chosen_pr_num}.\n\n"
         f"=== CHOSEN: PR #{chosen_pr_num} ===\n{chosen_pr_body}\n\n"
-        f"{later_sections}\n\n"
         f'Reply with ONLY a JSON object, no prose:\n'
         f'{{"verdict": "safe" | "hold", "reason": "<one short sentence>", '
         f'"fix_prs": [<pr numbers that are roll-forward fixes of CHOSEN>]}}\n'
@@ -550,12 +563,62 @@ def build_claude_prompt(
     )
 
 
-def call_claude(prompt: str, api_key: str, model: str = 'claude-sonnet-4-6') -> str:
-    """Call the Anthropic Messages API and return the assistant's text."""
+def build_claude_content(
+    image_name: str,
+    source_dir: str,
+    chosen_pr_num: int,
+    chosen_pr_body: str,
+    later_pr_bodies: list,  # [(pr_num, body_text), ...]
+) -> list:
+    """
+    Build the Messages API `content` blocks for one verdict request.
+
+    The static instructions + LATER-PR diffs form the first block and carry a
+    cache_control breakpoint. Connectors that share the same set of LATER PRs —
+    the common (and expensive) case after a monorepo-wide sweep PR, where one
+    large diff is a LATER PR for many connectors — produce a byte-identical
+    prefix, so every call after the first reads those diffs from cache (~0.1x
+    input price) instead of re-billing them in full at 1x. The per-connector
+    CHOSEN PR + question go in a trailing, uncached block.
+
+    cmd_check orders its calls so connectors sharing a LATER set run
+    back-to-back, keeping the cache entry warm within its TTL.
+    """
+    prefix = f'{_VERDICT_INSTRUCTIONS}\n\n{_later_section(later_pr_bodies)}'
+    suffix = _chosen_section(image_name, source_dir, chosen_pr_num, chosen_pr_body)
+    return [
+        {'type': 'text', 'text': prefix, 'cache_control': {'type': 'ephemeral'}},
+        {'type': 'text', 'text': suffix},
+    ]
+
+
+def build_claude_prompt(
+    image_name: str,
+    source_dir: str,
+    chosen_pr_num: int,
+    chosen_pr_body: str,
+    later_pr_bodies: list,  # [(pr_num, body_text), ...]
+) -> str:
+    """Full prompt text as a single string. build_claude_content holds the
+    cache-aware block split actually sent to the API; this mirrors it for
+    readability and tests."""
+    blocks = build_claude_content(
+        image_name, source_dir, chosen_pr_num, chosen_pr_body, later_pr_bodies
+    )
+    return '\n\n'.join(b['text'] for b in blocks)
+
+
+def call_claude(content, api_key: str, model: str = 'claude-sonnet-4-6') -> str:
+    """Call the Anthropic Messages API and return the assistant's text.
+
+    `content` is a Messages API content value — either a plain string or a list
+    of content blocks (the cache-aware form from build_claude_content). Token
+    usage (including cache reads/writes) is logged to stderr so the cache hit
+    rate is visible in CI logs."""
     payload = json.dumps({
         'model': model,
         'max_tokens': 1024,
-        'messages': [{'role': 'user', 'content': prompt}],
+        'messages': [{'role': 'user', 'content': content}],
     }).encode()
     req = urllib.request.Request(
         'https://api.anthropic.com/v1/messages',
@@ -568,7 +631,16 @@ def call_claude(prompt: str, api_key: str, model: str = 'claude-sonnet-4-6') -> 
     )
     try:
         with urllib.request.urlopen(req, timeout=90) as resp:
-            return json.loads(resp.read())['content'][0]['text']
+            obj = json.loads(resp.read())
+        u = obj.get('usage', {})
+        print(
+            f'    tokens: input={u.get("input_tokens", 0)} '
+            f'cache_write={u.get("cache_creation_input_tokens", 0)} '
+            f'cache_read={u.get("cache_read_input_tokens", 0)} '
+            f'output={u.get("output_tokens", 0)}',
+            file=sys.stderr,
+        )
+        return obj['content'][0]['text']
     except (urllib.error.URLError, KeyError, json.JSONDecodeError) as exc:
         raise RuntimeError(f'Claude API error: {exc}') from exc
 
@@ -708,7 +780,17 @@ def cmd_check(args: argparse.Namespace) -> None:
             )
         return pr_details_cache[pr_number]
 
-    for entry in plan:
+    # Process connectors grouped by their LATER-PR set. build_claude_content
+    # caches the (instructions + LATER diffs) prefix, which is identical for
+    # connectors sharing a LATER set; running them back-to-back keeps that
+    # cache entry warm so all but the first read it instead of re-billing the
+    # diffs. Iterate a sorted copy — `plan` stays in its original order for
+    # build_safe_plan below.
+    ordered = sorted(
+        plan,
+        key=lambda e: (sorted(later_map.get(e.image_name, [])), e.chosen_pr),
+    )
+    for entry in ordered:
         later_prs = later_map.get(entry.image_name, [])
         if not later_prs:
             continue
@@ -729,14 +811,14 @@ def cmd_check(args: argparse.Namespace) -> None:
             (pr, fetch_cached(pr))
             for pr in later_prs
         ]
-        prompt = build_claude_prompt(
+        content = build_claude_content(
             entry.image_name, entry.source_dir,
             entry.chosen_pr, chosen_body,
             later_bodies,
         )
 
         try:
-            raw = call_claude(prompt, api_key, model=args.model)
+            raw = call_claude(content, api_key, model=args.model)
         except RuntimeError as exc:
             print(f'::warning::{entry.image_name}: {exc}; treating as safe')
             verdict = Verdict(entry.image_name, 'safe', f'api error: {exc}')

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -8,6 +8,7 @@ from delayed_tag import (
     LaterEntry,
     Verdict,
     build_safe_plan,
+    build_claude_content,
     build_claude_prompt,
     find_boundary,
     parse_claude_verdict,
@@ -298,6 +299,42 @@ class TestBuildClaudePrompt(unittest.TestCase):
     def test_no_later_prs(self):
         prompt = build_claude_prompt('img', 'dir', 5, 'chosen body', [])
         self.assertIn('PR #5', prompt)
+
+
+# ---------------------------------------------------------------------------
+# build_claude_content (prompt caching)
+# ---------------------------------------------------------------------------
+
+class TestBuildClaudeContent(unittest.TestCase):
+
+    def test_two_blocks_prefix_is_cached(self):
+        blocks = build_claude_content('img', 'dir', 5, 'chosen', [(9, 'fix')])
+        self.assertEqual(len(blocks), 2)
+        self.assertEqual(blocks[0]['cache_control'], {'type': 'ephemeral'})
+        self.assertNotIn('cache_control', blocks[1])
+
+    def test_chosen_pr_is_in_uncached_tail(self):
+        # The per-connector CHOSEN PR must live in the trailing block, not the
+        # cached prefix — otherwise the prefix would differ per connector.
+        blocks = build_claude_content('img', 'dir', 5, 'chosen', [(9, 'fix')])
+        self.assertNotIn('CHOSEN: PR #5', blocks[0]['text'])
+        self.assertIn('CHOSEN: PR #5', blocks[1]['text'])
+        self.assertIn('LATER: PR #9', blocks[0]['text'])
+
+    def test_shared_later_set_yields_identical_prefix(self):
+        # The whole point: two connectors with different CHOSEN PRs but the same
+        # LATER set produce a byte-identical cacheable prefix (a cache hit).
+        later = [(99, 'sweep diff')]
+        a = build_claude_content('conn-a', 'conn-a', 1, 'a body', later)
+        b = build_claude_content('conn-b', 'conn-b', 2, 'b body', later)
+        self.assertEqual(a[0]['text'], b[0]['text'])
+        self.assertNotEqual(a[1]['text'], b[1]['text'])
+
+    def test_later_section_sorted_for_byte_stability(self):
+        # Same LATER set in different order must still produce the same prefix.
+        forward = build_claude_content('i', 'd', 1, 'c', [(10, 'x'), (20, 'y')])
+        reverse = build_claude_content('i', 'd', 1, 'c', [(20, 'y'), (10, 'x')])
+        self.assertEqual(forward[0]['text'], reverse[0]['text'])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Description:**

The daily "delayed tag" workflow asks Claude Sonnet, per connector with later
PRs, whether any later PR is a roll-forward fix of the chosen PR. Each call
re-sent the full PR diffs (chosen + every later PR, capped at 2000 lines each)
as uncached input at 1x price. On high-churn days — especially after a
monorepo-wide sweep PR that becomes a *later* PR for many connectors at once —
that one large diff is re-billed once per affected connector, and a single run
can cost ~$50 in input tokens.

This restructures the prompt so the shared content is cached:

- The static instructions + the LATER-PR diffs now form a single content block
  with a `cache_control: ephemeral` breakpoint. The per-connector CHOSEN PR and
  the JSON-response question move to a trailing, uncached block.
- Connectors that share the same set of LATER PRs (the common case behind the
  expensive runs) produce a byte-identical cached prefix. The LATER section is
  sorted by PR number so set-equality always yields identical bytes.
- `cmd_check` now processes connectors grouped by their LATER-PR set so calls
  sharing a prefix run back-to-back and keep the cache entry warm within its
  TTL. (`plan` order is preserved for the downstream safe/held split.)

For a sweep PR shared across N connectors, the dominant cost term drops from
~Nx to ~(1.25 + 0.1·(N−1))x — roughly a 10x reduction at large N. Connectors
with a unique LATER set pay only the one-time ~1.25x cache-write premium.

`call_claude` now logs per-call `input / cache_write / cache_read / output`
token counts to stderr so the cache hit rate is visible in the run logs.

No change to the verdict logic — the model sees the same information, only
reordered into two blocks.

**Workflow steps:**

No config or interface change. The `delayed-tag` cron workflow runs as before;
the `check` step is just cheaper. Token usage per call is now visible in the
step's stderr.

**Documentation links affected:**

None.

**Notes for reviewers:**

- The win only materializes when LATER sets repeat across connectors; runs
  where every connector has a distinct LATER set pay a small (~25%) write
  premium with no reuse — but those are the cheap runs anyway.
- Sonnet's minimum cacheable prefix is 2048 tokens; a connector whose only
  LATER PR has a tiny diff silently won't cache (no harm).
- `build_claude_prompt` is retained as a string wrapper over the new
  `build_claude_content` for readability and existing tests.
- New `TestBuildClaudeContent` cases cover the cached/uncached block split and
  byte-stability of the shared prefix; full suite is 42 tests, all passing.
- The ~$50 / ~10x figures are estimates from reading the code, not measured;
  the new token logging will confirm the real numbers on the next run.
- Out of scope (independent follow-ups): scoping `gh pr diff` to the
  connector's directory, and lowering `--diff-line-cap`. The diff-scoping one
  would compound with this.
