### PR TITLE
materialize-snowflake: remove header logging for insertReport

### DIFF
--- a/materialize-snowflake/pipe.go
+++ b/materialize-snowflake/pipe.go
@@ -375,7 +375,7 @@ func (c *PipeClient) InsertReport(pipeName string) (*InsertReportResponse, error
 
 	log.WithFields(log.Fields{
 		"url":      url,
-		"headers":  req.Header,
+		"status":   resp.StatusCode,
 		"response": response,
 	}).Debug("insertReport")
 


### PR DESCRIPTION
I want to make sure that the status code is as expected on this request, but more importantly remove the header logging since it contains sensitive info.

**Regression?**

No

**Description:**

I want to make sure that the status code is as expected on this request, but more importantly remove the header logging since it contains sensitive info.

**Workflow steps:**

Enable debug logging.

**Documentation links affected:**

No changes

**Notes for reviewers:**

(anything that might help someone review this PR)

