### PR TITLE
estuary-cdk: gate hard-delete reduction behind schema inference

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -495,29 +495,43 @@ def discovered(
         if resource.schema_inference:
             schema["x-infer-schema"] = True
 
-        # Materializations require this if/then/else conditional to support
-        # hard deletes. It tells Flow to use a top-level merge reduction
-        # strategy for deletions and mark them with `delete: True` so materializations
-        # know to issue DELETEs to destinations.
-        #
-        # `_meta` and `_meta.op` are both `required` in the `if` clause because
-        # JSON Schema's `properties` keyword passes when a key is absent.
-        # Without these `required` assertions, a document missing `_meta`
-        # or `_meta.op` would still match the `if` and get marked as a
-        # delete. The `required` clauses force the `if` to match only when
-        # `_meta.op` is present and equals `"d"`.
-        schema["if"] = {
-            "required": ["_meta"],
-            "properties": {
-                "_meta": {
-                    "required": ["op"],
-                    "properties": {"op": {"const": "d"}},
-                }
-            },
-        }
-        schema["then"] = {"reduce": {"strategy": "merge", "delete": True}}
-        if resource.reduction_strategy:
-            schema["else"] = {"reduce": {"strategy": resource.reduction_strategy}}
+            # Materializations require this if/then/else conditional to support
+            # hard deletes. It tells Flow to use a top-level merge reduction
+            # strategy for deletions and mark them with `delete: True` so materializations
+            # know to issue DELETEs to destinations.
+            #
+            # This is gated behind schema inference on purpose. On a delete, this
+            # merge reduction re-inflates the last-known full record and re-validates
+            # it against the connector's schema; if a field has narrowed since that
+            # record was written, the older stored value no longer matches and the
+            # materialization fails at runtime. Inference-off captures are the ones
+            # that break: before this block their deletes reduced with the default
+            # lastWriteWins, replacing the record with the sparse tombstone and never
+            # re-inflating old fields, so a routine source-side type narrowing was
+            # harmless. Inference-off resources therefore keep that pre-existing plain
+            # top-level reduction (the default lastWriteWins, or the resource's
+            # reduction_strategy).
+            #
+            # `_meta` and `_meta.op` are both `required` in the `if` clause because
+            # JSON Schema's `properties` keyword passes when a key is absent.
+            # Without these `required` assertions, a document missing `_meta`
+            # or `_meta.op` would still match the `if` and get marked as a
+            # delete. The `required` clauses force the `if` to match only when
+            # `_meta.op` is present and equals `"d"`.
+            schema["if"] = {
+                "required": ["_meta"],
+                "properties": {
+                    "_meta": {
+                        "required": ["op"],
+                        "properties": {"op": {"const": "d"}},
+                    }
+                },
+            }
+            schema["then"] = {"reduce": {"strategy": "merge", "delete": True}}
+            if resource.reduction_strategy:
+                schema["else"] = {"reduce": {"strategy": resource.reduction_strategy}}
+        elif resource.reduction_strategy:
+            schema["reduce"] = {"strategy": resource.reduction_strategy}
 
         bindings.append(
             response.DiscoveredBinding(

--- a/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-hubspot/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2,23 +2,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -202,12 +185,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -227,23 +204,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1583,12 +1543,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -1608,23 +1562,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1810,12 +1747,6 @@
       "required": [
         "listId"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1833,23 +1764,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3802,12 +3716,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -3827,23 +3735,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3893,12 +3784,6 @@
       "required": [
         "canonical-vid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3913,23 +3798,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4067,12 +3935,6 @@
       "required": [
         "pipelineId"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -4092,23 +3954,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5104,12 +4949,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -5129,23 +4968,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6142,12 +5964,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -6167,23 +5983,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6562,12 +6361,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -6588,23 +6381,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -6648,12 +6424,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -6670,23 +6440,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -7329,12 +7082,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -7354,23 +7101,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -8030,12 +7760,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -8055,23 +7779,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -8885,12 +8592,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -8910,23 +8611,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -9611,12 +9295,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -9636,23 +9314,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -10041,12 +9702,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -10066,23 +9721,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -10806,12 +10444,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -10831,23 +10463,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11497,12 +11112,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -11522,23 +11131,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -11603,12 +11195,6 @@
         "submittedAt",
         "formId"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -11629,23 +11215,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -12268,12 +11837,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -12293,23 +11856,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -12402,12 +11948,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -12427,23 +11967,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -12817,12 +12340,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -12842,23 +12359,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -14809,12 +14309,6 @@
         "property",
         "timestamp"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -14832,23 +14326,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -14948,12 +14425,6 @@
         "timestamp",
         "recipient"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -14974,23 +14445,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -15998,12 +15452,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -16023,23 +15471,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -16157,12 +15588,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]
@@ -16182,23 +15607,6 @@
   {
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -16292,12 +15700,6 @@
       "required": [
         "id"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": [
         "object"
       ]

--- a/source-posthog/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-posthog/tests/snapshots/snapshots__capture__stdout.json
@@ -27,6 +27,7 @@
       "date_marker": "2025-02-01T00:00:00Z",
       "deleted": false,
       "emoji": null,
+      "hidden_in_user_interface": null,
       "id": 317326,
       "insight_derived_name": null,
       "insight_name": null,

--- a/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
+++ b/source-recharge/tests/snapshots/snapshot__discover__capture.stdout.json
@@ -135,29 +135,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -680,29 +657,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -757,29 +711,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -996,29 +927,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -1227,29 +1135,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -1340,29 +1225,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -1493,29 +1355,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -2442,29 +2281,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -2622,29 +2438,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -2783,29 +2576,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -3059,29 +2829,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -82,6 +82,19 @@
             "id": "gid://shopify/Publication/148054310957",
             "name": "Online Store"
           }
+        },
+        {
+          "__parentId": "gid://shopify/Product/8086707830829",
+          "isPublished": true,
+          "publication": {
+            "catalog": {
+              "id": "gid://shopify/AppCatalog/105343287341",
+              "status": "ACTIVE",
+              "title": "Channel Catalog 204831391789 for Microsoft Copilot"
+            },
+            "id": "gid://shopify/Publication/204831391789",
+            "name": "Microsoft Copilot"
+          }
         }
       ],
       "seo": {
@@ -6563,6 +6576,14 @@
             "name": "Point of Sale"
           },
           "publishDate": "2025-01-14T15:09:43Z"
+        },
+        {
+          "__parentId": "gid://shopify/Collection/295442513965",
+          "publication": {
+            "id": "gid://shopify/Publication/204831391789",
+            "name": "Microsoft Copilot"
+          },
+          "publishDate": "2026-06-26T04:37:46Z"
         }
       ],
       "sortOrder": "BEST_SELLING",
@@ -6637,6 +6658,14 @@
             "name": "Online Store"
           },
           "publishDate": "2025-01-14T15:10:14Z"
+        },
+        {
+          "__parentId": "gid://shopify/Collection/295442612269",
+          "publication": {
+            "id": "gid://shopify/Publication/204831391789",
+            "name": "Microsoft Copilot"
+          },
+          "publishDate": "2026-06-26T04:37:46Z"
         }
       ],
       "sortOrder": "BEST_SELLING",

--- a/source-twilio/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-twilio/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2,23 +2,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -217,12 +200,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -237,23 +214,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -365,12 +325,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -385,23 +339,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -508,12 +445,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -531,23 +462,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -689,12 +603,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -709,23 +617,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -790,12 +681,6 @@
       "required": [
         "country"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -810,23 +695,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -945,12 +813,6 @@
       "required": [
         "phone_number"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -965,23 +827,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1100,12 +945,6 @@
       "required": [
         "phone_number"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1120,23 +959,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1255,12 +1077,6 @@
       "required": [
         "phone_number"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1275,23 +1091,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1534,12 +1333,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1557,23 +1350,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1671,12 +1447,6 @@
         "account_sid",
         "conference_sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1692,23 +1462,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1811,12 +1564,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1834,23 +1581,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -1944,12 +1674,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -1965,23 +1689,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2171,12 +1878,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -2192,23 +1893,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2316,12 +2000,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -2336,23 +2014,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2545,12 +2206,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -2566,23 +2221,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2665,12 +2303,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -2686,23 +2318,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -2800,12 +2415,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Executions",
       "type": "object"
     },
@@ -2821,23 +2430,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3099,12 +2691,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3119,23 +2705,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3175,12 +2744,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3195,23 +2758,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3269,12 +2815,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3292,23 +2832,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3460,12 +2983,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3483,23 +3000,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3557,12 +3057,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3577,23 +3071,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3678,12 +3155,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3698,23 +3169,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -3884,12 +3338,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -3908,23 +3356,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4000,12 +3431,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Roles Schema",
       "type": "object"
     },
@@ -4022,23 +3447,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4260,12 +3668,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Services Schema",
       "type": "object"
     },
@@ -4282,23 +3684,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4398,12 +3783,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Step Schema",
       "type": "object"
     },
@@ -4419,23 +3798,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4529,12 +3891,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -4550,23 +3906,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4739,12 +4078,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Trunks Schema",
       "type": "object"
     },
@@ -4760,23 +4093,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -4931,12 +4247,6 @@
         "account_sid",
         "category"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -4955,23 +4265,6 @@
   {
     "documentSchema": {
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5084,12 +4377,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "type": "object"
     },
     "key": [
@@ -5105,23 +4392,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5221,12 +4491,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Users Schema",
       "type": "object"
     },
@@ -5243,23 +4507,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5403,12 +4650,6 @@
       "required": [
         "account_sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "User Conversation Schema",
       "type": "object"
     },
@@ -5425,23 +4666,6 @@
     "documentSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": true,
-      "if": {
-        "properties": {
-          "_meta": {
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            },
-            "required": [
-              "op"
-            ]
-          }
-        },
-        "required": [
-          "_meta"
-        ]
-      },
       "properties": {
         "_meta": {
           "properties": {
@@ -5659,12 +4883,6 @@
       "required": [
         "sid"
       ],
-      "then": {
-        "reduce": {
-          "delete": true,
-          "strategy": "merge"
-        }
-      },
       "title": "Verify - Services Schema",
       "type": "object"
     },

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -319,7 +319,6 @@
         "update_user_own_signature": false,
         "user_view_access": "none",
         "view_access": "readonly",
-        "view_access_logs": false,
         "view_audit_logs": false,
         "view_deleted_tickets": false,
         "view_filter_tickets": true,

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -879,7 +879,6 @@
         "update_user_own_signature": false,
         "user_view_access": "none",
         "view_access": "readonly",
-        "view_access_logs": false,
         "view_audit_logs": false,
         "view_deleted_tickets": false,
         "view_filter_tickets": true,

--- a/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -94,29 +94,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -192,30 +169,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -283,29 +237,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -446,30 +377,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -607,29 +515,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -717,30 +602,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -836,29 +698,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -971,29 +810,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -1074,29 +890,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -1176,29 +969,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -1302,29 +1072,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -1509,30 +1256,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -1571,29 +1295,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -2601,29 +2302,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -3150,30 +2828,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -3394,30 +3049,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -3738,30 +3370,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -3828,30 +3437,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -4487,30 +4073,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -5093,30 +4656,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -5522,29 +5062,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -5670,29 +5187,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -5996,29 +5490,6 @@
             "row_id"
           ]
         }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
       }
     },
     "key": [
@@ -6104,29 +5575,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -6263,30 +5711,7 @@
       ],
       "required": [
         "id"
-      ],
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
-        }
-      }
+      ]
     },
     "key": [
       "/id"
@@ -6345,29 +5770,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },
@@ -6500,29 +5902,6 @@
           "required": [
             "row_id"
           ]
-        }
-      },
-      "if": {
-        "required": [
-          "_meta"
-        ],
-        "properties": {
-          "_meta": {
-            "required": [
-              "op"
-            ],
-            "properties": {
-              "op": {
-                "const": "d"
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "reduce": {
-          "strategy": "merge",
-          "delete": true
         }
       }
     },


### PR DESCRIPTION
**Regression?**

No.

**Description:**

867d1df76 added an `if op=="d" -> then {reduce: merge, delete: true}` block to every discovered binding so standard-updates materializations issue real DELETEs. On a delete, that merge reduction re-inflates the last-known full record and re-validates it against the connector's schema. If a field has narrowed since that record was written, the older stored value no longer matches and the materialization fails at runtime.

This only bites dataflows whose captures do not use schema inference. Before commit 867d1df76 their deletes reduced with the default `lastWriteWins`, replacing the record with the sparse tombstone and never re-inflating old fields, so a source-side type narrowing was harmless. After it, the same narrowing turns the next delete into a hard crash. Dataflows with captures using schema inference tolerate the narrowing and are unaffected.

This PR fixes this by gating the whole if/then/else block behind `resource.schema_inference`. Non-schema inference resources fall back to the pre-commit behavior: a plain top-level reduction when a `reduction_strategy` is set, or the default `lastWriteWins` otherwise.

Only the four imported Airbyte connectors not using schema inference are affected within this repo. Their discover snapshots are regenerated to drop the if/then/else block.

**Notes for reviewers:**

In practice, the four imported Airbyte connectors are unable to replicate the described failure mode since they never emit documents with `_meta/op = "d"`. But this change to the CDK is still needed regardless so connectors that emit deletions + don't use schema inference (like `source-netsuite` that lives outside this repo) will behave appropriately.

