### PR TITLE
materialize-s3-parquet/iceberg: return error instead of panicking on transient parquet sink write failure

### DIFF
--- a/filesink/format.go
+++ b/filesink/format.go
@@ -64,7 +64,7 @@ func NewParquetWriter(cfg ParquetConfig, b *pf.MaterializationSpec_Binding, w io
 	// compression.
 	opts = append(opts, writer.WithParquetCompression(writer.Snappy))
 
-	return writer.NewParquetWriter(w, sch, opts...), nil
+	return writer.NewParquetWriter(w, sch, opts...)
 }
 
 type CsvConfig struct {

--- a/go/writer/oomrepro_test.go
+++ b/go/writer/oomrepro_test.go
@@ -91,11 +91,14 @@ func TestOOMRepro(t *testing.T) {
 			stat["active_file"]/1024/1024, stat["inactive_file"]/1024/1024)
 	}
 
-	w := NewParquetWriter(oomReproDiscardCloser{}, sch,
+	w, err := NewParquetWriter(oomReproDiscardCloser{}, sch,
 		WithParquetRowGroupByteLimit(*oomReproRowGroupByteLimitMiB*1024*1024),
 		WithParquetRowGroupRowLimit(*oomReproRowGroupRowLimit),
 		WithParquetBufferSize(*oomReproBufferSizeMiB*1024*1024),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var totalBytes, maxRowsSeen int64
 	start := time.Now()

--- a/go/writer/pagecache_linux_test.go
+++ b/go/writer/pagecache_linux_test.go
@@ -130,7 +130,10 @@ func BenchmarkScratchPageCache(b *testing.B) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		w := NewParquetWriter(discardCloser{}, sch)
+		w, err := NewParquetWriter(discardCloser{}, sch)
+		if err != nil {
+			b.Fatal(err)
+		}
 		inClose.Store(false)
 		for i := range numRows {
 			if err := w.Write([]any{int64(i), fmt.Sprintf("%08d-%s", i, payload)}); err != nil {

--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -201,7 +201,7 @@ func WithParquetMetadata(meta map[string]string) ParquetOption {
 	}
 }
 
-func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption) *ParquetWriter {
+func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption) (*ParquetWriter, error) {
 	cfg := parquetConfig{
 		compression:       Uncompressed,
 		bufferSize:        defaultBufferSize,
@@ -221,14 +221,23 @@ func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption
 
 	cwc := &countingWriteCloser{w: w}
 
+	// Use the non-panicking constructor: the sink here is typically one end of an io.Pipe
+	// streaming to a cloud-storage upload, and its very first write (the parquet magic header)
+	// can fail transiently (e.g. a broken pipe). The legacy file.NewParquetWriter panics in that
+	// case; returning the error instead lets the caller surface it as a normal, retryable failure.
+	sinkWriter, err := file.NewParquetWriterWithError(cwc, schemaRoot, writerOpts(cfg)...)
+	if err != nil {
+		return nil, fmt.Errorf("initializing parquet sink writer: %w", err)
+	}
+
 	return &ParquetWriter{
 		cfg:        cfg,
 		schema:     sch,
 		schemaRoot: schemaRoot,
-		sinkWriter: file.NewParquetWriter(cwc, schemaRoot, writerOpts(cfg)...),
+		sinkWriter: sinkWriter,
 		cwc:        cwc,
 		rs:         newRowSizing(sch),
-	}
+	}, nil
 }
 
 func writerOpts(cfg parquetConfig) []file.WriteOption {
@@ -405,8 +414,12 @@ func (w *ParquetWriter) flushBuffer() error {
 			// Turning off stats calculations helps too, but just a tiny bit.
 			parquet.WithStats(false),
 		}
+		scratchWriter, err := file.NewParquetWriterWithError(scratchFile, w.schemaRoot, file.WithWriterProps(parquet.NewWriterProperties(scratchOpts...)))
+		if err != nil {
+			return fmt.Errorf("flushing buffer creating scratch writer: %w", err)
+		}
 		w.scratch.file = scratchFile
-		w.scratch.writer = file.NewParquetWriter(scratchFile, w.schemaRoot, file.WithWriterProps(parquet.NewWriterProperties(scratchOpts...)))
+		w.scratch.writer = scratchWriter
 	}
 
 	rgWriter := w.scratch.writer.AppendRowGroup()

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -47,7 +48,8 @@ func TestParquetWriter(t *testing.T) {
 			sink, err := os.CreateTemp(dir, "*.parquet")
 			require.NoError(t, err)
 
-			w := NewParquetWriter(sink, makeTestParquetSchema(!tt.nulls), tt.opts...)
+			w, err := NewParquetWriter(sink, makeTestParquetSchema(!tt.nulls), tt.opts...)
+			require.NoError(t, err)
 			for i := range 10 {
 				row := makeTestRow(t, i)
 				if tt.nulls {
@@ -62,6 +64,37 @@ func TestParquetWriter(t *testing.T) {
 	}
 }
 
+// errOnFirstWriteCloser fails its very first Write, simulating a transient
+// failure on the sink (e.g. a broken pipe to a cloud-storage upload) at the
+// point where the parquet magic header is written.
+type errOnFirstWriteCloser struct {
+	wrote bool
+}
+
+func (w *errOnFirstWriteCloser) Write(p []byte) (int, error) {
+	if !w.wrote {
+		w.wrote = true
+		return 0, fmt.Errorf("simulated transient write failure")
+	}
+	return len(p), nil
+}
+
+func (w *errOnFirstWriteCloser) Close() error { return nil }
+
+// A sink that fails its initial write (writing the parquet magic header) must
+// surface a returned error rather than panicking, so callers can handle it as
+// a normal, retryable failure. Regression test for the "failed to write magic
+// number" panic.
+func TestParquetWriterSinkWriteErrorReturnsError(t *testing.T) {
+	sch := ParquetSchema{
+		{Name: "field", DataType: LogicalTypeString, Required: false},
+	}
+
+	w, err := NewParquetWriter(&errOnFirstWriteCloser{}, sch)
+	require.Error(t, err)
+	require.Nil(t, w)
+}
+
 func TestParquetWriterTimestampNanos(t *testing.T) {
 	dir := t.TempDir()
 	sink, err := os.CreateTemp(dir, "*.parquet")
@@ -73,7 +106,8 @@ func TestParquetWriterTimestampNanos(t *testing.T) {
 
 	rows := []string{"2024-01-02T03:04:05.123456789Z", "1970-01-01T00:00:00.000000001Z", ""}
 
-	w := NewParquetWriter(sink, sch)
+	w, err := NewParquetWriter(sink, sch)
+	require.NoError(t, err)
 	for _, ts := range rows {
 		var val any
 		if ts != "" {

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -254,9 +254,10 @@ func runTimestampOverflowRegression(t *testing.T, cfg config) {
 	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
 	parquetFile, err := os.Create(parquetPath)
 	require.NoError(t, err)
-	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+	pqw, err := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "ts", DataType: writer.LogicalTypeTimestamp, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
+	require.NoError(t, err)
 	clampedTS, err := clampTimestamp("9999-12-31T23:59:59-14:00")
 	require.NoError(t, err)
 	require.NoError(t, pqw.Write([]any{clampedTS}))
@@ -335,9 +336,10 @@ func runDateOverflowRegression(t *testing.T, cfg config) {
 	parquetPath := filepath.Join(t.TempDir(), "data.parquet")
 	parquetFile, err := os.Create(parquetPath)
 	require.NoError(t, err)
-	pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+	pqw, err := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 		{Name: "d", DataType: writer.LogicalTypeDate, Required: false},
 	}, writer.WithParquetCompression(writer.Snappy))
+	require.NoError(t, err)
 	clampedDate, err := clampDate("10000-01-01")
 	require.NoError(t, err)
 	require.NoError(t, pqw.Write([]any{clampedDate}))
@@ -427,9 +429,10 @@ func runCheckpointFenceRegression(t *testing.T, cfg config) {
 		parquetPath := filepath.Join(t.TempDir(), "data.parquet")
 		parquetFile, err := os.Create(parquetPath)
 		require.NoError(t, err)
-		pqw := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
+		pqw, err := writer.NewParquetWriter(parquetFile, writer.ParquetSchema{
 			{Name: "v", DataType: writer.LogicalTypeString, Required: false},
 		}, writer.WithParquetCompression(writer.Snappy))
+		require.NoError(t, err)
 		require.NoError(t, pqw.Write([]any{v}))
 		require.NoError(t, pqw.Close())
 

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -120,7 +120,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	var group errgroup.Group
 	var states = t.state.BindingStates
 
-	startFile := func(b binding) {
+	startFile := func(b binding) error {
 		// Start uploading a new file, either because the binding changed or because the prior file
 		// got sufficiently large.
 		r, w := io.Pipe()
@@ -137,7 +137,15 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 			return nil
 		})
 
-		pqw = writer.NewParquetWriter(w, b.pqSchema, writer.WithParquetCompression(writer.Snappy))
+		var err error
+		pqw, err = writer.NewParquetWriter(w, b.pqSchema, writer.WithParquetCompression(writer.Snappy))
+		if err != nil {
+			// Unblock and terminate the upload goroutine so it doesn't leak waiting on the pipe.
+			w.CloseWithError(err)
+			return fmt.Errorf("creating parquet writer: %w", err)
+		}
+
+		return nil
 	}
 
 	finishFile := func() error {
@@ -165,7 +173,9 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		lastBinding = it.Binding
 
 		if pqw == nil {
-			startFile(b)
+			if err := startFile(b); err != nil {
+				return nil, fmt.Errorf("starting file: %w", err)
+			}
 		}
 
 		row, err := b.mapped.ConvertAll(it.Key, it.Values, it.RawJSON)

--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -122,7 +122,7 @@ func newBdecWriter(
 		})
 	}
 
-	pq := writer.NewParquetWriter(
+	pq, err := writer.NewParquetWriter(
 		blobStats,
 		sch,
 		writer.WithParquetCompression(writer.Snappy),
@@ -131,6 +131,9 @@ func newBdecWriter(
 		writer.WithParquetRowGroupByteLimit(MAX_CHUNK_SIZE_IN_BYTES_DEFAULT),
 		writer.WithParquetRowGroupRowLimit(math.MaxInt64), // no specific limit on the number of rows in a bdec chunk
 	)
+	if err != nil {
+		return nil, fmt.Errorf("creating parquet writer: %w", err)
+	}
 
 	return &bdecWriter{
 		pq:        pq,


### PR DESCRIPTION
## What

The shared parquet writer in `go/writer/parquet.go` called arrow-go's legacy `file.NewParquetWriter`, which **panics** with the literal string `failed to write magic number` when the initial write of the parquet magic header to the sink fails. In `materialize-s3-parquet` / `materialize-s3-iceberg` (and the other filesink parquet connectors), the sink is one end of an `io.Pipe` streaming to a cloud-storage upload, so a transient write failure (e.g. a broken pipe) while *starting a new file* crashed the shard with an unrecovered panic instead of surfacing a handleable error.

Flow auto-restarts the shard within seconds so there's no data loss, but each crash is a shard failure that can trip the `shardFailed` alert threshold on high-frequency tasks.

## Fix

Switch to arrow-go's non-panicking `file.NewParquetWriterWithError`, return the failure as a normal error, and propagate it through all callers:

- **`go/writer/parquet.go`** — `NewParquetWriter` now returns `(*ParquetWriter, error)`. Both the sink writer and the scratch-file writer (in `flushBuffer`) use the non-panicking constructor.
- **`filesink/format.go`** — forwards the error (covers `materialize-s3-parquet`, `materialize-gcs-parquet`, `materialize-azure-blob-parquet`).
- **`materialize-s3-iceberg/transactor.go`** — the `startFile` closure returns an error; on failure it calls `w.CloseWithError(err)` so the in-flight `PutStream` upload goroutine unblocks from the pipe and terminates rather than leaking.
- **`materialize-snowflake/bdec.go`** — propagates the error (its sink is an in-memory buffer, so this is just to satisfy the new signature).

The successful-write path and output file format/content are unchanged.

## Testing

- New regression test `TestParquetWriterSinkWriteErrorReturnsError`: constructs the writer with a sink whose first `Write` returns an error and asserts an error is returned rather than a panic.
- `go build ./...` and `go vet` pass across all affected packages; `go/writer` unit tests pass.

## Notes

- Root cause confirmed against the pinned arrow-go source (`v18.6.1-0.20260702190817`): `file.NewParquetWriter` now wraps `NewParquetWriterWithError` and re-panics for back-compat; its doc comment recommends new code use the error-returning variant.
- Not a regression from the arrow-go bump in #4750 — the earliest observed occurrence predates it.

Fixes #4801
