### PR TITLE
materialize-boilerplate: allow migrating flow_document

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -929,11 +929,12 @@ func (c *constrainterAdapter[EC, FC, RC, MT]) Compatible(existing ExistingField,
 // Generally this is true if there is a type change that can't be migrated.
 func mustRecreateTypeChange[MT MappedTyper](p *pf.Projection, mt MT, existing ExistingField) bool {
 	canMigrate := mt.CanMigrate(existing)
-	if p.IsRootDocumentProjection() || p.IsPrimaryKey {
-		// There are currently no known cases where migrating the root document
-		// column's type would be useful. Somewhat similarly, it would
-		// theoretically be possible for a few systems to migrate collection key
-		// columns, but for the most part this is not practical.
+	if p.IsPrimaryKey {
+		// It would theoretically be possible for a few systems to migrate
+		// collection key columns, but for the most part this is not practical, so
+		// a key type change still requires a backfill. The root document column,
+		// by contrast, is migratable: e.g. disabling objects_and_arrays_as_json
+		// converts its JSON column to text in place via the dialect's migration.
 		canMigrate = false
 	}
 


### PR DESCRIPTION
**Regression?**

No

**Description:**

- This is an old limitation that was cautious in nature. We now have a real use case for allowing flow_document to be migrated.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

