### PR TITLE
Provide explicit ser_policy defaults

### DIFF
--- a/materialize-azure-fabric-warehouse/driver.go
+++ b/materialize-azure-fabric-warehouse/driver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/estuary/connectors/go/dbt"
 	m "github.com/estuary/connectors/go/materialize"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/microsoft/go-mssqldb/azuread"
 )
@@ -161,6 +162,7 @@ func newDriver() *sql.Driver[config, tableConfig] {
 			return &sql.Endpoint[config]{
 				Config:              cfg,
 				Dialect:             dialect,
+				SerPolicy:           boilerplate.SerPolicyStd,
 				MetaCheckpoints:     sql.FlowCheckpointsTable([]string{cfg.Warehouse, cfg.Schema}),
 				NewClient:           newClient,
 				CreateTableTemplate: templates.createTargetTable,

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -283,6 +283,7 @@ func newRedshiftDriver() *sql.Driver[config, tableConfig] {
 			return &sql.Endpoint[config]{
 				Config:              cfg,
 				Dialect:             dialect,
+				SerPolicy:           boilerplate.SerPolicyStd,
 				MetaCheckpoints:     sql.FlowCheckpointsTable(metaBase),
 				NewClient:           newClient,
 				CreateTableTemplate: templates.createTargetTable,

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -85,6 +85,7 @@ func NewSQLiteDriver() *sql.Driver[config, tableConfig] {
 			return &sql.Endpoint[config]{
 				Config:              config{path: path},
 				Dialect:             sqliteDialect,
+				SerPolicy:           boilerplate.SerPolicyStd,
 				MetaCheckpoints:     nil,
 				NewClient:           newClient,
 				CreateTableTemplate: tplCreateTargetTable,


### PR DESCRIPTION
These connectors have relied on the runtime's hardcoded image-name-based serialization policy fallback to truncate large strings, objects, and arrays. Set boilerplate.SerPolicyStd on their endpoints — identical limits to the hardcoded fallback (64 KiB strings, 1000-element objects/arrays) — so the policy is negotiated via the connector protocol and the runtime fallback can eventually be removed.

No behavior change: built specs pick up the same limits they already had, now sourced from the Validated response instead of the runtime.

