### PR TITLE
source-mysql: Handle partially-parsed AlterTable DDL

### DIFF
--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -976,6 +976,29 @@ func (rs *mysqlReplicationStream) handleQuery(ctx context.Context, parser *sqlpa
 		}
 	case *sqlparser.AlterTable:
 		if streamID := resolveTableName(schema, stmt.Table); rs.tableActive(streamID) {
+			// The Vitess SQL parser does not error on DDL it can't fully understand. Instead it
+			// silently degrades the result into a partially parsed statement with FullyParsed set
+			// to false, typically with empty or incomplete AlterOptions.
+			//
+			// If this happens we can't reliably apply the alteration to our cached table metadata,
+			// so rather than silently capturing against incorrect metadata we mark the table as
+			// dropped and rely on a subsequent backfill to reinitialize with correct metadata.
+			if !stmt.FullyParsed {
+				logrus.WithFields(logrus.Fields{
+					"query":  query,
+					"stream": streamID,
+				}).Warn("unable to fully parse ALTER TABLE on active table, will backfill")
+				if err := rs.emitEvent(ctx, &sqlcapture.TableDropEvent{
+					StreamID: streamID,
+					Cause:    fmt.Sprintf("unable to fully parse alteration of table %q by query %q", streamID, query),
+				}); err != nil {
+					return err
+				} else if err := rs.deactivateTable(streamID); err != nil {
+					return fmt.Errorf("error deactivating table %q after incomplete ALTER TABLE parse: %w", streamID, err)
+				}
+				return nil
+			}
+
 			logrus.WithFields(logrus.Fields{
 				"query":         query,
 				"partitionSpec": stmt.PartitionSpec,


### PR DESCRIPTION
**Description:**

Apparently Vitess has the ability to "partially" parse `ALTER TABLE` queries when it matches the `ALTER TABLE <foo>` prefix but errors later on. We should detect when this happens and handle it rather than letting our metadata silently become incorrect.

It's an open question whether the correct handling here is to use a `TableDropEvent` to deactivate the table and let it automatically re-enable itself a little while later, or if we ought to just hard fail the capture until the binding is deactivated or backfilled by a human. Currently we already do the automatic deactivate/backfill recovery strategy in cases of inconsistent table metadata, so for symmetry I have opted to do the same here.

If instead we think this should be a hard failure, then so should the inconsistent metadata case. But my gut says that actually we should handle them both like this and if/when somebody makes a big enough fuss about tables getting automatically re-backfilled we should tackle it from the sqlcapture re-activation side anyway with some sort of advanced option to suppress that behavior or to fail the capture so a human looks at it or something.
