### PR TITLE
source-klaviyo: normalize consent timestamps to RFC3339

### DIFF
--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -34,9 +34,9 @@ LAG = 110
 # else untouched. The anchored regex is what keeps free-text values (e.g. "May 5, 2021")
 # safe from mangling.
 #
-# Matches "YYYY-MM-DD HH:MM:SS[.ffffff][ ](Z | +HH:MM | +HHMM)".
+# Matches the observed Klaviyo format "YYYY-MM-DD HH:MM:SS[.ffffff]+HH:MM".
 _SPACE_SEPARATED_DATETIME_RE = re.compile(
-    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?) ?(Z|[+-]\d{2}:?\d{2})$"
+    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2}:\d{2})$"
 )
 
 
@@ -45,8 +45,6 @@ def _normalize_datetime(value: str) -> str:
     if not match:
         return value
     date, time, tz = match.groups()
-    if tz != "Z" and ":" not in tz:
-        tz = f"{tz[:3]}:{tz[3:]}"  # +0000 -> +00:00
     return f"{date}T{time}{tz}"
 
 

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import re
 import urllib.parse
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, UTC
@@ -24,12 +25,46 @@ from .exceptions import KlaviyoBackoffError
 LAG = 110
 
 
-def _normalize_rfc3339(value: Any) -> Any:
-    # Klaviyo emits consent timestamps space-separated (e.g. "2026-06-23 00:15:23+00:00"),
-    # but the `format: date-time` contract requires the RFC3339 "T" separator.
-    if isinstance(value, str) and " " in value:
-        return value.replace(" ", "T")
-    return value
+# Klaviyo emits some datetime fields (e.g. consent timestamps) space-separated
+# (e.g. "2026-06-23 00:15:23.918411+00:00") rather than RFC3339. When schema inference
+# tags such a field `format: date-time`, the collection advertises an RFC3339 contract
+# the value violates, breaking downstream consumers. Rather than enumerate the known
+# offenders (Klaviyo custom properties are free-form, so new ones surface unpredictably),
+# we normalize any string that matches the space-separated shape and leave everything
+# else untouched. The anchored regex is what keeps free-text values (e.g. "May 5, 2021")
+# safe from mangling.
+#
+# Matches "YYYY-MM-DD HH:MM:SS[.ffffff][ ](Z | +HH:MM | +HHMM)".
+_SPACE_SEPARATED_DATETIME_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?) ?(Z|[+-]\d{2}:?\d{2})$"
+)
+
+
+def _normalize_datetime(value: str) -> str:
+    match = _SPACE_SEPARATED_DATETIME_RE.match(value)
+    if not match:
+        return value
+    date, time, tz = match.groups()
+    if tz != "Z" and ":" not in tz:
+        tz = f"{tz[:3]}:{tz[3:]}"  # +0000 -> +00:00
+    return f"{date}T{time}{tz}"
+
+
+def _normalize_datetimes(data: Any) -> None:
+    """Recursively normalize space-separated datetime strings in place."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, str):
+                data[key] = _normalize_datetime(value)
+            elif isinstance(value, (dict, list)):
+                _normalize_datetimes(value)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            if isinstance(item, str):
+                data[i] = _normalize_datetime(item)
+            elif isinstance(item, (dict, list)):
+                _normalize_datetimes(item)
+
 
 class KlaviyoStream(HttpStream, ABC):
     """Base stream for api version v2023-10-15"""
@@ -341,27 +376,7 @@ class Profiles(IncrementalKlaviyoStream):
 
     def map_record(self, record: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         record = super().map_record(record)
-
-        # Klaviyo returns the documented consent timestamps space-separated rather than
-        # RFC3339. We only normalize these known fields: `attributes/properties` is a
-        # free-form custom-property object, so we can't generically tell which arbitrary
-        # props are timestamps.
-        attributes = record.get("attributes") or {}
-
-        properties = attributes.get("properties")
-        if isinstance(properties, dict) and "$consent_timestamp" in properties:
-            properties["$consent_timestamp"] = _normalize_rfc3339(properties["$consent_timestamp"])
-
-        subscriptions = attributes.get("subscriptions") or {}
-        for channel_path in (("email", "marketing"), ("sms", "marketing"), ("sms", "transactional")):
-            node = subscriptions
-            for key in channel_path:
-                node = node.get(key) if isinstance(node, dict) else None
-                if node is None:
-                    break
-            if isinstance(node, dict) and "consent_timestamp" in node:
-                node["consent_timestamp"] = _normalize_rfc3339(node["consent_timestamp"])
-
+        _normalize_datetimes(record.get("attributes"))
         return record
 
 

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -23,6 +23,14 @@ from .exceptions import KlaviyoBackoffError
 # we only ask for data that older than LAG minutes in the `events` stream.
 LAG = 110
 
+
+def _normalize_rfc3339(value: Any) -> Any:
+    # Klaviyo emits consent timestamps space-separated (e.g. "2026-06-23 00:15:23+00:00"),
+    # but the `format: date-time` contract requires the RFC3339 "T" separator.
+    if isinstance(value, str) and " " in value:
+        return value.replace(" ", "T")
+    return value
+
 class KlaviyoStream(HttpStream, ABC):
     """Base stream for api version v2023-10-15"""
 
@@ -330,6 +338,31 @@ class Profiles(IncrementalKlaviyoStream):
         params = super().request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
         params.update({"additional-fields[profile]": "predictive_analytics,subscriptions"})
         return params
+
+    def map_record(self, record: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        record = super().map_record(record)
+
+        # Klaviyo returns the documented consent timestamps space-separated rather than
+        # RFC3339. We only normalize these known fields: `attributes/properties` is a
+        # free-form custom-property object, so we can't generically tell which arbitrary
+        # props are timestamps.
+        attributes = record.get("attributes") or {}
+
+        properties = attributes.get("properties")
+        if isinstance(properties, dict) and "$consent_timestamp" in properties:
+            properties["$consent_timestamp"] = _normalize_rfc3339(properties["$consent_timestamp"])
+
+        subscriptions = attributes.get("subscriptions") or {}
+        for channel_path in (("email", "marketing"), ("sms", "marketing"), ("sms", "transactional")):
+            node = subscriptions
+            for key in channel_path:
+                node = node.get(key) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if isinstance(node, dict) and "consent_timestamp" in node:
+                node["consent_timestamp"] = _normalize_rfc3339(node["consent_timestamp"])
+
+        return record
 
 
 class Campaigns(ArchivedRecordsMixin, IncrementalKlaviyoStream):

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -384,16 +384,16 @@ class TestProfilesStream:
                             # Documented consent field, and an arbitrary custom property that also
                             # happens to be a space-separated datetime: both should be normalized.
                             "$consent_timestamp": "2026-06-23 00:15:23.918411+00:00",
-                            "custom_signup_date": "2026-06-23 00:15:23+0000",
+                            "custom_signup_date": "2026-06-23 00:15:23+00:00",
                             # Free-text custom properties that merely contain spaces must be left alone.
                             "favorite_month": "May 5, 2021",
                             "status": "onboarding complete",
                         },
                         "subscriptions": {
-                            "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:23 +00:00"}},
+                            "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:23.918411+00:00"}},
                             "sms": {
                                 "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:24.000000+00:00"},
-                                "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:25.918411Z"}},
+                                "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:25.000000+00:00"}},
                         },
                     },
                 },
@@ -421,10 +421,10 @@ class TestProfilesStream:
                         "status": "onboarding complete",
                     },
                     "subscriptions": {
-                        "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:23+00:00"}},
+                        "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:23.918411+00:00"}},
                         "sms": {
                             "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:24.000000+00:00"},
-                            "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:25.918411Z"}},
+                            "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:25.000000+00:00"}},
                     },
                 },
             },

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -370,6 +370,61 @@ class TestProfilesStream:
             },
         ]
 
+    def test_parse_response_normalizes_consent_timestamps(self, mocker):
+        stream = Profiles(api_key=API_KEY, start_date=START_DATE.isoformat())
+        json = {
+            "data": [
+                {
+                    "type": "profile",
+                    "id": "00AA0A0AA0AA000AAAAAAA0AA0",
+                    "attributes": {
+                        "email": "name@airbyte.io",
+                        "updated": "2023-03-10T20:36:36+00:00",
+                        "properties": {"$consent_timestamp": "2026-06-23 00:15:23.918411+00:00"},
+                        "subscriptions": {
+                            "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:23.918411+00:00"}},
+                            "sms": {
+                                "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:24.000000+00:00"},
+                                "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:25.000000+00:00"},
+                            },
+                        },
+                    },
+                },
+                {
+                    "type": "profile",
+                    "id": "AAAA1A1AA1AA111AAAAAAA1AA1",
+                    "attributes": {"email": "name2@airbyte.io", "updated": "2023-02-10T20:36:36+00:00"},
+                },
+            ],
+            "links": {"self": "https://a.klaviyo.com/api/profiles/", "next": None, "prev": None},
+        }
+        records = list(stream.parse_response(mocker.Mock(json=mocker.Mock(return_value=json))))
+        assert records == [
+            {
+                "type": "profile",
+                "id": "00AA0A0AA0AA000AAAAAAA0AA0",
+                "updated": "2023-03-10T20:36:36+00:00",
+                "attributes": {
+                    "email": "name@airbyte.io",
+                    "updated": "2023-03-10T20:36:36+00:00",
+                    "properties": {"$consent_timestamp": "2026-06-23T00:15:23.918411+00:00"},
+                    "subscriptions": {
+                        "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:23.918411+00:00"}},
+                        "sms": {
+                            "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:24.000000+00:00"},
+                            "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:25.000000+00:00"},
+                        },
+                    },
+                },
+            },
+            {
+                "type": "profile",
+                "id": "AAAA1A1AA1AA111AAAAAAA1AA1",
+                "updated": "2023-02-10T20:36:36+00:00",
+                "attributes": {"email": "name2@airbyte.io", "updated": "2023-02-10T20:36:36+00:00"},
+            },
+        ]
+
 
 class TestGlobalExclusionsStream:
     def test_parse_response(self, mocker):

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -370,7 +370,7 @@ class TestProfilesStream:
             },
         ]
 
-    def test_parse_response_normalizes_consent_timestamps(self, mocker):
+    def test_parse_response_normalizes_datetimes(self, mocker):
         stream = Profiles(api_key=API_KEY, start_date=START_DATE.isoformat())
         json = {
             "data": [
@@ -380,13 +380,20 @@ class TestProfilesStream:
                     "attributes": {
                         "email": "name@airbyte.io",
                         "updated": "2023-03-10T20:36:36+00:00",
-                        "properties": {"$consent_timestamp": "2026-06-23 00:15:23.918411+00:00"},
+                        "properties": {
+                            # Documented consent field, and an arbitrary custom property that also
+                            # happens to be a space-separated datetime: both should be normalized.
+                            "$consent_timestamp": "2026-06-23 00:15:23.918411+00:00",
+                            "custom_signup_date": "2026-06-23 00:15:23+0000",
+                            # Free-text custom properties that merely contain spaces must be left alone.
+                            "favorite_month": "May 5, 2021",
+                            "status": "onboarding complete",
+                        },
                         "subscriptions": {
-                            "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:23.918411+00:00"}},
+                            "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:23 +00:00"}},
                             "sms": {
                                 "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:24.000000+00:00"},
-                                "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:25.000000+00:00"},
-                            },
+                                "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23 00:15:25.918411Z"}},
                         },
                     },
                 },
@@ -407,13 +414,17 @@ class TestProfilesStream:
                 "attributes": {
                     "email": "name@airbyte.io",
                     "updated": "2023-03-10T20:36:36+00:00",
-                    "properties": {"$consent_timestamp": "2026-06-23T00:15:23.918411+00:00"},
+                    "properties": {
+                        "$consent_timestamp": "2026-06-23T00:15:23.918411+00:00",
+                        "custom_signup_date": "2026-06-23T00:15:23+00:00",
+                        "favorite_month": "May 5, 2021",
+                        "status": "onboarding complete",
+                    },
                     "subscriptions": {
-                        "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:23.918411+00:00"}},
+                        "email": {"marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:23+00:00"}},
                         "sms": {
                             "marketing": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:24.000000+00:00"},
-                            "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:25.000000+00:00"},
-                        },
+                            "transactional": {"consent": "SUBSCRIBED", "consent_timestamp": "2026-06-23T00:15:25.918411Z"}},
                     },
                 },
             },


### PR DESCRIPTION
**Description:**

source-klaviyo passed Klaviyo consent timestamps through as-is, and Klaviyo formats them space-separated (`2026-06-23 00:15:23+00:00`) instead of RFC3339 `T`-separated. Once schema inference tags these `format: date-time`, the collection advertises an RFC3339 contract the values violate, breaking downstream consumers (surfaced as a materialize-sql `cannot parse ... as "T"` failure).

Normalizes the four documented consent fields on the `Profiles` stream via a `map_record` override (`GlobalExclusions` inherits it): `attributes.properties.$consent_timestamp` and `attributes.subscriptions.{email.marketing, sms.marketing, sms.transactional}.consent_timestamp`. Scope is limited to documented fields since `attributes/properties` is free-form. Follows the existing `Events` stream precedent (`.replace(" ", "T")`).

Fixes estuary/connectors#4726.

**Workflow steps:**

No user-facing change. Newly emitted profile records carry RFC3339 consent timestamps. Historical rows remain space-separated until backfilled (companion #4725 handles existing data on the read side).

**Notes for reviewers:**

- The issue listed subscription paths under `attributes/properties/subscriptions/...`; the real structure is `attributes/subscriptions/...` (per `GlobalExclusions` + fixtures) — corrected here.
- Kept the `+00:00` offset rather than converting to `Z`; both are valid RFC3339 and this matches the connector's other timestamps.
- Tests: added a regression test in `TestProfilesStream`; `poetry run pytest tests/test_streams.py` → 47 passed. Discover/spec snapshots unaffected.
