### PR TITLE
source-quickbooks: switch to "bring your own prod app" model

### DIFF
--- a/source-quickbooks/config.yaml
+++ b/source-quickbooks/config.yaml
@@ -3,6 +3,4 @@ credentials:
   client_secret: dummy_client_secret
   credentials_title: OAuth Credentials
   refresh_token: dummy_refresh_token
-  access_token: dummy_access_token
-  access_token_expires_at: 1762263652
 realm_id: "1234567890"

--- a/source-quickbooks/source_quickbooks/__init__.py
+++ b/source-quickbooks/source_quickbooks/__init__.py
@@ -15,7 +15,6 @@ from estuary_cdk.flow import (
 )
 
 from .models import (
-    OAUTH2_SPEC,
     ConnectorState,
     EndpointConfig,
 )
@@ -31,7 +30,6 @@ class Connector(
     async def spec(self, _: request.Spec, logger: Logger) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
-            oauth2=OAUTH2_SPEC,
             documentationUrl="https://go.estuary.dev/source-quickbooks",
             resourceConfigSchema=common.ResourceConfig.model_json_schema(),
             resourcePathPointers=common.ResourceConfig.PATH_POINTERS,

--- a/source-quickbooks/source_quickbooks/models.py
+++ b/source-quickbooks/source_quickbooks/models.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar, override
 
-from estuary_cdk.capture.common import (
-    BaseDocument,
-    ResourceState,
-)
 from estuary_cdk.capture.common import (
     ConnectorState as GenericConnectorState,
 )
+from estuary_cdk.capture.common import (
+    ResourceState,
+)
+from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.flow import (
     OAuth2ClientCredentialsPlacement,
     OAuth2Spec,
@@ -53,14 +53,32 @@ OAUTH2_SPEC = OAuth2Spec(
 )
 
 
-if TYPE_CHECKING:
-    OAuth2Credentials = RotatingOAuth2Credentials.with_client_credentials_placement(
+# Credentials for a user-provided Intuit app. Unlike credentials built with
+# `for_provider`, this class carries no `x-oauth2-provider` annotation, so the
+# UI collects the app's credentials directly instead of offering an OAuth login
+# against a shared Estuary app.
+class OAuth2Credentials(RotatingOAuth2Credentials):
+    client_credentials_placement: ClassVar[OAuth2ClientCredentialsPlacement] = (
         OAuth2ClientCredentialsPlacement.HEADERS
     )
-else:
-    OAuth2Credentials = RotatingOAuth2Credentials.with_client_credentials_placement(
-        OAuth2ClientCredentialsPlacement.HEADERS
-    ).for_provider(OAUTH2_SPEC.provider)
+
+    # `access_token` and `access_token_expires_at` are provided placeholders to
+    # users are not required to fill them in; the connector will generate new
+    # credentials on `Open`
+    access_token: str = Field(
+        default="PLACEHOLDER",
+        title="Access Token",
+        json_schema_extra={"secret": True, "x-hidden-field": True},
+    )
+    access_token_expires_at: datetime = Field(
+        default=EPOCH,
+        title="Access token expiration time.",
+        json_schema_extra={"x-hidden-field": True},
+    )
+
+    @override
+    def _you_must_build_oauth2_credentials_for_a_provider(self):
+        pass
 
 
 class EndpointConfig(BaseModel):

--- a/source-quickbooks/source_quickbooks/resources.py
+++ b/source-quickbooks/source_quickbooks/resources.py
@@ -5,12 +5,12 @@ from typing import TypeVar
 
 from estuary_cdk.capture import Task
 from estuary_cdk.capture.common import (
-    BaseDocument,
     Resource,
     ResourceConfig,
     ResourceState,
     open_binding,
 )
+from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.flow import CaptureBinding, ValidationError
 from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
 
@@ -30,11 +30,39 @@ from .models import (
     QuickBooksEntity,
 )
 
+AUTHENTICATION_ERROR_MSG = (
+    "Authentication with QuickBooks failed. This connector requires "
+    "your own QuickBooks app: please create one, or check the status "
+    "of your existing app, at https://developer.intuit.com. Then "
+    "confirm this capture is configured with the app's client ID and "
+    "client secret, and with an unexpired refresh token issued by it. "
+    "See https://go.estuary.dev/source-quickbooks for setup instructions."
+    "\n\n"
+)
+
 
 async def validate_credentials(http: HTTPMixin, config: EndpointConfig, log: Logger):
-    http.token_source = TokenSource(
-        oauth_spec=OAUTH2_SPEC, credentials=config.credentials
-    )
+    credentials = config.credentials
+    http.token_source = TokenSource(oauth_spec=OAUTH2_SPEC, credentials=credentials)
+
+    # An absent or expired access token must be temporarily exchanged here for
+    # the validation probe to have a usable token. Durable rotation will happen
+    # during connector startup. While most sources only offer single-use
+    # refresh tokens, QuickBooks' are reusable for prolonged periods of time.
+    if credentials.access_token_expires_at < datetime.now(tz=UTC) + timedelta(
+        minutes=5
+    ):
+        try:
+            token_response = await http.token_source.initialize_oauth2_tokens(log, http)
+        except HTTPError as err:
+            raise ValidationError([AUTHENTICATION_ERROR_MSG + err.message])
+
+        credentials.access_token = token_response.access_token
+        credentials.access_token_expires_at = datetime.now(tz=UTC) + timedelta(
+            seconds=token_response.expires_in
+        )
+        if token_response.refresh_token:
+            credentials.refresh_token = token_response.refresh_token
 
     base_url = SANDBOX_API_BASE_URL if config.is_sandbox else PROD_API_BASE_URL
 
@@ -53,7 +81,7 @@ async def validate_credentials(http: HTTPMixin, config: EndpointConfig, log: Log
     except HTTPError as err:
         msg = f"Encountered error validating credentials.\n\n{err.message}"
         if err.code == 401:
-            msg = f"Invalid credentials. Please confirm the provided credentials are correct.\n\n{err.message}"
+            msg = AUTHENTICATION_ERROR_MSG + err.message
 
         raise ValidationError([msg])
     except StopAsyncIteration:
@@ -111,9 +139,7 @@ async def all_resources(
             model=resource,
             open=functools.partial(open_all_bindings, resource),
             initial_state=ResourceState(
-                backfill=ResourceState.Backfill(
-                    cutoff=cutoff, next_page=None
-                ),
+                backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None),
                 inc=ResourceState.Incremental(cursor=cutoff),
             ),
             initial_config=ResourceConfig(

--- a/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-quickbooks/tests/snapshots/snapshots__spec__stdout.json
@@ -3,7 +3,7 @@
     "protocol": 3032023,
     "configSchema": {
       "$defs": {
-        "RotatingOAuth2Credentials": {
+        "OAuth2Credentials": {
           "properties": {
             "credentials_title": {
               "const": "OAuth Credentials",
@@ -27,26 +27,27 @@
               "type": "string"
             },
             "access_token": {
+              "default": "PLACEHOLDER",
               "secret": true,
               "title": "Access Token",
-              "type": "string"
+              "type": "string",
+              "x-hidden-field": true
             },
             "access_token_expires_at": {
+              "default": "1970-01-01T00:00:00Z",
               "format": "date-time",
               "title": "Access token expiration time.",
-              "type": "string"
+              "type": "string",
+              "x-hidden-field": true
             }
           },
           "required": [
             "client_id",
             "client_secret",
-            "refresh_token",
-            "access_token",
-            "access_token_expires_at"
+            "refresh_token"
           ],
           "title": "OAuth",
-          "type": "object",
-          "x-oauth2-provider": "intuit"
+          "type": "object"
         }
       },
       "properties": {
@@ -57,7 +58,7 @@
           "type": "string"
         },
         "credentials": {
-          "$ref": "#/$defs/RotatingOAuth2Credentials",
+          "$ref": "#/$defs/OAuth2Credentials",
           "order": 1,
           "title": "Authentication"
         },
@@ -120,21 +121,6 @@
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-quickbooks",
-    "oauth2": {
-      "provider": "intuit",
-      "authUrlTemplate": "https://appcenter.intuit.com/connect/oauth2?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=com.intuit.quickbooks.accounting&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
-      "accessTokenUrlTemplate": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
-      "accessTokenBody": "grant_type=authorization_code&code={{#urlencode}}{{{ code }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}",
-      "accessTokenHeaders": {
-        "Authorization": "Basic {{#basicauth}}{{{ client_id }}}:{{{ client_secret }}}{{/basicauth}}",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "accessTokenResponseMap": {
-        "access_token": "/access_token",
-        "access_token_expires_at": "{{#now_plus}}{{ expires_in }}{{/now_plus}}",
-        "refresh_token": "/refresh_token"
-      }
-    },
     "resourcePathPointers": [
       "/name"
     ]


### PR DESCRIPTION
**Description:**

The QuickBooks connector used to rely on an Estuary-hosted production application. While this worked initially, the API queries we run use a metered CorePlus endpoint that consumed our requests budget as adoption grew. Once the monthly budget was exhausted, access token refreshes would 429 until the month rolled over.

This commit switches to a new approach where users provide a client id, secret and refresh token for their own app. A single capture's API usage fits comfortably within the free tier.

This is a breaking change: all users will be required to apply for a new app before they can re-enable their tasks.

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Tested with a local stack using a sandbox environment on an unpublished app. Documents are captured as expected.

