### PR TITLE
materialize-motherduck: reject full-URI staging bucket paths

### DIFF
--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -90,7 +90,7 @@ func (c config) Validate() error {
 			return fmt.Errorf("bucket name must not contain '.'")
 		}
 
-		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathS3); err != nil {
+		if err := blob.ValidateBucketPath(c.effectiveBucketPath()); err != nil {
 			return fmt.Errorf("bucketPathS3 %w", err)
 		}
 	case stagingBucketTypeGCS:
@@ -115,7 +115,7 @@ func (c config) Validate() error {
 			return fmt.Errorf("invalid gcsHMACSecret: must be base64 encoded")
 		}
 
-		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathGCS); err != nil {
+		if err := blob.ValidateBucketPath(c.effectiveBucketPath()); err != nil {
 			return fmt.Errorf("bucketPathGCS %w", err)
 		}
 	case stagingBucketTypeAzure:
@@ -156,7 +156,7 @@ func (c config) Validate() error {
 			return fmt.Errorf("invalid containerName: must not contain consecutive hyphens")
 		}
 
-		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathAzure); err != nil {
+		if err := blob.ValidateBucketPath(c.effectiveBucketPath()); err != nil {
 			return fmt.Errorf("bucketPathAzure %w", err)
 		}
 	case "":
@@ -345,9 +345,24 @@ func (c *config) db(ctx context.Context) (*stdsql.DB, error) {
 	return db, err
 }
 
+func (c config) effectiveBucketPath() string {
+	var path string
+	switch c.StagingBucket.StagingBucketType {
+	case stagingBucketTypeS3:
+		path = c.StagingBucket.BucketPathS3
+	case stagingBucketTypeGCS:
+		path = c.StagingBucket.BucketPathGCS
+	case stagingBucketTypeAzure:
+		path = c.StagingBucket.BucketPathAzure
+	}
+
+	// If BucketPath starts with a /, trim it so we don't end up with repeated /
+	// chars in the URI and so the object key does not start with a /.
+	return strings.TrimPrefix(path, "/")
+}
+
 func (c *config) toBucketAndPath(ctx context.Context) (blob.Bucket, string, error) {
 	var bucket blob.Bucket
-	var path string
 	var err error
 
 	switch c.StagingBucket.StagingBucketType {
@@ -368,13 +383,11 @@ func (c *config) toBucketAndPath(ctx context.Context) (blob.Bucket, string, erro
 		if bucket, err = blob.NewS3Bucket(ctx, c.StagingBucket.BucketS3, creds, s3Opts...); err != nil {
 			return nil, "", fmt.Errorf("creating S3 bucket: %w", err)
 		}
-		path = c.StagingBucket.BucketPathS3
 	case stagingBucketTypeGCS:
 		auth := option.WithCredentialsJSON([]byte(c.StagingBucket.CredentialsJSON))
 		if bucket, err = blob.NewGCSBucket(ctx, c.StagingBucket.BucketGCS, auth); err != nil {
 			return nil, "", fmt.Errorf("creating GCS bucket: %w", err)
 		}
-		path = c.StagingBucket.BucketPathGCS
 	case stagingBucketTypeAzure:
 		azureBucket, err := blob.NewAzureBlobBucket(ctx,
 			c.StagingBucket.ContainerName,
@@ -388,14 +401,9 @@ func (c *config) toBucketAndPath(ctx context.Context) (blob.Bucket, string, erro
 			AzureBlobBucket: azureBucket,
 			container:       c.StagingBucket.ContainerName,
 		}
-		path = c.StagingBucket.BucketPathAzure
 	}
 
-	// If BucketPath starts with a /, trim it so we don't end up with repeated /
-	// chars in the URI and so the object key does not start with a /.
-	path = strings.TrimPrefix(path, "/")
-
-	return bucket, path, nil
+	return bucket, c.effectiveBucketPath(), nil
 }
 
 type tableConfig struct {

--- a/materialize-motherduck/config.go
+++ b/materialize-motherduck/config.go
@@ -89,6 +89,10 @@ func (c config) Validate() error {
 		if strings.Contains(c.StagingBucket.BucketS3, ".") {
 			return fmt.Errorf("bucket name must not contain '.'")
 		}
+
+		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathS3); err != nil {
+			return fmt.Errorf("bucketPathS3 %w", err)
+		}
 	case stagingBucketTypeGCS:
 		for _, req := range [][]string{
 			{"bucketGCS", c.StagingBucket.BucketGCS},
@@ -109,6 +113,10 @@ func (c config) Validate() error {
 			return fmt.Errorf("invalid gcsHMACSecret: must be 40 characters")
 		} else if _, err := base64.StdEncoding.DecodeString(c.StagingBucket.GCSHMACSecret); err != nil {
 			return fmt.Errorf("invalid gcsHMACSecret: must be base64 encoded")
+		}
+
+		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathGCS); err != nil {
+			return fmt.Errorf("bucketPathGCS %w", err)
 		}
 	case stagingBucketTypeAzure:
 		for _, req := range [][]string{
@@ -146,6 +154,10 @@ func (c config) Validate() error {
 		}
 		if strings.Contains(containerName, "--") {
 			return fmt.Errorf("invalid containerName: must not contain consecutive hyphens")
+		}
+
+		if err := blob.ValidateBucketPath(c.StagingBucket.BucketPathAzure); err != nil {
+			return fmt.Errorf("bucketPathAzure %w", err)
 		}
 	case "":
 		return fmt.Errorf("missing 'stagingBucketType'")

--- a/materialize-motherduck/config_test.go
+++ b/materialize-motherduck/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,4 +46,93 @@ func TestS3ConfigWithEndpoint(t *testing.T) {
 		err := cfg.Validate()
 		require.NoError(t, err)
 	})
+}
+
+func TestBucketPathValidation(t *testing.T) {
+	// Validate() only checks that each dot-separated part is valid base64url,
+	// so this doesn't need to look like a real JWT.
+	baseToken := "YQ.YQ.YQ"
+
+	s3Config := func() config {
+		return config{
+			Token:    baseToken,
+			Database: "test_db",
+			Schema:   "main",
+			StagingBucket: stagingBucketConfig{
+				StagingBucketType: stagingBucketTypeS3,
+				stagingBucketS3Config: stagingBucketS3Config{
+					BucketS3:           "mybucket",
+					AWSAccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+					AWSSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+					Region:             "us-east-1",
+				},
+			},
+		}
+	}
+
+	gcsConfig := func() config {
+		return config{
+			Token:    baseToken,
+			Database: "test_db",
+			Schema:   "main",
+			StagingBucket: stagingBucketConfig{
+				StagingBucketType: stagingBucketTypeGCS,
+				stagingBucketGCSConfig: stagingBucketGCSConfig{
+					BucketGCS:       "mybucket",
+					CredentialsJSON: "{}",
+					GCSHMACAccessID: strings.Repeat("a", 61),
+					GCSHMACSecret:   base64.StdEncoding.EncodeToString(make([]byte, 30)), // 40 base64 chars
+				},
+			},
+		}
+	}
+
+	azureConfig := func() config {
+		return config{
+			Token:    baseToken,
+			Database: "test_db",
+			Schema:   "main",
+			StagingBucket: stagingBucketConfig{
+				StagingBucketType: stagingBucketTypeAzure,
+				stagingBucketAzureConfig: stagingBucketAzureConfig{
+					StorageAccountName: "mystorageaccount",
+					StorageAccountKey:  base64.StdEncoding.EncodeToString([]byte("test-storage-account-key-bytes-here")),
+					ContainerName:      "mycontainer",
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		baseConfig func() config
+		setPath    func(cfg *config, path string)
+	}{
+		{"S3", s3Config, func(cfg *config, path string) { cfg.StagingBucket.BucketPathS3 = path }},
+		{"GCS", gcsConfig, func(cfg *config, path string) { cfg.StagingBucket.BucketPathGCS = path }},
+		{"Azure", azureConfig, func(cfg *config, path string) { cfg.StagingBucket.BucketPathAzure = path }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" valid bucket path prefix", func(t *testing.T) {
+			cfg := tc.baseConfig()
+			tc.setPath(&cfg, "some/prefix/path")
+			err := cfg.Validate()
+			require.NoError(t, err)
+		})
+
+		t.Run(tc.name+" rejects leading slash", func(t *testing.T) {
+			cfg := tc.baseConfig()
+			tc.setPath(&cfg, "/some/prefix")
+			err := cfg.Validate()
+			require.ErrorContains(t, err, "cannot start with /")
+		})
+
+		t.Run(tc.name+" rejects full URI", func(t *testing.T) {
+			cfg := tc.baseConfig()
+			tc.setPath(&cfg, "s3://bucket/prefix")
+			err := cfg.Validate()
+			require.ErrorContains(t, err, "must be a bare key prefix within the bucket")
+		})
+	}
 }

--- a/materialize-motherduck/config_test.go
+++ b/materialize-motherduck/config_test.go
@@ -121,16 +121,28 @@ func TestBucketPathValidation(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run(tc.name+" rejects leading slash", func(t *testing.T) {
+		t.Run(tc.name+" tolerates leading slash", func(t *testing.T) {
+			// A leading slash is trimmed by effectiveBucketPath() before it
+			// reaches ValidateBucketPath, so it validates successfully rather
+			// than being rejected. This preserves the connector's existing
+			// tolerance of a leading slash, matching effectiveBucketPath() on
+			// materialize-bigquery and materialize-redshift.
 			cfg := tc.baseConfig()
 			tc.setPath(&cfg, "/some/prefix")
 			err := cfg.Validate()
-			require.ErrorContains(t, err, "cannot start with /")
+			require.NoError(t, err)
 		})
 
 		t.Run(tc.name+" rejects full URI", func(t *testing.T) {
 			cfg := tc.baseConfig()
 			tc.setPath(&cfg, "s3://bucket/prefix")
+			err := cfg.Validate()
+			require.ErrorContains(t, err, "must be a bare key prefix within the bucket")
+		})
+
+		t.Run(tc.name+" rejects full URI with leading slash", func(t *testing.T) {
+			cfg := tc.baseConfig()
+			tc.setPath(&cfg, "/s3://bucket/prefix")
 			err := cfg.Validate()
 			require.ErrorContains(t, err, "must be a bare key prefix within the bucket")
 		})


### PR DESCRIPTION
## Problem

Follow-up to #4720 (shared `blob.ValidateBucketPath`). `materialize-motherduck` was missed in that pass. It has three staging-prefix fields — `bucketPathS3`, `bucketPathGCS`, `bucketPathAzure` — that are joined onto object keys via `path.Join` (`staged_file.go`, `driver.go`). A value set to a full URI like `s3://bucket/prefix` is collapsed by `path.Clean` to `s3:/prefix`, leaving a stray `s3:` path segment that corrupts staged-file keys — the same footgun #4720 fixed for the other object-staging materializations.

## Fix

Guard the staging bucket path in each backend branch of `config.Validate()` with the shared `blob.ValidateBucketPath` helper, wrapping the error with the actual JSON field name (`bucketPathS3` / `bucketPathGCS` / `bucketPathAzure`).

## Testing

- `go test ./materialize-motherduck/ -short` passes (includes `TestAzureConfigValidation`, which exercises `Validate()`).
- `go build` and `go vet` clean.

## Note

motherduck already trimmed a leading `/` and had no scheme check, so a full-URI staging path was already producing broken keys; rejecting it at publish surfaces the error earlier rather than regressing a working pipeline.
