### PR TITLE
materialize-boilerplate: run migrations for flow_document columns

### DIFF
--- a/materialize-bigquery/.snapshots/TestIntegration-flow_document-migration
+++ b/materialize-bigquery/.snapshots/TestIntegration-flow_document-migration
@@ -1,0 +1,42 @@
+Task: acmeCo/tests/materialize-bigquery
+
+Feature flags: "objects_and_arrays_as_json"
+Resource: estuary-theatre.testing.migration_test
+["applied.actionDescription", "CREATE TABLE IF NOT EXISTS `estuary-theatre`.testing.migration_test (\n\t\tid INTEGER NOT NULL,\n\t\tflow_published_at TIMESTAMP NOT NULL,\n\t\tobj JSON,\n\t\tflow_document JSON NOT NULL\n)\nCLUSTER BY id;\n"]
+
+{"Name":"flow_document","Nullable":false,"Type":"JSON"}
+{"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}
+{"Name":"id","Nullable":false,"Type":"INTEGER"}
+{"Name":"obj","Nullable":true,"Type":"JSON"}
+
+Table Data:
+{"flow_document":{"_meta":{"uuid":"13814000-1dd2-11b2-8000-071353030311"},"id":1,"obj":{"nested":"one"}},"flow_published_at":"1970-01-01T00:00:00Z","id":1,"obj":{"nested":"one"}}
+{"flow_document":{"_meta":{"uuid":"1419d680-1dd2-11b2-8000-071353030311"},"id":2,"obj":{"nested":"two"}},"flow_published_at":"1970-01-01T00:00:01Z","id":2,"obj":{"nested":"two"}}
+
+Feature flags: "no_objects_and_arrays_as_json"
+Resource: estuary-theatre.testing.migration_test
+["applied.actionDescription", "ALTER TABLE `estuary-theatre`.testing.migration_test ADD COLUMN obj_flowtmp1 STRING \nALTER TABLE `estuary-theatre`.testing.migration_test ADD COLUMN flow_document_flowtmp1 STRING \nUPDATE `estuary-theatre`.testing.migration_test SET obj_flowtmp1 = TO_JSON_STRING(obj), flow_document_flowtmp1 = TO_JSON_STRING(flow_document) WHERE true;\nALTER TABLE `estuary-theatre`.testing.migration_test DROP COLUMN obj\nALTER TABLE `estuary-theatre`.testing.migration_test DROP COLUMN flow_document\nALTER TABLE `estuary-theatre`.testing.migration_test RENAME COLUMN obj_flowtmp1 TO obj\nALTER TABLE `estuary-theatre`.testing.migration_test RENAME COLUMN flow_document_flowtmp1 TO flow_document"]
+
+{"Name":"flow_document","Nullable":true,"Type":"STRING"}
+{"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}
+{"Name":"id","Nullable":false,"Type":"INTEGER"}
+{"Name":"obj","Nullable":true,"Type":"STRING"}
+
+Table Data:
+{"flow_document":{"_meta":{"uuid":"13814000-1dd2-11b2-8000-071353030311"},"id":1,"obj":{"nested":"one"}},"flow_published_at":"1970-01-01T00:00:00Z","id":1,"obj":{"nested":"one"}}
+{"flow_document":{"_meta":{"uuid":"1419d680-1dd2-11b2-8000-071353030311"},"id":2,"obj":{"nested":"two"}},"flow_published_at":"1970-01-01T00:00:01Z","id":2,"obj":{"nested":"two"}}
+
+Feature flags: "objects_and_arrays_as_json"
+Resource: estuary-theatre.testing.migration_test
+["applied.actionDescription", "ALTER TABLE `estuary-theatre`.testing.migration_test ADD COLUMN obj_flowtmp1 JSON \nALTER TABLE `estuary-theatre`.testing.migration_test ADD COLUMN flow_document_flowtmp1 JSON \nUPDATE `estuary-theatre`.testing.migration_test SET obj_flowtmp1 = SAFE.PARSE_JSON(obj), flow_document_flowtmp1 = SAFE.PARSE_JSON(flow_document) WHERE true;\nALTER TABLE `estuary-theatre`.testing.migration_test DROP COLUMN obj\nALTER TABLE `estuary-theatre`.testing.migration_test DROP COLUMN flow_document\nALTER TABLE `estuary-theatre`.testing.migration_test RENAME COLUMN obj_flowtmp1 TO obj\nALTER TABLE `estuary-theatre`.testing.migration_test RENAME COLUMN flow_document_flowtmp1 TO flow_document"]
+
+{"Name":"flow_document","Nullable":true,"Type":"JSON"}
+{"Name":"flow_published_at","Nullable":false,"Type":"TIMESTAMP"}
+{"Name":"id","Nullable":false,"Type":"INTEGER"}
+{"Name":"obj","Nullable":true,"Type":"JSON"}
+
+Table Data:
+{"flow_document":{"_meta":{"uuid":"13814000-1dd2-11b2-8000-071353030311"},"id":1,"obj":{"nested":"one"}},"flow_published_at":"1970-01-01T00:00:00Z","id":1,"obj":{"nested":"one"}}
+{"flow_document":{"_meta":{"uuid":"1419d680-1dd2-11b2-8000-071353030311"},"id":2,"obj":{"nested":"two"}},"flow_published_at":"1970-01-01T00:00:01Z","id":2,"obj":{"nested":"two"}}
+
+

--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -38,5 +38,17 @@ func TestIntegration(t *testing.T) {
 	t.Run("migrate", func(t *testing.T) {
 		sql.RunMigrationTest(t, newBigQueryDriver(), "testdata/migrate.flow.yaml", makeResourceFn, nil)
 	})
+
+	// Toggling objects_and_arrays_as_json migrates the object column and the
+	// flow_document column between JSON and STRING in place. This exercises the
+	// root document JSON<->text migration end-to-end, the scenario that requires
+	// the root document to be migratable (rather than needing a backfill).
+	t.Run("flow_document-migration", func(t *testing.T) {
+		sql.RunFeatureFlagMigrationTest(t, newBigQueryDriver(), "testdata/migrate-doc.flow.yaml", makeResourceFn, []sql.FeatureFlagMigrationPhase{
+			{FeatureFlags: "objects_and_arrays_as_json", Fixture: "testdata/fixture.doc-migrate.json"},    // materialize as JSON
+			{FeatureFlags: "no_objects_and_arrays_as_json", Fixture: "testdata/fixture.doc-migrate.json"}, // migrate JSON -> STRING
+			{FeatureFlags: "objects_and_arrays_as_json", Fixture: "testdata/fixture.doc-migrate.json"},    // migrate STRING -> JSON
+		}, actionDescSanitizers)
+	})
 }
 

--- a/materialize-bigquery/sqlgen.go
+++ b/materialize-bigquery/sqlgen.go
@@ -170,6 +170,17 @@ func datetimeToStringCast(migration sql.ColumnTypeMigration) string {
 }
 
 func toJsonCast(migration sql.ColumnTypeMigration) string {
+	// Object and array fields stored as text hold serialized JSON (e.g. after
+	// objects_and_arrays_as_json was disabled, or the historical string
+	// behavior), so PARSE_JSON restores their structure when migrating back to a
+	// JSON column. SAFE.PARSE_JSON maps the empty-string representation of a null
+	// object/array to NULL rather than erroring. Scalar values widened to JSON
+	// are wrapped as-is with TO_JSON.
+	if slices.ContainsFunc(migration.Inference.Types, func(t string) bool {
+		return t == "object" || t == "array"
+	}) {
+		return fmt.Sprintf(`SAFE.PARSE_JSON(%s)`, migration.Identifier)
+	}
 	return fmt.Sprintf(`TO_JSON(%s)`, migration.Identifier)
 }
 

--- a/materialize-bigquery/testdata/fixture.doc-migrate.json
+++ b/materialize-bigquery/testdata/fixture.doc-migrate.json
@@ -1,0 +1,2 @@
+["key/value",{"id":1,"obj":{"nested":"one"}}]
+["key/value",{"id":2,"obj":{"nested":"two"}}]

--- a/materialize-bigquery/testdata/migrate-doc.flow.yaml
+++ b/materialize-bigquery/testdata/migrate-doc.flow.yaml
@@ -1,0 +1,34 @@
+# Fixture for the flow_document JSON<->TEXT migration test. A minimal collection
+# with an object field and the root document, materialized so that toggling
+# objects_and_arrays_as_json migrates both the `obj` column and flow_document
+# between JSON and STRING in place.
+collections:
+  key/value:
+    schema:
+      type: object
+      properties:
+        id: { type: integer }
+        obj:
+          type: object
+          properties:
+            nested: { type: string }
+      required: [id]
+    key: [/id]
+
+materializations:
+  acmeCo/tests/materialize-bigquery:
+    endpoint:
+      local:
+        command: ["go", "run", "."]
+        protobuf: true
+        config: config.yaml
+    bindings:
+    - resource:
+        table: doc_migrate
+      source: key/value
+      fields:
+        recommended: true
+        include:
+          # Force the object field to be materialized so the JSON<->TEXT
+          # migration is exercised on a value column as well as flow_document.
+          obj: {}

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -661,7 +661,16 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		}
 
 		existingResource := is.GetResource(mb.ResourcePath)
-		for _, p := range mb.Values {
+		// The root document column is migratable in the same way value columns
+		// are (see mustRecreateTypeChange): e.g. disabling
+		// objects_and_arrays_as_json converts its JSON column to text in place.
+		// Keys are intentionally excluded, since a key type change requires a
+		// backfill rather than an in-place migration.
+		migratable := mb.Values
+		if mb.Document != nil {
+			migratable = append(slices.Clone(mb.Values), *mb.Document)
+		}
+		for _, p := range migratable {
 			if existingField := existingResource.GetField(p.Field); existingField == nil {
 				continue
 			} else if !p.Mapped.Compatible(*existingField) && p.Mapped.CanMigrate(*existingField) {

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -356,6 +356,147 @@ func RunMigrationTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfi
 	cupaloy.SnapshotT(t, snap.String())
 }
 
+// FeatureFlagMigrationPhase is a single apply within a
+// RunFeatureFlagMigrationTest. The binding is materialized with the given
+// feature flags and fixture data. Running consecutive phases against the same
+// resource exercises column type migrations that are driven by a feature flag
+// change rather than a collection schema change.
+type FeatureFlagMigrationPhase struct {
+	// FeatureFlags is the value of the endpoint's advanced.feature_flags for
+	// this phase, e.g. "objects_and_arrays_as_json=false".
+	FeatureFlags string
+	// Fixture is the path to the fixture document data applied in this phase.
+	Fixture string
+}
+
+// RunFeatureFlagMigrationTest applies a single binding repeatedly against the
+// same resource, changing the endpoint's feature flags between each phase. It
+// verifies column type migrations that are triggered by a feature flag change
+// rather than a collection schema change - notably that the flow_document column
+// migrates in place between JSON and text when objects_and_arrays_as_json is
+// toggled, without requiring a backfill.
+//
+// The source spec must have one or more materialization tasks with a single
+// binding. Each phase snapshots the apply action (migration DDL) and the
+// resulting table so that both the schema and data can be verified.
+func RunFeatureFlagMigrationTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger, RC boilerplate.Resourcer[RC, EC], MT boilerplate.MappedTyper](
+	t *testing.T,
+	newMaterializer boilerplate.NewMaterializerFn[EC, FC, RC, MT],
+	sourcePath string,
+	makeResourceFn func(finalResourcePathPart string, deltaUpdates bool) RC,
+	phases []FeatureFlagMigrationPhase,
+	actionDescSanitizers []func(string) string,
+) {
+	ctx := context.Background()
+	var snap strings.Builder
+
+	bundled := RunFlowctl(t, "raw", "bundle", "--source", sourcePath)
+	suffix := testItemIdentifier + fmt.Sprintf("%d", time.Now().Unix())
+
+	for _, taskName := range taskNames(bundled) {
+		snap.WriteString(fmt.Sprintf("Task: %s\n\n", taskName))
+		snap.WriteString(runFeatureFlagMigrationForTask(t, ctx, newMaterializer, taskName, bundled, suffix, makeResourceFn, phases, actionDescSanitizers))
+	}
+
+	cupaloy.SnapshotT(t, snap.String())
+}
+
+func runFeatureFlagMigrationForTask[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger, RC boilerplate.Resourcer[RC, EC], MT boilerplate.MappedTyper](
+	t *testing.T,
+	ctx context.Context,
+	newMaterializer boilerplate.NewMaterializerFn[EC, FC, RC, MT],
+	taskName string,
+	bundled []byte,
+	suffix string,
+	makeResourceFn func(finalResourcePathPart string, deltaUpdates bool) RC,
+	phases []FeatureFlagMigrationPhase,
+	actionDescSanitizers []func(string) string,
+) string {
+	var snap strings.Builder
+
+	rndSuffix := "_" + uuid.NewString()[:8] + suffix
+	workingTableName := "migration_test" + rndSuffix
+	workingTaskName := taskName + rndSuffix
+
+	cfg := decryptConfig[EC](t, bundled, taskName)
+	materializer, err := newMaterializer(ctx, taskName, cfg, boilerplate.ParseFlags(cfg))
+	require.NoError(t, err)
+
+	res := makeResourceFn(workingTableName, false).WithDefaults(cfg)
+	resCfgRaw, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	bundled, err = sjson.SetBytes(
+		bundled,
+		fmt.Sprintf("materializations.%s.bindings.0.resource", taskName),
+		json.RawMessage(resCfgRaw),
+	)
+	require.NoError(t, err)
+
+	bundled, err = sjson.SetBytes(
+		bundled,
+		"materializations."+workingTaskName,
+		json.RawMessage(gjson.GetBytes(bundled, fmt.Sprintf("materializations.%s", taskName)).Raw),
+	)
+	require.NoError(t, err)
+
+	// The config is decrypted once so that each phase can override its feature
+	// flags. flowctl passes a plaintext (non-sops) config to the connector
+	// unchanged, so writing the decrypted config back inline is sufficient.
+	rawCfg := decryptConfigRaw(t, bundled, workingTaskName)
+
+	// The phase's flags are appended to whatever the source config already sets
+	// (later entries win in ParseFeatureFlags), so that flags the test relies on
+	// - notably allow_existing_tables_for_new_bindings, which lets each phase
+	// re-apply to the table created by the previous phase - are preserved.
+	baseFlags := gjson.GetBytes(rawCfg, "advanced.feature_flags").String()
+
+	path, _, err := res.Parameters()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		CleanupTestResources(t, ctx, materializer, [][]string{path}, suffix)
+		cleanupTestTasks(t, ctx, materializer, suffix)
+	})
+
+	for _, phase := range phases {
+		phaseFlags := phase.FeatureFlags
+		if baseFlags != "" {
+			phaseFlags = baseFlags + "," + phaseFlags
+		}
+		phaseCfg, err := sjson.SetBytes(rawCfg, "advanced.feature_flags", phaseFlags)
+		require.NoError(t, err)
+
+		phaseBundled, err := sjson.SetRawBytes(
+			bundled,
+			"materializations."+workingTaskName+".endpoint.local.config",
+			phaseCfg,
+		)
+		require.NoError(t, err)
+
+		source := filepath.Join(t.TempDir(), "source.flow.yaml")
+		require.NoError(t, os.WriteFile(source, phaseBundled, 0o600))
+
+		actionDescription := RunFlowctl(
+			t,
+			"preview",
+			"--name", workingTaskName,
+			"--source", source,
+			"--fixture", phase.Fixture,
+			"--network", "flow-test",
+			"--output-apply",
+		)
+		for _, sanitize := range actionDescSanitizers {
+			actionDescription = []byte(sanitize(string(actionDescription)))
+		}
+
+		snap.WriteString(fmt.Sprintf("Feature flags: %q\n", phase.FeatureFlags))
+		snap.WriteString(snapshotTestTable(t, ctx, materializer, res, actionDescription, rndSuffix, true))
+	}
+
+	return snap.String()
+}
+
 // RunMigrationTestParallel is like RunMigrationTest but runs tasks concurrently
 // (up to maxParallelTasks at a time). Use this for connectors where parallel
 // task execution is safe and beneficial.
@@ -523,7 +664,12 @@ func renderTestTableData(t *testing.T, columnNames []string, rows [][]any) strin
 	return data.String()
 }
 
-func decryptConfig[EC boilerplate.EndpointConfiger](t *testing.T, bundled []byte, taskName string) EC {
+// decryptConfigRaw returns a task's endpoint config as raw JSON. If the config
+// is sops-encrypted it is decrypted and the _sops suffixes are stripped, so the
+// result is the plaintext config the connector expects. A plaintext (non-sops)
+// config is passed through to flowctl and the connector unchanged, which allows
+// callers to edit it (e.g. overriding feature flags) between applies.
+func decryptConfigRaw(t *testing.T, bundled []byte, taskName string) json.RawMessage {
 	t.Helper()
 
 	raw := json.RawMessage(gjson.GetBytes(bundled, fmt.Sprintf("materializations.%s.endpoint.local.config", taskName)).Raw)
@@ -541,8 +687,14 @@ func decryptConfig[EC boilerplate.EndpointConfiger](t *testing.T, bundled []byte
 		require.NoError(t, sopsCmd.Wait())
 	}
 
+	return raw
+}
+
+func decryptConfig[EC boilerplate.EndpointConfiger](t *testing.T, bundled []byte, taskName string) EC {
+	t.Helper()
+
 	var out EC
-	require.NoError(t, boilerplate.UnmarshalStrict(raw, &out))
+	require.NoError(t, boilerplate.UnmarshalStrict(decryptConfigRaw(t, bundled, taskName), &out))
 
 	return out
 }

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -59,6 +59,24 @@ func RunMigrationTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[
 	testutil.RunMigrationTest(t, driver.newMaterialization, sourcePath, makeResourceFn, actionDescSanitizers)
 }
 
+// FeatureFlagMigrationPhase is one apply of a RunFeatureFlagMigrationTest.
+type FeatureFlagMigrationPhase = testutil.FeatureFlagMigrationPhase
+
+// RunFeatureFlagMigrationTest applies a binding repeatedly against the same
+// resource, changing the endpoint's feature flags between phases, to verify
+// migrations driven by a feature flag change (e.g. flow_document migrating
+// between JSON and text as objects_and_arrays_as_json is toggled).
+func RunFeatureFlagMigrationTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
+	t *testing.T,
+	driver *Driver[EC, RC],
+	sourcePath string,
+	makeResourceFn func(string, bool) RC,
+	phases []FeatureFlagMigrationPhase,
+	actionDescSanitizers []func(string) string,
+) {
+	testutil.RunFeatureFlagMigrationTest(t, driver.newMaterialization, sourcePath, makeResourceFn, phases, actionDescSanitizers)
+}
+
 // RunFencingTest is a generalized form of test cases over fencing behavior,
 // which ought to function with any Client implementation.
 func RunFencingTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](


### PR DESCRIPTION

**Regression?**

Yes #4738 

**Description:**

- Include `mb.Document` in migratable columns list so `flow_document` can also be migrated
- Add a new integration test harness mode where we can test toggling of feature flags
- Add tests for BigQuery to verify toggling objects_and_arrays_as_json can be toggled on and off repeatedly with consistent behaviour (found a bug while doing this, which is also fixed by attempting `PARSE_JSON` on object fields which have been turned to string previously)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

