### PR TITLE
source-kafka: route output through a buffered writer

### DIFF
--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::{BufWriter, Stdout, Write};
 
 use anyhow::{Context, Result};
 use configuration::{schema_for, EndpointConfig, Resource, SchemaRegistryConfig};
@@ -26,7 +26,7 @@ const KAFKA_METADATA_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 
 pub async fn run_connector(
     mut stdin: io::BufReader<io::Stdin>,
-    mut stdout: std::io::Stdout,
+    mut stdout: BufWriter<Stdout>,
 ) -> Result<(), anyhow::Error> {
     tracing::info!("running connector");
 
@@ -116,15 +116,18 @@ pub async fn run_connector(
     Ok(())
 }
 
-pub fn write_capture_response(
+pub fn write_capture_response<W: Write>(
     response: Response,
-    stdout: &mut std::io::Stdout,
+    out: &mut W,
 ) -> anyhow::Result<()> {
-    serde_json::to_writer(&mut *stdout, &response).context("serializing response")?;
-    writeln!(stdout).context("writing response newline")?;
+    serde_json::to_writer(&mut *out, &response).context("serializing response")?;
+    writeln!(out).context("writing response newline")?;
 
+    // Captured documents accumulate in the buffer and are flushed by the next
+    // Checkpoint. This batches many documents into a few large writes instead
+    // of one syscall per document.
     if response.captured.is_none() {
-        stdout.flush().context("flushing stdout")?;
+        out.flush().context("flushing output")?;
     }
     Ok(())
 }

--- a/source-kafka/src/main.rs
+++ b/source-kafka/src/main.rs
@@ -9,7 +9,10 @@ fn main() -> anyhow::Result<()> {
     let runtime = start_runtime()?;
 
     let stdin = io::BufReader::new(io::stdin());
-    let stdout = std::io::stdout();
+    // Wrap stdout in a BufWriter so captured documents are batched into a few
+    // large writes. Rust's `Stdout` is itself a LineWriter that would otherwise
+    // flush a syscall on every newline.
+    let stdout = std::io::BufWriter::with_capacity(256 * 1024, std::io::stdout());
 
     let result = runtime.block_on(run_connector(stdin, stdout));
 

--- a/source-kafka/src/pull.rs
+++ b/source-kafka/src/pull.rs
@@ -28,6 +28,7 @@ use rdkafka::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map};
 use std::collections::{hash_map::Entry, HashMap};
+use std::io::{BufWriter, Stdout};
 use time::{format_description, OffsetDateTime};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -73,7 +74,7 @@ enum MetaTimestamp {
     LogAppendTime(String),
 }
 
-pub async fn do_pull(req: Open, mut stdout: std::io::Stdout) -> Result<()> {
+pub async fn do_pull(req: Open, mut stdout: BufWriter<Stdout>) -> Result<()> {
     let spec = req.capture.expect("open must contain a capture spec");
 
     let state = if req.state_json == "{}" {
@@ -746,5 +747,62 @@ mod tests {
                 want
             )
         }
+    }
+
+    #[derive(Default)]
+    struct FlushCountingWriter {
+        buf: Vec<u8>,
+        flushes: usize,
+    }
+
+    impl std::io::Write for FlushCountingWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_write_capture_response_buffering() {
+        let mut out = FlushCountingWriter::default();
+
+        // A captured document is buffered (not flushed) and written as exactly
+        // one newline-terminated line.
+        write_capture_response(
+            Response {
+                captured: Some(response::Captured {
+                    binding: 0,
+                    doc_json: r#"{"a":1}"#.to_string().into(),
+                }),
+                ..Default::default()
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(out.flushes, 0, "captured documents must not flush");
+        let text = String::from_utf8(out.buf.clone()).unwrap();
+        assert_eq!(text.matches('\n').count(), 1);
+        assert!(text.ends_with('\n'));
+
+        // A checkpoint flushes, pushing itself and all preceding buffered
+        // documents to the runtime.
+        write_capture_response(
+            Response {
+                checkpoint: Some(Checkpoint {
+                    state: Some(ConnectorState {
+                        updated_json: "{}".to_string().into(),
+                        merge_patch: true,
+                    }),
+                }),
+                ..Default::default()
+            },
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(out.flushes, 1, "a checkpoint must flush");
     }
 }


### PR DESCRIPTION
**Regression?**

No

**Description:**

An active `source-kafka` capture appears resource constrained - throughput rose from ~60 GB / hr -> ~90 GB / hr just from moving it to a beefier reactor. Reviewing the connector, it does per-message I/O:
- It emits a `Captured` document & a `Checkpoint` after every message.
- Output goes to a raw `std::io::Stdout`, [which is a `LineWriter`](https://doc.rust-lang.org/src/std/io/stdio.rs.html#608-613) so every line forces a `write` syscall and the existing `if response.captured.is_none() { flush }` guard never actually batched anything.

The changes in this PR include:
- Buffering `stdout` in a 256 KiB `BufWriter` so captured docs accumulate and flush on the next checkpoint.