### PR TITLE
materialize-snowflake: continue pipe retry for minimum time

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -968,6 +968,10 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 	var retryDelay = 500 * time.Millisecond
 	var maxTryTime = time.Now().Add(10 * time.Minute)
 
+	// Try to get file status from the COPY_HISTORY for at least this long,
+	// even if no results are listed.
+	var minTryTime = time.Now().Add(30 * time.Minute)
+
 	for len(pipes) > 0 {
 		for pipeName, pipe := range pipes {
 			// if the pipe has no files to begin with, just skip it
@@ -1033,6 +1037,11 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				}
 
 				if len(pipe.files) > 0 {
+					if time.Now().Before(minTryTime) {
+						maxTryTime = time.Now().Add(1 * time.Minute)
+						time.Sleep(retryDelay)
+						continue
+					}
 					return nil, fmt.Errorf("snowpipe: could not find reports of successful processing for all files of pipe %v", pipe)
 				}
 


### PR DESCRIPTION
**Regression?**

No

**Description:**

When inserting files with snowpipe (non-streaming), we retry reading the insertReport for 10m and then begin checking the COPY_HISTORY table.  We continue doing this so long as there are some files that are in progress.

I think it may be possible for files to fall off the insertReport but not yet be added to the COPY_HISTORY table.  So this change adds a 30m minimum amount of time that we will keep checking the COPY_HISTORY before giving up.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

