### PR TITLE
materialize-clickhouse: run load queries per-binding in series

### DIFF
--- a/materialize-clickhouse/.snapshots/TestSQLGeneration
+++ b/materialize-clickhouse/.snapshots/TestSQLGeneration
@@ -120,12 +120,13 @@ SETTINGS select_sequential_consistency = 1;
 
 --- Begin key_value queryLoadTable ---
 
-SELECT 0::Int32, r.flow_document
+SELECT r.flow_document
 	FROM key_value AS r FINAL
 	JOIN flow_temp_load_0_key_value AS l
 		 ON l.key1 = r.key1
 		 AND l.key2 = r.key2
 		 AND l.`key!binary` = r.`key!binary`
+SETTINGS select_sequential_consistency = 1;
 --- End key_value queryLoadTable ---
 
 --- Begin delta_updates queryLoadTable ---
@@ -134,7 +135,7 @@ SELECT 0::Int32, r.flow_document
 
 --- Begin key_value queryLoadTableNoFlowDocument ---
 
-SELECT 0::Int32,
+SELECT
 concat('{',
 	'"key1":', ifNull(toJSONString(r.key1), 'null'), ',',
 	'"key2":', ifNull(toJSONString(r.key2), 'null'), ',',
@@ -167,11 +168,12 @@ concat('{',
 		 ON l.key1 = r.key1
 		 AND l.key2 = r.key2
 		 AND l.`key!binary` = r.`key!binary`
+SETTINGS select_sequential_consistency = 1;
 --- End key_value queryLoadTableNoFlowDocument ---
 
 --- Begin delta_updates queryLoadTableNoFlowDocument ---
 
-SELECT * FROM (SELECT -1::Int32, ''::String LIMIT 0) as nodoc
+SELECT ''::String LIMIT 0
 --- End delta_updates queryLoadTableNoFlowDocument ---
 
 --- Begin key_value insertLoadTable ---

--- a/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
+++ b/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
@@ -120,12 +120,13 @@ SETTINGS select_sequential_consistency = 1;
 
 --- Begin `key_value-@你好-``-"especiál` queryLoadTable ---
 
-SELECT 0::Int32, r.flow_document
+SELECT r.flow_document
 	FROM `key_value-@你好-``-"especiál` AS r FINAL
 	JOIN `flow_temp_load_0_key_value-@你好-``-"especiál` AS l
 		 ON l.key1 = r.key1
 		 AND l.key2 = r.key2
 		 AND l.`key!binary` = r.`key!binary`
+SETTINGS select_sequential_consistency = 1;
 --- End `key_value-@你好-``-"especiál` queryLoadTable ---
 
 --- Begin `delta_updates-@你好-``-"especiál` queryLoadTable ---
@@ -134,7 +135,7 @@ SELECT 0::Int32, r.flow_document
 
 --- Begin `key_value-@你好-``-"especiál` queryLoadTableNoFlowDocument ---
 
-SELECT 0::Int32,
+SELECT
 concat('{',
 	'"key1":', ifNull(toJSONString(r.key1), 'null'), ',',
 	'"key2":', ifNull(toJSONString(r.key2), 'null'), ',',
@@ -167,11 +168,12 @@ concat('{',
 		 ON l.key1 = r.key1
 		 AND l.key2 = r.key2
 		 AND l.`key!binary` = r.`key!binary`
+SETTINGS select_sequential_consistency = 1;
 --- End `key_value-@你好-``-"especiál` queryLoadTableNoFlowDocument ---
 
 --- Begin `delta_updates-@你好-``-"especiál` queryLoadTableNoFlowDocument ---
 
-SELECT * FROM (SELECT -1::Int32, ''::String LIMIT 0) as nodoc
+SELECT ''::String LIMIT 0
 --- End `delta_updates-@你好-``-"especiál` queryLoadTableNoFlowDocument ---
 
 --- Begin `key_value-@你好-``-"especiál` insertLoadTable ---

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -501,37 +501,37 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	}
 
 	// Keys are now ready to be JOIN'd between the temporary and target tables.
-	// The union query runs with select_sequential_consistency so that it
-	// observes both the just-inserted keys and target-table rows committed by
-	// prior transactions' partition moves, from any replica.
-
-	loadQueries := make([]string, 0, len(activeBindings))
-	for i := range activeBindings {
-		loadQueries = append(loadQueries, t.bindings[i].load.querySQL)
-	}
-	loadQueryUnionSQL := strings.Join(loadQueries, "\nUNION ALL\n") + "\nSETTINGS select_sequential_consistency = 1;"
-	rows, err := t.load.conn.Query(ctx, loadQueryUnionSQL)
-	if err != nil {
-		return fmt.Errorf("querying Load documents: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var bindingId int32
-		var doc json.RawMessage
-		if err = rows.Scan(&bindingId, &doc); err != nil {
-			return fmt.Errorf("scanning Load document: %w", err)
+	loadBinding := func(i int, b *binding) error {
+		rows, err := t.load.conn.Query(ctx, b.load.querySQL)
+		if err != nil {
+			return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
 		}
-		if b := t.bindings[bindingId]; len(b.nullFieldsToStrip) > 0 {
-			if doc, err = sql.StripNullFields(doc, b.nullFieldsToStrip); err != nil {
-				return fmt.Errorf("stripping null fields: %w", err)
+		defer rows.Close()
+
+		for rows.Next() {
+			var doc json.RawMessage
+			if err = rows.Scan(&doc); err != nil {
+				return fmt.Errorf("scanning Load document for %s: %w", b.target.Identifier, err)
+			}
+			if len(b.nullFieldsToStrip) > 0 {
+				if doc, err = sql.StripNullFields(doc, b.nullFieldsToStrip); err != nil {
+					return fmt.Errorf("stripping null fields: %w", err)
+				}
+			}
+			if err = loaded(i, doc); err != nil {
+				return err
 			}
 		}
-		if err = loaded(int(bindingId), doc); err != nil {
+		if err = rows.Err(); err != nil {
+			return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
+		}
+		return nil
+	}
+
+	for i := range activeBindings {
+		if err = loadBinding(i, t.bindings[i]); err != nil {
 			return err
 		}
-	}
-	if err = rows.Err(); err != nil {
-		return fmt.Errorf("querying Load documents: %w", err)
 	}
 
 	return nil

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -378,9 +378,8 @@ func loadDocuments(t *testing.T, ctx context.Context, loadConn chdriver.Conn, b 
 
 	var docs []string
 	for rows.Next() {
-		var bindingIdx int32
 		var doc string
-		require.NoError(t, rows.Scan(&bindingIdx, &doc))
+		require.NoError(t, rows.Scan(&doc))
 		docs = append(docs, doc)
 	}
 	_ = rows.Close()

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -496,15 +496,22 @@ INSERT INTO {{ template "loadTableName" . }} (
 )
 {{ end }}
 
+{{/*
+The load queries (queryLoadTable and queryLoadTableNoFlowDocument) each carry
+SETTINGS select_sequential_consistency = 1 so that a query observes both the
+just-inserted keys and target-table rows committed by prior transactions'
+partition moves, from any replica.
+*/}}
 {{ define "queryLoadTable" }}
 {{ if $.Document -}}
-SELECT {{ $.Binding }}::Int32, r.{{$.Document.Identifier}}
+SELECT r.{{$.Document.Identifier}}
 	FROM {{$.Identifier}} AS r FINAL
 	JOIN {{ template "loadTableName" . }} AS l
 	{{- range $ind, $key := $.Keys }}
 		{{ if $ind }} AND {{ else }} ON {{ end -}}
 		l.{{$key.Identifier}} = r.{{$key.Identifier}}
 	{{- end }}
+SETTINGS select_sequential_consistency = 1;
 {{ end -}}
 {{ end }}
 
@@ -536,7 +543,7 @@ SELECT {{ $.Binding }}::Int32, r.{{$.Document.Identifier}}
 
 {{ define "queryLoadTableNoFlowDocument" }}
 {{ if not $.DeltaUpdates -}}
-SELECT {{ $.Binding }}::Int32,
+SELECT
 concat('{',
 {{- range $i, $col := $.RootLevelColumns -}}
 	{{- if $i }}, ',',{{ end }}
@@ -549,8 +556,9 @@ concat('{',
 		{{ if $ind }} AND {{ else }} ON {{ end -}}
 		l.{{$key.Identifier}} = r.{{$key.Identifier}}
 	{{- end }}
+SETTINGS select_sequential_consistency = 1;
 {{ else -}}
-SELECT * FROM (SELECT -1::Int32, ''::String LIMIT 0) as nodoc
+SELECT ''::String LIMIT 0
 {{ end -}}
 {{ end }}
 


### PR DESCRIPTION
**Description:**

The ClickHouse load step combined every binding's `FINAL` join into one statement, so peak server memory scaled with the *sum* across all bindings reading the `flow_document` column. On a memory-constrained server this trips the OvercommitTracker (`code 241`), killing the query and dropping the connection — surfacing as `read: EOF` and a flapping shard (observed at a customer with ~40 bindings).

Now each binding's load query runs separately, in series, capping peak memory at the largest single binding. Trade-off: per-transaction load latency rises by ~the sum of N round-trips on large batches, but the implicit backpressure is desirable against a memory-constrained destination and throughput is approximately preserved.

**Workflow steps:**

No config or user-facing change. `select_sequential_consistency` moves into the load-query template; the per-row binding id is dropped (binding is known per loop).

**Notes for reviewers:**

- Delta bindings render an empty load query in standard mode and are skipped in the loop.
- SQL-generation snapshots regenerated (binding-id removed, `SETTINGS` baked in, delta stub now single-column).
- Full suite green incl. docker-compose integration tests (`go test ./materialize-clickhouse/`).
