### PR TITLE
materialize-clickhouse: retry transient connection drops during Load/Store

### DIFF
--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -410,8 +410,13 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		if len(batch) == 0 || lastBinding < 0 {
 			return nil
 		}
-		chBatch, err := t.load.conn.PrepareBatch(ctx, t.bindings[lastBinding].load.insertSQL)
-		if err != nil {
+		// PrepareBatch fails before any rows have been sent, so retrying a
+		// transient connection drop is a clean no-op on the ClickHouse side.
+		var chBatch chdriver.Batch
+		if err := transientRetryPolicy.retry(ctx, "preparing load batch", isTransientErr, func() (err error) {
+			chBatch, err = t.load.conn.PrepareBatch(ctx, t.bindings[lastBinding].load.insertSQL)
+			return err
+		}); err != nil {
 			return fmt.Errorf("preparing load batch: %w", err)
 		}
 		defer chBatch.Close()
@@ -502,30 +507,42 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 	// Keys are now ready to be JOIN'd between the temporary and target tables.
 	loadBinding := func(i int, b *binding) error {
-		rows, err := t.load.conn.Query(ctx, b.load.querySQL)
-		if err != nil {
-			return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var doc json.RawMessage
-			if err = rows.Scan(&doc); err != nil {
-				return fmt.Errorf("scanning Load document for %s: %w", b.target.Identifier, err)
-			}
-			if len(b.nullFieldsToStrip) > 0 {
-				if doc, err = sql.StripNullFields(doc, b.nullFieldsToStrip); err != nil {
-					return fmt.Errorf("stripping null fields: %w", err)
+		// Documents already delivered via loaded() cannot be recalled, so the
+		// query may only be retried while nothing has been emitted: re-running
+		// it afterwards would deliver duplicates, which the runtime would
+		// reduce together (double-counting under sum-style reductions). The
+		// transient failures seen in practice ("failed to read first block
+		// packet") surface from Query itself, before any rows are delivered.
+		var emitted bool
+		return transientRetryPolicy.retry(ctx, "querying Load documents",
+			func(err error) bool { return !emitted && isTransientErr(err) },
+			func() error {
+				rows, err := t.load.conn.Query(ctx, b.load.querySQL)
+				if err != nil {
+					return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
 				}
-			}
-			if err = loaded(i, doc); err != nil {
-				return err
-			}
-		}
-		if err = rows.Err(); err != nil {
-			return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
-		}
-		return nil
+				defer rows.Close()
+
+				for rows.Next() {
+					var doc json.RawMessage
+					if err = rows.Scan(&doc); err != nil {
+						return fmt.Errorf("scanning Load document for %s: %w", b.target.Identifier, err)
+					}
+					if len(b.nullFieldsToStrip) > 0 {
+						if doc, err = sql.StripNullFields(doc, b.nullFieldsToStrip); err != nil {
+							return fmt.Errorf("stripping null fields: %w", err)
+						}
+					}
+					emitted = true
+					if err = loaded(i, doc); err != nil {
+						return err
+					}
+				}
+				if err = rows.Err(); err != nil {
+					return fmt.Errorf("querying Load documents for %s: %w", b.target.Identifier, err)
+				}
+				return nil
+			})
 	}
 
 	for i := range activeBindings {
@@ -548,8 +565,13 @@ func (t *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		if len(batch) == 0 || lastBinding < 0 {
 			return nil
 		}
-		chBatch, err := t.store.conn.PrepareBatch(ctx, t.bindings[lastBinding].store.insertSQL)
-		if err != nil {
+		// As with the load batch, PrepareBatch fails before any rows have been
+		// sent and is safe to retry.
+		var chBatch chdriver.Batch
+		if err := transientRetryPolicy.retry(ctx, "preparing store batch", isTransientErr, func() (err error) {
+			chBatch, err = t.store.conn.PrepareBatch(ctx, t.bindings[lastBinding].store.insertSQL)
+			return err
+		}); err != nil {
 			return fmt.Errorf("preparing store batch: %w", err)
 		}
 		defer chBatch.Close()
@@ -766,7 +788,14 @@ func (t *transactor) moveStorePartitionsToTarget(ctx context.Context, b *binding
 	}
 
 	for _, partitionID := range partitionIDs {
-		if err = t.store.conn.Exec(ctx, b.store.movePartitionSQL, partitionID); err != nil {
+		// Retrying MOVE PARTITION after a transient connection drop is safe
+		// even if the server had already applied it: moving a partition with
+		// no remaining parts is a no-op, and the row accounting above plus the
+		// empty-stage check below still catch any genuinely stuck or partial
+		// move as a hard error.
+		if err = transientRetryPolicy.retry(ctx, "moving store table partition", isTransientErr, func() error {
+			return t.store.conn.Exec(ctx, b.store.movePartitionSQL, partitionID)
+		}); err != nil {
 			// Never truncate or drop here: unmoved staged rows must survive
 			// for a retry (or operator intervention, e.g. if the stage table
 			// schema has drifted from a target migrated while this commit was

--- a/materialize-clickhouse/retry.go
+++ b/materialize-clickhouse/retry.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"time"
+
+	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	log "github.com/sirupsen/logrus"
+)
+
+// retryPolicy bounds retries of transient ClickHouse failures by both attempt
+// count and total elapsed time. After the bounds are exhausted the last error
+// is returned and the shard fails as it would without retries, so a
+// persistently unhealthy cluster still surfaces promptly.
+type retryPolicy struct {
+	maxAttempts    int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	maxElapsed     time.Duration
+}
+
+// transientRetryPolicy rides out a ClickHouse Cloud replica recycle, which
+// typically resolves within seconds to a couple of minutes.
+var transientRetryPolicy = retryPolicy{
+	maxAttempts:    8,
+	initialBackoff: time.Second,
+	maxBackoff:     30 * time.Second,
+	maxElapsed:     5 * time.Minute,
+}
+
+// retry invokes op, retrying with exponential backoff while retryable reports
+// the error as worth retrying. Because the underlying clickhouse.Conn is a
+// pool that discards broken connections, each retry naturally dials fresh --
+// on a load-balanced endpoint this can land on a healthy replica.
+func (p retryPolicy) retry(ctx context.Context, desc string, retryable func(error) bool, op func() error) error {
+	var deadline = time.Now().Add(p.maxElapsed)
+	var backoff = p.initialBackoff
+
+	for attempt := 1; ; attempt++ {
+		var err = op()
+		if err == nil || !retryable(err) {
+			return err
+		}
+		if attempt >= p.maxAttempts || !time.Now().Add(backoff).Before(deadline) {
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"op":      desc,
+			"attempt": attempt,
+			"backoff": backoff.String(),
+			"error":   err.Error(),
+		}).Warn("retrying transient ClickHouse error")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > p.maxBackoff {
+			backoff = p.maxBackoff
+		}
+	}
+}
+
+// isTransientErr reports whether err is a transient connection-level failure
+// of the kind seen when a ClickHouse Cloud replica is recycled mid-query:
+// connection reset, EOF on the native protocol, or an i/o timeout. Server
+// exceptions (e.g. code 241 OOM kills, DDL errors) are never transient --
+// they need the query itself to change, not a retry -- and neither is
+// cancellation of our own context.
+func isTransientErr(err error) bool {
+	var exc *clickhouseproto.Exception
+	if errors.As(err, &exc) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// Any other net.Error (dial failure, read/write timeout) also indicates a
+	// connection-level problem rather than a server-side rejection.
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}

--- a/materialize-clickhouse/retry_test.go
+++ b/materialize-clickhouse/retry_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientErr(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			// The exact shape reported in the field: clickhouse-go wraps the
+			// underlying read error with %w.
+			name:      "EOF reading first block packet",
+			err:       fmt.Errorf("query processing: failed to read first block packet from 1.2.3.4:9440 (conn_id=7): %w", io.EOF),
+			transient: true,
+		},
+		{
+			name:      "unexpected EOF",
+			err:       fmt.Errorf("read: %w", io.ErrUnexpectedEOF),
+			transient: true,
+		},
+		{
+			name:      "connection reset",
+			err:       &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET},
+			transient: true,
+		},
+		{
+			name:      "broken pipe",
+			err:       &net.OpError{Op: "write", Net: "tcp", Err: syscall.EPIPE},
+			transient: true,
+		},
+		{
+			name:      "connection refused on dial",
+			err:       &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+			transient: true,
+		},
+		{
+			name:      "i/o timeout",
+			err:       fmt.Errorf("read: %w", &net.OpError{Op: "read", Net: "tcp", Err: errors.New("i/o timeout")}),
+			transient: true,
+		},
+		{
+			name:      "server OOM kill exception is not retryable",
+			err:       fmt.Errorf("querying: %w", &clickhouseproto.Exception{Code: 241, Message: "Memory limit (total) exceeded"}),
+			transient: false,
+		},
+		{
+			name:      "server DDL exception is not retryable",
+			err:       &clickhouseproto.Exception{Code: 60, Message: "Unknown table"},
+			transient: false,
+		},
+		{
+			name:      "context cancellation is not retryable",
+			err:       context.Canceled,
+			transient: false,
+		},
+		{
+			name:      "context deadline is not retryable",
+			err:       fmt.Errorf("querying: %w", context.DeadlineExceeded),
+			transient: false,
+		},
+		{
+			name:      "arbitrary error is not retryable",
+			err:       errors.New("something else entirely"),
+			transient: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.transient, isTransientErr(tt.err))
+		})
+	}
+}
+
+func TestRetryPolicy(t *testing.T) {
+	var policy = retryPolicy{
+		maxAttempts:    4,
+		initialBackoff: time.Millisecond,
+		maxBackoff:     4 * time.Millisecond,
+		maxElapsed:     time.Minute,
+	}
+	var transientErr = fmt.Errorf("read: %w", io.EOF)
+	var ctx = context.Background()
+
+	t.Run("succeeds without retrying", func(t *testing.T) {
+		var calls int
+		require.NoError(t, policy.retry(ctx, "op", isTransientErr, func() error {
+			calls++
+			return nil
+		}))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("retries transient errors until success", func(t *testing.T) {
+		var calls int
+		require.NoError(t, policy.retry(ctx, "op", isTransientErr, func() error {
+			if calls++; calls < 3 {
+				return transientErr
+			}
+			return nil
+		}))
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("does not retry non-transient errors", func(t *testing.T) {
+		var calls int
+		var permanentErr = errors.New("schema mismatch")
+		require.ErrorIs(t, policy.retry(ctx, "op", isTransientErr, func() error {
+			calls++
+			return permanentErr
+		}), permanentErr)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("gives up after maxAttempts", func(t *testing.T) {
+		var calls int
+		require.ErrorIs(t, policy.retry(ctx, "op", isTransientErr, func() error {
+			calls++
+			return transientErr
+		}), io.EOF)
+		require.Equal(t, policy.maxAttempts, calls)
+	})
+
+	t.Run("gives up when elapsed time is exhausted", func(t *testing.T) {
+		var shortPolicy = retryPolicy{
+			maxAttempts:    100,
+			initialBackoff: 50 * time.Millisecond,
+			maxBackoff:     50 * time.Millisecond,
+			maxElapsed:     time.Millisecond,
+		}
+		var calls int
+		require.ErrorIs(t, shortPolicy.retry(ctx, "op", isTransientErr, func() error {
+			calls++
+			return transientErr
+		}), io.EOF)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("stops retrying when the predicate declines", func(t *testing.T) {
+		var calls int
+		require.ErrorIs(t, policy.retry(ctx, "op", func(error) bool { return calls < 2 }, func() error {
+			calls++
+			return transientErr
+		}), io.EOF)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("returns promptly when the context is cancelled during backoff", func(t *testing.T) {
+		var slowPolicy = retryPolicy{
+			maxAttempts:    100,
+			initialBackoff: time.Minute,
+			maxBackoff:     time.Minute,
+			maxElapsed:     time.Hour,
+		}
+		cancelCtx, cancel := context.WithCancel(ctx)
+		var calls int
+		var done = make(chan error, 1)
+		go func() {
+			done <- slowPolicy.retry(cancelCtx, "op", isTransientErr, func() error {
+				calls++
+				return transientErr
+			})
+		}()
+		cancel()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+			require.Equal(t, 1, calls)
+		case <-time.After(5 * time.Second):
+			t.Fatal("retry did not return after context cancellation")
+		}
+	})
+}


### PR DESCRIPTION
**Description:**

Closes #4744. Adds bounded retry/backoff around ClickHouse operations that fail on transient connection drops (`read: EOF`, resets, i/o timeouts) when a ClickHouse Cloud replica is recycled, so a blip no longer causes a full shard failure.

- New `retryPolicy` helper: max 8 attempts, exponential backoff 1s→30s, 5 min elapsed cap; retries only connection-level errors — never server exceptions (e.g. code 241 OOM) or context cancellation.
- Applied to Load/Store `PrepareBatch` (fails before rows are sent), the per-binding Load JOIN query, and the `MOVE PARTITION` exec (idempotent; guarded by existing row-accounting checks).
- The Load query retry stops once any document has been emitted, since re-delivery would duplicate loaded documents.
- `Batch.Send` is not retried: a drop mid-send leaves the insert outcome unknown.

**Workflow steps:**

No user-facing change; existing materializations pick this up on upgrade.

**Notes for reviewers:**

Retry loop and error classification are unit-tested (`retry_test.go`), including the exact wrapped-`io.EOF` shape clickhouse-go produces. Full suite incl. `TestIntegration/*` passes locally.
