### PR TITLE
source-monday: reduce `items` page size used for subsequent pages during backfills

### DIFF
--- a/source-monday/source_monday/graphql/items.py
+++ b/source-monday/source_monday/graphql/items.py
@@ -37,8 +37,8 @@ ItemsPageRemainder = GraphQLResponseRemainder[ItemsPageRemainderData]
 MAX_CONCURRENT_ITEM_FETCHES = 5
 # The max complexity budget per request is 5 million and 10 million total per minute.
 BOARDS_PER_PAGE = 1
-ITEMS_PER_BOARD = 5
-ITEMS_LIMIT_BY_ID = 100
+ITEMS_PER_BOARD = 1
+ITEMS_LIMIT_BY_ID = 1
 
 
 class CursorCollector:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

The first page when fetching `items` during a backfill is small (`5`), but subsequent pages always requested `100` items. I suspect that's causing 500 errors from Monday's API during an ongoing backfill, so I'd like to try reducing the subsequent page size and see if that helps avoid those 500 errors.

**Notes for reviewers:**

I'm not confident `25` is low enough, and we may need to dynamically reduce the page size when the connector receives 500 responses from the API, but that's a pretty complex change I'd like to postpone if dropping the page size to `25` is sufficient to address the current issue.

