### PR TITLE
materialize-bigtable: add optional app profile config

### DIFF
--- a/materialize-bigtable/.snapshots/TestSpec
+++ b/materialize-bigtable/.snapshots/TestSpec
@@ -15,6 +15,12 @@
         "description": "Bigtable instance ID for the materialized tables.",
         "order": 1
       },
+      "app_profile": {
+        "type": "string",
+        "title": "Application Profile",
+        "description": "The Bigtable app profile ID to use for data operations. Leave blank to use the instance's default app profile.",
+        "order": 2
+      },
       "credentials": {
         "oneOf": [
           {
@@ -79,7 +85,7 @@
         "discriminator": {
           "propertyName": "auth_type"
         },
-        "order": 2,
+        "order": 3,
         "x-iam-auth": true
       },
       "hardDelete": {
@@ -87,7 +93,7 @@
         "title": "Hard Delete",
         "description": "If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).",
         "default": false,
-        "order": 3
+        "order": 4
       },
       "advanced": {
         "properties": {

--- a/materialize-bigtable/driver.go
+++ b/materialize-bigtable/driver.go
@@ -79,8 +79,9 @@ func (c *CredentialsConfig) Validate() error {
 type config struct {
 	ProjectID   string             `json:"project_id" jsonschema:"title=Project ID,description=Google Cloud Project ID that owns the Bigtable instance." jsonschema_extras:"order=0"`
 	InstanceID  string             `json:"instance_id" jsonschema:"title=Instance ID,description=Bigtable instance ID for the materialized tables." jsonschema_extras:"order=1"`
-	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=2"`
-	HardDelete  bool               `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=3"`
+	AppProfile  string             `json:"app_profile,omitempty" jsonschema:"title=Application Profile,description=The Bigtable app profile ID to use for data operations. Leave blank to use the instance's default app profile." jsonschema_extras:"order=2"`
+	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"x-iam-auth=true,order=3"`
+	HardDelete  bool               `json:"hardDelete,omitempty" jsonschema:"title=Hard Delete,description=If this option is enabled items deleted in the source will also be deleted from the destination. By default is disabled and _meta/op in the destination will signify whether rows have been deleted (soft-delete).,default=false" jsonschema_extras:"order=4"`
 
 	Advanced advancedConfig `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
@@ -153,7 +154,12 @@ func (c config) dataClient(ctx context.Context) (*bigtable.Client, error) {
 		return nil, err
 	}
 
-	cfg := bigtable.ClientConfig{MetricsProvider: bigtable.NoopMetricsProvider{}}
+	// AppProfile applies only to data operations; the admin client has no
+	// equivalent concept and routes through the instance directly.
+	cfg := bigtable.ClientConfig{
+		AppProfile:      c.AppProfile,
+		MetricsProvider: bigtable.NoopMetricsProvider{},
+	}
 	client, err := bigtable.NewClientWithConfig(ctx, c.ProjectID, c.InstanceID, cfg, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating bigtable data client: %w", err)


### PR DESCRIPTION
**Regression?**

Adds an `app_profile` endpoint setting that is passed to the Bigtable data client's ClientConfig, letting users route reads and writes through a specific app profile for workload isolation or routing. When left blank the instance's default app profile is used. App profiles apply only to data operations, so the admin client is unaffected.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

