### PR TITLE
source-postgres: Default 2m statement_timeout

### DIFF
--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -425,7 +425,7 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/capture_as_partitions` | Capture Partitioned Tables As Partitions | When set, the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without `publish_via_partition_root`. | boolean | `false` |
 | `/advanced/discover_unpublished_tables` | Discover Unpublished Tables | If `true`, the capture discovers all tables, even ones not currently in the publication. | boolean |  |
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
-| `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely. Options include `""`, `30s`, `1m`, `5m`, and `30m`. | string | `""` |
+| `/advanced/statement_timeout` | Statement Timeout | Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to `0` to disable statement timeouts entirely. Options include `""`, `0`, `30s`, `1m`, `2m`, `5m`, and `30m`. | string | `""` |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -160,7 +160,7 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/capture_as_partitions` | Capture Partitioned Tables As Partitions | When set, the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without `publish_via_partition_root`. | boolean | `false` |
 | `/advanced/discover_unpublished_tables` | Discover Unpublished Tables | If `true`, the capture discovers all tables, even ones not currently in the publication. | boolean |  |
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
-| `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely. Options include `""`, `30s`, `1m`, `5m`, and `30m`. | string | `""` |
+| `/advanced/statement_timeout` | Statement Timeout | Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to `0` to disable statement timeouts entirely. Options include `""`, `0`, `30s`, `1m`, `2m`, `5m`, and `30m`. | string | `""` |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -247,7 +247,7 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/capture_as_partitions` | Capture Partitioned Tables As Partitions | When set, the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without `publish_via_partition_root`. | boolean | `false` |
 | `/advanced/discover_unpublished_tables` | Discover Unpublished Tables | If `true`, the capture discovers all tables, even ones not currently in the publication. | boolean |  |
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
-| `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely. Options include `""`, `30s`, `1m`, `5m`, and `30m`. | string | `""` |
+| `/advanced/statement_timeout` | Statement Timeout | Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to `0` to disable statement timeouts entirely. Options include `""`, `0`, `30s`, `1m`, `2m`, `5m`, and `30m`. | string | `""` |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -181,7 +181,7 @@ See [connectors](../../../../concepts/connectors.md#using-connectors) to learn m
 | `/advanced/capture_as_partitions` | Capture Partitioned Tables As Partitions | When set, the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without `publish_via_partition_root`. | boolean | `false` |
 | `/advanced/discover_unpublished_tables` | Discover Unpublished Tables | If `true`, the capture discovers all tables, even ones not currently in the publication. | boolean |  |
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
-| `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely. Options include `""`, `30s`, `1m`, `5m`, and `30m`. | string | `""` |
+| `/advanced/statement_timeout` | Statement Timeout | Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to `0` to disable statement timeouts entirely. Options include `""`, `0`, `30s`, `1m`, `2m`, `5m`, and `30m`. | string | `""` |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
@@ -198,7 +198,7 @@ See [connectors](../../../../concepts/connectors.md#using-connectors) to learn m
 | `/advanced/capture_as_partitions` | Capture Partitioned Tables As Partitions | When set, the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without `publish_via_partition_root`. | boolean | `false` |
 | `/advanced/discover_unpublished_tables` | Discover Unpublished Tables | If `true`, the capture discovers all tables, even ones not currently in the publication. | boolean |  |
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
-| `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely. Options include `""`, `30s`, `1m`, `5m`, and `30m`. | string | `""` |
+| `/advanced/statement_timeout` | Statement Timeout | Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to `0` to disable statement timeouts entirely. Options include `""`, `0`, `30s`, `1m`, `2m`, `5m`, and `30m`. | string | `""` |
 
 #### Bindings
 

--- a/source-postgres/.snapshots/TestSpec
+++ b/source-postgres/.snapshots/TestSpec
@@ -234,13 +234,15 @@
             "type": "string",
             "enum": [
               "",
+              "0",
               "30s",
               "1m",
+              "2m",
               "5m",
               "30m"
             ],
             "title": "Statement Timeout",
-            "description": "Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely.",
+            "description": "Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to '0' to disable statement timeouts entirely.",
             "default": ""
           },
           "discover_only_published": {

--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,7 +1,8 @@
-# source-postgres
+# Changelog
 
-## v2, 2022-10-17
-- Use new network-tunnel
+## 2026-07-14
 
-## v1, 2022-07-27
-- Beginning of changelog.
+### Changed
+- Queries now use a default `statement_timeout` of 2 minutes when the
+  `statement_timeout` advanced option is left blank. Set to `0` for the
+  previous behavior of disabling timeouts.

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -171,7 +171,7 @@ type advancedConfig struct {
 	DiscoverUnpublishedTables bool     `json:"discover_unpublished_tables,omitempty" jsonschema:"title=Discover Unpublished Tables,description=When set the capture will discover all tables including those not currently in the publication. Unpublished tables will be added to the publication at capture time if possible. Use with caution as this requires appropriate database permissions."`
 	SourceTag                 string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
 	FeatureFlags              string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
-	StatementTimeout          string   `json:"statement_timeout,omitempty" jsonschema:"title=Statement Timeout,description=Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely.,enum=,enum=30s,enum=1m,enum=5m,enum=30m,default="`
+	StatementTimeout          string   `json:"statement_timeout,omitempty" jsonschema:"title=Statement Timeout,description=Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to '0' to disable statement timeouts entirely.,enum=,enum=0,enum=30s,enum=1m,enum=2m,enum=5m,enum=30m,default="`
 
 	DeprecatedDiscoverOnlyPublished bool `json:"discover_only_published,omitempty" jsonschema_extras:"x-hidden-field=true"` // Unused, only supported to avoid breaking existing captures
 }
@@ -426,6 +426,9 @@ func (db *postgresDatabase) HistoryMode() bool {
 	return db.config.HistoryMode
 }
 
+// The statement timeout applied to database connections when none is configured.
+const defaultStatementTimeout = 2 * time.Minute
+
 func (db *postgresDatabase) connect(ctx context.Context) error {
 	logrus.WithFields(logrus.Fields{
 		"address":  db.config.Address,
@@ -452,9 +455,9 @@ func (db *postgresDatabase) connect(ctx context.Context) error {
 		}
 
 		// Attempt (non-fatal) to set the statement_timeout parameter. If a timeout is
-		// configured in settings we use that, otherwise default to zero so that backfill
-		// queries never get interrupted.
-		var statementTimeout = "0"
+		// configured in settings we use that, otherwise fall back to a conservative
+		// default which bounds runaway queries.
+		var statementTimeout = fmt.Sprintf("%d", defaultStatementTimeout.Milliseconds())
 		if db.config.Advanced.StatementTimeout != "" {
 			if timeout, err := time.ParseDuration(db.config.Advanced.StatementTimeout); err == nil {
 				statementTimeout = fmt.Sprintf("%d", timeout.Milliseconds())
@@ -491,16 +494,12 @@ func (db *postgresDatabase) connect(ctx context.Context) error {
 		return fmt.Errorf("unable to connect to database: %w", err)
 	}
 
-	// Log a message about the statement_timeout setting. If we configured a specific timeout
-	// we just log the value for visibility. If we intended to disable the timeout (config empty
-	// or zero) but the database reports a nonzero value, we warn that backfills might be interrupted.
+	// Log the effective statement_timeout for visibility.
 	var actualTimeout string
 	if err := pool.QueryRow(ctx, "SHOW statement_timeout").Scan(&actualTimeout); err != nil {
 		logrus.WithField("err", err).Warn("failed to query statement_timeout")
-	} else if db.config.Advanced.StatementTimeout != "" {
+	} else {
 		logrus.WithField("timeout", actualTimeout).Info("queried statement_timeout")
-	} else if actualTimeout != "0" {
-		logrus.WithField("timeout", actualTimeout).Info("nonzero statement_timeout")
 	}
 
 	db.conn = pool


### PR DESCRIPTION
**Description:**

For historical reasons we defaulted to an unlimited statement timeout. This is probably not the right default behavior in the general case since it overrides any database-default timeouts _and_ an unlimited query timeout can cause issues in prod DBs.

After this change we will default to `2m` and if a user wants to let backfill queries run longer than that they are free to raise the timeout or set it to `0` for unlimited.

**Workflow steps:**

Users will now get a 2-minute timeout for all backfill queries by default. If the old behavior is desired, set `/advanced/statement_timeout` to `0`.

**Documentation links affected:**

Documentation is updated in this PR. Do we need to sync docs changes over to the Flow repo these days or what? It looks like right now the docs exist in both locations.
