### PR TITLE
materialize-iceberg: allow gated v3 fields on v2 files, but log them

### DIFF
--- a/materialize-iceberg/catalog/catalog.go
+++ b/materialize-iceberg/catalog/catalog.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/apache/iceberg-go/table"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/clientcredentials"
 	"resty.dev/v3"
 )
@@ -392,6 +394,54 @@ func (c *Catalog) ListTables(ctx context.Context, ns string) ([]string, error) {
 	return names, nil
 }
 
+// versionScopedMetadataFields are table metadata fields mapped to the format
+// version that introduced them. Some catalog services include fields from
+// newer format versions in metadata for older-version tables, most notably
+// the v3 row-lineage field 'next-row-id' appearing in v2 metadata. iceberg-go
+// v0.6.0+ rejects such metadata outright, where v0.5.0 ignored the extra
+// fields; dropping them before parsing retains the lenient reading behavior.
+var versionScopedMetadataFields = map[string]int{
+	"last-sequence-number": 2,
+	"next-row-id":          3,
+	"encryption-keys":      3,
+}
+
+// dropFieldsBeyondFormatVersion removes metadata fields that are only valid
+// in format versions newer than the metadata's declared format-version,
+// reporting the dropped field names and the declared version so callers can
+// log which catalog provider is writing out-of-spec metadata. The raw
+// metadata is returned unchanged if nothing needs to be dropped, or if it
+// isn't shaped like table metadata at all - full validation of the metadata
+// is left to iceberg-go's parsing.
+func dropFieldsBeyondFormatVersion(raw json.RawMessage) (json.RawMessage, []string, int) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return raw, nil, 0
+	}
+
+	var version int
+	if err := json.Unmarshal(fields["format-version"], &version); err != nil || version < 1 {
+		return raw, nil, 0
+	}
+
+	var dropped []string
+	for f, introduced := range versionScopedMetadataFields {
+		if _, present := fields[f]; present && version < introduced {
+			delete(fields, f)
+			dropped = append(dropped, f)
+		}
+	}
+	if len(dropped) == 0 {
+		return raw, nil, version
+	}
+	slices.Sort(dropped)
+
+	if sanitized, err := json.Marshal(fields); err == nil {
+		return sanitized, dropped, version
+	}
+	return raw, nil, version
+}
+
 func (c *Catalog) GetTable(ctx context.Context, ns string, name string) (*Table, error) {
 	type resp struct {
 		Config           tableConfig     `json:"config"`
@@ -404,7 +454,20 @@ func (c *Catalog) GetTable(ctx context.Context, ns string, name string) (*Table,
 		return nil, err
 	}
 
-	meta, err := table.ParseMetadataBytes(res.RawMeta)
+	sanitized, dropped, version := dropFieldsBeyondFormatVersion(res.RawMeta)
+	if len(dropped) > 0 {
+		// Identify catalog providers that write out-of-spec metadata so they
+		// can be notified upstream.
+		log.WithFields(log.Fields{
+			"catalog":       c.rHttp.BaseURL(),
+			"namespace":     ns,
+			"table":         name,
+			"formatVersion": version,
+			"fields":        dropped,
+		}).Warn("dropped metadata fields not valid for the table's format version")
+	}
+
+	meta, err := table.ParseMetadataBytes(sanitized)
 	if err != nil {
 		return nil, err
 	}

--- a/materialize-iceberg/catalog/metadata_lenient_test.go
+++ b/materialize-iceberg/catalog/metadata_lenient_test.go
@@ -1,0 +1,143 @@
+package catalog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetTableToleratesVersionScopedFields is a regression test for a
+// production failure seen after upgrading iceberg-go from v0.5.0 to v0.6.0:
+//
+//	completeRecovery: store.RestoreCheckpoint: getting table: invalid or
+//	missing format-version in table metadata: v3-only field 'next-row-id'
+//	present in v2 metadata
+//
+// Some catalog services include fields from newer format versions in
+// loadTable responses for older-version tables. iceberg-go v0.6.0 added
+// strict version-scoped field validation which rejects such metadata, where
+// v0.5.0 ignored the extra fields. GetTable drops those fields before
+// parsing to retain the lenient reading behavior.
+//
+// The fixture is real v2 metadata produced by the local docker-compose
+// Polaris stack after a Spark data commit; the offending fields are injected
+// per test case.
+func TestGetTableToleratesVersionScopedFields(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/v2-metadata.json")
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name   string
+		inject map[string]any
+	}{
+		{name: "clean metadata", inject: nil},
+		{name: "next-row-id in v2", inject: map[string]any{"next-row-id": 0}},
+		{name: "encryption-keys in v2", inject: map[string]any{
+			"encryption-keys": []map[string]string{{"key-id": "k1", "encrypted-key-metadata": "abc123"}},
+		}},
+		{name: "both v3-only fields in v2", inject: map[string]any{
+			"next-row-id":     42,
+			"encryption-keys": []map[string]string{{"key-id": "k1", "encrypted-key-metadata": "abc123"}},
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var meta map[string]any
+			require.NoError(t, json.Unmarshal(fixture, &meta))
+			for k, v := range tt.inject {
+				meta[k] = v
+			}
+			metaBytes, err := json.Marshal(meta)
+			require.NoError(t, err)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /v1/config", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"defaults":  map[string]string{},
+					"overrides": map[string]string{},
+				})
+			})
+			mux.HandleFunc("GET /v1/namespaces/some_ns/tables/some_table", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"metadata-location": "s3://bucket/metadata/v2.metadata.json",
+					"metadata":          json.RawMessage(metaBytes),
+				})
+			})
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			scope := "my-scope"
+			cat, err := New(t.Context(), ts.URL, "my-warehouse", WithClientCredential("my-creds", "my-uri", &scope))
+			require.NoError(t, err)
+
+			table, err := cat.GetTable(t.Context(), "some_ns", "some_table")
+			require.NoError(t, err)
+			require.EqualValues(t, 2, table.Metadata.Version())
+			require.Len(t, table.Metadata.Snapshots(), 1)
+			require.Equal(t, "s3://bucket/metadata/v2.metadata.json", table.MetadataLocation)
+		})
+	}
+}
+
+// TestDropFieldsBeyondFormatVersion covers the sanitizer's edge cases
+// directly: metadata that isn't JSON at all, missing or invalid
+// format-version, and fields that are legitimate for the declared version
+// must all pass through unchanged.
+func TestDropFieldsBeyondFormatVersion(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		in          string
+		want        string
+		wantDropped []string
+	}{
+		{
+			name: "not an object passes through",
+			in:   `"just a string"`,
+			want: `"just a string"`,
+		},
+		{
+			name: "missing format-version passes through",
+			in:   `{"next-row-id": 0}`,
+			want: `{"next-row-id": 0}`,
+		},
+		{
+			name: "invalid format-version passes through",
+			in:   `{"format-version": "two", "next-row-id": 0}`,
+			want: `{"format-version": "two", "next-row-id": 0}`,
+		},
+		{
+			name: "v3 keeps its own fields",
+			in:   `{"format-version": 3, "next-row-id": 7}`,
+			want: `{"format-version": 3, "next-row-id": 7}`,
+		},
+		{
+			name: "v2 keeps last-sequence-number",
+			in:   `{"format-version": 2, "last-sequence-number": 5}`,
+			want: `{"format-version":2,"last-sequence-number":5}`,
+		},
+		{
+			name:        "v2 drops next-row-id",
+			in:          `{"format-version": 2, "next-row-id": 0, "last-sequence-number": 5}`,
+			want:        `{"format-version":2,"last-sequence-number":5}`,
+			wantDropped: []string{"next-row-id"},
+		},
+		{
+			name:        "v1 drops last-sequence-number and v3-only fields",
+			in:          `{"format-version": 1, "last-sequence-number": 5, "next-row-id": 0, "encryption-keys": []}`,
+			want:        `{"format-version":1}`,
+			wantDropped: []string{"encryption-keys", "last-sequence-number", "next-row-id"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, dropped, _ := dropFieldsBeyondFormatVersion(json.RawMessage(tt.in))
+			require.JSONEq(t, tt.want, string(got))
+			require.Equal(t, tt.wantDropped, dropped)
+		})
+	}
+}

--- a/materialize-iceberg/catalog/testdata/v2-metadata.json
+++ b/materialize-iceberg/catalog/testdata/v2-metadata.json
@@ -1,0 +1,104 @@
+{
+  "format-version": 2,
+  "table-uuid": "cefe08fd-c720-4f53-8a07-e142d48a4d6d",
+  "location": "s3://warehouse/repro_ns/repro_table",
+  "last-sequence-number": 1,
+  "last-updated-ms": 1783445069235,
+  "last-column-id": 2,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "identifier-field-ids": [
+        1
+      ],
+      "fields": [
+        {
+          "id": 1,
+          "name": "id",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "val",
+          "required": false,
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": []
+    }
+  ],
+  "last-partition-id": 999,
+  "default-sort-order-id": 0,
+  "sort-orders": [
+    {
+      "order-id": 0,
+      "fields": []
+    }
+  ],
+  "properties": {
+    "created-at": "2026-07-07T17:23:08.098523967Z",
+    "write.parquet.compression-codec": "zstd",
+    "flow_test": "1"
+  },
+  "current-snapshot-id": 7132070734803993372,
+  "refs": {
+    "main": {
+      "snapshot-id": 7132070734803993372,
+      "type": "branch"
+    }
+  },
+  "snapshots": [
+    {
+      "sequence-number": 1,
+      "snapshot-id": 7132070734803993372,
+      "timestamp-ms": 1783445069235,
+      "summary": {
+        "operation": "append",
+        "spark.app.id": "app-20260707172202-0000",
+        "added-data-files": "1",
+        "added-records": "1",
+        "added-files-size": "651",
+        "changed-partition-count": "1",
+        "total-records": "1",
+        "total-files-size": "651",
+        "total-data-files": "1",
+        "total-delete-files": "0",
+        "total-position-deletes": "0",
+        "total-equality-deletes": "0",
+        "engine-version": "3.5.5",
+        "app-id": "app-20260707172202-0000",
+        "engine-name": "spark",
+        "iceberg-version": "Apache Iceberg 1.6.1 (commit 8e9d59d299be42b0bca9461457cd1e95dbaad086)"
+      },
+      "manifest-list": "s3://warehouse/repro_ns/repro_table/metadata/snap-7132070734803993372-1-8cfcf776-d065-48b8-993f-fd48764f65de.avro",
+      "schema-id": 0
+    }
+  ],
+  "statistics": [],
+  "partition-statistics": [],
+  "snapshot-log": [
+    {
+      "timestamp-ms": 1783445069235,
+      "snapshot-id": 7132070734803993372
+    }
+  ],
+  "metadata-log": [
+    {
+      "timestamp-ms": 1783444988162,
+      "metadata-file": "s3://warehouse/repro_ns/repro_table/metadata/00000-f1b2ba12-2de1-4a0c-8534-2ec473235f56.metadata.json"
+    },
+    {
+      "timestamp-ms": 1783445018036,
+      "metadata-file": "s3://warehouse/repro_ns/repro_table/metadata/00001-f68f62ed-1bc9-4454-98bd-36be42ce4c22.metadata.json"
+    }
+  ]
+}


### PR DESCRIPTION
**Regression?**

Yes https://github.com/estuary/connectors/pull/4750

**Description:**

- see https://github.com/apache/iceberg-go/commit/2e6b2b6da79189232189d4714bec2b09cd9bc98b
- iceberg-go v0.5.0 used to allow these invalid metadata. Now it rejects them with an error.
- For now we want to still allow them, but added a log so we can contact the catalog providers to fix this and then we can remove this "drop the extra metadata" logic

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

