### PR TITLE
source-kafka: use `jemalloc` as the global allocator

### DIFF
--- a/source-kafka/Cargo.lock
+++ b/source-kafka/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#4360bd459bbf993715893f5c8132bcea175de5c6"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -874,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#4360bd459bbf993715893f5c8132bcea175de5c6"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -1990,8 +1990,8 @@ checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck",
  "itertools 0.14.0",
- "prost 0.14.4",
- "prost-types 0.14.4",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.14.4",
+ "prost",
  "prost-build",
  "serde",
 ]
@@ -2136,22 +2136,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.4",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2166,24 +2156,11 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.14.4",
- "prost-types 0.14.4",
+ "prost",
+ "prost-types",
  "regex",
  "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2201,25 +2178,15 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.7"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
 dependencies = [
  "base64 0.22.1",
- "once_cell",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost",
+ "prost-types",
  "serde",
  "serde-value",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost 0.13.5",
 ]
 
 [[package]]
@@ -2228,18 +2195,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.4",
+ "prost",
 ]
 
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#4360bd459bbf993715893f5c8132bcea175de5c6"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
 dependencies = [
  "bytes",
  "pbjson",
  "pbjson-types",
- "prost 0.14.4",
+ "prost",
  "proto-gazette",
  "serde",
  "serde_json",
@@ -2249,12 +2216,12 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#4360bd459bbf993715893f5c8132bcea175de5c6"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
 dependencies = [
  "bytes",
  "pbjson",
  "pbjson-types",
- "prost 0.14.4",
+ "prost",
  "serde",
  "thiserror",
  "uuid",
@@ -2597,7 +2564,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3087,7 +3054,7 @@ dependencies = [
  "json",
  "lazy_static",
  "prost-reflect",
- "prost-types 0.13.5",
+ "prost-types",
  "proto-flow",
  "rdkafka",
  "reqwest",
@@ -3207,7 +3174,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3515,7 +3482,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#4360bd459bbf993715893f5c8132bcea175de5c6"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
 dependencies = [
  "memchr",
  "serde_json",

--- a/source-kafka/Cargo.lock
+++ b/source-kafka/Cargo.lock
@@ -37,6 +37,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator"
+version = "0.0.0"
+source = "git+https://github.com/estuary/flow#d82d0f0fa5a2ffb671d6efcbdd211fc16aee8cbd"
+dependencies = [
+ "jemalloc-ctl",
+ "jemallocator",
+ "lazy_static",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,7 +793,7 @@ dependencies = [
  "bytes",
  "futures",
  "highway",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "json",
  "proto-gazette",
  "regex",
@@ -874,7 +884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1572,6 +1582,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cffc705424a344c054e135d12ee591402f4539245e8bbd64e6c9eaa9458b63c"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,7 +1641,7 @@ dependencies = [
  "bigdecimal",
  "bitvec",
  "iri-string",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "lazy_static",
  "percent-encoding",
  "regex",
@@ -1973,6 +2014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pbjson"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -2170,7 +2217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2564,7 +2611,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3038,6 +3085,7 @@ dependencies = [
 name = "source-kafka"
 version = "0.1.0"
 dependencies = [
+ "allocator",
  "anyhow",
  "apache-avro",
  "async-trait",
@@ -3174,7 +3222,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/source-kafka/Cargo.toml
+++ b/source-kafka/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 
 [dependencies]
+allocator = { git = "https://github.com/estuary/flow" }
 doc = { git = "https://github.com/estuary/flow" }
 json = { git = "https://github.com/estuary/flow" }
 proto-flow = { git = "https://github.com/estuary/flow" }

--- a/source-kafka/Cargo.toml
+++ b/source-kafka/Cargo.toml
@@ -38,8 +38,8 @@ futures = "0.3"
 apache-avro = "0.19"
 bigdecimal = "0.4"
 time = "0.3"
-prost-reflect = { version = "0.14", features = ["serde"] }
-prost-types = "0.13"
+prost-reflect = { version = "0.16", features = ["serde"] }
+prost-types = "0.14"
 
 
 [dev-dependencies]

--- a/source-kafka/src/main.rs
+++ b/source-kafka/src/main.rs
@@ -1,3 +1,6 @@
+// Links in the allocator crate, which sets the global allocator to jemalloc.
+extern crate allocator;
+
 use anyhow::Context;
 use source_kafka::run_connector;
 use tokio::io;


### PR DESCRIPTION
**Regression?**

No

**Description:**

Profiling with `perf` showed allocation pressure on the read path for a capture with steady throughput at ~90 GB / hr. This PR switches the connector to `jemalloc` via the shared `allocator` crate.

Using that crate required a current `flow` rev, and the latest rev moved `flow` onto `prost` 0.14, so the first commit bumps the `flow` deps and aligns the connector's `prost` stack (`prost-reflect` 0.14→0.16, `prost-types` 0.13→0.14) onto a single `prost` 0.14.

We're hoping for a small (~5%) performance gain from these changes on the bottlenecked capture, and we'll measure the actual improvement after rolling out this change.

**Notes for reviewers**

A transient HTTP error failed the first run of the `source-kafka` CI check. I cancelled the remaining checks so I could retry the relevant `source-kafka` one sooner, and that's why so many of the checks are cancelled.
