### PR TITLE
estuary-cdk: warn once when the rate limiter saturates at `MAX_DELAY`

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -461,8 +461,9 @@ class RateLimiter:
 
     failed: int = 0
     total: int = 0
+    has_reached_max_delay: bool = False
 
-    def update(self, cur_delay: float, failed: bool):
+    def update(self, log: Logger, cur_delay: float, failed: bool) -> None:
         self.total += 1
         update: float
 
@@ -476,6 +477,17 @@ class RateLimiter:
 
         self.delay = (1 - self.gain) * self.delay + self.gain * update
         self.delay = min(self.delay, self.MAX_DELAY)
+
+        if self.delay >= self.MAX_DELAY and not self.has_reached_max_delay:
+            self.has_reached_max_delay = True
+            log.warning(
+                "rate limiter has reached its maximum delay",
+                {
+                    "delay": self.delay,
+                    "failed": self.failed,
+                    "total": self.total,
+                },
+            )
 
     @property
     def error_ratio(self) -> float:
@@ -615,7 +627,7 @@ class HTTPMixin(Mixin, HTTPSession):
 
             should_release_response = True
             try:
-                self.rate_limiter.update(cur_delay, resp.status == 429)
+                self.rate_limiter.update(log, cur_delay, resp.status == 429)
 
                 if resp.status == 429:
                     if self.rate_limiter.failed / self.rate_limiter.total > 0.05:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

The only rate limiter logging is gated on the cumulative `failed/total` ratio exceeding 5%, which dilutes to permanent silence in long-lived sessions where we receive multiple 200 OK responses at the beginning of the session then a slew of 429s later on.  A saturated limiter looks like a stalled capture, and the current logs can't confirm or rule it out. Warn once per `RateLimiter` when the delay first saturates so this state is observable.

**Notes for reviewers:**

We may be able to improve the existing rate limiting logging by not considering `failed / total > 5%` for the life of the current capture invocation but rather for a time bound (ex; the past hour, etc.). But I'd rather add another log right now instead of changing the existing logging condition until I see how frequently the described scenario of multiple 200 OKs then a slew of 429s much later actually happen & max out the `RateLimiter`'s delay.