### PR TITLE
materialize-boilerplate: retain_existing_data should disable load opt

### DIFF
--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -796,8 +796,15 @@ func RunNewTransactor[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC
 	}
 
 	return transactor, &pm.Response_Opened{
-		RuntimeCheckpoint:       cp,
-		DisableLoadOptimization: featureFlags["allow_existing_tables_for_new_bindings"],
+		RuntimeCheckpoint: cp,
+		// retain_existing_data_on_backfill skips truncating a table on
+		// backfill, but the runtime's per-binding load-key optimization is
+		// reset by a backfill and would skip loads, causing backfills to
+		// insert duplicate rows alongside the retained data instead of
+		// merging with it. Disabling the load optimization forces loads so
+		// that retained data is merged correctly.
+		DisableLoadOptimization: featureFlags["allow_existing_tables_for_new_bindings"] ||
+			featureFlags["retain_existing_data_on_backfill"],
 	}, &mCfg.MaterializeOptions, nil
 }
 


### PR DESCRIPTION
**Description:**

- [materialize-boilerplate: retain_existing_data should disable load opt](https://github.com/estuary/connectors/pull/4757/changes/5aa4a868066e07676ec884c95f5aa24302431121)
- Resolves #4702 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

