### PR TITLE
source-kafka: serialize protobuf messages directly to a JSON value

### DIFF
--- a/source-kafka/src/pull.rs
+++ b/source-kafka/src/pull.rs
@@ -365,15 +365,10 @@ async fn parse_datum(
                     let message = crate::protobuf::decode_protobuf_message(&descriptor, &datum[5 + payload_offset..])?;
 
                     // Convert to JSON using proto field names (snake_case) to match discovered schemas
-                    let json_value: serde_json::Value = {
-                        let mut buf = Vec::new();
-                        let mut serializer = serde_json::Serializer::new(&mut buf);
-                        message.serialize_with_options(
-                            &mut serializer,
-                            &prost_reflect::SerializeOptions::new().use_proto_field_name(true),
-                        )?;
-                        serde_json::from_slice(&buf)?
-                    };
+                    let json_value: serde_json::Value = message.serialize_with_options(
+                        serde_json::value::Serializer,
+                        &prost_reflect::SerializeOptions::new().use_proto_field_name(true),
+                    )?;
 
                     // For keys that are not objects, wrap in a synthetic _key field
                     if is_key && !json_value.is_object() {


### PR DESCRIPTION


**Regression?**

No.

**Description:**

The protobuf decode path serialized each `DynamicMessage` to a byte buffer and then re-parsed those bytes into a `serde_json::Value`. This was a redundant round-trip that profiling flagged as a hot spot.

This PR avoids that extra serialization by passing a `serde_json::value::Serializer` to `serialize_with_options` so the message is built straight into the `Value` in one pass, dropping the intermediate buffer and the re-parse.