### PR TITLE
sqlcapture: Lower rediscovery interval

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -174,7 +174,7 @@ type Capture struct {
 }
 
 const (
-	rediscoverInterval        = 5 * time.Minute  // The capture will re-run discovery and reinitialize missing/pending tables this frequently.
+	rediscoverInterval        = 15 * time.Minute // The capture will re-run discovery and reinitialize missing/pending tables this frequently.
 	periodicChecksInterval    = 10 * time.Minute // The capture may run some database-specific sanity checks periodically at this interval.
 	streamingProgressInterval = 5 * time.Minute  // How often to log progress and diagnostics during a long-running streaming cycle.
 )


### PR DESCRIPTION
**Description:**

During the main capture loop we re-run discovery every 5 minutes to drive several behaviors like sourcedSchema generation and re- enabling dropped tables if/when they come back. The specific 5m interval was somewhat arbitrary and predicated on the assumption that discovery is tolerably cheap.

Since we're seeing some production databases struggling with the burden of all the discovery queries we send (from multiple captures) let's turn the obvious tuning knob up to 15m. This is still plenty fast for our purposes but means 1/3rd as much discovery work, so it's a cheap win while we finish the real performance improvements.
