### PR TITLE
materialize-s3-iceberg: parallelize appendFiles duplicate-file check

### DIFF
--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -542,13 +543,42 @@ func (c *catalog) appendFiles(
 			return fmt.Errorf("marshaling checkpoints: %w", err)
 		}
 
-		tx := tbl.NewTransaction()
-		// ignoreDuplicates=false preserves the pyiceberg default
+		// The duplicate-file check preserves the pyiceberg default
 		// (check_duplicate_files): a file already referenced by the table
 		// fails the append rather than being silently re-added, which guards
 		// against a zombie process double-appending the same paths in the
-		// window between the checkpoint-fence read and commit.
-		if err := tx.AddFiles(ctx, filePaths, nil, false); err != nil {
+		// window between the checkpoint-fence read and commit. It runs here
+		// instead of via AddFiles' ignoreDuplicates=false because iceberg-go
+		// scans the snapshot's manifests one S3 read at a time, and tables
+		// accumulate a manifest per transaction — a sequential scan cannot
+		// finish within the Acknowledge deadline on long-lived tables.
+		if referenced, err := referencedFilePaths(ctx, tbl, filePaths); err != nil {
+			err = fmt.Errorf("checking for referenced files in %q: %w", fqn, err)
+			if attempt >= maxAttempts {
+				return err
+			}
+			logger.WithError(err).WithField("attempt", attempt).Warn("append_files: retrying")
+			if err := sleepCtx(ctx, time.Duration(attempt*2)*time.Second); err != nil {
+				return err
+			}
+			continue
+		} else if len(referenced) > 0 {
+			// Retryable: when the files were appended by a zombie's completed
+			// commit, the next attempt's checkpoint-fence read observes that
+			// checkpoint and skips the append cleanly instead of failing.
+			err := fmt.Errorf("cannot add files that are already referenced by table %q: %v", fqn, referenced)
+			if attempt >= maxAttempts {
+				return err
+			}
+			logger.WithError(err).WithField("attempt", attempt).Warn("append_files: retrying")
+			if err := sleepCtx(ctx, time.Duration(attempt*2)*time.Second); err != nil {
+				return err
+			}
+			continue
+		}
+
+		tx := tbl.NewTransaction()
+		if err := tx.AddFiles(ctx, filePaths, nil, true); err != nil {
 			err = fmt.Errorf("staging files for %q: %w", fqn, err)
 			if attempt >= maxAttempts {
 				return err
@@ -577,6 +607,65 @@ func (c *catalog) appendFiles(
 		logger.WithField("attempt", attempt).Info("append_files: committed")
 		return nil
 	}
+}
+
+// manifestReadConcurrency bounds concurrent manifest fetches during the
+// duplicate-file check. Manifest reads are small network-bound object-store
+// GETs, so the bound is a fixed fan-out rather than GOMAXPROCS.
+const manifestReadConcurrency = 16
+
+// referencedFilePaths returns the subset of filePaths that are live data files
+// of tbl's current snapshot. Deleted manifest entries are ignored, matching
+// pyiceberg's check_duplicate_files, so a path no longer referenced by the
+// table can be appended again.
+func referencedFilePaths(ctx context.Context, tbl *icebergtable.Table, filePaths []string) ([]string, error) {
+	snap := tbl.CurrentSnapshot()
+	if snap == nil {
+		return nil, nil
+	}
+
+	fs, err := tbl.FS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	manifests, err := snap.Manifests(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	want := make(map[string]struct{}, len(filePaths))
+	for _, p := range filePaths {
+		want[p] = struct{}{}
+	}
+
+	var mu sync.Mutex
+	var referenced []string
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(manifestReadConcurrency)
+	for _, m := range manifests {
+		group.Go(func() error {
+			if err := groupCtx.Err(); err != nil {
+				return err
+			}
+			for entry, err := range m.Entries(fs, true) {
+				if err != nil {
+					return fmt.Errorf("reading manifest %q: %w", m.FilePath(), err)
+				}
+				if _, ok := want[entry.DataFile().FilePath()]; ok {
+					mu.Lock()
+					referenced = append(referenced, entry.DataFile().FilePath())
+					mu.Unlock()
+				}
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	return referenced, nil
 }
 
 func sleepCtx(ctx context.Context, d time.Duration) error {

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -149,6 +149,10 @@ func TestIntegration(t *testing.T) {
 		runDateOverflowRegression(t, cfg)
 	})
 
+	t.Run("duplicate-append-regression", func(t *testing.T) {
+		runDuplicateAppendRegression(t, cfg)
+	})
+
 	// Migration test is skipped because Iceberg does not support the type
 	// migrations exercised by the test (e.g. long→string).
 	//t.Run("migrate", func(t *testing.T) {
@@ -366,6 +370,101 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 		"",
 		"deadbeefdeadbeef",
 	))
+}
+
+// runDuplicateAppendRegression locks in the duplicate-file semantics that
+// appendFiles preserves from pyiceberg's check_duplicate_files: a file that is
+// already live in the table fails a subsequent append under a new checkpoint,
+// while replaying an already-recorded checkpoint is skipped by the fence
+// rather than tripping the duplicate check.
+func runDuplicateAppendRegression(t *testing.T, cfg config) {
+	ctx := context.Background()
+
+	cat, err := newCatalog(ctx, cfg, NestedLocationStyle)
+	require.NoError(t, err)
+
+	const (
+		namespace       = "tests"
+		table           = "duplicate_append_regression"
+		materialization = "acmeCo/tests/regression"
+	)
+	tableIdent := icebergtable.Identifier{namespace, table}
+
+	// Tolerate leftovers from a prior run of this test.
+	_ = cat.cat.DropTable(ctx, tableIdent)
+	if err := cat.createNamespace(ctx, namespace); err != nil &&
+		!errors.Is(err, icebergcatalog.ErrNamespaceAlreadyExists) {
+		t.Fatalf("create-namespace: %v", err)
+	}
+
+	schema := iceberg.NewSchema(0, iceberg.NestedField{
+		ID:       1,
+		Name:     "v",
+		Type:     iceberg.PrimitiveTypes.String,
+		Required: false,
+	})
+
+	nameMappingJSON, err := json.Marshal(schema.NameMapping())
+	require.NoError(t, err)
+
+	tblLocation := tablePath(cfg.Bucket, cfg.Prefix, namespace, table, NestedLocationStyle)
+	_, err = cat.cat.CreateTable(ctx, tableIdent, schema,
+		icebergcatalog.WithLocation(tblLocation),
+		icebergcatalog.WithProperties(iceberg.Properties{
+			icebergtable.DefaultNameMappingKey: string(nameMappingJSON),
+		}),
+	)
+	require.NoError(t, err)
+
+	s3client := s3.New(s3.Options{
+		Region:       cfg.Region,
+		Credentials:  credentials.NewStaticCredentialsProvider(cfg.Credentials.AWSAccessKeyID, cfg.Credentials.AWSSecretAccessKey, ""),
+		BaseEndpoint: aws.String(cfg.S3Endpoint),
+		UsePathStyle: true,
+	})
+
+	uploadParquet := func(v string) string {
+		parquetPath := filepath.Join(t.TempDir(), "data.parquet")
+		parquetFile, err := os.Create(parquetPath)
+		require.NoError(t, err)
+		pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+			{Name: "v", DataType: writer.LogicalTypeString, Required: false},
+		}, writer.WithParquetCompression(writer.Snappy))
+		require.NoError(t, pqw.Write([]any{v}))
+		require.NoError(t, pqw.Close())
+
+		s3Path := strings.TrimSuffix(tblLocation, "/") + "/data/" + uuid.New().String() + ".parquet"
+		uploadFile, err := os.Open(parquetPath)
+		require.NoError(t, err)
+		defer uploadFile.Close()
+		_, err = s3client.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(cfg.Bucket),
+			Key:    aws.String(strings.TrimPrefix(s3Path, "s3://"+cfg.Bucket+"/")),
+			Body:   uploadFile,
+		})
+		require.NoError(t, err)
+
+		return s3Path
+	}
+
+	first := uploadParquet("one")
+	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
+		[]string{first}, "", "checkpoint-1"))
+
+	// The same path under a new checkpoint must be rejected as a duplicate.
+	err = cat.appendFiles(ctx, materialization, tableIdent,
+		[]string{first}, "checkpoint-1", "checkpoint-2")
+	require.ErrorContains(t, err, "already referenced")
+
+	// Replaying the already-committed checkpoint is skipped by the fence, so
+	// the duplicate path is not an error.
+	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
+		[]string{first}, "", "checkpoint-1"))
+
+	// A fresh file advances the checkpoint through the duplicate check.
+	second := uploadParquet("two")
+	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
+		[]string{second}, "checkpoint-1", "checkpoint-2"))
 }
 
 // TestNormalizeLegacyCredentials guards the parity with the removed Python


### PR DESCRIPTION
**Regression?**

Yes — #4347's iceberg-go duplicate-file check scans all manifests sequentially, one S3 GET at a time. On long-lived tables this exceeds the 5-minute appendFiles deadline and the shard crash-loops.

**Description:**

- Replace the built-in check with a connector-side `referencedFilePaths` that reads manifests concurrently, then call `AddFiles` with `ignoreDuplicates=true`.
- Matches pyiceberg's `check_duplicate_files` semantics (deleted entries ignored); duplicate hits stay retryable so the checkpoint fence resolves zombie double-appends.
- New `duplicate-append-regression` integration test.

**Notes for reviewers:**

Full suite passes locally, including Glue and snapshot parity; no snapshot changes.
