### PR TITLE
materialize-mongodb: preserve integer precision in stored documents

### DIFF
--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -252,15 +252,20 @@ func (d *materialization) NewTransactor(
 ) (m.Transactor, error) {
 	var bindings []*binding
 	for _, b := range mappedBindings {
-		var keyTokens [][]string
-		for _, k := range b.Keys {
-			keyTokens = append(keyTokens, parsePointerTokens(k.Ptr))
+		var keyRestorations []keyRestoration
+		for i, k := range b.Keys {
+			if isIntegerKeyType(k.Inference.Types) {
+				keyRestorations = append(keyRestorations, keyRestoration{
+					tupleIndex: i,
+					tokens:     parsePointerTokens(k.Ptr),
+				})
+			}
 		}
 
 		bindings = append(bindings, &binding{
-			collection:   d.client.Database(d.cfg.Database).Collection(b.ResourcePath[1]),
-			deltaUpdates: b.DeltaUpdates,
-			keyTokens:    keyTokens,
+			collection:      d.client.Database(d.cfg.Database).Collection(b.ResourcePath[1]),
+			deltaUpdates:    b.DeltaUpdates,
+			keyRestorations: keyRestorations,
 		})
 	}
 
@@ -269,6 +274,27 @@ func (d *materialization) NewTransactor(
 		client:   d.client,
 		bindings: bindings,
 	}, nil
+}
+
+// isIntegerKeyType reports whether a key field's declared JSON-schema types
+// (from its projection's Inference.Types) are exactly "integer", modulo
+// "null" — the only shape whose stored precision needs restoring (see
+// storeDocument). A polymorphic key (e.g. ["integer","string"]) is excluded:
+// its packed tuple element isn't guaranteed to be an integer, so restoring it
+// unconditionally could flip its stored BSON type inconsistently across
+// documents.
+func isIntegerKeyType(types []string) bool {
+	nonNull, isInteger := 0, false
+	for _, t := range types {
+		if t == "null" {
+			continue
+		}
+		nonNull++
+		if t == "integer" {
+			isInteger = true
+		}
+	}
+	return nonNull == 1 && isInteger
 }
 
 func (d *materialization) ListTestTasks(ctx context.Context) ([]string, error) {

--- a/materialize-mongodb/driver.go
+++ b/materialize-mongodb/driver.go
@@ -252,9 +252,15 @@ func (d *materialization) NewTransactor(
 ) (m.Transactor, error) {
 	var bindings []*binding
 	for _, b := range mappedBindings {
+		var keyTokens [][]string
+		for _, k := range b.Keys {
+			keyTokens = append(keyTokens, parsePointerTokens(k.Ptr))
+		}
+
 		bindings = append(bindings, &binding{
 			collection:   d.client.Database(d.cfg.Database).Collection(b.ResourcePath[1]),
 			deltaUpdates: b.DeltaUpdates,
+			keyTokens:    keyTokens,
 		})
 	}
 

--- a/materialize-mongodb/driver_test.go
+++ b/materialize-mongodb/driver_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestIsIntegerKeyType guards the eligibility filter that decides which key
+// fields storeDocument attempts to restore. Only a solely-integer type (modulo
+// null) qualifies: a polymorphic key isn't guaranteed to pack as int64, so
+// restoring it unconditionally could flip its stored BSON type inconsistently
+// across documents.
+func TestIsIntegerKeyType(t *testing.T) {
+	cases := []struct {
+		name  string
+		types []string
+		want  bool
+	}{
+		{"integer", []string{"integer"}, true},
+		{"nullable integer", []string{"integer", "null"}, true},
+		{"string", []string{"string"}, false},
+		{"boolean", []string{"boolean"}, false},
+		{"polymorphic integer or string", []string{"integer", "string"}, false},
+		{"only null", []string{"null"}, false},
+		{"empty", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, isIntegerKeyType(c.types))
+		})
+	}
+}
+
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -72,10 +73,21 @@ type transactor struct {
 type binding struct {
 	collection   *mongo.Collection
 	deltaUpdates bool
-	// keyTokens holds the parsed RFC6901 JSON pointer tokens of the binding's
-	// key fields, in the same order as a store's key tuple, used to restore
-	// exact integer key values in the stored document.
-	keyTokens [][]string
+	// keyRestorations holds, for each of the binding's key fields declared as
+	// JSON-schema integer (the only type whose stored precision needs
+	// restoring — see storeDocument), its index into a store's key tuple and
+	// parsed RFC6901 JSON pointer tokens. Key fields of other declared types
+	// are omitted so the per-document restore loop never re-derives their
+	// (never-integer) type.
+	keyRestorations []keyRestoration
+}
+
+// keyRestoration is a single entry of binding.keyRestorations. tupleIndex
+// indexes into a store's key tuple; tokens is the pre-parsed JSON pointer to
+// that key field's location in the stored document.
+type keyRestoration struct {
+	tupleIndex int
+	tokens     []string
 }
 
 func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.MaterializationSpec, rangeSpec pf.RangeSpec) (m.RuntimeCheckpoint, error) {
@@ -191,7 +203,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			batchSize += len(key)
 		} else {
 			b := t.bindings[it.Binding]
-			doc, err := storeDocument(it.RawJSON, key, b.deltaUpdates, it.Key, b.keyTokens)
+			doc, err := storeDocument(it.RawJSON, key, b.deltaUpdates, it.Key, b.keyRestorations)
 			if err != nil {
 				return nil, err
 			}
@@ -466,7 +478,7 @@ func storeRetryDelay(ctx context.Context, attempt int) error {
 // document body a rounded key field would no longer match — provoking a
 // duplicate-key crash loop. Non-key numbers are intentionally left as float64 so
 // a field's BSON type stays stable regardless of its value.
-func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, key tuple.Tuple, keyTokens [][]string) (bson.M, error) {
+func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, key tuple.Tuple, keyRestorations []keyRestoration) (bson.M, error) {
 	var doc bson.M
 	if err := json.Unmarshal(rawJSON, &doc); err != nil {
 		return nil, fmt.Errorf("unmarshalling json doc: %w", err)
@@ -478,16 +490,27 @@ func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, k
 	// skipped there to avoid needlessly flipping a key field's BSON type from
 	// double to long. Done before the _id rename below so a key located at /_id
 	// is corrected in place and then carried into _flow_id. Only int64 values are
-	// restored; strings and booleans already decode exactly, and keys beyond
-	// int64 (uint64) remain lossy, which BSON cannot represent faithfully anyway.
+	// restored; strings and booleans already decode exactly. keyRestorations is
+	// pre-filtered (see driver.go) to only the key fields declared as
+	// JSON-schema integer, so non-integer key fields never enter this loop.
 	if !deltaUpdates {
-		if len(key) != len(keyTokens) {
-			panic(fmt.Sprintf("store key tuple has %d elements but binding declares %d key fields", len(key), len(keyTokens)))
-		}
-		for i, tokens := range keyTokens {
-			if v, ok := key[i].(int64); ok {
-				setAtPointer(doc, tokens, v)
+		for _, kr := range keyRestorations {
+			if kr.tupleIndex >= len(key) {
+				panic(fmt.Sprintf("store key tuple has %d elements but binding declares a key field at index %d", len(key), kr.tupleIndex))
 			}
+			v, ok := key[kr.tupleIndex].(int64)
+			if !ok {
+				continue
+			}
+			// Fast path for the overwhelmingly common case: a key at the
+			// document's root (a single pointer segment). This skips
+			// setAtPointer's generic tree walk, which is only needed when a
+			// key is nested under an object or array.
+			if len(kr.tokens) == 1 {
+				doc[kr.tokens[0]] = v
+				continue
+			}
+			setAtPointer(doc, kr.tokens, v)
 		}
 	}
 
@@ -509,8 +532,8 @@ func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, k
 }
 
 // parsePointerTokens splits an RFC6901 JSON pointer into its decoded reference
-// tokens. It is computed once per binding (see binding.keyTokens) so that
-// setAtPointer need not re-parse the pointer on every stored document.
+// tokens. It is computed once per binding (see binding.keyRestorations) so
+// that setAtPointer need not re-parse the pointer on every stored document.
 func parsePointerTokens(ptr string) []string {
 	if ptr == "" {
 		return nil
@@ -525,13 +548,13 @@ func parsePointerTokens(ptr string) []string {
 }
 
 // setAtPointer writes val at the location addressed by the parsed JSON pointer
-// tokens within doc, traversing both JSON objects and arrays. It no-ops when the
-// location is absent or a token does not address its parent's type, degrading to
-// the value json.Unmarshal already decoded rather than altering the document's
-// shape.
-func setAtPointer(doc bson.M, tokens []string, val any) {
+// tokens within doc, traversing both JSON objects and arrays. It reports
+// whether the write succeeded; it fails (returns false) without altering doc
+// when the location is absent or a token does not address its parent's type,
+// rather than guessing and altering the document's shape.
+func setAtPointer(doc bson.M, tokens []string, val any) bool {
 	if len(tokens) == 0 {
-		return
+		return false
 	}
 
 	// Walk to the parent of the leaf. Objects decoded by json.Unmarshal are
@@ -542,7 +565,7 @@ func setAtPointer(doc bson.M, tokens []string, val any) {
 	for _, token := range tokens[:len(tokens)-1] {
 		current = childAtToken(current, token)
 		if current == nil {
-			return
+			return false
 		}
 	}
 
@@ -550,13 +573,14 @@ func setAtPointer(doc bson.M, tokens []string, val any) {
 	switch parent := current.(type) {
 	case map[string]interface{}:
 		parent[leaf] = val
-	case bson.M:
-		parent[leaf] = val
+		return true
 	case []interface{}:
 		if idx, ok := arrayIndex(leaf, len(parent)); ok {
 			parent[idx] = val
+			return true
 		}
 	}
+	return false
 }
 
 // childAtToken returns the child of node addressed by a single JSON pointer
@@ -565,8 +589,6 @@ func setAtPointer(doc bson.M, tokens []string, val any) {
 func childAtToken(node any, token string) any {
 	switch n := node.(type) {
 	case map[string]interface{}:
-		return n[token]
-	case bson.M:
 		return n[token]
 	case []interface{}:
 		if idx, ok := arrayIndex(token, len(n)); ok {
@@ -616,4 +638,25 @@ func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 	}
 
 	return doc
+}
+
+// sanitizeArrayInner is sanitizeDocumentInner's counterpart for array elements.
+func sanitizeArrayInner(arr []interface{}) []interface{} {
+	for i, value := range arr {
+		switch v := value.(type) {
+		case float64:
+			if math.IsNaN(v) {
+				arr[i] = "NaN"
+			}
+		case map[string]interface{}:
+			arr[i] = sanitizeDocumentInner(v)
+		case primitive.M:
+			arr[i] = sanitizeDocumentInner(v)
+		case primitive.A:
+			arr[i] = sanitizeArrayInner(v)
+		case []interface{}:
+			arr[i] = sanitizeArrayInner(v)
+		}
+	}
+	return arr
 }

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -484,42 +484,66 @@ func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, k
 		return nil, fmt.Errorf("unmarshalling json doc: %w", err)
 	}
 
+	// Renaming runs before key restoration below so a key pointer can be
+	// redirected to wherever its value actually ends up living.
+	_, hadIDCollision := doc[idField]
+	if hadIDCollision {
+		// Preserve the original value of a collection field with a name
+		// that collides with the MongoDB _id field by materializing it
+		// with an alternate name.
+		doc[idFieldAlt] = doc[idField]
+		delete(doc, idField)
+	}
+
 	// Restoring exact integer keys only matters for standard updates, where the
 	// runtime re-derives a store's key from the loaded document body. Delta
 	// updates never load documents and let MongoDB mint a fresh _id, so it is
 	// skipped there to avoid needlessly flipping a key field's BSON type from
-	// double to long. Done before the _id rename below so a key located at /_id
-	// is corrected in place and then carried into _flow_id. Only int64 values are
-	// restored; strings and booleans already decode exactly. keyRestorations is
-	// pre-filtered (see driver.go) to only the key fields declared as
-	// JSON-schema integer, so non-integer key fields never enter this loop.
+	// double to long. Only int64 values are restored; strings and booleans
+	// already decode exactly. keyRestorations is pre-filtered (see driver.go)
+	// to only the key fields declared as JSON-schema integer, so non-integer
+	// key fields never enter this loop.
 	if !deltaUpdates {
 		for _, kr := range keyRestorations {
 			if kr.tupleIndex >= len(key) {
-				panic(fmt.Sprintf("store key tuple has %d elements but binding declares a key field at index %d", len(key), kr.tupleIndex))
+				return nil, fmt.Errorf("store key tuple has %d elements but binding declares a key field at index %d", len(key), kr.tupleIndex)
 			}
 			v, ok := key[kr.tupleIndex].(int64)
 			if !ok {
 				continue
 			}
+
+			// A key pointer of exactly /_id addresses the field the rename above
+			// just relocated to _flow_id; redirect there so the value lands where
+			// it now actually lives. A key pointer of exactly /_flow_id colliding
+			// with a renamed _id is irreconcilable: the document has both a
+			// literal _flow_id (the key) and a literal _id (an unrelated value
+			// the rename just pushed onto _flow_id), so there's no single
+			// location left to hold both — fail rather than let the rename
+			// silently clobber the key.
+			target := kr.tokens
+			if hadIDCollision && len(target) == 1 {
+				switch target[0] {
+				case idField:
+					target = []string{idFieldAlt}
+				case idFieldAlt:
+					return nil, fmt.Errorf("document has a field named %q which collides with the reserved name used to materialize its key %q", idField, idFieldAlt)
+				}
+			}
+
 			// Fast path for the overwhelmingly common case: a key at the
 			// document's root (a single pointer segment). This skips
 			// setAtPointer's generic tree walk, which is only needed when a
 			// key is nested under an object or array.
-			if len(kr.tokens) == 1 {
-				doc[kr.tokens[0]] = v
+			if len(target) == 1 {
+				doc[target[0]] = v
 				continue
 			}
-			setAtPointer(doc, kr.tokens, v)
-		}
-	}
 
-	if idVal, ok := doc[idField]; ok {
-		// Preserve the original value of a collection field with a name
-		// that collides with the MongoDB _id field by materializing it
-		// with an alternate name.
-		doc[idFieldAlt] = idVal
-		delete(doc, idField)
+			if !setAtPointer(doc, target, v) {
+				return nil, fmt.Errorf("key field at pointer %v could not be located in the document body", target)
+			}
+		}
 	}
 
 	// In case of delta updates, we don't want to set the _id. We want MongoDB to generate a new
@@ -625,6 +649,15 @@ func sanitizedLoadedDocument(doc map[string]interface{}) map[string]interface{} 
 	return sanitizeDocumentInner(doc)
 }
 
+// sanitizeDocumentInner recurses through a loaded document's values, converting
+// any BSON double NaN to the string "NaN" (json.Marshal rejects NaN outright).
+// The mongo-driver decodes nested BSON sub-documents and arrays into the named
+// types primitive.M and primitive.A respectively, never plain
+// map[string]interface{} or []interface{}, so both the named and plain forms
+// are matched here: a type switch only matches the exact dynamic type, and
+// named/unnamed forms of the same underlying type are distinct for that
+// purpose. The plain forms are kept so this is also callable with
+// hand-constructed maps/slices, e.g. from tests.
 func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 	for key, value := range doc {
 		switch v := value.(type) {
@@ -634,6 +667,12 @@ func sanitizeDocumentInner(doc map[string]interface{}) map[string]interface{} {
 			}
 		case map[string]interface{}:
 			doc[key] = sanitizeDocumentInner(v)
+		case primitive.M:
+			doc[key] = sanitizeDocumentInner(v)
+		case primitive.A:
+			doc[key] = sanitizeArrayInner(v)
+		case []interface{}:
+			doc[key] = sanitizeArrayInner(v)
 		}
 	}
 

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -472,6 +472,25 @@ func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, k
 		return nil, fmt.Errorf("unmarshalling json doc: %w", err)
 	}
 
+	// Restoring exact integer keys only matters for standard updates, where the
+	// runtime re-derives a store's key from the loaded document body. Delta
+	// updates never load documents and let MongoDB mint a fresh _id, so it is
+	// skipped there to avoid needlessly flipping a key field's BSON type from
+	// double to long. Done before the _id rename below so a key located at /_id
+	// is corrected in place and then carried into _flow_id. Only int64 values are
+	// restored; strings and booleans already decode exactly, and keys beyond
+	// int64 (uint64) remain lossy, which BSON cannot represent faithfully anyway.
+	if !deltaUpdates {
+		if len(key) != len(keyTokens) {
+			panic(fmt.Sprintf("store key tuple has %d elements but binding declares %d key fields", len(key), len(keyTokens)))
+		}
+		for i, tokens := range keyTokens {
+			if v, ok := key[i].(int64); ok {
+				setAtPointer(doc, tokens, v)
+			}
+		}
+	}
+
 	if idVal, ok := doc[idField]; ok {
 		// Preserve the original value of a collection field with a name
 		// that collides with the MongoDB _id field by materializing it

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	m "github.com/estuary/connectors/go/materialize"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -69,6 +72,10 @@ type transactor struct {
 type binding struct {
 	collection   *mongo.Collection
 	deltaUpdates bool
+	// keyTokens holds the parsed RFC6901 JSON pointer tokens of the binding's
+	// key fields, in the same order as a store's key tuple, used to restore
+	// exact integer key values in the stored document.
+	keyTokens [][]string
 }
 
 func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.MaterializationSpec, rangeSpec pf.RangeSpec) (m.RuntimeCheckpoint, error) {
@@ -183,22 +190,10 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			batch = append(batch, del)
 			batchSize += len(key)
 		} else {
-			var doc bson.M
-			if err := json.Unmarshal(it.RawJSON, &doc); err != nil {
-				return nil, fmt.Errorf("bson unmarshalling json doc: %w", err)
-			}
-			if idVal, ok := doc[idField]; ok {
-				// Preserve the original value of a collection field with a name
-				// that collides with the MongoDB _id field by materializing it
-				// with an alternate name.
-				doc[idFieldAlt] = idVal
-				delete(doc, idField)
-			}
-
-			// In case of delta updates, we don't want to set the _id. We want MongoDB to generate a new
-			// _id for each record we insert
-			if !t.bindings[it.Binding].deltaUpdates {
-				doc[idField] = key
+			b := t.bindings[it.Binding]
+			doc, err := storeDocument(it.RawJSON, key, b.deltaUpdates, it.Key, b.keyTokens)
+			if err != nil {
+				return nil, err
 			}
 
 			var m mongo.WriteModel
@@ -459,6 +454,117 @@ func storeRetryDelay(ctx context.Context, attempt int) error {
 	case <-time.After(d):
 		return nil
 	}
+}
+
+// storeDocument builds the MongoDB document for a store from the raw Flow
+// document JSON. It renames any field colliding with MongoDB's reserved _id
+// field and, for standard updates, sets _id to the packed key.
+//
+// Integer key fields are restored to their exact values from the store's key
+// tuple: json.Unmarshal decodes JSON numbers as float64, which rounds integers
+// beyond 2^53, and because the runtime re-derives a store's key from the loaded
+// document body a rounded key field would no longer match — provoking a
+// duplicate-key crash loop. Non-key numbers are intentionally left as float64 so
+// a field's BSON type stays stable regardless of its value.
+func storeDocument(rawJSON json.RawMessage, idValue string, deltaUpdates bool, key tuple.Tuple, keyTokens [][]string) (bson.M, error) {
+	var doc bson.M
+	if err := json.Unmarshal(rawJSON, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshalling json doc: %w", err)
+	}
+
+	if idVal, ok := doc[idField]; ok {
+		// Preserve the original value of a collection field with a name
+		// that collides with the MongoDB _id field by materializing it
+		// with an alternate name.
+		doc[idFieldAlt] = idVal
+		delete(doc, idField)
+	}
+
+	// In case of delta updates, we don't want to set the _id. We want MongoDB to generate a new
+	// _id for each record we insert
+	if !deltaUpdates {
+		doc[idField] = idValue
+	}
+
+	return doc, nil
+}
+
+// parsePointerTokens splits an RFC6901 JSON pointer into its decoded reference
+// tokens. It is computed once per binding (see binding.keyTokens) so that
+// setAtPointer need not re-parse the pointer on every stored document.
+func parsePointerTokens(ptr string) []string {
+	if ptr == "" {
+		return nil
+	}
+
+	tokens := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
+	for i, token := range tokens {
+		token = strings.ReplaceAll(token, "~1", "/")
+		tokens[i] = strings.ReplaceAll(token, "~0", "~")
+	}
+	return tokens
+}
+
+// setAtPointer writes val at the location addressed by the parsed JSON pointer
+// tokens within doc, traversing both JSON objects and arrays. It no-ops when the
+// location is absent or a token does not address its parent's type, degrading to
+// the value json.Unmarshal already decoded rather than altering the document's
+// shape.
+func setAtPointer(doc bson.M, tokens []string, val any) {
+	if len(tokens) == 0 {
+		return
+	}
+
+	// Walk to the parent of the leaf. Objects decoded by json.Unmarshal are
+	// map[string]interface{} (the root is the equivalent bson.M) and arrays are
+	// []interface{}; slices are reference types, so writing back through the
+	// parent below is visible in doc.
+	var current any = map[string]interface{}(doc)
+	for _, token := range tokens[:len(tokens)-1] {
+		current = childAtToken(current, token)
+		if current == nil {
+			return
+		}
+	}
+
+	leaf := tokens[len(tokens)-1]
+	switch parent := current.(type) {
+	case map[string]interface{}:
+		parent[leaf] = val
+	case bson.M:
+		parent[leaf] = val
+	case []interface{}:
+		if idx, ok := arrayIndex(leaf, len(parent)); ok {
+			parent[idx] = val
+		}
+	}
+}
+
+// childAtToken returns the child of node addressed by a single JSON pointer
+// token, or nil when node is neither an object nor an array or the token does
+// not address an existing element.
+func childAtToken(node any, token string) any {
+	switch n := node.(type) {
+	case map[string]interface{}:
+		return n[token]
+	case bson.M:
+		return n[token]
+	case []interface{}:
+		if idx, ok := arrayIndex(token, len(n)); ok {
+			return n[idx]
+		}
+	}
+	return nil
+}
+
+// arrayIndex parses an RFC6901 array-index token and reports whether it is a
+// valid in-bounds index into a slice of the given length.
+func arrayIndex(token string, length int) (int, bool) {
+	idx, err := strconv.Atoi(token)
+	if err != nil || idx < 0 || idx >= length {
+		return 0, false
+	}
+	return idx, true
 }
 
 func sanitizedLoadedDocument(doc map[string]interface{}) map[string]interface{} {

--- a/materialize-mongodb/transactor_unit_test.go
+++ b/materialize-mongodb/transactor_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -160,6 +161,21 @@ func TestStoreDocumentIdCollisionKey(t *testing.T) {
 		"a key at /_id must round-trip exactly through the _flow_id rename")
 }
 
+// TestStoreDocumentIdFlowIdCollisionReturnsError is the regression test for the
+// _id/_flow_id collision clobbering a restored key: when a document has both a
+// literal _id field and a key field literally named _flow_id, the _id-collision
+// rename has nowhere safe to put the displaced _id value without destroying the
+// key. storeDocument must fail loudly rather than silently let the rename
+// overwrite the restored key with the unrelated _id value.
+func TestStoreDocumentIdFlowIdCollisionReturnsError(t *testing.T) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"_id":"arbitrary","_flow_id":%d}`, id))
+
+	_, err := storeDocument(raw, "00", false,
+		tuple.Tuple{id}, []keyRestoration{{tupleIndex: 0, tokens: []string{"_flow_id"}}})
+	require.Error(t, err)
+}
+
 // TestStoreDocumentCompositeMixedKey verifies positional correspondence between
 // the key tuple and key pointers, and that only the int64 key element is
 // overwritten (the string key and non-key number are left as decoded).
@@ -196,16 +212,84 @@ func TestStoreDocumentDeltaUpdatesLeavesKeyAsDouble(t *testing.T) {
 	require.False(t, hasID, "delta updates must not set _id")
 }
 
-// TestStoreDocumentKeyFieldCountMismatchPanics asserts that a key tuple whose
-// length disagrees with the binding's key field count — an impossible state,
-// since the runtime packs exactly one key element per declared key field — fails
-// loudly rather than silently storing a document with un-restored key precision.
-func TestStoreDocumentKeyFieldCountMismatchPanics(t *testing.T) {
+// TestStoreDocumentKeyIndexOutOfBoundsReturnsError asserts that a
+// keyRestoration whose tupleIndex falls outside the store's key tuple — an
+// impossible state, since the runtime packs exactly one key element per
+// declared key field — fails loudly rather than silently storing a document
+// with un-restored key precision.
+func TestStoreDocumentKeyIndexOutOfBoundsReturnsError(t *testing.T) {
 	raw := json.RawMessage(`{"id":1}`)
-	require.Panics(t, func() {
-		_, _ = storeDocument(raw, "00", false,
-			tuple.Tuple{int64(1)}, []keyRestoration{{tupleIndex: 5, tokens: []string{"id"}}})
-	})
+	_, err := storeDocument(raw, "00", false,
+		tuple.Tuple{int64(1)}, []keyRestoration{{tupleIndex: 5, tokens: []string{"id"}}})
+	require.Error(t, err)
+}
+
+// TestStoreDocumentKeyPointerUnresolvedReturnsError asserts that storeDocument
+// fails loudly, rather than silently storing a document with un-restored key
+// precision, when a key field's declared JSON pointer doesn't resolve in the
+// document body (here, the intermediate object "a" is missing entirely).
+func TestStoreDocumentKeyPointerUnresolvedReturnsError(t *testing.T) {
+	raw := json.RawMessage(`{}`)
+	_, err := storeDocument(raw, "00", false,
+		tuple.Tuple{int64(1)}, []keyRestoration{{tupleIndex: 0, tokens: []string{"a", "id"}}})
+	require.Error(t, err)
+}
+
+// TestSanitizeDocumentInnerArrayNaN is the regression test for NaN nested
+// inside an array surviving load-side sanitization: the mongo-driver decodes a
+// loaded document's nested BSON arrays as primitive.A (bson.A), never
+// []interface{}, so a NaN nested inside an array element — e.g.
+// {"items": [{"val": NaN}]} — passed through sanitizeDocumentInner untouched
+// and broke the subsequent json.Marshal of the loaded document. The array is
+// round-tripped through bson.Marshal/Unmarshal so the test exercises the
+// driver-authentic primitive.A shape rather than a hand-built []interface{}.
+func TestSanitizeDocumentInnerArrayNaN(t *testing.T) {
+	encoded, err := bson.Marshal(bson.M{"items": bson.A{bson.M{"val": math.NaN()}}})
+	require.NoError(t, err)
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(encoded, &doc))
+
+	sanitized := sanitizeDocumentInner(doc)
+	_, err = json.Marshal(sanitized)
+	require.NoError(t, err, "NaN nested inside an array must be sanitized before marshaling")
+}
+
+// TestSanitizeDocumentInnerNestedObjectNaN is the regression test for the
+// sibling gap to TestSanitizeDocumentInnerArrayNaN: the mongo-driver decodes a
+// loaded document's nested sub-objects as primitive.M (bson.M), never plain
+// map[string]interface{}, so a NaN nested inside a sub-object — not even
+// inside an array — also passed through sanitizeDocumentInner untouched.
+func TestSanitizeDocumentInnerNestedObjectNaN(t *testing.T) {
+	encoded, err := bson.Marshal(bson.M{"obj": bson.M{"val": math.NaN()}})
+	require.NoError(t, err)
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(encoded, &doc))
+
+	sanitized := sanitizeDocumentInner(doc)
+	_, err = json.Marshal(sanitized)
+	require.NoError(t, err, "NaN nested inside a sub-object must be sanitized before marshaling")
+}
+
+// BenchmarkStoreDocumentCompositeKey measures storeDocument's restore loop for
+// a composite key with one integer field (eligible for restoration) and two
+// non-integer fields (string, boolean) that keyRestorations excludes
+// up front. It exists to confirm the eligibility filter and root-level fast
+// path keep this loop's cost close to the single-key case rather than scaling
+// with the binding's total key-field count.
+func BenchmarkStoreDocumentCompositeKey(b *testing.B) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"id":%d,"code":"abc","active":true,"name":"n"}`, id))
+	key := tuple.Tuple{id, "abc", true}
+	// Only "id" is integer-typed; driver.go's isIntegerKeyType filter would
+	// exclude "code" and "active" from keyRestorations entirely.
+	restorations := []keyRestoration{{tupleIndex: 0, tokens: []string{"id"}}}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := storeDocument(raw, "00", false, key, restorations); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // bulkErr builds a mongo.BulkWriteException with one per-item WriteError per

--- a/materialize-mongodb/transactor_unit_test.go
+++ b/materialize-mongodb/transactor_unit_test.go
@@ -21,11 +21,11 @@ import (
 // runtime would parse to re-derive the key.
 func storeAndReload(t *testing.T, raw json.RawMessage, idValue string, deltaUpdates bool, key tuple.Tuple, keyPtrs []string) (bson.M, []byte) {
 	t.Helper()
-	var keyTokens [][]string
-	for _, ptr := range keyPtrs {
-		keyTokens = append(keyTokens, parsePointerTokens(ptr))
+	var restorations []keyRestoration
+	for i, ptr := range keyPtrs {
+		restorations = append(restorations, keyRestoration{tupleIndex: i, tokens: parsePointerTokens(ptr)})
 	}
-	doc, err := storeDocument(raw, idValue, deltaUpdates, key, keyTokens)
+	doc, err := storeDocument(raw, idValue, deltaUpdates, key, restorations)
 	require.NoError(t, err)
 
 	encoded, err := bson.Marshal(doc)
@@ -204,7 +204,7 @@ func TestStoreDocumentKeyFieldCountMismatchPanics(t *testing.T) {
 	raw := json.RawMessage(`{"id":1}`)
 	require.Panics(t, func() {
 		_, _ = storeDocument(raw, "00", false,
-			tuple.Tuple{int64(1), int64(2)}, [][]string{{"id"}})
+			tuple.Tuple{int64(1)}, []keyRestoration{{tupleIndex: 5, tokens: []string{"id"}}})
 	})
 }
 

--- a/materialize-mongodb/transactor_unit_test.go
+++ b/materialize-mongodb/transactor_unit_test.go
@@ -1,16 +1,212 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// storeAndReload runs storeDocument and then simulates the MongoDB store + load
+// round-trip (BSON marshal/unmarshal followed by the connector's load
+// sanitization), returning both the stored BSON document and the JSON the
+// runtime would parse to re-derive the key.
+func storeAndReload(t *testing.T, raw json.RawMessage, idValue string, deltaUpdates bool, key tuple.Tuple, keyPtrs []string) (bson.M, []byte) {
+	t.Helper()
+	var keyTokens [][]string
+	for _, ptr := range keyPtrs {
+		keyTokens = append(keyTokens, parsePointerTokens(ptr))
+	}
+	doc, err := storeDocument(raw, idValue, deltaUpdates, key, keyTokens)
+	require.NoError(t, err)
+
+	encoded, err := bson.Marshal(doc)
+	require.NoError(t, err)
+	var reloaded bson.M
+	require.NoError(t, bson.Unmarshal(encoded, &reloaded))
+	loadedJSON, err := json.Marshal(sanitizedLoadedDocument(reloaded))
+	require.NoError(t, err)
+
+	return doc, loadedJSON
+}
+
+// numberAt decodes loadedJSON with UseNumber and returns the json.Number at the
+// given top-level field, so tests can assert exact (non-lossy) round-tripping.
+func numberAt(t *testing.T, loadedJSON []byte, field string) json.Number {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(loadedJSON))
+	dec.UseNumber()
+	var m map[string]interface{}
+	require.NoError(t, dec.Decode(&m))
+	n, ok := m[field].(json.Number)
+	require.True(t, ok, "field %q is not a number: %v", field, m[field])
+	return n
+}
+
+// TestStoreDocumentPreservesLargeIntegerKey is the regression test for the
+// duplicate-key crash loop on large integer keys. A key beyond float64's exact
+// integer range (2^53) must round-trip through a store and a subsequent load
+// without losing precision: the runtime re-derives a store's key from the
+// document body returned by Load (a Loaded response carries no key), so a lossy
+// EVENT_ID makes the runtime fail to match the load, report Exists=false, and
+// the connector then issues a strict InsertOne for an _id that already exists →
+// E11000, permanently.
+func TestStoreDocumentPreservesLargeIntegerKey(t *testing.T) {
+	// A real colliding EVENT_ID from the field: ~-9.2e18, far beyond 2^53, and
+	// odd (so not representable as a float64, whose ULP at this magnitude is 2048).
+	const eventID int64 = -9223341701339290697
+	raw := json.RawMessage(fmt.Sprintf(`{"EVENT_ID":%d,"EVENT_TYPE":"u","NEW_VALUE":1.5}`, eventID))
+	// _id is the exact packed key; it is always faithful. The bug is in the body.
+	const packedKeyHex = "0c80001b97099fe3b6"
+
+	_, loadedJSON := storeAndReload(t, raw, packedKeyHex, false,
+		tuple.Tuple{eventID}, []string{"/EVENT_ID"})
+
+	// The runtime re-derives the key by parsing EVENT_ID out of the loaded doc.
+	require.Equal(t, fmt.Sprint(eventID), numberAt(t, loadedJSON, "EVENT_ID").String(),
+		"EVENT_ID must round-trip exactly; a lossy value re-derives a different key and breaks load matching")
+}
+
+// TestStoreDocumentLeavesNonKeyIntegersAsDouble verifies the key-scoped design:
+// only key fields get exact integer precision, while non-key numbers decode as
+// float64 exactly as before. This keeps BSON types stable across documents (a
+// non-key field never flips between int64 and double based on its value) and
+// avoids a fleet-wide type change on existing collections.
+func TestStoreDocumentLeavesNonKeyIntegersAsDouble(t *testing.T) {
+	const key int64 = 1
+	const nonKey int64 = 9223372036854775807 // MaxInt64, far beyond 2^53
+	raw := json.RawMessage(fmt.Sprintf(`{"id":%d,"COUNT":%d}`, key, nonKey))
+
+	doc, loadedJSON := storeAndReload(t, raw, "00", false,
+		tuple.Tuple{key}, []string{"/id"})
+
+	require.IsType(t, int64(0), doc["id"], "key field must be stored as int64")
+	require.IsType(t, float64(0), doc["COUNT"], "non-key integer must stay float64 (stable BSON type)")
+
+	require.Equal(t, fmt.Sprint(key), numberAt(t, loadedJSON, "id").String(),
+		"key round-trips exactly")
+	require.NotEqual(t, fmt.Sprint(nonKey), numberAt(t, loadedJSON, "COUNT").String(),
+		"non-key integer beyond 2^53 is expected to be lossy (unchanged pre-PR behavior)")
+}
+
+// TestStoreDocumentNestedKeyPointer exercises a key at a nested JSON pointer,
+// guarding setAtPointer's traversal of both the root bson.M and nested
+// map[string]interface{} produced by json.Unmarshal.
+func TestStoreDocumentNestedKeyPointer(t *testing.T) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"a":{"b":{"id":%d}}}`, id))
+
+	_, loadedJSON := storeAndReload(t, raw, "00", false,
+		tuple.Tuple{id}, []string{"/a/b/id"})
+
+	var got struct {
+		A struct {
+			B struct {
+				ID json.Number `json:"id"`
+			} `json:"b"`
+		} `json:"a"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(loadedJSON))
+	dec.UseNumber()
+	require.NoError(t, dec.Decode(&got))
+	require.Equal(t, fmt.Sprint(id), got.A.B.ID.String(), "nested key must round-trip exactly")
+}
+
+// TestStoreDocumentArrayNestedKey exercises a key located beneath a JSON array
+// element (a legal Flow key location). setAtPointer must traverse the
+// []interface{} that json.Unmarshal produces and restore the exact int64;
+// otherwise the lossy float64 re-derives a mismatched key and provokes the
+// duplicate-key crash loop.
+func TestStoreDocumentArrayNestedKey(t *testing.T) {
+	const id int64 = 9223372036854775807 // MaxInt64, far beyond 2^53
+	raw := json.RawMessage(fmt.Sprintf(`{"items":[{"id":%d}]}`, id))
+
+	_, loadedJSON := storeAndReload(t, raw, "00", false,
+		tuple.Tuple{id}, []string{"/items/0/id"})
+
+	var got struct {
+		Items []struct {
+			ID json.Number `json:"id"`
+		} `json:"items"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(loadedJSON))
+	dec.UseNumber()
+	require.NoError(t, dec.Decode(&got))
+	require.Len(t, got.Items, 1)
+	require.Equal(t, fmt.Sprint(id), got.Items[0].ID.String(),
+		"array-nested key must round-trip exactly")
+}
+
+// TestStoreDocumentIdCollisionKey guards the ordering of key overwrite vs the
+// _id-collision rename: a key located at /_id must be corrected in place before
+// the rename moves it to _flow_id, so it round-trips exactly after the load path
+// reverses the rename.
+func TestStoreDocumentIdCollisionKey(t *testing.T) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"_id":%d}`, id))
+
+	_, loadedJSON := storeAndReload(t, raw, "00", false,
+		tuple.Tuple{id}, []string{"/_id"})
+
+	require.Equal(t, fmt.Sprint(id), numberAt(t, loadedJSON, "_id").String(),
+		"a key at /_id must round-trip exactly through the _flow_id rename")
+}
+
+// TestStoreDocumentCompositeMixedKey verifies positional correspondence between
+// the key tuple and key pointers, and that only the int64 key element is
+// overwritten (the string key and non-key number are left as decoded).
+func TestStoreDocumentCompositeMixedKey(t *testing.T) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"id":%d,"name":"abc","n":5}`, id))
+
+	doc, loadedJSON := storeAndReload(t, raw, "00", false,
+		tuple.Tuple{id, "abc"}, []string{"/id", "/name"})
+
+	require.IsType(t, int64(0), doc["id"], "int64 key element is overwritten exactly")
+	require.Equal(t, "abc", doc["name"], "string key element is left untouched")
+	require.IsType(t, float64(0), doc["n"], "non-key integer stays float64")
+
+	require.Equal(t, fmt.Sprint(id), numberAt(t, loadedJSON, "id").String(),
+		"int64 key round-trips exactly")
+}
+
+// TestStoreDocumentDeltaUpdatesLeavesKeyAsDouble verifies that delta-update
+// bindings skip int64 key restoration. They never load documents and let MongoDB
+// generate the _id, so restoring precision serves no purpose and would needlessly
+// flip an integer key field's BSON type from double to long on existing
+// collections.
+func TestStoreDocumentDeltaUpdatesLeavesKeyAsDouble(t *testing.T) {
+	const id int64 = 9223372036854775807
+	raw := json.RawMessage(fmt.Sprintf(`{"id":%d}`, id))
+
+	doc, _ := storeAndReload(t, raw, "00", true,
+		tuple.Tuple{id}, []string{"/id"})
+
+	require.IsType(t, float64(0), doc["id"],
+		"delta-update key field must stay float64 (BSON type unchanged)")
+	_, hasID := doc[idField]
+	require.False(t, hasID, "delta updates must not set _id")
+}
+
+// TestStoreDocumentKeyFieldCountMismatchPanics asserts that a key tuple whose
+// length disagrees with the binding's key field count — an impossible state,
+// since the runtime packs exactly one key element per declared key field — fails
+// loudly rather than silently storing a document with un-restored key precision.
+func TestStoreDocumentKeyFieldCountMismatchPanics(t *testing.T) {
+	raw := json.RawMessage(`{"id":1}`)
+	require.Panics(t, func() {
+		_, _ = storeDocument(raw, "00", false,
+			tuple.Tuple{int64(1), int64(2)}, [][]string{{"id"}})
+	})
+}
 
 // bulkErr builds a mongo.BulkWriteException with one per-item WriteError per
 // entry in codeByIndex (index -> MongoDB error code). It is returned by value,


### PR DESCRIPTION
**Regression?**

Latent since the connector's first commit; surfaced as a crash by the strict-insert path added later. Brief history:
- `ed8b7ac41` (2023-03-06) — first commit stores docs via `json.Unmarshal` into `bson.M`, which decodes JSON numbers as `float64`, silently rounding integers > 2^53. Harmless then: every store was an idempotent upsert.
- `ae246b889` (2023-09-08) — switched to load-driven strict `InsertOne` on `!Exists`. From here the rounding can cause a duplicate-key crash.

**Description:**

Preserve integer precision when building MongoDB documents to store. A large integer key (e.g. an `EVENT_ID` near 2^63) was stored as a rounded `float64`. The runtime re-derives a store's key from the document body returned by Load (a `Loaded` carries no key), so the rounded value no longer matched the requested key → `Exists=false` → strict `InsertOne` of an `_id` that already exists → `E11000`, in a permanent crash loop (a backfill can't fix it; the key re-corrupts immediately).

Fix: decode with `json.Decoder.UseNumber()` and keep integral values that fit as `int64` (recursively). Keys now round-trip exactly. The `E11000` tripwire is untouched — no idempotent masking.

**Workflow steps:**

Behavior-only; no config/API change. Standard materializations with integer keys beyond 2^53 stop diverging.

**Notes for reviewers:**

- Three commits: behavior-preserving `storeDocument` extraction (green) → failing regression test (red) → fix (green).
- `TestStoreDocumentPreservesLargeIntegerKey` drives the full store→BSON→load-sanitize→re-extract round-trip.
- Out of scope: values genuinely outside the int64 range still fall back to `float64` — BSON has no native uint64; pre-existing.
- Affected destinations should be re-backfilled after deploy to rewrite the lossy doubles already stored.
