### PR TITLE
materialize-iceberg: don't add new required columns to existing tables

### DIFF
--- a/materialize-iceberg/.snapshots/TestComputeSchemas
+++ b/materialize-iceberg/.snapshots/TestComputeSchemas
@@ -22,10 +22,11 @@ table {
 	7: decimalToFloat: required decimal(38, 0)
 	8: timestampToStr: required timestamptz
 	13: new: optional string
-	14: dateToStr_flow_tmp: optional string
-	15: intToDecimal_flow_tmp: optional decimal(38, 0)
-	16: decimalToFloat_flow_tmp: required double
-	17: timestampToStr_flow_tmp: optional string
+	14: newRequired: optional string
+	15: dateToStr_flow_tmp: optional string
+	16: intToDecimal_flow_tmp: optional decimal(38, 0)
+	17: decimalToFloat_flow_tmp: optional double
+	18: timestampToStr_flow_tmp: optional string
 }
 
 --- After Migrate Schema ---
@@ -35,8 +36,9 @@ table {
 	3: val1: required string
 	4: val2: optional boolean
 	13: new: optional string
-	14: dateToStr: optional string
-	15: intToDecimal: optional decimal(38, 0)
-	16: decimalToFloat: required double
-	17: timestampToStr: optional string
+	14: newRequired: optional string
+	15: dateToStr: optional string
+	16: intToDecimal: optional decimal(38, 0)
+	17: decimalToFloat: optional double
+	18: timestampToStr: optional string
 }

--- a/materialize-iceberg/.snapshots/TestIntegration-apply
+++ b/materialize-iceberg/.snapshots/TestIntegration-apply
@@ -317,7 +317,7 @@ remove a single required field:
 add and remove many fields:
 {"Name":"_meta/flow_truncated","Nullable":false,"Type":"boolean"}
 {"Name":"addedOptionalString","Nullable":true,"Type":"string"}
-{"Name":"addedRequiredString","Nullable":false,"Type":"string"}
+{"Name":"addedRequiredString","Nullable":true,"Type":"string"}
 {"Name":"flow_document","Nullable":false,"Type":"string"}
 {"Name":"flow_published_at","Nullable":false,"Type":"timestamptz"}
 {"Name":"key","Nullable":false,"Type":"string"}

--- a/materialize-iceberg/type_mapping.go
+++ b/materialize-iceberg/type_mapping.go
@@ -142,10 +142,10 @@ func computeSchemaForNewTable(res boilerplate.MappedBinding[config, resource, ma
 	var fields []iceberg.NestedField
 
 	// In Iceberg terms, identifier fields are the "keys" of a table.
-	identifierFields, lastId := appendProjectionsAsFields(&fields, res.Keys, 0)
-	_, lastId = appendProjectionsAsFields(&fields, res.Values, lastId)
+	identifierFields, lastId := appendProjectionsAsFields(&fields, res.Keys, 0, false)
+	_, lastId = appendProjectionsAsFields(&fields, res.Values, lastId, false)
 	if p := res.Document; p != nil {
-		appendProjectionsAsFields(&fields, []boilerplate.MappedProjection[mapped]{*p}, lastId)
+		appendProjectionsAsFields(&fields, []boilerplate.MappedProjection[mapped]{*p}, lastId, false)
 	}
 
 	if res.DeltaUpdates {
@@ -188,8 +188,15 @@ func computeSchemaForUpdatedTable(
 		tempMigrateProjections = append(tempMigrateProjections, temp)
 	}
 
-	_, lastId := appendProjectionsAsFields(&nextFields, update.NewProjections, currentHighestID)
-	appendProjectionsAsFields(&nextFields, tempMigrateProjections, lastId)
+	// S3 Tables' REST catalog rejects an add-schema update that introduces a
+	// brand-new required column, even with initial-default/write-default set.
+	// Columns newly appended to an existing table - ordinary new projections
+	// and migration temp columns alike - are therefore always created
+	// optional, matching how materialize-sql treats newly-added columns as
+	// nullable regardless of MustExist and only enforces required-ness at
+	// fresh table creation.
+	_, lastId := appendProjectionsAsFields(&nextFields, update.NewProjections, currentHighestID, true)
+	appendProjectionsAsFields(&nextFields, tempMigrateProjections, lastId, true)
 
 	return iceberg.NewSchemaWithIdentifiers(current.ID+1, current.IdentifierFieldIDs, nextFields...)
 }
@@ -230,7 +237,7 @@ func computeSchemaForCompletedMigrations(current *iceberg.Schema, fieldsToMigrat
 	return iceberg.NewSchemaWithIdentifiers(current.ID+1, current.IdentifierFieldIDs, nextFields...)
 }
 
-func appendProjectionsAsFields(dst *[]iceberg.NestedField, ps []boilerplate.MappedProjection[mapped], startID int) ([]int, int) {
+func appendProjectionsAsFields(dst *[]iceberg.NestedField, ps []boilerplate.MappedProjection[mapped], startID int, forceOptional bool) ([]int, int) {
 	id := startID
 	var ids []int
 
@@ -241,11 +248,13 @@ func appendProjectionsAsFields(dst *[]iceberg.NestedField, ps []boilerplate.Mapp
 			id += 1
 		}
 
+		required := !forceOptional && ((p.MustExist && !p.Mapped.Nullable) || p.IsPrimaryKey)
+
 		*dst = append(*dst, iceberg.NestedField{
 			ID:       id,
 			Name:     p.Mapped.Name,
 			Type:     p.Mapped.type_,
-			Required: (p.MustExist && !p.Mapped.Nullable) || p.IsPrimaryKey,
+			Required: required,
 			Doc:      strings.ReplaceAll(p.Comment, "\n", " - "), // Glue catalogs don't support newlines in field comments
 		})
 		ids = append(ids, id)

--- a/materialize-iceberg/type_mapping_test.go
+++ b/materialize-iceberg/type_mapping_test.go
@@ -63,7 +63,10 @@ func TestComputeSchemas(t *testing.T) {
 	}
 
 	update := boilerplate.BindingUpdate[config, resource, mapped]{
-		NewProjections:      []boilerplate.MappedProjection[mapped]{mappedProjection("new", false, iceberg.StringType{})},
+		NewProjections: []boilerplate.MappedProjection[mapped]{
+			mappedProjection("new", false, iceberg.StringType{}),
+			mappedProjection("newRequired", true, iceberg.StringType{}),
+		},
 		NewlyNullableFields: []boilerplate.ExistingField{{Name: "dateToStr"}, {Name: "dateToStr" + migrateFieldSuffix}},
 		FieldsToMigrate: []boilerplate.MigrateField[mapped]{
 			{


### PR DESCRIPTION
**Description:**

Fixes materialize-iceberg apply failing against AWS S3 Tables with `400 Bad Request: The specified metadata is not valid` during schema evolution (#4775).

Root-caused via direct experimentation against a live S3 Tables catalog: S3 Tables rejects any `add-schema` update that introduces a brand-new *required* column, regardless of any default value or other changes batched into the same update. Relaxing/tightening existing fields and adding new *optional* fields all succeed. Glue and generic REST catalogs tolerate the (not fully spec-compliant) request; S3 Tables validates strictly.

Fix: `appendProjectionsAsFields` now takes a `forceOptional` flag. Fields appended to a *new* table still respect `MustExist`; fields newly appended to an *existing* table (both ordinary new columns and migration temp-columns) are now always created optional.

This isn't a new restriction we're introducing — every SQL-based materialize connector already does this. Postgres/Snowflake/BigQuery's `ADD COLUMN` templates all render new columns via `NullableDDL`, never `NOT NULL`, regardless of `MustExist`; Postgres's own `TestIntegration-apply` snapshot confirms the identical `addandremovefields` test case already produces `{"Name":"addedRequiredString","Nullable":true,...}`. materialize-iceberg was the outlier in marking newly-added columns required — Glue/REST catalogs just silently tolerated it where S3 Tables hard-rejects it.

**Workflow steps:**

No user-facing workflow change. A destination field that's required in the source will now land as a nullable Iceberg column when added via schema evolution (it's still always populated); this brings iceberg in line with every other materialize connector.

**Notes for reviewers:**

- Commit 1 is the regression test (fails on `main`), commit 2 is the fix.
- Verified against the live S3 Tables test catalog: all three `s3tables*` integration tasks pass, plus the full `TestIntegration/apply` suite across all 10 catalog configs with no regressions.