### PR TITLE
materialize-s3-iceberg: drop appendFiles duplicate-file check

### DIFF
--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/apache/iceberg-go"
@@ -543,41 +542,12 @@ func (c *catalog) appendFiles(
 			return fmt.Errorf("marshaling checkpoints: %w", err)
 		}
 
-		// The duplicate-file check preserves the pyiceberg default
-		// (check_duplicate_files): a file already referenced by the table
-		// fails the append rather than being silently re-added, which guards
-		// against a zombie process double-appending the same paths in the
-		// window between the checkpoint-fence read and commit. It runs here
-		// instead of via AddFiles' ignoreDuplicates=false because iceberg-go
-		// scans the snapshot's manifests one S3 read at a time, and tables
-		// accumulate a manifest per transaction — a sequential scan cannot
-		// finish within the Acknowledge deadline on long-lived tables.
-		if referenced, err := referencedFilePaths(ctx, tbl, filePaths); err != nil {
-			err = fmt.Errorf("checking for referenced files in %q: %w", fqn, err)
-			if attempt >= maxAttempts {
-				return err
-			}
-			logger.WithError(err).WithField("attempt", attempt).Warn("append_files: retrying")
-			if err := sleepCtx(ctx, time.Duration(attempt*2)*time.Second); err != nil {
-				return err
-			}
-			continue
-		} else if len(referenced) > 0 {
-			// Retryable: when the files were appended by a zombie's completed
-			// commit, the next attempt's checkpoint-fence read observes that
-			// checkpoint and skips the append cleanly instead of failing.
-			err := fmt.Errorf("cannot add files that are already referenced by table %q: %v", fqn, referenced)
-			if attempt >= maxAttempts {
-				return err
-			}
-			logger.WithError(err).WithField("attempt", attempt).Warn("append_files: retrying")
-			if err := sleepCtx(ctx, time.Duration(attempt*2)*time.Second); err != nil {
-				return err
-			}
-			continue
-		}
-
 		tx := tbl.NewTransaction()
+		// ignoreDuplicates=true: checking for duplicates requires reading
+		// every manifest of the current snapshot, which cannot finish within
+		// the Acknowledge deadline on long-lived tables. The checkpoint fence
+		// above is the guard against replaying an already-recorded append,
+		// matching the pyiceberg 0.7.0 behavior this connector shipped with.
 		if err := tx.AddFiles(ctx, filePaths, nil, true); err != nil {
 			err = fmt.Errorf("staging files for %q: %w", fqn, err)
 			if attempt >= maxAttempts {
@@ -607,65 +577,6 @@ func (c *catalog) appendFiles(
 		logger.WithField("attempt", attempt).Info("append_files: committed")
 		return nil
 	}
-}
-
-// manifestReadConcurrency bounds concurrent manifest fetches during the
-// duplicate-file check. Manifest reads are small network-bound object-store
-// GETs, so the bound is a fixed fan-out rather than GOMAXPROCS.
-const manifestReadConcurrency = 16
-
-// referencedFilePaths returns the subset of filePaths that are live data files
-// of tbl's current snapshot. Deleted manifest entries are ignored, matching
-// pyiceberg's check_duplicate_files, so a path no longer referenced by the
-// table can be appended again.
-func referencedFilePaths(ctx context.Context, tbl *icebergtable.Table, filePaths []string) ([]string, error) {
-	snap := tbl.CurrentSnapshot()
-	if snap == nil {
-		return nil, nil
-	}
-
-	fs, err := tbl.FS(ctx)
-	if err != nil {
-		return nil, err
-	}
-	manifests, err := snap.Manifests(fs)
-	if err != nil {
-		return nil, err
-	}
-
-	want := make(map[string]struct{}, len(filePaths))
-	for _, p := range filePaths {
-		want[p] = struct{}{}
-	}
-
-	var mu sync.Mutex
-	var referenced []string
-
-	group, groupCtx := errgroup.WithContext(ctx)
-	group.SetLimit(manifestReadConcurrency)
-	for _, m := range manifests {
-		group.Go(func() error {
-			if err := groupCtx.Err(); err != nil {
-				return err
-			}
-			for entry, err := range m.Entries(fs, true) {
-				if err != nil {
-					return fmt.Errorf("reading manifest %q: %w", m.FilePath(), err)
-				}
-				if _, ok := want[entry.DataFile().FilePath()]; ok {
-					mu.Lock()
-					referenced = append(referenced, entry.DataFile().FilePath())
-					mu.Unlock()
-				}
-			}
-			return nil
-		})
-	}
-	if err := group.Wait(); err != nil {
-		return nil, err
-	}
-
-	return referenced, nil
 }
 
 func sleepCtx(ctx context.Context, d time.Duration) error {

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -149,8 +149,8 @@ func TestIntegration(t *testing.T) {
 		runDateOverflowRegression(t, cfg)
 	})
 
-	t.Run("duplicate-append-regression", func(t *testing.T) {
-		runDuplicateAppendRegression(t, cfg)
+	t.Run("checkpoint-fence-regression", func(t *testing.T) {
+		runCheckpointFenceRegression(t, cfg)
 	})
 
 	// Migration test is skipped because Iceberg does not support the type
@@ -372,12 +372,12 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 	))
 }
 
-// runDuplicateAppendRegression locks in the duplicate-file semantics that
-// appendFiles preserves from pyiceberg's check_duplicate_files: a file that is
-// already live in the table fails a subsequent append under a new checkpoint,
-// while replaying an already-recorded checkpoint is skipped by the fence
-// rather than tripping the duplicate check.
-func runDuplicateAppendRegression(t *testing.T, cfg config) {
+// runCheckpointFenceRegression locks in the checkpoint-fence semantics of
+// appendFiles: replaying an already-recorded checkpoint is skipped rather
+// than re-appending its files. The fence is the sole duplicate guard —
+// appendFiles does not scan existing manifests for duplicate paths, matching
+// the pyiceberg 0.7.0 behavior this connector originally shipped with.
+func runCheckpointFenceRegression(t *testing.T, cfg config) {
 	ctx := context.Background()
 
 	cat, err := newCatalog(ctx, cfg, NestedLocationStyle)
@@ -385,7 +385,7 @@ func runDuplicateAppendRegression(t *testing.T, cfg config) {
 
 	const (
 		namespace       = "tests"
-		table           = "duplicate_append_regression"
+		table           = "checkpoint_fence_regression"
 		materialization = "acmeCo/tests/regression"
 	)
 	tableIdent := icebergtable.Identifier{namespace, table}
@@ -451,20 +451,30 @@ func runDuplicateAppendRegression(t *testing.T, cfg config) {
 	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
 		[]string{first}, "", "checkpoint-1"))
 
-	// The same path under a new checkpoint must be rejected as a duplicate.
-	err = cat.appendFiles(ctx, materialization, tableIdent,
-		[]string{first}, "checkpoint-1", "checkpoint-2")
-	require.ErrorContains(t, err, "already referenced")
-
 	// Replaying the already-committed checkpoint is skipped by the fence, so
-	// the duplicate path is not an error.
+	// the same path is not re-appended.
 	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
 		[]string{first}, "", "checkpoint-1"))
 
-	// A fresh file advances the checkpoint through the duplicate check.
 	second := uploadParquet("two")
 	require.NoError(t, cat.appendFiles(ctx, materialization, tableIdent,
 		[]string{second}, "checkpoint-1", "checkpoint-2"))
+
+	// Two data files total: the replay added nothing.
+	tbl, err := cat.cat.LoadTable(ctx, tableIdent)
+	require.NoError(t, err)
+	fs, err := tbl.FS(ctx)
+	require.NoError(t, err)
+	manifests, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	var livePaths []string
+	for _, m := range manifests {
+		for entry, err := range m.Entries(fs, true) {
+			require.NoError(t, err)
+			livePaths = append(livePaths, entry.DataFile().FilePath())
+		}
+	}
+	require.ElementsMatch(t, []string{first, second}, livePaths)
 }
 
 // TestNormalizeLegacyCredentials guards the parity with the removed Python


### PR DESCRIPTION
**Regression?**

Yes — #4347 replaced the Python (pyiceberg 0.7.0) appendFiles with iceberg-go and added a duplicate-file check that scans every manifest of the current snapshot. On long-lived tables the scan exceeds the 5-minute appendFiles deadline, crash-looping the task on recovery. #4797 parallelized the scan 16-way, which proved insufficient for a customer's largest tables.

**Description:**

Remove the duplicate-file check entirely; `AddFiles` keeps `ignoreDuplicates=true`. The checkpoint fence remains the guard against replaying an already-recorded append. This matches actual pre-#4347 production behavior: pyiceberg 0.7.0's `add_files` had no duplicate check (`check_duplicate_files` was only added in pyiceberg 0.8.0), so appendFiles cost is back to O(files being added), independent of table history.

**Workflow steps:**

No user-facing change.

**Documentation links affected:**

None.

**Notes for reviewers:**

The prior regression test asserted the duplicate-rejection behavior; it's reworked as `checkpoint-fence-regression`, which replays a committed checkpoint and verifies the table's live data files show nothing was re-appended. Full suite passes including `TestIntegration` and `TestIntegrationGlue`.
