### PR TITLE
materialize-iceberg: propagate errors of dropFieldsBeyondFormatVersion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,9 @@ All connector configurations use JSON Schema. See [config_schema_guidelines.md](
 - Include edge cases: data types, limits, error conditions
 - Integration tests capture to SQLite and verify against `expected.txt`
 
+### Error Handling
+- Do not swallow errors, we must propagate errors and should never silently drop errors
+
 ## Protocol References
 
 - [capture.proto](https://github.com/estuary/flow/blob/master/go/protocols/capture/capture.proto) — Capture protocol

--- a/materialize-iceberg/catalog/catalog.go
+++ b/materialize-iceberg/catalog/catalog.go
@@ -409,19 +409,26 @@ var versionScopedMetadataFields = map[string]int{
 // dropFieldsBeyondFormatVersion removes metadata fields that are only valid
 // in format versions newer than the metadata's declared format-version,
 // reporting the dropped field names and the declared version so callers can
-// log which catalog provider is writing out-of-spec metadata. The raw
-// metadata is returned unchanged if nothing needs to be dropped, or if it
-// isn't shaped like table metadata at all - full validation of the metadata
-// is left to iceberg-go's parsing.
-func dropFieldsBeyondFormatVersion(raw json.RawMessage) (json.RawMessage, []string, int) {
+// log which catalog provider is writing out-of-spec metadata. Metadata
+// without a format-version field is returned unchanged: iceberg-go's parsing
+// produces the canonical error for that case, and full validation of the
+// metadata is left to it in general.
+func dropFieldsBeyondFormatVersion(raw json.RawMessage) (json.RawMessage, []string, int, error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
-		return raw, nil, 0
+		return nil, nil, 0, fmt.Errorf("parsing table metadata: %w", err)
 	}
 
+	versionRaw, ok := fields["format-version"]
+	if !ok {
+		return raw, nil, 0, nil
+	}
 	var version int
-	if err := json.Unmarshal(fields["format-version"], &version); err != nil || version < 1 {
-		return raw, nil, 0
+	if err := json.Unmarshal(versionRaw, &version); err != nil {
+		return nil, nil, 0, fmt.Errorf("parsing format-version: %w", err)
+	}
+	if version < 1 {
+		return nil, nil, 0, fmt.Errorf("invalid format-version %d", version)
 	}
 
 	var dropped []string
@@ -432,14 +439,15 @@ func dropFieldsBeyondFormatVersion(raw json.RawMessage) (json.RawMessage, []stri
 		}
 	}
 	if len(dropped) == 0 {
-		return raw, nil, version
+		return raw, nil, version, nil
 	}
 	slices.Sort(dropped)
 
-	if sanitized, err := json.Marshal(fields); err == nil {
-		return sanitized, dropped, version
+	sanitized, err := json.Marshal(fields)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("re-encoding sanitized table metadata: %w", err)
 	}
-	return raw, nil, version
+	return sanitized, dropped, version, nil
 }
 
 func (c *Catalog) GetTable(ctx context.Context, ns string, name string) (*Table, error) {
@@ -454,7 +462,10 @@ func (c *Catalog) GetTable(ctx context.Context, ns string, name string) (*Table,
 		return nil, err
 	}
 
-	sanitized, dropped, version := dropFieldsBeyondFormatVersion(res.RawMeta)
+	sanitized, dropped, version, err := dropFieldsBeyondFormatVersion(res.RawMeta)
+	if err != nil {
+		return nil, fmt.Errorf("sanitizing table metadata: %w", err)
+	}
 	if len(dropped) > 0 {
 		// Identify catalog providers that write out-of-spec metadata so they
 		// can be notified upstream.

--- a/materialize-iceberg/catalog/metadata_lenient_test.go
+++ b/materialize-iceberg/catalog/metadata_lenient_test.go
@@ -95,11 +95,12 @@ func TestDropFieldsBeyondFormatVersion(t *testing.T) {
 		in          string
 		want        string
 		wantDropped []string
+		wantErr     string
 	}{
 		{
-			name: "not an object passes through",
-			in:   `"just a string"`,
-			want: `"just a string"`,
+			name:    "not an object errors",
+			in:      `"just a string"`,
+			wantErr: "parsing table metadata",
 		},
 		{
 			name: "missing format-version passes through",
@@ -107,9 +108,14 @@ func TestDropFieldsBeyondFormatVersion(t *testing.T) {
 			want: `{"next-row-id": 0}`,
 		},
 		{
-			name: "invalid format-version passes through",
-			in:   `{"format-version": "two", "next-row-id": 0}`,
-			want: `{"format-version": "two", "next-row-id": 0}`,
+			name:    "non-integer format-version errors",
+			in:      `{"format-version": "two", "next-row-id": 0}`,
+			wantErr: "parsing format-version",
+		},
+		{
+			name:    "nonsensical format-version errors",
+			in:      `{"format-version": 0, "next-row-id": 0}`,
+			wantErr: "invalid format-version 0",
 		},
 		{
 			name: "v3 keeps its own fields",
@@ -135,7 +141,12 @@ func TestDropFieldsBeyondFormatVersion(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, dropped, _ := dropFieldsBeyondFormatVersion(json.RawMessage(tt.in))
+			got, dropped, _, err := dropFieldsBeyondFormatVersion(json.RawMessage(tt.in))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
 			require.JSONEq(t, tt.want, string(got))
 			require.Equal(t, tt.wantDropped, dropped)
 		})


### PR DESCRIPTION
**Regression?**

yes #4771

**Description:**

- properly propagate errors in `dropFieldsBeyondFormatVersion`

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

