### PR TITLE
materialize-clickhouse: identify Estuary Flow in the ClickHouse client name

### DIFF
--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.gazette.dev/core/consumer/protocol"
 )
+
+// connectorVersion is the connector's release tag, embedded so the client
+// identification reported to ClickHouse stays in sync with the image version.
+//
+//go:embed VERSION
+var connectorVersion string
 
 type authType string
 
@@ -134,7 +141,16 @@ func (c config) newClickhouseOptions() *clickhouse.Options {
 	}
 	return &clickhouse.Options{
 		Addr: []string{c.resolvedAddress()},
-		TLS:  tlsConfig,
+		// Identify Estuary Flow in the client name reported to ClickHouse
+		// (system.query_log, system.processes, etc.), which otherwise only
+		// shows the generic clickhouse-go driver.
+		ClientInfo: clickhouse.ClientInfo{
+			Products: []struct{ Name, Version string }{
+				{Name: "EstuaryFlow", Version: strings.TrimSpace(connectorVersion)},
+			},
+			Comment: []string{"materialize-clickhouse"},
+		},
+		TLS: tlsConfig,
 		Auth: clickhouse.Auth{
 			Database: c.Database,
 			Username: c.Credentials.Username,


### PR DESCRIPTION
## Description

Closes #4806.

materialize-clickhouse previously set no client identification, so its queries appeared in the destination's `system.query_log` / `system.processes` with the generic driver `client_name` (`clickhouse-go/2.43.0 (lv:go/…; os:linux)`).

This sets `clickhouse.Options.ClientInfo` in `config.newClickhouseOptions()` — the single helper all connections (apply client, transactor load/store) are built from — using the `EstuaryFlow` product token established in #3347, plus a `materialize-clickhouse` comment for connector-level attribution. The product version is embedded from the connector's `VERSION` file via `go:embed` so it tracks the released image tag automatically.

The connector uses the native TCP protocol, so the "user-agent" equivalent is the handshake client name rather than an HTTP header; `ClientInfo` is the driver's supported mechanism for it.

## Verification

Verified against the connector's docker-compose ClickHouse 25.8 by opening a connection through the real `newClickhouseOptions()` path and querying `system.processes` for the server-observed client name:

```
EstuaryFlow/v1 clickhouse-go/2.43.0 (materialize-clickhouse; lv:go/1.26.1; os:darwin)
```

`go build`, `go vet`, and `go test -short ./materialize-clickhouse/...` (the Dockerfile's test invocation) all pass.


## Workflow steps

(How does one use this feature, and how has it changed)