### PR TITLE
source-kafka: log consumer lag every minute

### DIFF
--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -1,9 +1,16 @@
 use anyhow::Result;
 use rdkafka::client::{ClientContext, OAuthToken};
 use rdkafka::consumer::{BaseConsumer, ConsumerContext};
+use rdkafka::statistics::Statistics;
 use rdkafka::ClientConfig;
 use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de, Deserialize, Deserializer, Serialize};
+
+// How often in milliseconds librdkafka computes consumer statistics and
+// delivers them to the `stats` callback, which logs per-partition lag. This is
+// serviced on the same thread that polls for messages, so the interval is kept
+// coarse to keep the logging overhead negligible.
+const STATISTICS_INTERVAL_MS: &str = "300000"; // 5 minutes
 
 #[derive(Serialize, Deserialize)]
 pub struct EndpointConfig {
@@ -299,9 +306,79 @@ impl ClientContext for FlowConsumerContext {
             _ => Err(anyhow::anyhow!("generate_oauth_token called without AWS credentials").into()),
         }
     }
+
+    fn stats(&self, statistics: Statistics) {
+        log_partition_lag(&statistics);
+    }
 }
 
 impl ConsumerContext for FlowConsumerContext {}
+
+// Logs consumer lag, rolled up per topic. Because the connector emits
+// exactly one captured document per Kafka message, "messages behind"
+// is equivalently "documents behind", and a topic is exactly one
+// binding/collection.
+//
+// librdkafka delivers `statistics` on the `statistics.interval.ms` cadence via
+// the poll thread, so this only runs once per interval.
+fn log_partition_lag(statistics: &Statistics) {
+    for topic in statistics.topics.values() {
+        let mut partitions: u64 = 0;
+        let mut partitions_behind: u64 = 0;
+        let mut total_messages_behind: i64 = 0;
+        let mut max_messages_behind: i64 = 0;
+        // The partition owning `max_messages_behind`; a caught-up topic still
+        // names a real partition (the first one seen).
+        let mut max_lag_partition: i32 = -1;
+
+        for partition in topic.partitions.values() {
+            // librdkafka reports an internal aggregate entry under partition -1.
+            if partition.partition < 0 {
+                continue;
+            }
+
+            // `app_offset` is the offset of the last message handed to us, which
+            // is our true read position. It is unset until the first message of
+            // a session is consumed, so fall back to the fetch position and then
+            // the low watermark for a freshly-assigned partition. We avoid
+            // librdkafka's `consumer_lag` field, which is derived from the
+            // committed offset: this connector never commits offsets (it tracks
+            // them in Flow checkpoints), so that field is unreliable.
+            let read_offset = [partition.app_offset, partition.next_offset]
+                .into_iter()
+                .find(|&offset| offset >= 0)
+                .unwrap_or(partition.lo_offset.max(0));
+
+            let messages_behind = (partition.hi_offset - read_offset).max(0);
+
+            // The first real partition, or a new maximum, owns the worst-lag slot.
+            if partitions == 0 || messages_behind > max_messages_behind {
+                max_messages_behind = messages_behind;
+                max_lag_partition = partition.partition;
+            }
+            partitions += 1;
+            total_messages_behind += messages_behind;
+            if messages_behind > 0 {
+                partitions_behind += 1;
+            }
+        }
+
+        // Skip topics with no assigned partitions, which carry no useful signal.
+        if partitions == 0 {
+            continue;
+        }
+
+        tracing::info!(
+            topic = topic.topic.as_str(),
+            partitions,
+            partitions_behind,
+            total_messages_behind,
+            max_messages_behind,
+            max_lag_partition,
+            "consumer lag",
+        );
+    }
+}
 
 impl EndpointConfig {
     pub async fn to_consumer(&self) -> Result<BaseConsumer<FlowConsumerContext>> {
@@ -311,6 +388,7 @@ impl EndpointConfig {
         config.set("enable.auto.commit", "false");
         config.set("group.id", "source-kafka"); // librdkafka will throw an error if this is left blank
         config.set("security.protocol", self.security_protocol());
+        config.set("statistics.interval.ms", STATISTICS_INTERVAL_MS);
 
         match &self.credentials {
             Some(Credentials::UserPassword {

--- a/source-kafka/src/configuration.rs
+++ b/source-kafka/src/configuration.rs
@@ -5,6 +5,7 @@ use rdkafka::statistics::Statistics;
 use rdkafka::ClientConfig;
 use schemars::{schema::RootSchema, JsonSchema};
 use serde::{de, Deserialize, Deserializer, Serialize};
+use std::sync::Mutex;
 
 // How often in milliseconds librdkafka computes consumer statistics and
 // delivers them to the `stats` callback, which logs per-partition lag. This is
@@ -275,6 +276,9 @@ impl JsonSchema for EndpointConfig {
 
 pub struct FlowConsumerContext {
     auth: Option<Credentials>,
+    // The last connectorStatus message emitted, used to suppress duplicate
+    // status updates so an unchanged status is not re-logged every interval.
+    last_status: Mutex<Option<String>>,
 }
 
 impl ClientContext for FlowConsumerContext {
@@ -308,75 +312,107 @@ impl ClientContext for FlowConsumerContext {
     }
 
     fn stats(&self, statistics: Statistics) {
-        log_partition_lag(&statistics);
+        self.report_lag(&statistics);
     }
 }
 
 impl ConsumerContext for FlowConsumerContext {}
 
-// Logs consumer lag, rolled up per topic. Because the connector emits
-// exactly one captured document per Kafka message, "messages behind"
-// is equivalently "documents behind", and a topic is exactly one
-// binding/collection.
-//
-// librdkafka delivers `statistics` on the `statistics.interval.ms` cadence via
-// the poll thread, so this only runs once per interval.
-fn log_partition_lag(statistics: &Statistics) {
-    for topic in statistics.topics.values() {
-        let mut partitions: u64 = 0;
-        let mut partitions_behind: u64 = 0;
-        let mut total_messages_behind: i64 = 0;
-        let mut max_messages_behind: i64 = 0;
-        // The partition owning `max_messages_behind`; a caught-up topic still
-        // names a real partition (the first one seen).
-        let mut max_lag_partition: i32 = -1;
+impl FlowConsumerContext {
+    // Reports consumer lag once per `statistics.interval.ms`. For each topic it
+    // logs a detail line rolled up across the topic's partitions, and it rolls
+    // the whole capture up into a single `connectorStatus` line.
+    // Because the connector emits exactly one captured document per Kafka
+    // message, "messages behind" is equivalently "documents behind", and a topic
+    // is exactly one binding/collection.
+    //
+    // librdkafka delivers `statistics` via the poll thread, so this runs on the
+    // same thread that consumes messages.
+    fn report_lag(&self, statistics: &Statistics) {
+        let mut total_behind: i64 = 0;
+        let mut topics_total: u64 = 0;
+        let mut topics_behind: u64 = 0;
 
-        for partition in topic.partitions.values() {
-            // librdkafka reports an internal aggregate entry under partition -1.
-            if partition.partition < 0 {
+        for topic in statistics.topics.values() {
+            let mut partitions: u64 = 0;
+            let mut partitions_behind: u64 = 0;
+            let mut total_messages_behind: i64 = 0;
+            let mut max_messages_behind: i64 = 0;
+            // The partition owning `max_messages_behind`; a caught-up topic still
+            // names a real partition (the first one seen).
+            let mut max_lag_partition: i32 = -1;
+
+            for partition in topic.partitions.values() {
+                // librdkafka reports an internal aggregate entry under partition -1.
+                if partition.partition < 0 {
+                    continue;
+                }
+
+                // `app_offset` is the offset of the last message handed to us,
+                // which is our true read position. It is unset until the first
+                // message of a session is consumed, so fall back to the fetch
+                // position and then the low watermark for a freshly-assigned
+                // partition. We avoid librdkafka's `consumer_lag` field, which is
+                // derived from the committed offset: this connector never commits
+                // offsets (it tracks them in Flow checkpoints), so that field is
+                // unreliable.
+                let read_offset = [partition.app_offset, partition.next_offset]
+                    .into_iter()
+                    .find(|&offset| offset >= 0)
+                    .unwrap_or(partition.lo_offset.max(0));
+
+                let messages_behind = (partition.hi_offset - read_offset).max(0);
+
+                // The first real partition, or a new maximum, owns the worst-lag slot.
+                if partitions == 0 || messages_behind > max_messages_behind {
+                    max_messages_behind = messages_behind;
+                    max_lag_partition = partition.partition;
+                }
+                partitions += 1;
+                total_messages_behind += messages_behind;
+                if messages_behind > 0 {
+                    partitions_behind += 1;
+                }
+            }
+
+            // Skip topics with no assigned partitions, which carry no useful signal.
+            if partitions == 0 {
                 continue;
             }
 
-            // `app_offset` is the offset of the last message handed to us, which
-            // is our true read position. It is unset until the first message of
-            // a session is consumed, so fall back to the fetch position and then
-            // the low watermark for a freshly-assigned partition. We avoid
-            // librdkafka's `consumer_lag` field, which is derived from the
-            // committed offset: this connector never commits offsets (it tracks
-            // them in Flow checkpoints), so that field is unreliable.
-            let read_offset = [partition.app_offset, partition.next_offset]
-                .into_iter()
-                .find(|&offset| offset >= 0)
-                .unwrap_or(partition.lo_offset.max(0));
+            tracing::info!(
+                topic = topic.topic.as_str(),
+                partitions,
+                partitions_behind,
+                total_messages_behind,
+                max_messages_behind,
+                max_lag_partition,
+                "consumer lag",
+            );
 
-            let messages_behind = (partition.hi_offset - read_offset).max(0);
-
-            // The first real partition, or a new maximum, owns the worst-lag slot.
-            if partitions == 0 || messages_behind > max_messages_behind {
-                max_messages_behind = messages_behind;
-                max_lag_partition = partition.partition;
-            }
-            partitions += 1;
-            total_messages_behind += messages_behind;
-            if messages_behind > 0 {
-                partitions_behind += 1;
+            topics_total += 1;
+            total_behind += total_messages_behind;
+            if total_messages_behind > 0 {
+                topics_behind += 1;
             }
         }
 
-        // Skip topics with no assigned partitions, which carry no useful signal.
-        if partitions == 0 {
-            continue;
+        // Nothing assigned yet (e.g. before partition assignment): no status.
+        if topics_total == 0 {
+            return;
         }
 
-        tracing::info!(
-            topic = topic.topic.as_str(),
-            partitions,
-            partitions_behind,
-            total_messages_behind,
-            max_messages_behind,
-            max_lag_partition,
-            "consumer lag",
+        let status = format!(
+            "{total_behind} messages behind across {topics_behind} of {topics_total} topics"
         );
+
+        // Only emit connectorStatus when it changes to avoid re-logging an
+        // unchanged status every interval.
+        let mut last_status = self.last_status.lock().unwrap();
+        if last_status.as_deref() != Some(status.as_str()) {
+            tracing::info!(eventType = "connectorStatus", "{status}");
+            *last_status = Some(status);
+        }
     }
 }
 
@@ -411,6 +447,7 @@ impl EndpointConfig {
 
         let ctx = FlowConsumerContext {
             auth: self.credentials.clone(),
+            last_status: Mutex::new(None),
         };
 
         let consumer: BaseConsumer<FlowConsumerContext> = config.create_with_context(ctx)?;

--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -60,6 +60,8 @@ pub async fn run_connector(
 
             write_capture_response(res, &mut stdout)?;
         } else if let Some(req) = request.validate {
+            tracing::info!(eventType = "connectorStatus", "Validating capture configuration");
+
             let res = Response {
                 validated: Some(Validated {
                     bindings: do_validate(req).await?,
@@ -69,6 +71,8 @@ pub async fn run_connector(
 
             write_capture_response(res, &mut stdout)?;
         } else if request.apply.is_some() {
+            tracing::info!(eventType = "connectorStatus", "Applying capture configuration");
+
             let res = Response {
                 applied: Some(Applied {
                     action_description: String::new(),
@@ -88,6 +92,8 @@ pub async fn run_connector(
                 },
                 &mut stdout,
             )?;
+
+            tracing::info!(eventType = "connectorStatus", "Starting capture");
 
             let eof = tokio::spawn(async move {
                 let mut line_string = String::new();


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Lag among a single topic's partitions are rolled up into a single log. Log lines look like:
```jsonl
{"level":"INFO","message":"consumer lag","topic":"events","partitions":1,"partitions_behind":1,"total_messages_behind":50,"max_messages_behind":50,"max_lag_partition":0}
{"level":"INFO","message":"consumer lag","topic":"orders","partitions":3,"partitions_behind":2,"total_messages_behind":854,"max_messages_behind":812,"max_lag_partition":2}
```
We can identify the total number of messages a topic / binding is behind as well as which partition for a topic is lagging the most & by how many messages. I think this level of granularity makes sense, but if you think we should have more granular detail (ex: log stats for each partition so we can determine how far behind we are for each), I'm happy to adjust.


I also added some basic connector status events so it's easier to answer the "is my capture behind & if so, by how many messages?" question by glancing at the dashboard.