### PR TITLE
materialize-*: migrate constraints to projection_constraints

### DIFF
--- a/filesink/filesink.go
+++ b/filesink/filesink.go
@@ -143,14 +143,17 @@ func (d FileDriver[T, R]) Validate(ctx context.Context, req *pm.Request_Validate
 			return nil, fmt.Errorf("parsing resource config: %w", err)
 		}
 
-		constraints := make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, p := range b.Collection.Projections {
-			constraints[p.Field] = d.NewConstraints(&p)
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      p.Field,
+				Constraint: d.NewConstraints(&p),
+			})
 		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: config.CommonConfig().CaseInsensitiveFields,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          true,
 			ResourcePath:          []string{res.Path},
 		})

--- a/materialize-google-pubsub/driver.go
+++ b/materialize-google-pubsub/driver.go
@@ -144,7 +144,7 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 
 		topicNames[res.TopicName] = struct{}{}
 
-		constraints := make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, projection := range b.Collection.Projections {
 			var constraint = new(pm.Response_Validated_Constraint)
 			switch {
@@ -157,7 +157,10 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
 				constraint.Reason = "PubSub only materializes the full document"
 			}
-			constraints[projection.Field] = constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: constraint,
+			})
 		}
 
 		// Include identifier in the resource path if configured.
@@ -168,7 +171,7 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          true,
 			ResourcePath:          resourcePath,
 		})

--- a/materialize-google-sheets/main.go
+++ b/materialize-google-sheets/main.go
@@ -154,7 +154,7 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 			return nil, fmt.Errorf("parsing resource config: %w", err)
 		}
 
-		var constraints = make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, projection := range binding.Collection.Projections {
 			var constraint = new(pm.Response_Validated_Constraint)
 			switch {
@@ -174,12 +174,15 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_OPTIONAL
 				constraint.Reason = "Field is optional"
 			}
-			constraints[projection.Field] = constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: constraint,
+			})
 		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          false,
 			ResourcePath:          []string{res.Sheet},
 		})

--- a/materialize-pinecone/driver.go
+++ b/materialize-pinecone/driver.go
@@ -196,7 +196,7 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 			return nil, err
 		}
 
-		constraints := make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, projection := range b.Collection.Projections {
 
 			var constraint = new(pm.Response_Validated_Constraint)
@@ -218,12 +218,15 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_OPTIONAL
 				constraint.Reason = "This field can be materializaed"
 			}
-			constraints[projection.Field] = constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: constraint,
+			})
 		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          true,
 			ResourcePath:          []string{cfg.Index, res.Namespace},
 		})

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -85,17 +85,20 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 			return nil, fmt.Errorf("parsing resource config: %w", err)
 		}
 
-		var constraints = make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
+		var sawText, sawTs bool
 		for _, projection := range binding.Collection.Projections {
 			var constraint pm.Response_Validated_Constraint
 
 			switch {
 			case projection.Field == "ts":
+				sawTs = true
 				constraint = pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "The Slack materialization requires a message timestamp",
 				}
 			case projection.Field == "text":
+				sawText = true
 				constraint = pm.Response_Validated_Constraint{
 					Type:   pm.Response_Validated_Constraint_FIELD_REQUIRED,
 					Reason: "The Slack materialization requires 'text'",
@@ -116,19 +119,22 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 					Reason: "All fields other than 'ts', 'text', and 'blocks' will be ignored",
 				}
 			}
-			constraints[projection.Field] = &constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: &constraint,
+			})
 		}
 
-		if constraints["text"] == nil {
+		if !sawText {
 			return nil, fmt.Errorf("'text' field required")
 		}
-		if constraints["ts"] == nil {
+		if !sawTs {
 			return nil, fmt.Errorf("'ts' field required")
 		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          true,
 			ResourcePath:          []string{res.Channel},
 		})

--- a/materialize-sns/driver.go
+++ b/materialize-sns/driver.go
@@ -280,7 +280,7 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 		}
 		topicARN := res.arn(cfg.Region, account)
 
-		constraints := make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, projection := range b.Collection.Projections {
 			var constraint = new(pm.Response_Validated_Constraint)
 			switch {
@@ -293,7 +293,10 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
 				constraint.Reason = "SNS only materializes the full document"
 			}
-			constraints[projection.Field] = constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: constraint,
+			})
 		}
 
 		// Surface authentication / region errors up front, but ignore NotFound — Apply() will
@@ -309,7 +312,7 @@ func (d driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Res
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			DeltaUpdates:          true,
 			ResourcePath:          []string{res.TopicName},
 		})

--- a/materialize-webhook/driver.go
+++ b/materialize-webhook/driver.go
@@ -118,7 +118,7 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 			return nil, fmt.Errorf("resolved webhook address %s is not absolute", resolved)
 		}
 
-		var constraints = make(map[string]*pm.Response_Validated_Constraint)
+		var constraints []*pm.Response_Validated_ProjectionConstraint
 		for _, projection := range binding.Collection.Projections {
 			var constraint = new(pm.Response_Validated_Constraint)
 			switch {
@@ -132,12 +132,15 @@ func (driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Respo
 				constraint.Type = pm.Response_Validated_Constraint_FIELD_FORBIDDEN
 				constraint.Reason = "Webhooks only materialize the full document"
 			}
-			constraints[projection.Field] = constraint
+			constraints = append(constraints, &pm.Response_Validated_ProjectionConstraint{
+				Field:      projection.Field,
+				Constraint: constraint,
+			})
 		}
 
 		out = append(out, &pm.Response_Validated_Binding{
 			CaseInsensitiveFields: false,
-			Constraints:           constraints,
+			ProjectionConstraints: constraints,
 			// Only delta updates are supported by webhooks.
 			DeltaUpdates: true,
 			ResourcePath: []string{resolved.String()},


### PR DESCRIPTION
**Description:**

- Migrate all materializations to use the new `projection_constraints` so we can remove the deprecated `constraints` from the protocol

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

