### PR TITLE
delayed_tag: retry Claude API errors instead of assuming safe

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -765,13 +765,18 @@ def build_claude_prompt(
     return '\n\n'.join(b['text'] for b in blocks)
 
 
-def call_claude(content, api_key: str, model: str = 'claude-sonnet-4-6') -> str:
-    """Call the Anthropic Messages API and return the assistant's text.
+# HTTP statuses worth retrying: rate-limit (429), request timeout/conflict, and
+# server/gateway/overload errors. Any other 4xx (e.g. 401 auth, 400 bad request)
+# won't be fixed by retrying, so we fail fast and loudly on those.
+_RETRYABLE_STATUS = frozenset({408, 409, 429, 500, 502, 503, 504, 529})
 
-    `content` is a Messages API content value — either a plain string or a list
-    of content blocks (the cache-aware form from build_claude_content). Token
-    usage (including cache reads/writes) is logged to stderr so the cache hit
-    rate is visible in CI logs."""
+
+def _claude_request(content, api_key: str, model: str) -> str:
+    """One Anthropic Messages API call. Returns the assistant's text, or raises
+    urllib/JSONDecodeError on failure — call_claude decides what is retryable.
+    A 200 with an unexpected body shape raises KeyError, which call_claude does
+    NOT retry: an identical request would parse identically, so it propagates
+    immediately and fails the run."""
     payload = json.dumps({
         'model': model,
         'max_tokens': 1024,
@@ -786,20 +791,67 @@ def call_claude(content, api_key: str, model: str = 'claude-sonnet-4-6') -> str:
             'content-type': 'application/json',
         },
     )
-    try:
-        with urllib.request.urlopen(req, timeout=90) as resp:
-            obj = json.loads(resp.read())
-        u = obj.get('usage', {})
-        print(
-            f'    tokens: input={u.get("input_tokens", 0)} '
-            f'cache_write={u.get("cache_creation_input_tokens", 0)} '
-            f'cache_read={u.get("cache_read_input_tokens", 0)} '
-            f'output={u.get("output_tokens", 0)}',
-            file=sys.stderr,
-        )
-        return obj['content'][0]['text']
-    except (urllib.error.URLError, KeyError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f'Claude API error: {exc}') from exc
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        obj = json.loads(resp.read())
+    u = obj.get('usage', {})
+    print(
+        f'    tokens: input={u.get("input_tokens", 0)} '
+        f'cache_write={u.get("cache_creation_input_tokens", 0)} '
+        f'cache_read={u.get("cache_read_input_tokens", 0)} '
+        f'output={u.get("output_tokens", 0)}',
+        file=sys.stderr,
+    )
+    return obj['content'][0]['text']
+
+
+def call_claude(
+    content,
+    api_key: str,
+    model: str = 'claude-sonnet-4-6',
+    *,
+    attempts: int = 4,
+    base_delay: float = 2.0,
+    sleep: Callable = time.sleep,
+) -> str:
+    """Call the Anthropic Messages API and return the assistant's text.
+
+    `content` is a Messages API content value — either a plain string or a list
+    of content blocks (the cache-aware form from build_claude_content). Token
+    usage (including cache reads/writes) is logged to stderr so the cache hit
+    rate is visible in CI logs.
+
+    Transient failures (network errors, HTTP 429/5xx, malformed responses) are
+    retried up to `attempts` times with exponential backoff; non-retryable
+    failures (e.g. HTTP 401/400) raise immediately. When every attempt is
+    exhausted the final RuntimeError propagates. Callers MUST NOT downgrade this
+    to a 'safe' verdict: a roll-forward check we never ran is not a check that
+    passed, and treating it as safe could ship a known-buggy image to
+    ':delayed'."""
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return _claude_request(content, api_key, model)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in _RETRYABLE_STATUS:
+                raise RuntimeError(
+                    f'Claude API error: HTTP {exc.code} {exc.reason}'
+                ) from exc
+            last_exc = exc
+        except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_exc = exc
+
+        if attempt < attempts:
+            delay = base_delay * (2 ** (attempt - 1))
+            print(
+                f'    Claude API attempt {attempt}/{attempts} failed'
+                f' ({last_exc}); retrying in {delay:.0f}s',
+                file=sys.stderr,
+            )
+            sleep(delay)
+
+    raise RuntimeError(
+        f'Claude API failed after {attempts} attempts: {last_exc}'
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -995,11 +1047,10 @@ def cmd_check(args: argparse.Namespace) -> None:
     # Prior-run verdicts, restored across runs via actions/cache. Reused
     # whenever a connector's (chosen_pr, source_dir, later set) is unchanged.
     prior_cache = load_verdict_cache(args.verdict_cache)
-    # Verdicts to persist for the next run. Keyed by verdict_cache_key. We omit
-    # API-error verdicts (errored set) so a transient failure isn't cached as a
-    # sticky 'safe' that suppresses a real check next run.
+    # Verdicts to persist for the next run, keyed by verdict_cache_key. Written
+    # in a finally below so progress survives even if a later connector aborts
+    # the run on an unrecoverable API error.
     new_cache: dict = {}
-    errored: set = set()
     api_calls = 0
     prior_hits = 0
     # Cache PR details by PR number so large LATER PRs shared across multiple
@@ -1023,70 +1074,70 @@ def cmd_check(args: argparse.Namespace) -> None:
         plan,
         key=lambda e: (sorted(later_map.get(e.image_name, [])), e.chosen_pr),
     )
-    for entry in ordered:
-        later_prs = later_map.get(entry.image_name, [])
-        if not later_prs:
-            continue
+    try:
+        for entry in ordered:
+            later_prs = later_map.get(entry.image_name, [])
+            if not later_prs:
+                continue
 
-        xrun_key = verdict_cache_key(entry.chosen_pr, entry.source_dir, later_prs)
-        in_run_key = (entry.chosen_pr, entry.source_dir)
+            xrun_key = verdict_cache_key(entry.chosen_pr, entry.source_dir, later_prs)
+            in_run_key = (entry.chosen_pr, entry.source_dir)
 
-        if in_run_key in verdict_cache:
-            cached = verdict_cache[in_run_key]
-            verdict = Verdict(entry.image_name, cached.verdict, cached.reason)
-            print(f'  {entry.image_name}: reusing verdict from sibling connector')
-        elif xrun_key in prior_cache:
-            prev = prior_cache[xrun_key]
-            verdict = Verdict(entry.image_name, prev['verdict'], prev.get('reason', ''))
-            verdict_cache[in_run_key] = verdict
-            prior_hits += 1
-            print(
-                f'  {entry.image_name}: reusing prior-run verdict'
-                f' ({verdict.verdict}; PR #{entry.chosen_pr} + later set unchanged)'
-            )
-        else:
-            print(
-                f'Checking {entry.image_name}: PR #{entry.chosen_pr}'
-                f' ({len(later_prs)} later PR(s))'
-            )
-            chosen_body = fetch_cached(entry.chosen_pr)
-            later_bodies = [
-                (pr, fetch_cached(pr))
-                for pr in later_prs
-            ]
-            content = build_claude_content(
-                entry.image_name, entry.source_dir,
-                entry.chosen_pr, chosen_body,
-                later_bodies,
-            )
-
-            try:
-                raw = call_claude(content, api_key, model=args.model)
-            except RuntimeError as exc:
-                print(f'::warning::{entry.image_name}: {exc}; treating as safe')
-                verdict = Verdict(entry.image_name, 'safe', f'api error: {exc}')
-                errored.add(xrun_key)
+            if in_run_key in verdict_cache:
+                cached = verdict_cache[in_run_key]
+                verdict = Verdict(entry.image_name, cached.verdict, cached.reason)
+                print(f'  {entry.image_name}: reusing verdict from sibling connector')
+            elif xrun_key in prior_cache:
+                prev = prior_cache[xrun_key]
+                verdict = Verdict(entry.image_name, prev['verdict'], prev.get('reason', ''))
+                verdict_cache[in_run_key] = verdict
+                prior_hits += 1
+                print(
+                    f'  {entry.image_name}: reusing prior-run verdict'
+                    f' ({verdict.verdict}; PR #{entry.chosen_pr} + later set unchanged)'
+                )
             else:
+                print(
+                    f'Checking {entry.image_name}: PR #{entry.chosen_pr}'
+                    f' ({len(later_prs)} later PR(s))'
+                )
+                chosen_body = fetch_cached(entry.chosen_pr)
+                later_bodies = [
+                    (pr, fetch_cached(pr))
+                    for pr in later_prs
+                ]
+                content = build_claude_content(
+                    entry.image_name, entry.source_dir,
+                    entry.chosen_pr, chosen_body,
+                    later_bodies,
+                )
+
+                # No fallback to 'safe' on failure: call_claude already retries
+                # transient errors, so an exception here means the check could
+                # not be performed. Let it abort the run rather than risk
+                # promoting an unchecked, possibly-buggy image to ':delayed'.
+                raw = call_claude(content, api_key, model=args.model)
                 verdict = parse_claude_verdict(raw, entry.image_name)
                 api_calls += 1
+                verdict_cache[in_run_key] = verdict
 
-            verdict_cache[in_run_key] = verdict
+                if verdict.verdict == 'hold':
+                    print(f'::warning::{entry.image_name}: HOLD — {verdict.reason}')
+                else:
+                    print(f'  {entry.image_name}: safe — {verdict.reason or "no roll-forward fix"}')
 
-            if verdict.verdict == 'hold':
-                print(f'::warning::{entry.image_name}: HOLD — {verdict.reason}')
-            else:
-                print(f'  {entry.image_name}: safe — {verdict.reason or "no roll-forward fix"}')
-
-        verdicts.append(verdict)
-        if xrun_key not in errored:
+            verdicts.append(verdict)
             new_cache[xrun_key] = {'verdict': verdict.verdict, 'reason': verdict.reason}
+    finally:
+        # Persist verdicts computed so far so the next run reuses them even when
+        # this run aborts partway on an unrecoverable API error.
+        write_verdict_cache(new_cache, args.verdict_cache)
 
     verdict_map = {v.image_name: v for v in verdicts}
     safe, held = build_safe_plan(plan, verdict_map)
 
     write_safe_plan(safe, args.output_safe)
     write_verdicts(verdicts, args.output_verdicts)
-    write_verdict_cache(new_cache, args.verdict_cache)
 
     print(
         f'\nClaude checked {api_calls} connector(s) via API;'

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -3,7 +3,9 @@
 import json
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest import mock
 from delayed_tag import (
     ConnectorImage,
     PullRequest,
@@ -13,6 +15,7 @@ from delayed_tag import (
     build_safe_plan,
     build_claude_content,
     build_claude_prompt,
+    call_claude,
     filter_backward_moves,
     find_boundary,
     load_verdict_cache,
@@ -548,6 +551,76 @@ class TestVerdictCacheIO(unittest.TestCase):
                 load_verdict_cache(str(path)),
                 {'good': {'verdict': 'safe', 'reason': 'r'}},
             )
+
+
+# ---------------------------------------------------------------------------
+# call_claude retry / fail-loud behavior
+# ---------------------------------------------------------------------------
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError('https://api', code, f'status {code}', None, None)
+
+
+class TestCallClaudeRetry(unittest.TestCase):
+
+    def setUp(self):
+        self.slept = []
+        self.sleep = lambda d: self.slept.append(d)
+
+    def call(self, side_effect, attempts=4):
+        with mock.patch('delayed_tag._claude_request', side_effect=side_effect) as m:
+            result = call_claude(
+                'prompt', 'key', attempts=attempts,
+                base_delay=2.0, sleep=self.sleep,
+            )
+        return result, m
+
+    def test_returns_on_first_success(self):
+        result, m = self.call(['ok'])
+        self.assertEqual(result, 'ok')
+        self.assertEqual(m.call_count, 1)
+        self.assertEqual(self.slept, [])  # no retry, no sleep
+
+    def test_retries_transient_then_succeeds(self):
+        result, m = self.call([urllib.error.URLError('boom'), _http_error(503), 'ok'])
+        self.assertEqual(result, 'ok')
+        self.assertEqual(m.call_count, 3)
+        self.assertEqual(self.slept, [2.0, 4.0])  # exponential backoff
+
+    def test_retries_rate_limit(self):
+        result, m = self.call([_http_error(429), 'ok'])
+        self.assertEqual(result, 'ok')
+        self.assertEqual(m.call_count, 2)
+
+    def test_retries_truncated_json(self):
+        result, m = self.call([json.JSONDecodeError('x', 'doc', 0), 'ok'])
+        self.assertEqual(result, 'ok')
+        self.assertEqual(m.call_count, 2)
+
+    def test_unexpected_shape_not_retried(self):
+        # A 200 with a missing key surfaces as KeyError: an identical request
+        # would parse identically, so it propagates without retrying.
+        with self.assertRaises(KeyError):
+            self.call([KeyError('content'), 'ok'])
+        self.assertEqual(self.slept, [])
+
+    def test_exhausts_attempts_then_raises(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.call([urllib.error.URLError('down')] * 4, attempts=4)
+        self.assertIn('after 4 attempts', str(ctx.exception))
+        self.assertEqual(self.slept, [2.0, 4.0, 8.0])  # 3 sleeps between 4 tries
+
+    def test_non_retryable_status_fails_fast(self):
+        # 401 won't be fixed by retrying: raise immediately, no sleeps.
+        with self.assertRaises(RuntimeError) as ctx:
+            self.call([_http_error(401), 'ok'])
+        self.assertIn('401', str(ctx.exception))
+        self.assertEqual(self.slept, [])
+
+    def test_bad_request_fails_fast(self):
+        with self.assertRaises(RuntimeError):
+            self.call([_http_error(400)] + ['ok'])
+        self.assertEqual(self.slept, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description:**

- We assume safety when there is a Claude error, which is quite dangerous. This changes it so we first attempt retry, and if that doesn't work, we fail the pipeline

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

