### PR TITLE
materialize-boilerplate: raise stale test-item cleanup threshold to 60 minutes

### DIFF
--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -1216,7 +1216,10 @@ func shouldCleanup(t *testing.T, now time.Time, item string, suffix string) bool
 		t.Log("malformed test item name", item)
 	} else if seconds, err := strconv.Atoi(parts[len(parts)-1]); err != nil {
 		t.Log("failed to parse timestamp from test item name", item, err)
-	} else if timestamp := time.Unix(int64(seconds), 0); now.Sub(timestamp) > 5*time.Minute {
+	} else if timestamp := time.Unix(int64(seconds), 0); now.Sub(timestamp) > 60*time.Minute {
+		// The threshold must comfortably exceed the longest single test run,
+		// since concurrent CI jobs sharing a database will otherwise drop each
+		// other's in-use tables mid-test.
 		t.Log("will cleanup old test item", item)
 		return true
 	}


### PR DESCRIPTION
**Regression?**

Not a product regression, but improves upon #4782: since that change, the materialize-databricks `TestIntegration/migrate` DDL execution can take longer than 5 minutes, which exposed a test-harness race (observed as a CI flake on #4776).

**Description:**

Integration test cleanup deletes any test table in the shared database whose embedded timestamp is more than 5 minutes old. A concurrently running CI job can therefore drop a table that another job's still-running test is using, failing it with `TABLE_OR_VIEW_NOT_FOUND`. This raises the staleness threshold to 60 minutes so it comfortably exceeds the longest single test run.

**Notes for reviewers:**

Orphaned tables from crashed runs now linger up to an hour before being swept — a mild trade-off versus deleting live tables mid-test.
