### PR TITLE
estuary-cdk: time out of long-running OAuth token exchanges

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -24,7 +24,12 @@ from ..flow import (
 )
 from ..http import HTTPMixin, TokenSource
 from ..logger import FlowLogger
-from ..utils import format_error_message, get_running_tasks_info, sort_dict
+from ..utils import (
+    format_error_message,
+    get_running_tasks_info,
+    sort_dict,
+    surface_slow,
+)
 from . import Request, Response, Task, request, response
 from ._emit import emit_bytes
 from .common import _ConnectorState
@@ -39,6 +44,8 @@ PERIODIC_RESTART_INTERVAL = 24 * 60 * 60  # 24 hours
 GRACEFUL_SHUTDOWN_TIMEOUT = 30 * 60  # 30 minutes
 TASK_CANCELLATION_TIMEOUT = 5 * 60  # 5 minutes
 WEBHOOK_SHUTDOWN_TIMEOUT = 60  # 1 minute
+
+OAUTH2_ROTATION_DEADLINE = 10 * 60  # 10 minutes
 
 
 class TerminateTaskGroup(Exception):
@@ -346,11 +353,16 @@ class BaseCaptureConnector(
         if access_token_expiration < now + timedelta(minutes=5):
             # Exchange for new access token & refresh token.
             log.info("Attempting to rotate OAuth2 tokens.")
-            token_exchange_response = await self.token_source.initialize_oauth2_tokens(
-                log, self
+            token_exchange_response = await surface_slow(
+                log,
+                "OAuth2 token exchange",
+                self.token_source.initialize_oauth2_tokens(log, self),
+                deadline=OAUTH2_ROTATION_DEADLINE,
             )
 
-            # Replace tokens in the config.
+            # Replace tokens in the config. From here until the control plane
+            # publishes the emitted config update, these in-memory tokens are
+            # the only valid copy.
             credentials = self.token_source.credentials
             credentials.access_token = token_exchange_response.access_token
             credentials.refresh_token = token_exchange_response.refresh_token

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -34,6 +34,7 @@ from .utils import format_error_message
 
 DEFAULT_AUTHORIZATION_HEADER = "Authorization"
 DEFAULT_AUTHORIZATION_TOKEN_TYPE = "Bearer"
+OAUTH2_TOKEN_EXCHANGE_TIMEOUT = 30.0  # seconds, per attempt
 
 T = TypeVar("T")
 
@@ -432,6 +433,10 @@ class TokenSource:
             headers=headers,
             form=form,
             with_token=False,
+            # Bound each attempt and don't retry server errors forever, so that
+            # a misbehaving provider surfaces as a loggable failure.
+            should_retry=lambda status, headers, body, attempt: attempt < 5,
+            timeout=aiohttp.ClientTimeout(total=OAUTH2_TOKEN_EXCHANGE_TIMEOUT),
         )
         return self.AccessTokenResponse.model_validate_json(response)
 

--- a/estuary-cdk/estuary_cdk/utils.py
+++ b/estuary-cdk/estuary_cdk/utils.py
@@ -1,13 +1,70 @@
 import asyncio
+import time
 import traceback
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from logging import Logger
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+async def surface_slow(
+    log: Logger,
+    op: str,
+    aw: Awaitable[T],
+    *,
+    warn_after: float = 30.0,
+    warn_interval: float = 60.0,
+    deadline: float | None = None,
+) -> T:
+    """
+    Await `aw`, periodically logging a warning while it runs so that slow
+    external calls are visible in task and build logs instead of hanging
+    silently. A first warning is logged after `warn_after` seconds and then
+    every `warn_interval` seconds.
+
+    If `deadline` is set, the awaitable is cancelled once it elapses and a
+    TimeoutError is raised. Leave `deadline` as None for operations that must
+    not be cancelled once started, such as work following an irreversible
+    side effect.
+    """
+    task = asyncio.ensure_future(aw)
+    started = time.monotonic()
+    next_warn = warn_after
+
+    while True:
+        try:
+            return await asyncio.wait_for(asyncio.shield(task), timeout=next_warn)
+        except asyncio.CancelledError:
+            # Our caller was cancelled; don't leak the shielded task.
+            _ = task.cancel()
+            raise
+        except TimeoutError:
+            if task.done():
+                # The awaitable itself raised TimeoutError, as opposed to our
+                # polling timeout having elapsed; propagate its outcome.
+                return task.result()
+            elapsed = time.monotonic() - started
+            if deadline is not None and elapsed >= deadline:
+                _ = task.cancel()
+                raise TimeoutError(
+                    f"{op} did not complete within {deadline:.0f} seconds (giving up)"
+                )
+            log.warning(
+                f"{op} is still running",
+                {
+                    "elapsed_seconds": round(elapsed),
+                    "deadline_seconds": deadline,
+                },
+            )
+            next_warn = warn_interval
 
 
 @dataclass
 class TaskInfo:
     """Information about an asyncio task."""
+
     task: asyncio.Task[Any]
     task_name: str
     coro_name: str

--- a/estuary-cdk/tests/test_surface_slow.py
+++ b/estuary-cdk/tests/test_surface_slow.py
@@ -1,0 +1,142 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from estuary_cdk.utils import surface_slow
+
+
+@pytest.mark.asyncio
+async def test_fast_completion_returns_value_without_warnings():
+    log = MagicMock()
+
+    async def fast() -> int:
+        return 42
+
+    result = await surface_slow(log, "fast op", fast(), warn_after=0.5)
+
+    assert result == 42
+    log.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slow_completion_warns_and_returns_value():
+    log = MagicMock()
+
+    async def slow() -> str:
+        await asyncio.sleep(0.25)
+        return "done"
+
+    result = await surface_slow(
+        log, "slow op", slow(), warn_after=0.05, warn_interval=0.05
+    )
+
+    assert result == "done"
+    assert log.warning.call_count >= 2
+
+    message, fields = log.warning.call_args_list[0].args
+    assert message == "slow op is still running"
+    assert fields["deadline_seconds"] is None
+    assert isinstance(fields["elapsed_seconds"], int)
+
+
+@pytest.mark.asyncio
+async def test_deadline_cancels_and_raises():
+    log = MagicMock()
+    cancelled = asyncio.Event()
+
+    async def hangs() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    with pytest.raises(TimeoutError, match="hung op did not complete within"):
+        await surface_slow(
+            log,
+            "hung op",
+            hangs(),
+            warn_after=0.02,
+            warn_interval=0.02,
+            deadline=0.1,
+        )
+
+    # The shielded inner task must actually be cancelled, not leaked.
+    _ = await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+    assert log.warning.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_no_deadline_never_cancels():
+    log = MagicMock()
+
+    async def eventually() -> str:
+        await asyncio.sleep(0.25)
+        return "finished"
+
+    result = await surface_slow(
+        log, "patient op", eventually(), warn_after=0.05, warn_interval=0.05
+    )
+
+    assert result == "finished"
+    # Several warning intervals elapsed, yet the operation ran to completion.
+    assert log.warning.call_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_inner_exception_propagates():
+    log = MagicMock()
+
+    async def fails() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await surface_slow(log, "failing op", fails(), warn_after=0.5)
+
+
+@pytest.mark.asyncio
+async def test_inner_timeout_error_propagates_promptly():
+    # Regression: an awaitable that itself raises TimeoutError must not be
+    # mistaken for our polling timeout, which would loop warning forever.
+    log = MagicMock()
+
+    async def times_out() -> None:
+        await asyncio.sleep(0.06)
+        raise TimeoutError("inner timeout")
+
+    with pytest.raises(TimeoutError, match="inner timeout"):
+        await asyncio.wait_for(
+            surface_slow(
+                log,
+                "inner-timeout op",
+                times_out(),
+                warn_after=0.02,
+                warn_interval=0.02,
+            ),
+            timeout=1.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_cancels_inner_task():
+    log = MagicMock()
+    cancelled = asyncio.Event()
+
+    async def hangs() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    outer = asyncio.ensure_future(
+        surface_slow(log, "cancelled op", hangs(), warn_after=10.0)
+    )
+    await asyncio.sleep(0.05)
+    _ = outer.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)


### PR DESCRIPTION
**Description:**
We found that `source-quickbooks` OAuth token exchanges can get stuck on infinite 429 backoff loops until the control plane kills our `Validate` RPCs. Since we don't expect rotations to take more than 10 minutes, it's safe to error out early and provide a more specific error instead.

This commit also logs warnings at regular intervals when specific function calls take longer than expected.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

