### PR TITLE
materialize-sql: tolerate near-RFC3339 timestamps in datetime converters

### DIFF
--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -39,10 +39,9 @@ var clickHouseClampDate = sql.StringCastConverter(func(str string) (interface{},
 // year 0, since ClickHouse's DateTime type has a minimum value of 1925-01-01. It also returns a
 // time.Time rather than a string, as required by the ClickHouse driver.
 var clickHouseClampDatetime = sql.StringCastConverter(func(str string) (interface{}, error) {
-	str = strings.ToUpper(str)
-	parsed, err := time.Parse(time.RFC3339Nano, str)
+	parsed, _, err := sql.ParseRFC3339Nano(str)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse %q as RFC3339 date-time: %w", str, err)
+		return nil, err
 	}
 	if parsed.Year() < 1925 {
 		parsed, _ = time.Parse(time.RFC3339Nano, clickhouseMinimumDatetime)

--- a/materialize-clickhouse/sqlgen_test.go
+++ b/materialize-clickhouse/sqlgen_test.go
@@ -179,15 +179,15 @@ func TestClickHouseClampDatetime(t *testing.T) {
 			want:  time.Date(2026, 6, 23, 0, 15, 23, 918411000, time.UTC),
 		},
 		{
-			input: "2025-11-29 01:05:28",
-			want:  time.Date(2025, 11, 29, 1, 5, 28, 0, time.UTC),
-		},
-		{
 			input: "1900-01-01 00:00:00Z",
 			want:  time.Date(1925, 1, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			input:   "not a timestamp",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29 01:05:28",
 			wantErr: true,
 		},
 	} {

--- a/materialize-clickhouse/sqlgen_test.go
+++ b/materialize-clickhouse/sqlgen_test.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
 	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
 )
 
 var testDialect = clickHouseDialect("test_db")
@@ -156,4 +158,82 @@ func TestSQLGenerationQuotedTableNames(t *testing.T) {
 	}
 
 	cupaloy.SnapshotT(t, snap.String())
+}
+
+func TestClickHouseClampDatetime(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			input: "2023-08-29T16:17:18Z",
+			want:  time.Date(2023, 8, 29, 16, 17, 18, 0, time.UTC),
+		},
+		{
+			input: "2025-11-29 01:05:28+00:00",
+			want:  time.Date(2025, 11, 29, 1, 5, 28, 0, time.UTC),
+		},
+		{
+			input: "2026-06-23 00:15:23.918411+00:00",
+			want:  time.Date(2026, 6, 23, 0, 15, 23, 918411000, time.UTC),
+		},
+		{
+			input: "2025-11-29 01:05:28",
+			want:  time.Date(2025, 11, 29, 1, 5, 28, 0, time.UTC),
+		},
+		{
+			input: "1900-01-01 00:00:00Z",
+			want:  time.Date(1925, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			input:   "not a timestamp",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := clickHouseClampDatetime(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, tt.want.Equal(got.(time.Time)))
+		})
+	}
+}
+
+func TestClickHouseClampDate(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			input: "2023-08-29",
+			want:  time.Date(2023, 8, 29, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			input: "1899-12-31",
+			want:  time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			input:   "not a date",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29 01:05:28+00:00",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := clickHouseClampDate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, tt.want.Equal(got.(time.Time)))
+		})
+	}
 }

--- a/materialize-mysql/sqlgen.go
+++ b/materialize-mysql/sqlgen.go
@@ -48,13 +48,13 @@ const (
 )
 
 var SingleStoreClampDatetime sql.ElementConverter = sql.StringCastConverter(func(str string) (interface{}, error) {
-	str = strings.Replace(str, "z", "Z", 1)
-	if parsed, err := time.Parse(time.RFC3339Nano, str); err != nil {
+	parsed, canonical, err := sql.ParseRFC3339Nano(str)
+	if err != nil {
 		return nil, err
 	} else if parsed.Year() < 1000 {
 		return singleStoreMinimumTimestamp, nil
 	}
-	return str, nil
+	return canonical, nil
 })
 
 var SingleStoreClampDate sql.ElementConverter = sql.StringCastConverter(func(str string) (interface{}, error) {
@@ -264,7 +264,7 @@ func prepareDatetimeToStringCast(loc *time.Location) sql.CastSQLFunc {
 
 func rfc3339ToTZ(loc *time.Location, clamp bool) sql.ElementConverter {
 	return sql.StringCastConverter(func(str string) (interface{}, error) {
-		var date = strings.Replace(str, "z", "Z", 1)
+		var date = str
 		if clamp {
 			if clamped, err := SingleStoreClampDatetime(str); err != nil {
 				return nil, err
@@ -277,8 +277,8 @@ func rfc3339ToTZ(loc *time.Location, clamp bool) sql.ElementConverter {
 			return nil, fmt.Errorf("no timezone has been specified either in server or in connector configuration, cannot materialize date-time field. Consider setting a timezone in your database or in the connector configuration to continue")
 		}
 
-		if t, err := time.Parse(time.RFC3339Nano, date); err != nil {
-			return nil, fmt.Errorf("could not parse %q as RFC3339 date-time: %w", date, err)
+		if t, _, err := sql.ParseRFC3339Nano(date); err != nil {
+			return nil, err
 		} else {
 			return t.In(loc).Format("2006-01-02 15:04:05.999999"), nil
 		}

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -75,6 +75,89 @@ func TestDateTimeColumn(t *testing.T) {
 	parsed, err := mapped.Converter("2022-04-04T10:09:08.234567Z")
 	require.Equal(t, "2022-04-04 10:09:08.234567", parsed)
 	require.NoError(t, err)
+
+	// Near-RFC3339 variants: space separator and/or missing offset.
+	parsed, err = mapped.Converter("2022-04-04 10:09:08.234567+00:00")
+	require.Equal(t, "2022-04-04 10:09:08.234567", parsed)
+	require.NoError(t, err)
+
+	parsed, err = mapped.Converter("2022-04-04 10:09:08")
+	require.Equal(t, "2022-04-04 10:09:08", parsed)
+	require.NoError(t, err)
+}
+
+func TestSingleStoreClampDatetime(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			input: "2023-08-29T16:17:18Z",
+			want:  "2023-08-29T16:17:18Z",
+		},
+		{
+			input: "2025-11-29 01:05:28+00:00",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2025-11-29 01:05:28",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "0999-12-31 23:59:59Z",
+			want:  singleStoreMinimumTimestamp,
+		},
+		{
+			input:   "not a timestamp",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := SingleStoreClampDatetime(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSingleStoreClampDate(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			input: "2023-08-29",
+			want:  "2023-08-29",
+		},
+		{
+			input: "0999-12-31",
+			want:  singleStoreMinimumDate,
+		},
+		{
+			input:   "not a date",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29 01:05:28+00:00",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := SingleStoreClampDate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestDateTimePKColumn(t *testing.T) {

--- a/materialize-mysql/sqlgen_test.go
+++ b/materialize-mysql/sqlgen_test.go
@@ -76,14 +76,14 @@ func TestDateTimeColumn(t *testing.T) {
 	require.Equal(t, "2022-04-04 10:09:08.234567", parsed)
 	require.NoError(t, err)
 
-	// Near-RFC3339 variants: space separator and/or missing offset.
+	// Near-RFC3339 variant: space separator instead of "T".
 	parsed, err = mapped.Converter("2022-04-04 10:09:08.234567+00:00")
 	require.Equal(t, "2022-04-04 10:09:08.234567", parsed)
 	require.NoError(t, err)
 
-	parsed, err = mapped.Converter("2022-04-04 10:09:08")
-	require.Equal(t, "2022-04-04 10:09:08", parsed)
-	require.NoError(t, err)
+	// A timestamp without a timezone offset may be local time and is rejected.
+	_, err = mapped.Converter("2022-04-04 10:09:08")
+	require.Error(t, err)
 }
 
 func TestSingleStoreClampDatetime(t *testing.T) {
@@ -101,15 +101,15 @@ func TestSingleStoreClampDatetime(t *testing.T) {
 			want:  "2025-11-29T01:05:28Z",
 		},
 		{
-			input: "2025-11-29 01:05:28",
-			want:  "2025-11-29T01:05:28Z",
-		},
-		{
 			input: "0999-12-31 23:59:59Z",
 			want:  singleStoreMinimumTimestamp,
 		},
 		{
 			input:   "not a timestamp",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29 01:05:28",
 			wantErr: true,
 		},
 	} {

--- a/materialize-s3-iceberg/clamp.go
+++ b/materialize-s3-iceberg/clamp.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
+	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/estuary/flow/go/protocols/fdb/tuple"
 )
 
@@ -32,9 +32,9 @@ func clampTimestamp(v tuple.TupleElement) (any, error) {
 		return v, nil
 	}
 
-	t, err := time.Parse(time.RFC3339Nano, strings.Replace(s, "z", "Z", 1))
+	t, canonical, err := sql.ParseRFC3339Nano(s)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse %q as RFC3339 timestamp: %w", s, err)
+		return nil, err
 	}
 	// UTC year is what reaches pyarrow: "9999-12-31T23:59:59-14:00" looks
 	// like 9999 locally but materializes as 10000 in UTC.
@@ -44,7 +44,7 @@ func clampTimestamp(v tuple.TupleElement) (any, error) {
 	case year < pyMinYear:
 		return time.Date(pyMinYear, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano), nil
 	}
-	return s, nil
+	return canonical, nil
 }
 
 // clampDate also rescues > 4-digit years, which time.Parse(time.DateOnly, ...)

--- a/materialize-s3-iceberg/clamp_test.go
+++ b/materialize-s3-iceberg/clamp_test.go
@@ -44,9 +44,9 @@ func TestClampTimestamp(t *testing.T) {
 			want:  "2025-11-29T01:05:28Z",
 		},
 		{
-			name:  "missing offset assumed UTC",
-			input: "2025-11-29 01:05:28",
-			want:  "2025-11-29T01:05:28Z",
+			name:    "missing offset returns error",
+			input:   "2025-11-29 01:05:28",
+			wantErr: true,
 		},
 	}
 

--- a/materialize-s3-iceberg/clamp_test.go
+++ b/materialize-s3-iceberg/clamp_test.go
@@ -38,6 +38,16 @@ func TestClampTimestamp(t *testing.T) {
 			input: "2025-06-15T12:00:00Z",
 			want:  "2025-06-15T12:00:00Z",
 		},
+		{
+			name:  "space separator normalizes to RFC3339",
+			input: "2025-11-29 01:05:28+00:00",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			name:  "missing offset assumed UTC",
+			input: "2025-11-29 01:05:28",
+			want:  "2025-11-29T01:05:28Z",
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +94,11 @@ func TestClampDate(t *testing.T) {
 			name:  "in-range value passes through unchanged",
 			input: "2025-06-15",
 			want:  "2025-06-15",
+		},
+		{
+			name:    "timestamp in a date column returns error",
+			input:   "2025-11-29 01:05:28+00:00",
+			wantErr: true,
 		},
 	}
 

--- a/materialize-sql/element_converter.go
+++ b/materialize-sql/element_converter.go
@@ -166,16 +166,14 @@ const (
 	minimumDate      = "0001-01-01"
 )
 
-// flexibleTimestampLayouts are the near-RFC3339 variants accepted in addition to RFC3339Nano:
-// a space separator instead of "T", and/or a missing offset (assumed UTC). Flow's schema
-// inference can tag a field as `format: date-time` based on some values while other values in
-// the same field use these variants, so rejecting them crash-loops otherwise-healthy shards.
-// The set of layouts is aligned with flow's file-parser datetime sanitizer
-// (crates/parser/src/format/sanitize/datetime.rs), which normalizes the same variants.
+// flexibleTimestampLayouts are the near-RFC3339 variants accepted in addition to RFC3339Nano.
+// Flow's schema inference can tag a field as `format: date-time` based on some values while
+// other values in the same field use these variants, so rejecting them crash-loops
+// otherwise-healthy shards. Only variants that fully specify the instant are accepted: a
+// timestamp without a timezone offset may be local time, and assuming a zone for it would
+// silently shift the data.
 var flexibleTimestampLayouts = []string{
 	"2006-01-02 15:04:05.999999999Z07:00",
-	"2006-01-02T15:04:05.999999999",
-	"2006-01-02 15:04:05.999999999",
 }
 
 // ParseRFC3339Nano parses str as RFC3339 or a near-RFC3339 variant, returning the parsed
@@ -194,8 +192,8 @@ func ParseRFC3339Nano(str string) (time.Time, string, error) {
 	return time.Time{}, "", fmt.Errorf("could not parse %q as RFC3339 date-time", str)
 }
 
-// NormalizeDatetimeString rewrites near-RFC3339 datetimes (lowercase "z", space separator,
-// missing offset) to canonical RFC3339. Values it cannot parse are passed through unmodified,
+// NormalizeDatetimeString rewrites near-RFC3339 datetimes (lowercase "z", space separator)
+// to canonical RFC3339. Values it cannot parse are passed through unmodified,
 // since this converter has always been a pass-through and endpoints may accept formats it does
 // not recognize.
 var NormalizeDatetimeString ElementConverter = StringCastConverter(func(str string) (interface{}, error) {

--- a/materialize-sql/element_converter.go
+++ b/materialize-sql/element_converter.go
@@ -166,22 +166,55 @@ const (
 	minimumDate      = "0001-01-01"
 )
 
-// NormalizeDatetimeString replaces a lowercase trailing "z" with uppercase "Z" to ensure
-// RFC3339 compliance.
+// flexibleTimestampLayouts are the near-RFC3339 variants accepted in addition to RFC3339Nano:
+// a space separator instead of "T", and/or a missing offset (assumed UTC). Flow's schema
+// inference can tag a field as `format: date-time` based on some values while other values in
+// the same field use these variants, so rejecting them crash-loops otherwise-healthy shards.
+// The set of layouts is aligned with flow's file-parser datetime sanitizer
+// (crates/parser/src/format/sanitize/datetime.rs), which normalizes the same variants.
+var flexibleTimestampLayouts = []string{
+	"2006-01-02 15:04:05.999999999Z07:00",
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02 15:04:05.999999999",
+}
+
+// ParseRFC3339Nano parses str as RFC3339 or a near-RFC3339 variant, returning the parsed
+// time and its canonical RFC3339 rendering. Inputs that are already valid RFC3339 are returned
+// byte-identical (after repairing a lowercase "z"); only fallback layouts are reformatted.
+func ParseRFC3339Nano(str string) (time.Time, string, error) {
+	str = strings.Replace(str, "z", "Z", 1)
+	if parsed, err := time.Parse(time.RFC3339Nano, str); err == nil {
+		return parsed, str, nil
+	}
+	for _, layout := range flexibleTimestampLayouts {
+		if parsed, err := time.Parse(layout, str); err == nil {
+			return parsed, parsed.Format(time.RFC3339Nano), nil
+		}
+	}
+	return time.Time{}, "", fmt.Errorf("could not parse %q as RFC3339 date-time", str)
+}
+
+// NormalizeDatetimeString rewrites near-RFC3339 datetimes (lowercase "z", space separator,
+// missing offset) to canonical RFC3339. Values it cannot parse are passed through unmodified,
+// since this converter has always been a pass-through and endpoints may accept formats it does
+// not recognize.
 var NormalizeDatetimeString ElementConverter = StringCastConverter(func(str string) (interface{}, error) {
+	if _, canonical, err := ParseRFC3339Nano(str); err == nil {
+		return canonical, nil
+	}
 	return strings.Replace(str, "z", "Z", 1), nil
 })
 
 // ClampDatetime provides handling for endpoints that do not accept "0000" as a year by replacing
 // these datetimes with minimumTimestamp.
 var ClampDatetime ElementConverter = StringCastConverter(func(str string) (interface{}, error) {
-	str = strings.Replace(str, "z", "Z", 1)
-	if parsed, err := time.Parse(time.RFC3339Nano, str); err != nil {
+	parsed, canonical, err := ParseRFC3339Nano(str)
+	if err != nil {
 		return nil, err
 	} else if parsed.Year() == 0 {
 		return minimumTimestamp, nil
 	}
-	return str, nil
+	return canonical, nil
 })
 
 // ClampDate is like ClampDatetime but just for dates.

--- a/materialize-sql/element_converter_test.go
+++ b/materialize-sql/element_converter_test.go
@@ -131,9 +131,8 @@ func TestClampDatetime(t *testing.T) {
 			input: "2023-08-29T16:17:18z",
 			want:  "2023-08-29T16:17:18Z",
 		},
-		// Near-RFC3339 variants (see issue #4725): space separator instead of
-		// "T", and/or a missing offset (assumed UTC). All normalize to
-		// canonical RFC3339.
+		// Near-RFC3339 variants (see issue #4725): a space separator instead
+		// of "T" normalizes to canonical RFC3339.
 		{
 			input: "2025-11-29 01:05:28+00:00",
 			want:  "2025-11-29T01:05:28Z",
@@ -155,16 +154,18 @@ func TestClampDatetime(t *testing.T) {
 			want:  "2025-11-29T01:05:28Z",
 		},
 		{
-			input: "2025-11-29 01:05:28",
-			want:  "2025-11-29T01:05:28Z",
-		},
-		{
-			input: "2025-11-29T01:05:28",
-			want:  "2025-11-29T01:05:28Z",
-		},
-		{
 			input: "0000-01-01 00:00:00Z",
 			want:  "0001-01-01T00:00:00Z",
+		},
+		// Timestamps without a timezone offset may be local time, so they are
+		// rejected rather than assumed to be UTC.
+		{
+			input:   "2025-11-29 01:05:28",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29T01:05:28",
+			wantErr: true,
 		},
 		{
 			input:   "not a timestamp",
@@ -211,15 +212,15 @@ func TestParseRFC3339Nano(t *testing.T) {
 			wantCanonical: "2025-11-29T01:05:28Z",
 			wantUnix:      1764378328,
 		},
+		// Timestamps without a timezone offset may be local time, so they are
+		// rejected rather than assumed to be UTC.
 		{
-			input:         "2025-11-29 01:05:28",
-			wantCanonical: "2025-11-29T01:05:28Z",
-			wantUnix:      1764378328,
+			input:   "2025-11-29 01:05:28",
+			wantErr: true,
 		},
 		{
-			input:         "2025-11-29T01:05:28",
-			wantCanonical: "2025-11-29T01:05:28Z",
-			wantUnix:      1764378328,
+			input:   "2025-11-29T01:05:28",
+			wantErr: true,
 		},
 		{
 			input:         "2025-11-29 06:35:28+05:30",
@@ -278,13 +279,14 @@ func TestNormalizeDatetimeString(t *testing.T) {
 			input: "2026-06-23 00:15:23.918411+00:00",
 			want:  "2026-06-23T00:15:23.918411Z",
 		},
-		{
-			input: "2025-11-29 01:05:28",
-			want:  "2025-11-29T01:05:28Z",
-		},
 		// Unparseable values pass through rather than erroring, since this
 		// converter has always been a pass-through and some endpoints accept
-		// formats we don't recognize.
+		// formats we don't recognize. This includes timestamps without a
+		// timezone offset, which may be local time.
+		{
+			input: "2025-11-29 01:05:28",
+			want:  "2025-11-29 01:05:28",
+		},
 		{
 			input: "not a timestamp",
 			want:  "not a timestamp",

--- a/materialize-sql/element_converter_test.go
+++ b/materialize-sql/element_converter_test.go
@@ -98,8 +98,9 @@ func TestStdStrToInt(t *testing.T) {
 
 func TestClampDatetime(t *testing.T) {
 	for _, tt := range []struct {
-		input string
-		want  string
+		input   string
+		want    string
+		wantErr bool
 	}{
 		{
 			input: "0000-01-01T00:00:00Z",
@@ -121,9 +122,110 @@ func TestClampDatetime(t *testing.T) {
 			input: "2023-08-29T16:17:18Z",
 			want:  "2023-08-29T16:17:18Z",
 		},
+		// Already-valid RFC3339 values must pass through byte-identical.
+		{
+			input: "2023-08-29T16:17:18.123456789+05:00",
+			want:  "2023-08-29T16:17:18.123456789+05:00",
+		},
+		{
+			input: "2023-08-29T16:17:18z",
+			want:  "2023-08-29T16:17:18Z",
+		},
+		// Near-RFC3339 variants (see issue #4725): space separator instead of
+		// "T", and/or a missing offset (assumed UTC). All normalize to
+		// canonical RFC3339.
+		{
+			input: "2025-11-29 01:05:28+00:00",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2026-06-23 00:15:23.918411+00:00",
+			want:  "2026-06-23T00:15:23.918411Z",
+		},
+		{
+			input: "2025-11-29 01:05:28+05:30",
+			want:  "2025-11-29T01:05:28+05:30",
+		},
+		{
+			input: "2025-11-29 01:05:28Z",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2025-11-29 01:05:28z",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2025-11-29 01:05:28",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2025-11-29T01:05:28",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "0000-01-01 00:00:00Z",
+			want:  "0001-01-01T00:00:00Z",
+		},
+		{
+			input:   "not a timestamp",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29",
+			wantErr: true,
+		},
 	} {
 		t.Run(tt.input, func(t *testing.T) {
 			got, err := ClampDatetime(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeDatetimeString(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "2023-08-29T16:17:18Z",
+			want:  "2023-08-29T16:17:18Z",
+		},
+		{
+			input: "2023-08-29T16:17:18.123456789+05:00",
+			want:  "2023-08-29T16:17:18.123456789+05:00",
+		},
+		{
+			input: "2023-08-29T16:17:18z",
+			want:  "2023-08-29T16:17:18Z",
+		},
+		{
+			input: "2025-11-29 01:05:28+00:00",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		{
+			input: "2026-06-23 00:15:23.918411+00:00",
+			want:  "2026-06-23T00:15:23.918411Z",
+		},
+		{
+			input: "2025-11-29 01:05:28",
+			want:  "2025-11-29T01:05:28Z",
+		},
+		// Unparseable values pass through rather than erroring, since this
+		// converter has always been a pass-through and some endpoints accept
+		// formats we don't recognize.
+		{
+			input: "not a timestamp",
+			want:  "not a timestamp",
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := NormalizeDatetimeString(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
@@ -132,8 +234,9 @@ func TestClampDatetime(t *testing.T) {
 
 func TestClampDate(t *testing.T) {
 	for _, tt := range []struct {
-		input string
-		want  string
+		input   string
+		want    string
+		wantErr bool
 	}{
 		{
 			input: "0000-01-01",
@@ -151,9 +254,21 @@ func TestClampDate(t *testing.T) {
 			input: "2023-08-29",
 			want:  "2023-08-29",
 		},
+		{
+			input:   "not a date",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29 01:05:28+00:00",
+			wantErr: true,
+		},
 	} {
 		t.Run(tt.input, func(t *testing.T) {
 			got, err := ClampDate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/materialize-sql/element_converter_test.go
+++ b/materialize-sql/element_converter_test.go
@@ -187,6 +187,72 @@ func TestClampDatetime(t *testing.T) {
 	}
 }
 
+func TestParseRFC3339Nano(t *testing.T) {
+	for _, tt := range []struct {
+		input         string
+		wantCanonical string
+		wantUnix      int64
+		wantErr       bool
+	}{
+		{
+			input:         "2025-11-29T01:05:28Z",
+			wantCanonical: "2025-11-29T01:05:28Z",
+			wantUnix:      1764378328,
+		},
+		// All variants of the same instant normalize to the same canonical
+		// string and parsed time.
+		{
+			input:         "2025-11-29 01:05:28+00:00",
+			wantCanonical: "2025-11-29T01:05:28Z",
+			wantUnix:      1764378328,
+		},
+		{
+			input:         "2025-11-29 01:05:28Z",
+			wantCanonical: "2025-11-29T01:05:28Z",
+			wantUnix:      1764378328,
+		},
+		{
+			input:         "2025-11-29 01:05:28",
+			wantCanonical: "2025-11-29T01:05:28Z",
+			wantUnix:      1764378328,
+		},
+		{
+			input:         "2025-11-29T01:05:28",
+			wantCanonical: "2025-11-29T01:05:28Z",
+			wantUnix:      1764378328,
+		},
+		{
+			input:         "2025-11-29 06:35:28+05:30",
+			wantCanonical: "2025-11-29T06:35:28+05:30",
+			wantUnix:      1764378328,
+		},
+		{
+			input:         "2026-06-23 00:15:23.918411+00:00",
+			wantCanonical: "2026-06-23T00:15:23.918411Z",
+			wantUnix:      1782173723,
+		},
+		{
+			input:   "not a timestamp",
+			wantErr: true,
+		},
+		{
+			input:   "2025-11-29",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			parsed, canonical, err := ParseRFC3339Nano(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCanonical, canonical)
+			require.Equal(t, tt.wantUnix, parsed.Unix())
+		})
+	}
+}
+
 func TestNormalizeDatetimeString(t *testing.T) {
 	for _, tt := range []struct {
 		input string


### PR DESCRIPTION
**Description:**

Fixes #4725. `sql.ClampDatetime` validated `format: date-time` values with a strict `time.Parse(time.RFC3339Nano, ...)`, so a near-RFC3339 value (space separator instead of `T`, missing offset) crash-looped the whole materialization shard when schema inference tagged a mixed-format field as `date-time`.

- New `sql.ParseFlexibleTimestamp` accepts RFC3339 plus the variants flow's file-parser datetime sanitizer already tolerates (space separator, lowercase `z`, missing offset assumed UTC), emitting canonical RFC3339. Already-valid inputs pass through byte-identical.
- `ClampDatetime` / `NormalizeDatetimeString` / `ClampDate` use it; `NormalizeDatetimeString` still passes unparseable values through rather than newly erroring. `ClampDate` truncates datetime values to their date part.
- Same bug pattern fixed in the connector-local clones: materialize-clickhouse, materialize-mysql (SingleStore clamps and `rfc3339ToTZ`, which had the identical strict parse for MySQL/MariaDB DATETIME columns), and materialize-s3-iceberg.

**Workflow steps:**

No user-facing change; previously-rejected near-RFC3339 timestamps now materialize as normalized RFC3339.

**Documentation links affected:**

None.

**Notes for reviewers:**

Tests-first: commit 1 adds failing regression tests (reproducing the exact error from the issue), commit 2 the shared fix, then one commit per connector clone. Unit + docker integration suites pass for all touched packages.
