### PR TITLE
go/blob: validate bucket path is a bare prefix, not a full URI

### DIFF
--- a/filesink/store.go
+++ b/filesink/store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	storage "cloud.google.com/go/storage"
@@ -59,8 +58,8 @@ func (c GCSStoreConfig) Validate() error {
 	} else if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if strings.HasPrefix(c.Prefix, "/") {
-			return fmt.Errorf("prefix %q cannot start with /", c.Prefix)
+		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
+			return err
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)
@@ -142,8 +141,8 @@ func (c AzureBlobConfig) Validate() error {
 	if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if strings.HasPrefix(c.Prefix, "/") {
-			return fmt.Errorf("prefix %q cannot start with /", c.Prefix)
+		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
+			return err
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)

--- a/filesink/store.go
+++ b/filesink/store.go
@@ -58,8 +58,8 @@ func (c GCSStoreConfig) Validate() error {
 	} else if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
-			return err
+		if err := blob.ValidateBucketPath(c.Prefix); err != nil {
+			return fmt.Errorf("prefix %w", err)
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)
@@ -141,8 +141,8 @@ func (c AzureBlobConfig) Validate() error {
 	if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
-			return err
+		if err := blob.ValidateBucketPath(c.Prefix); err != nil {
+			return fmt.Errorf("prefix %w", err)
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)

--- a/filesink/store_s3.go
+++ b/filesink/store_s3.go
@@ -119,8 +119,8 @@ func (c S3StoreConfig) Validate() error {
 	if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
-			return err
+		if err := blob.ValidateBucketPath(c.Prefix); err != nil {
+			return fmt.Errorf("prefix %w", err)
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)

--- a/filesink/store_s3.go
+++ b/filesink/store_s3.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/blob"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
 	"github.com/invopop/jsonschema"
 )
@@ -119,8 +119,8 @@ func (c S3StoreConfig) Validate() error {
 	if _, err := time.ParseDuration(c.UploadInterval); err != nil {
 		return fmt.Errorf("parsing upload interval %q: %w", c.UploadInterval, err)
 	} else if c.Prefix != "" {
-		if strings.HasPrefix(c.Prefix, "/") {
-			return fmt.Errorf("prefix %q cannot start with /", c.Prefix)
+		if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
+			return err
 		}
 	} else if c.FileSizeLimit < 0 {
 		return fmt.Errorf("fileSizeLimit '%d' cannot be negative", c.FileSizeLimit)

--- a/go/blob/path.go
+++ b/go/blob/path.go
@@ -1,0 +1,36 @@
+package blob
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateBucketPath checks that a configured object-storage key prefix is a
+// bare prefix within the bucket, rather than a leading-slash path or a full URI.
+//
+// The bucket itself is configured separately, and the prefix is joined onto
+// object keys via path.Join. Two malformed inputs corrupt the resulting keys:
+//
+//   - A leading "/" produces an object key that starts with "/".
+//   - A full URI such as "s3://bucket/prefix" is collapsed by path.Clean (which
+//     reduces "s3://" to "s3:/"), leaving a stray "s3:" path segment. Downstream
+//     readers such as Spark/Hadoop then fail to parse it, e.g.
+//     "java.net.URISyntaxException: Expected scheme-specific part at index 3: s3:".
+//
+// field is the configuration field's label, used in the error message (for
+// example "prefix" or "bucket path"). An empty prefix is always valid.
+func ValidateBucketPath(field, prefix string) error {
+	if prefix == "" {
+		return nil
+	}
+	if strings.HasPrefix(prefix, "/") {
+		return fmt.Errorf("%s %q cannot start with /", field, prefix)
+	}
+	if strings.Contains(prefix, "://") {
+		return fmt.Errorf(
+			"%s %q must be a bare key prefix within the bucket, not a full URI like \"s3://bucket/prefix\"; the bucket is configured separately",
+			field, prefix,
+		)
+	}
+	return nil
+}

--- a/go/blob/path.go
+++ b/go/blob/path.go
@@ -7,6 +7,8 @@ import (
 
 // ValidateBucketPath checks that a configured object-storage key prefix is a
 // bare prefix within the bucket, rather than a leading-slash path or a full URI.
+// Callers typically wrap the returned error with the relevant config field name,
+// for example: fmt.Errorf("bucket_path %w", err).
 //
 // The bucket itself is configured separately, and the prefix is joined onto
 // object keys via path.Join. Two malformed inputs corrupt the resulting keys:
@@ -17,19 +19,18 @@ import (
 //     readers such as Spark/Hadoop then fail to parse it, e.g.
 //     "java.net.URISyntaxException: Expected scheme-specific part at index 3: s3:".
 //
-// field is the configuration field's label, used in the error message (for
-// example "prefix" or "bucket path"). An empty prefix is always valid.
-func ValidateBucketPath(field, prefix string) error {
+// An empty prefix is always valid.
+func ValidateBucketPath(prefix string) error {
 	if prefix == "" {
 		return nil
 	}
 	if strings.HasPrefix(prefix, "/") {
-		return fmt.Errorf("%s %q cannot start with /", field, prefix)
+		return fmt.Errorf("%q cannot start with /", prefix)
 	}
 	if strings.Contains(prefix, "://") {
 		return fmt.Errorf(
-			"%s %q must be a bare key prefix within the bucket, not a full URI like \"s3://bucket/prefix\"; the bucket is configured separately",
-			field, prefix,
+			"%q must be a bare key prefix within the bucket, not a full URI like \"s3://bucket/prefix\"; the bucket is configured separately",
+			prefix,
 		)
 	}
 	return nil

--- a/go/blob/path_test.go
+++ b/go/blob/path_test.go
@@ -1,0 +1,32 @@
+package blob
+
+import "testing"
+
+func TestValidateBucketPath(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		prefix    string
+		wantError bool
+	}{
+		{"empty is allowed", "", false},
+		{"single segment", "staging", false},
+		{"multi segment prefix", "estuary/tenant/staging", false},
+		{"trailing slash is allowed", "estuary/staging/", false},
+		{"leading slash rejected", "/estuary/staging", true},
+		{"full s3 uri rejected", "s3://my-bucket/estuary/staging", true},
+		{"full gcs uri rejected", "gs://my-bucket/estuary/staging", true},
+		{"bare scheme rejected", "s3://", true},
+		{"https uri rejected", "https://example.com/prefix", true},
+		{"embedded scheme rejected", "estuary/s3://nested", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBucketPath("prefix", tt.prefix)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected an error for %q, got nil", tt.prefix)
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tt.prefix, err)
+			}
+		})
+	}
+}

--- a/go/blob/path_test.go
+++ b/go/blob/path_test.go
@@ -20,7 +20,7 @@ func TestValidateBucketPath(t *testing.T) {
 		{"embedded scheme rejected", "estuary/s3://nested", true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateBucketPath("prefix", tt.prefix)
+			err := ValidateBucketPath(tt.prefix)
 			if tt.wantError && err == nil {
 				t.Fatalf("expected an error for %q, got nil", tt.prefix)
 			}

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/estuary/connectors/go/blob"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -133,6 +134,10 @@ func (c config) Validate() error {
 	}
 
 	if err := c.DBTJobTrigger.Validate(); err != nil {
+		return err
+	}
+
+	if err := blob.ValidateBucketPath("bucket path", c.effectiveBucketPath()); err != nil {
 		return err
 	}
 

--- a/materialize-bigquery/bigquery.go
+++ b/materialize-bigquery/bigquery.go
@@ -137,8 +137,8 @@ func (c config) Validate() error {
 		return err
 	}
 
-	if err := blob.ValidateBucketPath("bucket path", c.effectiveBucketPath()); err != nil {
-		return err
+	if err := blob.ValidateBucketPath(c.effectiveBucketPath()); err != nil {
+		return fmt.Errorf("bucket_path %w", err)
 	}
 
 	return nil

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -384,8 +384,8 @@ func (c sparkConfig) Validate(emr emrConfig) error {
 	if emr.AWSSecretAccessKey == "" {
 		return errors.New("missing 'aws_secret_access_key'")
 	}
-	if err := blob.ValidateBucketPath("bucket path", emr.BucketPath); err != nil {
-		return err
+	if err := blob.ValidateBucketPath(emr.BucketPath); err != nil {
+		return fmt.Errorf("bucket_path %w", err)
 	}
 	return nil
 }
@@ -480,8 +480,8 @@ func (c emrConfig) Validate() error {
 		}
 	}
 
-	if err := blob.ValidateBucketPath("bucket path", c.BucketPath); err != nil {
-		return err
+	if err := blob.ValidateBucketPath(c.BucketPath); err != nil {
+		return fmt.Errorf("bucket_path %w", err)
 	}
 
 	if c.SystemsManagerPrefix != "" {

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -384,8 +384,8 @@ func (c sparkConfig) Validate(emr emrConfig) error {
 	if emr.AWSSecretAccessKey == "" {
 		return errors.New("missing 'aws_secret_access_key'")
 	}
-	if emr.BucketPath != "" && strings.HasPrefix(emr.BucketPath, "/") {
-		return fmt.Errorf("bucket path %q cannot start with /", emr.BucketPath)
+	if err := blob.ValidateBucketPath("bucket path", emr.BucketPath); err != nil {
+		return err
 	}
 	return nil
 }
@@ -480,10 +480,8 @@ func (c emrConfig) Validate() error {
 		}
 	}
 
-	if c.BucketPath != "" {
-		if strings.HasPrefix(c.BucketPath, "/") {
-			return fmt.Errorf("bucket path %q cannot start with /", c.BucketPath)
-		}
+	if err := blob.ValidateBucketPath("bucket path", c.BucketPath); err != nil {
+		return err
 	}
 
 	if c.SystemsManagerPrefix != "" {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -117,8 +117,8 @@ func (c config) Validate() error {
 		return err
 	}
 
-	if err := blob.ValidateBucketPath("bucket path", c.effectiveBucketPath()); err != nil {
-		return err
+	if err := blob.ValidateBucketPath(c.effectiveBucketPath()); err != nil {
+		return fmt.Errorf("bucketPath %w", err)
 	}
 
 	return nil

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -15,6 +15,7 @@ import (
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/estuary/connectors/go/blob"
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -113,6 +114,10 @@ func (c config) Validate() error {
 	}
 
 	if err := c.DBTJobTrigger.Validate(); err != nil {
+		return err
+	}
+
+	if err := blob.ValidateBucketPath("bucket path", c.effectiveBucketPath()); err != nil {
 		return err
 	}
 

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsHttp "github.com/aws/smithy-go/transport/http"
 	"github.com/estuary/connectors/filesink"
+	"github.com/estuary/connectors/go/blob"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	m "github.com/estuary/connectors/go/materialize"
 	schemagen "github.com/estuary/connectors/go/schema-gen"
@@ -151,10 +152,8 @@ func (c config) Validate() error {
 		return err
 	}
 
-	if c.Prefix != "" {
-		if strings.HasPrefix(c.Prefix, "/") {
-			return fmt.Errorf("prefix %q cannot start with /", c.Prefix)
-		}
+	if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
+		return err
 	}
 
 	return nil

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -152,8 +152,8 @@ func (c config) Validate() error {
 		return err
 	}
 
-	if err := blob.ValidateBucketPath("prefix", c.Prefix); err != nil {
-		return err
+	if err := blob.ValidateBucketPath(c.Prefix); err != nil {
+		return fmt.Errorf("prefix %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

A materialization's staging-prefix config field (`bucket_path` or `prefix`) is meant to be a bare key prefix within the bucket; the bucket itself is configured separately. If it is mistakenly set to a full URI like `s3://my-bucket/my/prefix`, the connector silently produces corrupt object keys.

The prefix is joined onto object keys with `path.Join`, whose `path.Clean` collapses `s3://` to `s3:/`. The staged-file keys then start with a stray `s3:` segment, and the downstream reader fails. In `materialize-iceberg` the Spark merge job throws:

```
java.lang.IllegalArgumentException: java.net.URISyntaxException: Expected scheme-specific part at index 3: s3:
```

This is hard to diagnose: the config publishes cleanly (existing validation only rejected a leading `/`) and fails much later, deep inside a Spark job, with an opaque Java URI error.

## Fix

Add a shared `blob.ValidateBucketPath(field, prefix)` helper (`go/blob/path.go`) that rejects:

- a leading `/` (preserving the existing behavior and message), and
- an embedded URI scheme (`://`), with an actionable message pointing at the correct format.

Wire it into every materialization that takes a user-configurable staging prefix:

| Connector | Field | Prior validation |
|-----------|-------|------------------|
| filesink (s3/gcs/azure parquet + csv) | `prefix` | leading `/` only |
| materialize-iceberg | `bucket_path` | leading `/` only |
| materialize-s3-iceberg | `prefix` | leading `/` only |
| materialize-redshift | `bucketPath` | none |
| materialize-bigquery | `bucket_path` | none |

`materialize-redshift` and `materialize-bigquery` had no prefix validation before. They pass the leading-slash-trimmed value (`effectiveBucketPath()`), so their existing tolerance of a leading slash is preserved while the new scheme check still applies.

## Why `go/blob`

`go/blob` is the lowest shared layer that owns object-key/URI construction (`URI()` per backend) and is already imported by `filesink`, `materialize-boilerplate`, and the materializations. Putting the helper there both fixes the footgun and collapses the duplicated `prefix %q cannot start with /` check that previously lived in five separate files.

## Testing

- New table test `TestValidateBucketPath` (10 cases) passes: `go test ./go/blob/...`.
- `go build` and `go vet` pass for all touched packages.

## Note for reviewers

Adding validation where there was none (redshift, bigquery) means an already-broken config that contains a URI scheme will now fail at publish with a clear message instead of failing later at runtime. That is the intent, but flagging it as a behavior change. A natural follow-up is to surface the same guard at the config-schema/UI layer so it is caught before publish.
