### PR TITLE
delayed_tag: bound prompt size + dry-run the pipeline on PRs

### DIFF
--- a/.github/scripts/delayed_tag.py
+++ b/.github/scripts/delayed_tag.py
@@ -367,12 +367,55 @@ def _rest_pr_files(pr_number: int, owner: str, repo: str, token: str) -> list:
     return paths
 
 
+# Diff size caps. The diff dominates the prompt we send Claude, and a single PR
+# can regenerate golden snapshot files (e.g. several connectors'
+# .snapshots/TestIntegration-migrate) whose diffs pack tens of thousands of
+# characters onto a SINGLE line. A line-count cap alone does not bound such a
+# diff: 2000 lines at 60k chars each is ~3 MB / ~800k tokens, which the
+# Anthropic API rejects with HTTP 400 "prompt is too long", aborting the run.
+# We therefore also truncate any individual over-long line (keeping the file
+# visible without its noise) and cap the diff's total character count.
+DEFAULT_DIFF_LINE_CAP = 2000
+DEFAULT_LINE_CHAR_CAP = 1000
+DEFAULT_DIFF_CHAR_CAP = 120_000
+
+
+def _truncate_diff(
+    lines: list,
+    line_cap: int,
+    line_char_cap: int,
+    char_cap: int,
+) -> str:
+    """
+    Bound a diff three ways so it can never blow the model's context window:
+    by line count, by per-line length (over-long generated/snapshot lines are
+    truncated in place, not dropped, so the file stays visible), and by total
+    character count. Returns the joined, truncated diff text.
+    """
+    out: list = []
+    chars = 0
+    for i, line in enumerate(lines):
+        if i >= line_cap:
+            out.append(f'... [truncated at {line_cap} lines]')
+            break
+        if len(line) > line_char_cap:
+            line = f'{line[:line_char_cap]} ... [line truncated, was {len(line)} chars]'
+        if chars + len(line) > char_cap:
+            out.append(f'... [truncated at {char_cap} chars]')
+            break
+        out.append(line)
+        chars += len(line) + 1  # +1 for the newline added by the final join
+    return '\n'.join(out)
+
+
 def _rest_pr_diff(
     pr_number: int,
     owner: str,
     repo: str,
     token: str,
-    diff_line_cap: int = 2000,
+    diff_line_cap: int = DEFAULT_DIFF_LINE_CAP,
+    line_char_cap: int = DEFAULT_LINE_CHAR_CAP,
+    diff_char_cap: int = DEFAULT_DIFF_CHAR_CAP,
 ) -> str:
     """
     Reconstruct a diff from the paginated 'list PR files' REST API.
@@ -383,10 +426,10 @@ def _rest_pr_diff(
     so large PRs can still be summarised file-by-file.
 
     Binary files and files whose individual diff is also too large have no
-    `patch` field; they are noted with a placeholder line.
+    `patch` field; they are noted with a placeholder line. The collected lines
+    are bounded by _truncate_diff before returning.
     """
-    lines_seen = 0
-    parts: list = []
+    lines: list = []
     page = 1
 
     while True:
@@ -404,27 +447,20 @@ def _rest_pr_diff(
         if not batch:
             break
 
-        truncated = False
         for f in batch:
-            header = f'--- a/{f["filename"]}\n+++ b/{f["filename"]}'
+            lines.append(f'--- a/{f["filename"]}\n+++ b/{f["filename"]}')
             patch = f.get('patch') or (
                 f'(binary or oversized file; {f.get("changes", "?")} changes)'
             )
-            file_lines = [header] + patch.splitlines()
+            lines.extend(patch.splitlines())
 
-            if lines_seen + len(file_lines) > diff_line_cap:
-                parts.append(f'... [truncated at {diff_line_cap} lines]')
-                truncated = True
-                break
-
-            parts.extend(file_lines)
-            lines_seen += len(file_lines)
-
-        if truncated or len(batch) < 100:
+        # Stop paginating once we already have more than enough lines to fill
+        # the cap; _truncate_diff makes the final cut below.
+        if len(lines) > diff_line_cap or len(batch) < 100:
             break
         page += 1
 
-    return '\n'.join(parts)
+    return _truncate_diff(lines, diff_line_cap, line_char_cap, diff_char_cap)
 
 
 def _iso_to_epoch(iso: str) -> int:
@@ -630,7 +666,9 @@ def fetch_pr_details(
     owner: str,
     repo: str,
     token: str,
-    diff_line_cap: int = 2000,
+    diff_line_cap: int = DEFAULT_DIFF_LINE_CAP,
+    line_char_cap: int = DEFAULT_LINE_CHAR_CAP,
+    diff_char_cap: int = DEFAULT_DIFF_CHAR_CAP,
 ) -> str:
     """
     Fetch PR title, body, and diff.
@@ -638,7 +676,9 @@ def fetch_pr_details(
     Tries gh pr diff first (fast, single request). If GitHub rejects it with
     HTTP 406 (PR exceeds the aggregate diff limit of 300 files / 20 000 lines),
     falls back to the paginated 'list PR files' REST API which returns per-file
-    patches without that aggregate limit.
+    patches without that aggregate limit. Either way the diff is bounded by
+    _truncate_diff so a PR that regenerates large golden files cannot push the
+    prompt past the model's context window.
     """
     try:
         meta = subprocess.check_output(
@@ -657,14 +697,15 @@ def fetch_pr_details(
             text=True,
             stderr=subprocess.DEVNULL,
         ).splitlines()
-        diff = '\n'.join(diff_lines[:diff_line_cap])
-        if len(diff_lines) > diff_line_cap:
-            diff += f'\n... [truncated at {diff_line_cap} lines]'
+        diff = _truncate_diff(diff_lines, diff_line_cap, line_char_cap, diff_char_cap)
     except subprocess.CalledProcessError:
         # HTTP 406: PR exceeds GitHub's aggregate diff size limit.
         # Fall back to the paginated files API which returns per-file patches.
         try:
-            diff = _rest_pr_diff(pr_number, owner, repo, token, diff_line_cap)
+            diff = _rest_pr_diff(
+                pr_number, owner, repo, token,
+                diff_line_cap, line_char_cap, diff_char_cap,
+            )
         except Exception as exc:
             diff = f'(diff not available: {exc})'
 
@@ -771,6 +812,26 @@ def build_claude_prompt(
 _RETRYABLE_STATUS = frozenset({408, 409, 429, 500, 502, 503, 504, 529})
 
 
+def _content_chars(content) -> int:
+    """Approximate prompt size in characters, for logging how close a request
+    sits to the model's context window."""
+    if isinstance(content, list):
+        return sum(len(b.get('text', '')) for b in content)
+    return len(content)
+
+
+def _http_error_body(exc: urllib.error.HTTPError) -> str:
+    """Read an HTTPError's response body. The Anthropic API returns a JSON error
+    whose message states the precise cause (e.g. 'prompt is too long: 812345
+    tokens > 200000 maximum'), which is exactly what we want in the CI log when
+    a request is rejected. Returns '' if the body can't be read, and truncates
+    so a large body can't flood the log."""
+    try:
+        return exc.read().decode('utf-8', 'replace')[:2000]
+    except Exception:
+        return ''
+
+
 def _claude_request(content, api_key: str, model: str) -> str:
     """One Anthropic Messages API call. Returns the assistant's text, or raises
     urllib/JSONDecodeError on failure — call_claude decides what is retryable.
@@ -791,6 +852,7 @@ def _claude_request(content, api_key: str, model: str) -> str:
             'content-type': 'application/json',
         },
     )
+    print(f'    request: ~{_content_chars(content)} chars', file=sys.stderr)
     with urllib.request.urlopen(req, timeout=90) as resp:
         obj = json.loads(resp.read())
     u = obj.get('usage', {})
@@ -832,10 +894,17 @@ def call_claude(
         try:
             return _claude_request(content, api_key, model)
         except urllib.error.HTTPError as exc:
+            body = _http_error_body(exc)
             if exc.code not in _RETRYABLE_STATUS:
+                # Include the API's error body so the CI log states exactly why
+                # the request was rejected (e.g. an over-long prompt), rather
+                # than a bare 'HTTP 400'.
                 raise RuntimeError(
                     f'Claude API error: HTTP {exc.code} {exc.reason}'
+                    + (f': {body}' if body else '')
                 ) from exc
+            if body:
+                print(f'    Claude API HTTP {exc.code} body: {body}', file=sys.stderr)
             last_exc = exc
         except (urllib.error.URLError, json.JSONDecodeError) as exc:
             last_exc = exc
@@ -933,6 +1002,15 @@ def write_skips(skips: list, path: str) -> None:
     with open(path, 'w') as f:
         for entry, current in skips:
             f.write(f'{entry.image_name}\t{entry.chosen_sha7}\t{current}\n')
+
+
+def write_check_failures(failures: list, path: str) -> None:
+    """Write the (image, error) connectors whose roll-forward check could not be
+    completed. Errors are flattened to a single line so the TSV stays one row
+    per connector."""
+    with open(path, 'w') as f:
+        for image, error in failures:
+            f.write(f'{image}\t{" ".join(error.split())}\n')
 
 
 # ---------------------------------------------------------------------------
@@ -1053,6 +1131,10 @@ def cmd_check(args: argparse.Namespace) -> None:
     new_cache: dict = {}
     api_calls = 0
     prior_hits = 0
+    # (image_name, error) for connectors whose check could not be completed.
+    # Surfaced loudly (::error:: + summary file) so a persistently-failing
+    # connector is visible even though it no longer aborts the whole run.
+    check_failures: list = []
     # Cache PR details by PR number so large LATER PRs shared across multiple
     # connectors (e.g. a monorepo sweep) are only fetched once.
     pr_details_cache: dict = {}
@@ -1060,7 +1142,10 @@ def cmd_check(args: argparse.Namespace) -> None:
     def fetch_cached(pr_number: int) -> str:
         if pr_number not in pr_details_cache:
             pr_details_cache[pr_number] = fetch_pr_details(
-                pr_number, owner, repo, gh_token, diff_line_cap=args.diff_line_cap
+                pr_number, owner, repo, gh_token,
+                diff_line_cap=args.diff_line_cap,
+                line_char_cap=args.line_char_cap,
+                diff_char_cap=args.diff_char_cap,
             )
         return pr_details_cache[pr_number]
 
@@ -1112,11 +1197,30 @@ def cmd_check(args: argparse.Namespace) -> None:
                     later_bodies,
                 )
 
-                # No fallback to 'safe' on failure: call_claude already retries
-                # transient errors, so an exception here means the check could
-                # not be performed. Let it abort the run rather than risk
-                # promoting an unchecked, possibly-buggy image to ':delayed'.
-                raw = call_claude(content, api_key, model=args.model)
+                # No fallback to 'safe' on failure. call_claude already retries
+                # transient errors, so a RuntimeError here means the check could
+                # not be performed for THIS connector. We HOLD it (exclude it
+                # from tagging) rather than promote an unchecked, possibly-buggy
+                # image to ':delayed' — but we isolate the failure to this one
+                # connector and keep going, so a single bad PR can't freeze the
+                # whole pipeline (the prior behaviour, where one failure aborted
+                # the run and no connector was ever tagged). The synthetic hold
+                # is deliberately NOT persisted to new_cache below, so the
+                # connector is re-checked next run instead of being stuck held.
+                try:
+                    raw = call_claude(content, api_key, model=args.model)
+                except RuntimeError as exc:
+                    print(
+                        f'::error::{entry.image_name}: roll-forward check could'
+                        f' not be completed; holding (not tagging) — {exc}'
+                    )
+                    verdict = Verdict(
+                        entry.image_name, 'hold', f'roll-forward check failed: {exc}'
+                    )
+                    verdict_cache[in_run_key] = verdict
+                    verdicts.append(verdict)
+                    check_failures.append((entry.image_name, str(exc)))
+                    continue
                 verdict = parse_claude_verdict(raw, entry.image_name)
                 api_calls += 1
                 verdict_cache[in_run_key] = verdict
@@ -1138,6 +1242,7 @@ def cmd_check(args: argparse.Namespace) -> None:
 
     write_safe_plan(safe, args.output_safe)
     write_verdicts(verdicts, args.output_verdicts)
+    write_check_failures(check_failures, args.output_failures)
 
     print(
         f'\nClaude checked {api_calls} connector(s) via API;'
@@ -1145,6 +1250,11 @@ def cmd_check(args: argparse.Namespace) -> None:
     )
     if held:
         print(f'Held ({len(held)}): {", ".join(e.image_name for e in held)}')
+    if check_failures:
+        print(
+            f'::warning::{len(check_failures)} connector(s) could not be checked'
+            f' and were held: {", ".join(img for img, _ in check_failures)}'
+        )
     print(f'Tagging {len(safe)}/{len(plan)} connector(s) after hold filter')
 
 
@@ -1249,9 +1359,15 @@ def main(argv: Optional[list] = None) -> None:
     p.add_argument('--plan',            default='/tmp/plan.tsv')
     p.add_argument('--later',           default='/tmp/later.tsv')
     p.add_argument('--model',           default='claude-sonnet-4-6')
-    p.add_argument('--diff-line-cap',   type=int, default=2000)
+    p.add_argument('--diff-line-cap',   type=int, default=DEFAULT_DIFF_LINE_CAP)
+    p.add_argument('--line-char-cap',   type=int, default=DEFAULT_LINE_CHAR_CAP,
+                   help='truncate any single diff line longer than this')
+    p.add_argument('--diff-char-cap',   type=int, default=DEFAULT_DIFF_CHAR_CAP,
+                   help="cap each PR's diff at this many characters")
     p.add_argument('--output-safe',     default='/tmp/safe_plan.tsv')
     p.add_argument('--output-verdicts', default='/tmp/claude_verdicts.tsv')
+    p.add_argument('--output-failures', default='/tmp/check_failures.tsv',
+                   help='connectors whose roll-forward check could not be completed')
     p.add_argument('--verdict-cache',   default='/tmp/verdict_cache.json',
                    help='cross-run verdict cache (restored/saved via actions/cache)')
 

--- a/.github/scripts/test_delayed_tag.py
+++ b/.github/scripts/test_delayed_tag.py
@@ -1,5 +1,6 @@
 """Unit tests for delayed_tag.py."""
 
+import io
 import json
 import tempfile
 import unittest
@@ -12,6 +13,8 @@ from delayed_tag import (
     PlanEntry,
     LaterEntry,
     Verdict,
+    _http_error_body,
+    _truncate_diff,
     build_safe_plan,
     build_claude_content,
     build_claude_prompt,
@@ -621,6 +624,87 @@ class TestCallClaudeRetry(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.call([_http_error(400)] + ['ok'])
         self.assertEqual(self.slept, [])
+
+
+# ---------------------------------------------------------------------------
+# _truncate_diff — diff size caps
+# ---------------------------------------------------------------------------
+
+class TestTruncateDiff(unittest.TestCase):
+
+    def test_under_all_caps_is_unchanged(self):
+        lines = ['+a', '-b', ' c']
+        self.assertEqual(
+            _truncate_diff(lines, line_cap=10, line_char_cap=10, char_cap=1000),
+            '+a\n-b\n c',
+        )
+
+    def test_line_count_cap(self):
+        lines = [f'+line{i}' for i in range(100)]
+        out = _truncate_diff(lines, line_cap=5, line_char_cap=100, char_cap=10_000)
+        self.assertEqual(len(out.splitlines()), 6)  # 5 lines + the marker
+        self.assertIn('truncated at 5 lines', out)
+
+    def test_long_line_truncated_in_place_not_dropped(self):
+        # A single enormous line (a regenerated golden-snapshot line) is the bug
+        # that 400'd the run: it must be truncated, not silently dropped.
+        lines = ['+' + 'x' * 60_000, '+kept']
+        out = _truncate_diff(lines, line_cap=10, line_char_cap=100, char_cap=10_000)
+        self.assertIn('line truncated, was 60001 chars', out)
+        self.assertIn('+kept', out)
+        # No remaining line is anywhere near the original 60k chars.
+        self.assertTrue(all(len(l) < 200 for l in out.splitlines()))
+
+    def test_total_char_cap(self):
+        lines = ['+' + 'a' * 50 for _ in range(100)]  # ~5100 chars total
+        out = _truncate_diff(lines, line_cap=1000, line_char_cap=1000, char_cap=200)
+        self.assertIn('truncated at 200 chars', out)
+        self.assertLess(len(out), 400)
+
+    def test_caps_compose_keep_request_bounded(self):
+        # 2000 lines of 60k chars each — the EventBridge case — must collapse to
+        # a small, sendable diff under all three caps applied together.
+        lines = ['+' + 'x' * 60_000 for _ in range(2000)]
+        out = _truncate_diff(lines, line_cap=2000, line_char_cap=1000, char_cap=120_000)
+        self.assertLessEqual(len(out), 121_000)
+
+
+# ---------------------------------------------------------------------------
+# _http_error_body / call_claude error surfacing
+# ---------------------------------------------------------------------------
+
+class TestHttpErrorBody(unittest.TestCase):
+
+    def test_reads_body(self):
+        exc = urllib.error.HTTPError(
+            'https://api', 400, 'Bad Request', {},
+            io.BytesIO(b'{"error":{"message":"prompt is too long"}}'),
+        )
+        self.assertIn('prompt is too long', _http_error_body(exc))
+
+    def test_unreadable_body_is_empty(self):
+        exc = urllib.error.HTTPError('https://api', 400, 'Bad Request', {}, None)
+        self.assertEqual(_http_error_body(exc), '')
+
+    def test_body_truncated(self):
+        exc = urllib.error.HTTPError(
+            'https://api', 400, 'Bad Request', {}, io.BytesIO(b'x' * 5000),
+        )
+        self.assertEqual(len(_http_error_body(exc)), 2000)
+
+    def test_call_claude_includes_body_in_error(self):
+        # The fail-fast RuntimeError must carry the API's reason so CI logs say
+        # WHY, not just 'HTTP 400'.
+        def boom(*a, **k):
+            raise urllib.error.HTTPError(
+                'https://api', 400, 'Bad Request', {},
+                io.BytesIO(b'{"error":{"message":"prompt is too long: 9 > 8"}}'),
+            )
+        with mock.patch('delayed_tag._claude_request', side_effect=boom):
+            with self.assertRaises(RuntimeError) as ctx:
+                call_claude('prompt', 'key', attempts=1, sleep=lambda d: None)
+        self.assertIn('prompt is too long', str(ctx.exception))
+        self.assertIn('400', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -32,12 +32,23 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+  # Dry-run on PRs that change the delayed-tag logic, so the plan/check/guard
+  # steps can be exercised end-to-end before merge. The tag + DB-refresh steps
+  # are skipped on pull_request (see their `if:` guards), so a PR run never
+  # publishes a ':delayed' tag or mutates the connector_tags DB.
+  pull_request:
+    paths:
+      - '.github/workflows/delayed-tag.yaml'
+      - '.github/scripts/delayed_tag.py'
+      - '.github/scripts/test_delayed_tag.py'
 
 concurrency:
-  # Shared with the manual forward-delayed-tag workflow so the two never race
-  # on the same ':delayed' tag / DB rows.
-  group: delayed-tag
-  cancel-in-progress: false
+  # Production runs (nightly schedule + manual forward-delayed-tag) share one
+  # group so they never race on the same ':delayed' tag / DB rows. PR dry-runs
+  # touch neither, so they get their own per-ref group: they don't queue behind
+  # — or block — production, and a new push cancels the previous PR run.
+  group: ${{ github.event_name == 'pull_request' && format('delayed-tag-pr-{0}', github.ref) || 'delayed-tag' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -134,11 +145,17 @@ jobs:
         run: python3 .github/scripts/delayed_tag.py guard
 
       - name: Tag images as ':delayed'
+        # On pull_request this runs as a DRY RUN: it still resolves the plan and
+        # checks each boundary image exists in the registry (read-only), but
+        # skips the `imagetools create` re-tag. Nothing is published.
+        env:
+          DRY_RUN: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
           set -uo pipefail
           tagged=0; missing=0; failed=0
           : > /tmp/tagged.txt
           : > /tmp/missing.txt
+          [ -n "${DRY_RUN}" ] && echo "DRY RUN (pull_request): no images will actually be tagged"
           while IFS=$'\t' read -r IMAGE SHA; do
             [ -z "${IMAGE}" ] && continue
             SRC="ghcr.io/estuary/${IMAGE}:${SHA}"
@@ -151,6 +168,12 @@ jobs:
               echo "skip ${IMAGE}: no image at ${SHA} (may have been pruned from registry)"
               printf '%s\t%s\n' "${IMAGE}" "${SHA}" >> /tmp/missing.txt
               missing=$((missing + 1))
+              continue
+            fi
+            if [ -n "${DRY_RUN}" ]; then
+              echo "would tag ${DST} -> ${SHA}"
+              echo "${IMAGE}" >> /tmp/tagged.txt
+              tagged=$((tagged + 1))
               continue
             fi
             if docker buildx imagetools create --tag "${DST}" "${SRC}" >/dev/null; then
@@ -168,11 +191,14 @@ jobs:
           fi
 
       - name: Install psql
+        # Skipped on PR dry-runs: nothing was tagged, so there is no DB to refresh.
+        if: github.event_name != 'pull_request'
         run: |
           sudo apt update
           sudo apt install -y postgresql-client
 
       - name: Refresh connector_tags rows for ':delayed'
+        if: github.event_name != 'pull_request'
         env:
           PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
           PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
@@ -192,11 +218,19 @@ jobs:
         if: always()
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
           set -uo pipefail
           {
             echo "## Delayed Tag Run — $(date -u '+%Y-%m-%d')"
             echo ""
+            if [ -n "${DRY_RUN}" ]; then
+              echo "> **DRY RUN (pull_request)** — the plan, Claude check, and"
+              echo "> backward-move guard ran for real, but nothing was tagged"
+              echo "> and the connector_tags DB was not touched. The \"Tagged\""
+              echo "> table below lists what a production run *would* tag."
+              echo ""
+            fi
 
             TAGGED_COUNT=$(wc -l < /tmp/tagged.txt 2>/dev/null | tr -d ' ') || TAGGED_COUNT=0
             HELD_COUNT=$(wc -l < /tmp/claude_verdicts.tsv 2>/dev/null \

--- a/.github/workflows/delayed-tag.yaml
+++ b/.github/workflows/delayed-tag.yaml
@@ -236,6 +236,23 @@ jobs:
               fi
             fi
 
+            if [ -s /tmp/check_failures.tsv ]; then
+              echo "### ⚠️ Roll-forward check failed (held)"
+              echo ""
+              echo "Claude could not be consulted for these connectors (e.g. an"
+              echo "over-long prompt or a persistent API error), so they were held"
+              echo "rather than tagged. They are re-checked on the next run; a"
+              echo "connector that stays here needs investigation."
+              echo ""
+              echo "| Connector | Error |"
+              echo "|-----------|-------|"
+              while IFS=$'\t' read -r IMAGE ERROR; do
+                [ -z "${IMAGE}" ] && continue
+                echo "| \`${IMAGE}\` | ${ERROR} |"
+              done < /tmp/check_failures.tsv
+              echo ""
+            fi
+
             if [ -s /tmp/backward_skips.tsv ]; then
               echo "### ⏪ Held to avoid moving \`:delayed\` backward"
               echo ""


### PR DESCRIPTION
## Problem

Some connectors — `materialize-eventbridge` being the consistent example — were **persistently failing** the Claude roll-forward guard in the nightly `delayed-tag` workflow ([failing run](https://github.com/estuary/connectors/actions/runs/28013492420/job/82912378814)).

Root cause chain:
1. PR #4537 regenerated `.snapshots/TestIntegration-migrate` golden files across many materialize connectors. Those files pack enormous single-line content — **up to 62,011 chars on one line**.
2. EventBridge's 2-week boundary lands on #4537. Its diff, capped at 2000 **lines**, was still **~3.1 MB**, because the cap was by line *count* — which does nothing to bound a diff made of huge lines.
3. ~3.1 MB ≈ ~800k tokens, far over Sonnet's 200k context → the Anthropic API returns **HTTP 400 "prompt is too long"**.
4. 400 is non-retryable → `call_claude` raised → the exception propagated out of `cmd_check` and **aborted the entire nightly run** before anything was tagged.
5. Because the run aborted, EventBridge's verdict never reached the cross-run cache. Every other connector was a cache hit, so each night EventBridge was again the *only* live call → same 400 → same abort. A self-reinforcing loop.

The old log only showed a bare `HTTP 400 Bad Request`; the API's actual reason was never logged, which made this hard to diagnose.

## Fix (`delayed_tag.py`)

1. **Prevent** — `_truncate_diff` bounds every PR diff three ways: line count, per-line length (a giant snapshot line is truncated *in place*, not dropped), and total chars. The EventBridge request drops from ~3.1 MB to **~243k chars (~60k tokens)** — verified against the real PRs.
2. **Log more** — `call_claude` now reads and surfaces the Anthropic error response body (e.g. *"prompt is too long: N tokens > 200000 maximum"*) in the `RuntimeError` and stderr, and the request size is logged before each call.
3. **Isolate** — a non-retryable per-connector failure now **holds that one connector** (never tags an unchecked image) and continues, instead of freezing the whole pipeline. Failures are emitted as `::error::`, written to `check_failures.tsv`, and surfaced in a new job-summary section. The synthetic hold is not cached, so the connector is re-checked next run.

## Trying it out (`delayed-tag.yaml`)

Adds a path-filtered `pull_request` trigger so the plan → check → guard logic runs end-to-end on this PR. **PR runs are a dry run**: the tagging step skips the `imagetools create` re-tag (it still verifies images exist in the registry), and the psql + DB-refresh steps are skipped entirely — a PR run never publishes a `:delayed` tag or mutates the production `connector_tags` DB. PR runs use a separate per-ref concurrency group so they don't queue behind or block production.

## Tests

All unit tests pass, including new `TestTruncateDiff` and `TestHttpErrorBody` coverage (79 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)