### PR TITLE
materialize-snowflake: optimise memory consumption of snowpipe streaming

### DIFF
--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
-	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/estuary/connectors/go/writer"
 	sql "github.com/estuary/connectors/materialize-sql"
 )
@@ -237,21 +236,47 @@ func (bw *bdecWriter) writeRow(row []any) error {
 func (bw *bdecWriter) close() error {
 	if err := bw.pq.Close(); err != nil {
 		return fmt.Errorf("closing parquet writer: %w", err)
-	} else if bw.blobStats.parquetMetadata, err = bw.pq.FileMetadata(); err != nil {
+	}
+	fm, err := bw.pq.FileMetadata()
+	if err != nil {
 		return fmt.Errorf("getting parquet file metadata: %w", err)
 	}
 
 	// A couple of easy sanity checks to verify the recorded blob metadata vs.
 	// the written parquet file metadata. The uncompressed length is taken
 	// directly from the parquet metadata assuming everything else matches.
-	if bw.blobStats.parquetMetadata.NumRowGroups() != 1 {
-		return fmt.Errorf("internal appication error: expected exactly one row group in bdec file, got %d", bw.blobStats.parquetMetadata.NumRowGroups())
-	} else if bw.blobStats.rows != int(bw.blobStats.parquetMetadata.NumRows) {
-		return fmt.Errorf("internal appication error: row count mismatch: %d rows written, but parquet metadata has %d", bw.blobStats.rows, bw.blobStats.parquetMetadata.NumRows)
+	if fm.NumRowGroups() != 1 {
+		return fmt.Errorf("internal appication error: expected exactly one row group in bdec file, got %d", fm.NumRowGroups())
+	} else if bw.blobStats.rows != int(fm.NumRows) {
+		return fmt.Errorf("internal appication error: row count mismatch: %d rows written, but parquet metadata has %d", bw.blobStats.rows, fm.NumRows)
 	}
-	bw.blobStats.lengthUncompressed = int(bw.blobStats.parquetMetadata.RowGroups[0].TotalByteSize)
+	bw.blobStats.lengthUncompressed = int(fm.RowGroups[0].TotalByteSize)
+
+	// Only the scalars needed later are kept from the file metadata: retaining
+	// the *metadata.FileMetaData itself would pin the encoded column
+	// statistics, which can be several MiB per blob when column values are
+	// large, for as long as the tracker is retained.
+	bw.blobStats.parquetStats = parquetFileStats{
+		numRows:         fm.NumRows,
+		numRowGroups:    fm.NumRowGroups(),
+		rowGroupNumRows: fm.RowGroups[0].NumRows,
+		totalByteSize:   fm.RowGroups[0].TotalByteSize,
+	}
+	if s := fm.RowGroups[0].TotalCompressedSize; s != nil {
+		bw.blobStats.parquetStats.totalCompressedSize = *s
+	}
 
 	return nil
+}
+
+// parquetFileStats holds the scalars from the written parquet file's metadata
+// that are used after the blob is finished.
+type parquetFileStats struct {
+	numRows             int64
+	numRowGroups        int
+	rowGroupNumRows     int64
+	totalByteSize       int64
+	totalCompressedSize int64
 }
 
 type blobStatsTracker struct {
@@ -267,7 +292,7 @@ type blobStatsTracker struct {
 	length             int          // total number of bytes in the blob
 	lengthUncompressed int          // estimate of the uncompressed byte size of the blob's data
 
-	parquetMetadata *metadata.FileMetaData // As-written parquet file metadata
+	parquetStats parquetFileStats // As-written parquet file metadata scalars
 
 	columns []*columnStatsTracker
 
@@ -277,25 +302,37 @@ type blobStatsTracker struct {
 	buf    []byte
 }
 
+// encryptChunkSize bounds the scratch buffer used to encrypt bytes on their
+// way to the output. Encrypting in fixed-size chunks keeps the buffer small no
+// matter how large the writes from the parquet writer are (single compressed
+// pages can be tens of MB when values are large), which matters because each
+// blob's tracker is retained until the transaction commits.
+const encryptChunkSize = 64 * 1024
+
 func (bs *blobStatsTracker) Write(p []byte) (int, error) {
-	n := len(p)
-	if n > cap(bs.buf) {
-		bs.buf = slices.Grow(bs.buf, n-len(bs.buf))
+	if bs.buf == nil {
+		bs.buf = make([]byte, encryptChunkSize)
 	}
 
-	bs.stream.XORKeyStream(bs.buf[:n], p)
-	if written, err := bs.w.Write(bs.buf[:n]); err != nil {
-		return written, fmt.Errorf("blobStatsTracker error writing to output: %w", err)
-	} else if written != n {
-		return written, fmt.Errorf("written bytes %d != expected bytes %d", written, n)
-	} else if hashed, err := bs.md5.Write(bs.buf[:n]); err != nil {
-		return written, fmt.Errorf("failed to write md5 for blob: %w", err)
-	} else if hashed != n {
-		return written, fmt.Errorf("hashed bytes %d != expected bytes %d", hashed, n)
+	var total int
+	for len(p) > 0 {
+		n := min(len(p), encryptChunkSize)
+		bs.stream.XORKeyStream(bs.buf[:n], p[:n])
+		if written, err := bs.w.Write(bs.buf[:n]); err != nil {
+			return total + written, fmt.Errorf("blobStatsTracker error writing to output: %w", err)
+		} else if written != n {
+			return total + written, fmt.Errorf("written bytes %d != expected bytes %d", written, n)
+		} else if hashed, err := bs.md5.Write(bs.buf[:n]); err != nil {
+			return total + n, fmt.Errorf("failed to write md5 for blob: %w", err)
+		} else if hashed != n {
+			return total + n, fmt.Errorf("hashed bytes %d != expected bytes %d", hashed, n)
+		}
+		total += n
+		p = p[n:]
 	}
 
-	bs.length += n
-	return n, nil
+	bs.length += total
+	return total, nil
 }
 
 func (bs *blobStatsTracker) Close() error {
@@ -303,6 +340,7 @@ func (bs *blobStatsTracker) Close() error {
 		return fmt.Errorf("blobStatsTracker error closing output: %w", err)
 	}
 	bs.finish = time.Now()
+	bs.buf = nil // nothing more will be written; don't retain the buffer
 
 	return nil
 }
@@ -341,23 +379,32 @@ func (cs *columnStatsTracker) nextStr(v string) {
 		panic(fmt.Sprintf("internal error: nextStr called on non-string column %q", cs.name))
 	}
 
+	cs.strStats.maxLen = max(len(v), cs.strStats.maxLen)
+
+	if len(v) > MAX_LOB_LENGTH+1 {
+		// These ultimately get truncated to MAX_LOB_LENGTH per
+		// truncateBytesAsHex, so there is no reason to buffer more than that
+		// plus one byte, with the extra byte preserving the "value was longer"
+		// signal truncateBytesAsHex uses to round the maximum value up.
+		v = v[:MAX_LOB_LENGTH+1]
+	}
+
+	// Stored values must be cloned: a substring of v aliases v's backing
+	// array, and would otherwise pin the entire value in memory for as long as
+	// the tracker is retained, which is until the transaction commits.
 	if !cs.hasData {
-		cs.strStats.maxLen = len(v)
-		cs.strStats.maxVal = v
-		cs.strStats.minVal = v
+		cs.strStats.maxVal = strings.Clone(v)
+		cs.strStats.minVal = strings.Clone(v)
 		cs.hasData = true
 		return
 	}
 
-	cs.strStats.maxLen = max(len(v), cs.strStats.maxLen)
-
-	if len(v) > MAX_LOB_LENGTH {
-		// These ultimately get truncated per truncateBytesAsHex, so there is no
-		// reason to buffer more than this length.
-		v = v[:MAX_LOB_LENGTH]
+	if v > cs.strStats.maxVal {
+		cs.strStats.maxVal = strings.Clone(v)
 	}
-	cs.strStats.maxVal = max(cs.strStats.maxVal, v)
-	cs.strStats.minVal = min(cs.strStats.minVal, v)
+	if v < cs.strStats.minVal {
+		cs.strStats.minVal = strings.Clone(v)
+	}
 }
 
 func (cs *columnStatsTracker) nextInt(v decimal128.Num) {

--- a/materialize-snowflake/repro_oom_test.go
+++ b/materialize-snowflake/repro_oom_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"testing"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamingMemoryClimbRepro reproduces the memory accumulation observed
+// with Snowpipe Streaming during large transactions. It mimics exactly what
+// streamManager does over the Store phase of a single transaction: rows are
+// written to a bdecWriter, the blob is rotated when its single row group
+// reaches MAX_CHUNK_SIZE_IN_BYTES_DEFAULT (256 MiB), and each finished blob's
+// blobStatsTracker is retained until the transaction commits (flush).
+//
+// Memory that should be released (or never held) per finished blob is instead
+// retained until commit:
+//
+//  1. blobStatsTracker.buf grows to the largest single Write from the parquet
+//     writer -- roughly one Snappy-compressed page, which for large document
+//     values is close to an entire ~25 MiB scratch row group column chunk --
+//     and is kept per blob.
+//  2. columnStatsTracker min/max string statistics alias the backing arrays of
+//     full document values, pinning up to two whole documents per string or
+//     variant column per blob.
+//
+// The test fails ("OOM") when the live heap after GC exceeds MEM_LIMIT_BYTES
+// (default 1 GiB, matching the connector container limit). Run with:
+//
+//	RUN_MEM_REPRO=1 go test -v -run TestStreamingMemoryClimbRepro -timeout 30m ./materialize-snowflake
+//
+// Knobs: MEM_LIMIT_BYTES (default 1 GiB), DOC_KB (default 1024), MAX_BLOBS
+// (default 48; 48 blobs is a ~12 GiB transaction).
+func TestStreamingMemoryClimbRepro(t *testing.T) {
+	if os.Getenv("RUN_MEM_REPRO") != "1" {
+		t.Skip("set RUN_MEM_REPRO=1 to run this memory reproduction")
+	}
+
+	memLimit := envInt("MEM_LIMIT_BYTES", 1<<30)
+	docKB := envInt("DOC_KB", 1024)
+	maxBlobs := envInt("MAX_BLOBS", 48)
+
+	zeroScale := 0
+	mapped := []*sql.Column{{Identifier: "ID"}, {Identifier: "DOC"}}
+	existing := []tableColumn{
+		{Name: "ID", Type: "number", LogicalType: "fixed", PhysicalType: "SB16", Scale: &zeroScale, Nullable: false, Ordinal: 1},
+		{Name: "DOC", Type: "variant", LogicalType: "variant", PhysicalType: "LOB", Nullable: true, Ordinal: 2},
+	}
+
+	encryptionKey := "aGVsbG8K"
+	rng := rand.New(rand.NewSource(1))
+
+	// Mimics streamManager.blobStats: one tracker per finished blob, all
+	// retained until the transaction's StartCommit calls flush.
+	var trackers []*blobStatsTracker
+	var totalBytes int64
+	var rowID int64
+
+	logMem := func(blobs int) uint64 {
+		runtime.GC()
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		var bufBytes int
+		for _, tr := range trackers {
+			bufBytes += cap(tr.buf)
+		}
+		t.Logf("blobs=%d dataWritten=%dMiB liveHeapAfterGC=%dMiB retainedXORBufs=%dMiB",
+			blobs, totalBytes>>20, ms.HeapAlloc>>20, bufBytes>>20)
+		return ms.HeapAlloc
+	}
+
+	for n := range maxBlobs {
+		bw, err := newBdecWriter(
+			discardWriteCloser{},
+			mapped,
+			existing,
+			encryptionKey,
+			blobFileName(fmt.Sprintf("blob_%d.bdec", n)),
+		)
+		require.NoError(t, err)
+
+		// Write rows until the blob's single row group is full, exactly as
+		// streamManager.writeRow does.
+		for !bw.done {
+			doc := makeDoc(rng, docKB<<10)
+			totalBytes += int64(len(doc))
+			require.NoError(t, bw.writeRow([]any{rowID, json.RawMessage(doc)}))
+			rowID++
+		}
+		require.NoError(t, bw.close())
+		trackers = append(trackers, bw.blobStats)
+
+		if live := logMem(n + 1); live > uint64(memLimit) {
+			t.Fatalf(
+				"OOM: live heap %d MiB exceeds %d MiB limit after %d blobs (%d MiB of transaction data)",
+				live>>20, memLimit>>20, n+1, totalBytes>>20,
+			)
+		}
+	}
+
+	// Optionally write a heap profile while the trackers are still retained,
+	// to attribute any remaining per-blob memory growth.
+	if profilePath := os.Getenv("HEAP_PROFILE"); profilePath != "" {
+		runtime.GC()
+		f, err := os.Create(profilePath)
+		require.NoError(t, err)
+		require.NoError(t, pprof.WriteHeapProfile(f))
+		require.NoError(t, f.Close())
+		t.Logf("wrote heap profile to %s", profilePath)
+	}
+
+	// Transaction commit: blob metadata is generated and the trackers are
+	// released, as streamManager.flush does.
+	ch := &channel{Database: "DB", Schema: "S", Table: "T", Channel: "C"}
+	for i, tr := range trackers {
+		_ = generateBlobMetadata(tr, ch, blobToken("basetoken", i))
+	}
+	trackers = nil
+	logMem(-1)
+}
+
+// makeDoc produces a JSON document of roughly n bytes with incompressible
+// content, approximating a real flow_document of that size.
+func makeDoc(rng *rand.Rand, n int) []byte {
+	raw := make([]byte, n*3/4)
+	rng.Read(raw)
+	return []byte(`{"data":"` + base64.StdEncoding.EncodeToString(raw) + `"}`)
+}
+
+func envInt(name string, fallback int) int {
+	if v := os.Getenv(name); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			panic(fmt.Sprintf("invalid %s: %v", name, err))
+		}
+		return n
+	}
+	return fallback
+}

--- a/materialize-snowflake/stream_http.go
+++ b/materialize-snowflake/stream_http.go
@@ -587,11 +587,11 @@ func generateBlobMetadata(
 		"rows":                                 tracked.rows,
 		"length":                               tracked.length,
 		"lengthUncompressed":                   tracked.lengthUncompressed,
-		"parquetMetadata.NumRows":              tracked.parquetMetadata.FileMetaData.NumRows,
-		"parquetMetadata.NumRowGroups":         len(tracked.parquetMetadata.FileMetaData.RowGroups),
-		"parquetMetadata.RowGroups[0].NumRows": tracked.parquetMetadata.FileMetaData.RowGroups[0].NumRows,
-		"parquetMetadata.RowGroups[0].TotalCompressedSize": tracked.parquetMetadata.FileMetaData.RowGroups[0].TotalCompressedSize,
-		"parquetMetadata.RowGroups[0].TotalByteSize":       tracked.parquetMetadata.FileMetaData.RowGroups[0].TotalByteSize,
+		"parquetMetadata.NumRows":              tracked.parquetStats.numRows,
+		"parquetMetadata.NumRowGroups":         tracked.parquetStats.numRowGroups,
+		"parquetMetadata.RowGroups[0].NumRows": tracked.parquetStats.rowGroupNumRows,
+		"parquetMetadata.RowGroups[0].TotalCompressedSize": tracked.parquetStats.totalCompressedSize,
+		"parquetMetadata.RowGroups[0].TotalByteSize":       tracked.parquetStats.totalByteSize,
 	}).Info("generated bdec metadata")
 
 	return &out


### PR DESCRIPTION
**Description:**

- reproduced the memory issues we saw with OOMing snowpipe streaming with large transactions (see `repro_oom_test.go`)
- fixed the memory consumption by capping it by:
  - most importantly by cutting the max/min string length statistics to `MAX_LOB_LENGTH` which could have grown to gigabytes if not truncated (the values get truncated anyway here https://github.com/estuary/connectors/blob/5517ed10f/materialize-snowflake/stream_http.go#L567-L571)
  - limit the chunk buffers we XOR during encryption to 64 KiB, these could have grown to megabytes per blob
  - we don't need to keep the whole `FileMetaData` from parquet, we only use some of it. `FileMetaData` has parts which are large (e.g. `Min` and `Max`) that we don't need to keep

Resolves #4710 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

