### PR TITLE
ci: cross-run cache for delayed tag verdicts

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -884,6 +884,49 @@ def write_skips(skips: list, path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Cross-run verdict cache
+# ---------------------------------------------------------------------------
+#
+# A roll-forward verdict is fully determined by its inputs: the CHOSEN PR, the
+# connector's source dir, and the set of LATER PRs (PR diffs are immutable once
+# merged). The `check` step runs nightly, but most connectors are idle from one
+# night to the next — same boundary, same LATER set — so re-asking Claude the
+# identical question every night is pure waste. The workflow persists this
+# cache across runs via actions/cache; a later run reuses any verdict whose key
+# is unchanged and only calls Claude for connectors that actually moved.
+
+def verdict_cache_key(chosen_pr: int, source_dir: str, later_prs: list) -> str:
+    """Stable key identifying the inputs to a roll-forward verdict. Variants
+    share source_dir (and therefore boundary + LATER set), so they collapse to
+    the same key. Sorted LATER PRs keep the key order-independent."""
+    later = ','.join(str(n) for n in sorted(later_prs))
+    return f'{chosen_pr}|{source_dir}|{later}'
+
+
+def load_verdict_cache(path: str) -> dict:
+    """Load the prior run's verdict cache (key -> {'verdict', 'reason'}). A
+    missing or unparseable file yields an empty cache: a cold start re-checks
+    every connector, it never produces a wrong verdict."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        k: v for k, v in data.items()
+        if isinstance(v, dict) and v.get('verdict') in ('safe', 'hold')
+    }
+
+
+def write_verdict_cache(cache: dict, path: str) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump(cache, f, indent=0, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
 # Subcommands
 # ---------------------------------------------------------------------------
 
@@ -946,9 +989,19 @@ def cmd_check(args: argparse.Namespace) -> None:
 
     later_map = read_later(args.later)
     verdicts: list = []
-    # Cache keyed by (chosen_pr, source_dir) so variants sharing the same
+    # In-run cache keyed by (chosen_pr, source_dir) so variants sharing the same
     # parent dir don't trigger duplicate Claude API calls.
     verdict_cache: dict = {}
+    # Prior-run verdicts, restored across runs via actions/cache. Reused
+    # whenever a connector's (chosen_pr, source_dir, later set) is unchanged.
+    prior_cache = load_verdict_cache(args.verdict_cache)
+    # Verdicts to persist for the next run. Keyed by verdict_cache_key. We omit
+    # API-error verdicts (errored set) so a transient failure isn't cached as a
+    # sticky 'safe' that suppresses a real check next run.
+    new_cache: dict = {}
+    errored: set = set()
+    api_calls = 0
+    prior_hits = 0
     # Cache PR details by PR number so large LATER PRs shared across multiple
     # connectors (e.g. a monorepo sweep) are only fetched once.
     pr_details_cache: dict = {}
@@ -975,51 +1028,70 @@ def cmd_check(args: argparse.Namespace) -> None:
         if not later_prs:
             continue
 
-        cache_key = (entry.chosen_pr, entry.source_dir)
-        if cache_key in verdict_cache:
-            cached = verdict_cache[cache_key]
-            verdicts.append(Verdict(entry.image_name, cached.verdict, cached.reason))
+        xrun_key = verdict_cache_key(entry.chosen_pr, entry.source_dir, later_prs)
+        in_run_key = (entry.chosen_pr, entry.source_dir)
+
+        if in_run_key in verdict_cache:
+            cached = verdict_cache[in_run_key]
+            verdict = Verdict(entry.image_name, cached.verdict, cached.reason)
             print(f'  {entry.image_name}: reusing verdict from sibling connector')
-            continue
-
-        print(
-            f'Checking {entry.image_name}: PR #{entry.chosen_pr}'
-            f' ({len(later_prs)} later PR(s))'
-        )
-        chosen_body = fetch_cached(entry.chosen_pr)
-        later_bodies = [
-            (pr, fetch_cached(pr))
-            for pr in later_prs
-        ]
-        content = build_claude_content(
-            entry.image_name, entry.source_dir,
-            entry.chosen_pr, chosen_body,
-            later_bodies,
-        )
-
-        try:
-            raw = call_claude(content, api_key, model=args.model)
-        except RuntimeError as exc:
-            print(f'::warning::{entry.image_name}: {exc}; treating as safe')
-            verdict = Verdict(entry.image_name, 'safe', f'api error: {exc}')
+        elif xrun_key in prior_cache:
+            prev = prior_cache[xrun_key]
+            verdict = Verdict(entry.image_name, prev['verdict'], prev.get('reason', ''))
+            verdict_cache[in_run_key] = verdict
+            prior_hits += 1
+            print(
+                f'  {entry.image_name}: reusing prior-run verdict'
+                f' ({verdict.verdict}; PR #{entry.chosen_pr} + later set unchanged)'
+            )
         else:
-            verdict = parse_claude_verdict(raw, entry.image_name)
+            print(
+                f'Checking {entry.image_name}: PR #{entry.chosen_pr}'
+                f' ({len(later_prs)} later PR(s))'
+            )
+            chosen_body = fetch_cached(entry.chosen_pr)
+            later_bodies = [
+                (pr, fetch_cached(pr))
+                for pr in later_prs
+            ]
+            content = build_claude_content(
+                entry.image_name, entry.source_dir,
+                entry.chosen_pr, chosen_body,
+                later_bodies,
+            )
 
-        verdict_cache[cache_key] = verdict
+            try:
+                raw = call_claude(content, api_key, model=args.model)
+            except RuntimeError as exc:
+                print(f'::warning::{entry.image_name}: {exc}; treating as safe')
+                verdict = Verdict(entry.image_name, 'safe', f'api error: {exc}')
+                errored.add(xrun_key)
+            else:
+                verdict = parse_claude_verdict(raw, entry.image_name)
+                api_calls += 1
+
+            verdict_cache[in_run_key] = verdict
+
+            if verdict.verdict == 'hold':
+                print(f'::warning::{entry.image_name}: HOLD — {verdict.reason}')
+            else:
+                print(f'  {entry.image_name}: safe — {verdict.reason or "no roll-forward fix"}')
+
         verdicts.append(verdict)
-
-        if verdict.verdict == 'hold':
-            print(f'::warning::{entry.image_name}: HOLD — {verdict.reason}')
-        else:
-            print(f'  {entry.image_name}: safe — {verdict.reason or "no roll-forward fix"}')
+        if xrun_key not in errored:
+            new_cache[xrun_key] = {'verdict': verdict.verdict, 'reason': verdict.reason}
 
     verdict_map = {v.image_name: v for v in verdicts}
     safe, held = build_safe_plan(plan, verdict_map)
 
     write_safe_plan(safe, args.output_safe)
     write_verdicts(verdicts, args.output_verdicts)
+    write_verdict_cache(new_cache, args.verdict_cache)
 
-    print(f'\nClaude checked {len(verdict_cache)} unique connector(s)')
+    print(
+        f'\nClaude checked {api_calls} connector(s) via API;'
+        f' {prior_hits} reused from prior-run cache'
+    )
     if held:
         print(f'Held ({len(held)}): {", ".join(e.image_name for e in held)}')
     print(f'Tagging {len(safe)}/{len(plan)} connector(s) after hold filter')
@@ -1129,6 +1201,8 @@ def main(argv: Optional[list] = None) -> None:
     p.add_argument('--diff-line-cap',   type=int, default=2000)
     p.add_argument('--output-safe',     default='/tmp/safe_plan.tsv')
     p.add_argument('--output-verdicts', default='/tmp/claude_verdicts.tsv')
+    p.add_argument('--verdict-cache',   default='/tmp/verdict_cache.json',
+                   help='cross-run verdict cache (restored/saved via actions/cache)')
 
     p = sub.add_parser(
         'guard',

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -1,6 +1,9 @@
 """Unit tests for delayed_tag.py."""
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
 from delayed_tag import (
     ConnectorImage,
     PullRequest,
@@ -12,10 +15,13 @@ from delayed_tag import (
     build_claude_prompt,
     filter_backward_moves,
     find_boundary,
+    load_verdict_cache,
     parse_claude_verdict,
     pr_touches_dir,
     resolve_family,
     select_commit_tag,
+    verdict_cache_key,
+    write_verdict_cache,
 )
 
 
@@ -455,6 +461,93 @@ class TestFilterBackwardMoves(unittest.TestCase):
         )
         self.assertEqual([e.image_name for e in kept], ['norm', 'fresh'])
         self.assertEqual([e.image_name for e, _ in skipped], ['fwd'])
+
+
+# ---------------------------------------------------------------------------
+# verdict cache key
+# ---------------------------------------------------------------------------
+
+class TestVerdictCacheKey(unittest.TestCase):
+
+    def test_later_order_independent(self):
+        self.assertEqual(
+            verdict_cache_key(10, 'source-foo', [3, 1, 2]),
+            verdict_cache_key(10, 'source-foo', [2, 3, 1]),
+        )
+
+    def test_differs_on_chosen_pr(self):
+        self.assertNotEqual(
+            verdict_cache_key(10, 'source-foo', [1]),
+            verdict_cache_key(11, 'source-foo', [1]),
+        )
+
+    def test_differs_on_source_dir(self):
+        self.assertNotEqual(
+            verdict_cache_key(10, 'source-foo', [1]),
+            verdict_cache_key(10, 'source-bar', [1]),
+        )
+
+    def test_differs_on_later_set(self):
+        self.assertNotEqual(
+            verdict_cache_key(10, 'source-foo', [1]),
+            verdict_cache_key(10, 'source-foo', [1, 2]),
+        )
+
+    def test_variants_share_key_via_source_dir(self):
+        # A connector and its variant share source_dir, so they collapse to the
+        # same key and the verdict is computed once.
+        self.assertEqual(
+            verdict_cache_key(10, 'materialize-foo', [1]),
+            verdict_cache_key(10, 'materialize-foo', [1]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# verdict cache round-trip
+# ---------------------------------------------------------------------------
+
+class TestVerdictCacheIO(unittest.TestCase):
+
+    def round_trip(self, cache: dict) -> dict:
+        with tempfile.TemporaryDirectory() as d:
+            path = str(Path(d) / 'sub' / 'verdict_cache.json')  # parent missing
+            write_verdict_cache(cache, path)
+            return load_verdict_cache(path)
+
+    def test_round_trip_preserves_entries(self):
+        cache = {
+            '10|source-foo|1,2': {'verdict': 'safe', 'reason': 'ok'},
+            '11|source-bar|': {'verdict': 'hold', 'reason': 'fix of 11'},
+        }
+        self.assertEqual(self.round_trip(cache), cache)
+
+    def test_write_creates_missing_parent_dir(self):
+        # round_trip points at a non-existent 'sub/' dir; success implies mkdir.
+        self.assertEqual(self.round_trip({'k': {'verdict': 'safe', 'reason': ''}}),
+                         {'k': {'verdict': 'safe', 'reason': ''}})
+
+    def test_missing_file_is_empty_cache(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(load_verdict_cache(str(Path(d) / 'nope.json')), {})
+
+    def test_corrupt_file_is_empty_cache(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / 'bad.json'
+            path.write_text('{not json')
+            self.assertEqual(load_verdict_cache(str(path)), {})
+
+    def test_drops_entries_with_invalid_verdict(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / 'c.json'
+            path.write_text(json.dumps({
+                'good': {'verdict': 'safe', 'reason': 'r'},
+                'bad-value': {'verdict': 'maybe', 'reason': 'r'},
+                'bad-shape': ['not', 'a', 'dict'],
+            }))
+            self.assertEqual(
+                load_verdict_cache(str(path)),
+                {'good': {'verdict': 'safe', 'reason': 'r'}},
+            )
 
 
 if __name__ == '__main__':

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -78,17 +78,46 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 .github/scripts/delayed_tag.py plan
 
+      - name: Restore roll-forward verdict cache
+        # A verdict is determined by (CHOSEN PR, source dir, LATER-PR set), all
+        # of which are stable for an idle connector from one night to the next.
+        # Restoring the prior run's verdicts lets the check step reuse them and
+        # only call Claude for connectors that actually moved. The key is unique
+        # per run (so each run saves a fresh entry); restore-keys falls back to
+        # the most recent prior save.
+        uses: actions/cache/restore@v4
+        with:
+          path: verdict-cache
+          key: delayed-verdict-${{ github.run_id }}
+          restore-keys: |
+            delayed-verdict-
+
       - name: Check for roll-forward fixes via Claude
         # For each connector that has LATER PRs, ask Claude Sonnet whether any
         # LATER PR is a roll-forward fix of the CHOSEN PR (i.e. it patches a
         # regression introduced by CHOSEN). Connectors flagged "hold" are
         # excluded from /tmp/safe_plan.tsv so they don't get tagged.
+        # Reuses any unchanged verdict from verdict-cache/verdict_cache.json
+        # (restored above) instead of re-calling Claude.
         # Writes: /tmp/safe_plan.tsv      (image, sha7) — connectors to tag
         #         /tmp/claude_verdicts.tsv (image, verdict, reason)
+        #         verdict-cache/verdict_cache.json — verdicts for the next run
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 .github/scripts/delayed_tag.py check
+        run: >
+          python3 .github/scripts/delayed_tag.py check
+          --verdict-cache verdict-cache/verdict_cache.json
+
+      - name: Save roll-forward verdict cache
+        # Always save: the check step rewrites the cache with this run's
+        # verdicts (dropping connectors no longer in the plan), and on a crash
+        # the restored copy is preserved under the new key so it isn't lost.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: verdict-cache
+          key: delayed-verdict-${{ github.run_id }}
 
       - name: Guard against moving ':delayed' backward
         # Drop any connector whose 2-week boundary is OLDER than the image


### PR DESCRIPTION
**Description:**

- Cache verdicts in GitHub actions and restore on new runs and use if the PR set for a connector has not changed

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

