### PR TITLE
materialize-snowflake: Snowpipe Streaming via high-performance REST API (SDK protocol)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,16 @@ jobs:
   build_connectors:
     runs-on: ubuntu-24.04
     needs: build_base_image
+    env:
+      # The estuary/flow repository stores some large files in Git LFS, so Go
+      # module zips of a commit pseudo-version differ depending on whether Git
+      # LFS is installed on the machine building them: the GitHub runner (LFS
+      # installed) smudges the real file contents, while proxy.golang.org and
+      # the Docker builder (no LFS) keep the small pointer files, and only one
+      # of the two resulting checksums can match go.sum. Skipping the smudge
+      # makes every step of this job produce the pointer-file zips that match
+      # proxy.golang.org. See also the same setting on the Go tests step.
+      GIT_LFS_SKIP_SMUDGE: 1
     strategy:
       fail-fast: false
       matrix:

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.10
+	github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc
@@ -80,7 +80,7 @@ require (
 	github.com/tidwall/gjson v1.17.3
 	github.com/tidwall/sjson v1.2.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
+	go.gazette.dev/core v0.103.1-0.20260615140749-4c82daea983c
 	go.mongodb.org/mongo-driver v1.17.7
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/estuary/flow v0.6.10 h1:Z+zM5Qct0aR5EQAhfHmi4bR3jZPDpNwK0R5KPlZz/Wc=
-github.com/estuary/flow v0.6.10/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c h1:/e2h6w0cEzETiKIRGFb0V9PT+YPhoRB1wHLa8l7V7h8=
+github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c/go.mod h1:hJKr8VJaI0HB56EwcwxLRiOtivrKAIlHIn533NwH5UU=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
@@ -1075,8 +1075,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee h1:yceN2m1184/i4YSN4tlfMSdpnV+xnePgnUf4KFa00oE=
-go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260615140749-4c82daea983c h1:QAAURKZd4rZz3TEtiCIFW7SPo6V1vijzA1VGnh/Kfh8=
+go.gazette.dev/core v0.103.1-0.20260615140749-4c82daea983c/go.mod h1:e+xn7dj32gVL1K9U8gJ7br7HJmcHnffBcQ6/RyuK3d8=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
 go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=

--- a/go.sum
+++ b/go.sum
@@ -412,7 +412,7 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c h1:/e2h6w0cEzETiKIRGFb0V9PT+YPhoRB1wHLa8l7V7h8=
+github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c h1:1/dPnLqMMqQYCOw33C6quwEGJG0p3i74PzHV1OKKZGY=
 github.com/estuary/flow v0.6.11-0.20260713164751-17081a46f85c/go.mod h1:hJKr8VJaI0HB56EwcwxLRiOtivrKAIlHIn533NwH5UU=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=

--- a/materialize-snowflake/CHANGELOG.md
+++ b/materialize-snowflake/CHANGELOG.md
@@ -1,4 +1,13 @@
 # materialize-snowflake
 
+## 2026-07-15
+
+### Added
+- New opt-in feature flag `snowpipe_streaming_sdk`: delta-updates bindings using
+  Private Key (JWT) authentication stream data through Snowflake's
+  high-performance Snowpipe Streaming architecture, ingesting rows through each
+  table's default streaming pipe. The original streaming protocol remains the
+  default and is unchanged.
+
 ## v1, 2022-07-27
 - Beginning of changelog.

--- a/materialize-snowflake/config.go
+++ b/materialize-snowflake/config.go
@@ -18,7 +18,12 @@ import (
 var featureFlagDefaults = map[string]bool{
 	// Use Snowpipe streaming for delta-updates bindings that use JWT
 	// authentication.
-	"snowpipe_streaming":               true,
+	"snowpipe_streaming": true,
+	// Use the Snowpipe Streaming high-performance architecture (the protocol
+	// of Snowflake's current streaming SDKs) instead of the original streaming
+	// protocol for delta-updates bindings that use JWT authentication.
+	// Requires running on the v2 runtime.
+	"snowpipe_streaming_sdk":           false,
 	"datetime_keys_as_string":          true,
 	"retain_existing_data_on_backfill": false,
 	"native_binary_column_type":        true,

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -232,7 +232,10 @@ type transactor struct {
 	db                *stdsql.DB
 	streamManager     *streamManager
 	sdkStreamManager  *sdkStreamManager
-	pipeClient        *PipeClient
+	// sdkStreaming routes new delta-updates data through the SDK streaming
+	// path. The manager itself is available for checkpoint replay regardless.
+	sdkStreaming bool
+	pipeClient   *PipeClient
 
 	// Variables exclusively used by Load.
 	load struct {
@@ -322,6 +325,7 @@ func newTransactor(
 		db:                db,
 		streamManager:     sm,
 		sdkStreamManager:  sdkSM,
+		sdkStreaming:      sdkSM != nil,
 		pipeClient:        pipeClient,
 		_range:            open.Range,
 		version:           open.Version,
@@ -399,28 +403,24 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table, streaming
 	b.load.mergeBounds = sql.NewMergeBoundsBuilder(target.Keys, d.ep.Dialect.Literal)
 	b.store.mergeBounds = sql.NewMergeBoundsBuilder(target.Keys, d.ep.Dialect.Literal)
 
-	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && d.sdkStreamManager != nil {
+	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && d.sdkStreaming {
+		// The SDK streaming path is explicitly opted into, so a table that
+		// cannot use it is an error rather than a reason to fall back to a
+		// strategy built on APIs that Snowflake is retiring.
 		loc := d.ep.Dialect.TableLocator(b.target.Path)
 		columnNames := make([]string, 0, len(target.Columns()))
 		for _, col := range target.Columns() {
 			columnNames = append(columnNames, d.ep.Dialect.ColumnLocator(col.Field))
 		}
 		if err := d.sdkStreamManager.addBinding(ctx, loc.TableSchema, loc.TableName, columnNames, target); err != nil {
-			if errors.Is(err, ErrPermanent) {
-				// The table cannot use the high-performance streaming API, so
-				// fall back to a non-SDK strategy for it.
-				log.WithError(err).WithField("table", b.target.Path).Info("not using Snowpipe Streaming SDK for table")
-			} else {
-				return fmt.Errorf("adding binding to SDK stream manager: %w", err)
-			}
-		} else {
-			b.streaming = true
-			b.sdk = true
-			b.sdkSchema = loc.TableSchema
-			b.sdkPipe = defaultPipeName(loc.TableName)
-			d.bindings = append(d.bindings, b)
-			return nil
+			return fmt.Errorf("adding binding to SDK stream manager: %w", err)
 		}
+		b.streaming = true
+		b.sdk = true
+		b.sdkSchema = loc.TableSchema
+		b.sdkPipe = defaultPipeName(loc.TableName)
+		d.bindings = append(d.bindings, b)
+		return nil
 	}
 
 	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && streamingEnabled {

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -315,15 +315,7 @@ func newTransactor(
 		}
 	}
 
-	var sdkStreaming bool
-	if featureFlags["snowpipe_streaming_sdk"] && sdkSM != nil {
-		// Only the v2 runtime populates the Open request's sealed config.
-		if len(open.SealedConfigJson) == 0 {
-			log.Info("snowpipe_streaming_sdk is enabled but this task is not running on the v2 runtime; using the original streaming protocol")
-		} else {
-			sdkStreaming = true
-		}
-	}
+	var sdkStreaming = featureFlags["snowpipe_streaming_sdk"] && sdkSM != nil
 
 	var d = &transactor{
 		runtimeCheckpoint: fence.Checkpoint,

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -307,13 +307,21 @@ func newTransactor(
 			return nil, fmt.Errorf("NewPipeClient: %w", err)
 		}
 
-		if featureFlags["snowpipe_streaming_sdk"] {
-			// Only the v2 runtime populates the Open request's sealed config.
-			if len(open.SealedConfigJson) == 0 {
-				log.Info("snowpipe_streaming_sdk is enabled but this task is not running on the v2 runtime; using the original streaming protocol")
-			} else if sdkSM, err = newSdkStreamManager(&cfg, open.Materialization.TaskName(), accountName, open.Range.KeyBegin, db); err != nil {
-				return nil, fmt.Errorf("newSdkStreamManager: %w", err)
-			}
+		// The SDK stream manager is always constructed so that SDK streaming
+		// checkpoints can be replayed even after the feature flag is turned
+		// off or the task moves off the v2 runtime.
+		if sdkSM, err = newSdkStreamManager(&cfg, open.Materialization.TaskName(), accountName, open.Range.KeyBegin, db); err != nil {
+			return nil, fmt.Errorf("newSdkStreamManager: %w", err)
+		}
+	}
+
+	var sdkStreaming bool
+	if featureFlags["snowpipe_streaming_sdk"] && sdkSM != nil {
+		// Only the v2 runtime populates the Open request's sealed config.
+		if len(open.SealedConfigJson) == 0 {
+			log.Info("snowpipe_streaming_sdk is enabled but this task is not running on the v2 runtime; using the original streaming protocol")
+		} else {
+			sdkStreaming = true
 		}
 	}
 
@@ -325,7 +333,7 @@ func newTransactor(
 		db:                db,
 		streamManager:     sm,
 		sdkStreamManager:  sdkSM,
-		sdkStreaming:      sdkSM != nil,
+		sdkStreaming:      sdkStreaming,
 		pipeClient:        pipeClient,
 		_range:            open.Range,
 		version:           open.Version,
@@ -984,7 +992,7 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 			})
 		} else if len(item.SdkChunks) > 0 {
 			if d.sdkStreamManager == nil {
-				return nil, fmt.Errorf("checkpoint for %s contains chunks of the high-performance streaming API, but it is not active; is the snowpipe_streaming_sdk feature flag still enabled?", path)
+				return nil, fmt.Errorf("checkpoint for %s contains chunks of the high-performance streaming API, which requires Private Key (JWT) authentication to replay", path)
 			}
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -231,6 +231,7 @@ type transactor struct {
 	ep                *sql.Endpoint[config]
 	db                *stdsql.DB
 	streamManager     *streamManager
+	sdkStreamManager  *sdkStreamManager
 	pipeClient        *PipeClient
 
 	// Variables exclusively used by Load.
@@ -291,6 +292,7 @@ func newTransactor(
 	}
 
 	var sm *streamManager
+	var sdkSM *sdkStreamManager
 	var pipeClient *PipeClient
 	if cfg.Credentials.AuthType == snowflake_auth.JWT {
 		var accountName string
@@ -302,6 +304,14 @@ func newTransactor(
 			return nil, fmt.Errorf("NewPipeClient: %w", err)
 		}
 
+		if featureFlags["snowpipe_streaming_sdk"] {
+			// Only the v2 runtime populates the Open request's sealed config.
+			if len(open.SealedConfigJson) == 0 {
+				log.Info("snowpipe_streaming_sdk is enabled but this task is not running on the v2 runtime; using the original streaming protocol")
+			} else if sdkSM, err = newSdkStreamManager(&cfg, open.Materialization.TaskName(), accountName, open.Range.KeyBegin, db); err != nil {
+				return nil, fmt.Errorf("newSdkStreamManager: %w", err)
+			}
+		}
 	}
 
 	var d = &transactor{
@@ -311,6 +321,7 @@ func newTransactor(
 		templates:         renderTemplates(ep.Dialect),
 		db:                db,
 		streamManager:     sm,
+		sdkStreamManager:  sdkSM,
 		pipeClient:        pipeClient,
 		_range:            open.Range,
 		version:           open.Version,
@@ -355,6 +366,11 @@ type binding struct {
 	target sql.Table
 
 	streaming bool
+	// sdk indicates the binding streams via the high-performance streaming
+	// API rather than the original streaming protocol.
+	sdk       bool
+	sdkSchema string
+	sdkPipe   string
 	pipeName  string
 	// clusteringExpr is the parenthesized CLUSTER BY expression for this
 	// binding, or empty if clustering is not configured.
@@ -382,6 +398,30 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table, streaming
 	b.nullFieldsToStrip = target.NullableFieldsToStrip()
 	b.load.mergeBounds = sql.NewMergeBoundsBuilder(target.Keys, d.ep.Dialect.Literal)
 	b.store.mergeBounds = sql.NewMergeBoundsBuilder(target.Keys, d.ep.Dialect.Literal)
+
+	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && d.sdkStreamManager != nil {
+		loc := d.ep.Dialect.TableLocator(b.target.Path)
+		columnNames := make([]string, 0, len(target.Columns()))
+		for _, col := range target.Columns() {
+			columnNames = append(columnNames, d.ep.Dialect.ColumnLocator(col.Field))
+		}
+		if err := d.sdkStreamManager.addBinding(ctx, loc.TableSchema, loc.TableName, columnNames, target); err != nil {
+			if errors.Is(err, ErrPermanent) {
+				// The table cannot use the high-performance streaming API, so
+				// fall back to a non-SDK strategy for it.
+				log.WithError(err).WithField("table", b.target.Path).Info("not using Snowpipe Streaming SDK for table")
+			} else {
+				return fmt.Errorf("adding binding to SDK stream manager: %w", err)
+			}
+		} else {
+			b.streaming = true
+			b.sdk = true
+			b.sdkSchema = loc.TableSchema
+			b.sdkPipe = defaultPipeName(loc.TableName)
+			d.bindings = append(d.bindings, b)
+			return nil
+		}
+	}
 
 	if b.target.DeltaUpdates && d.cfg.Credentials.AuthType == snowflake_auth.JWT && streamingEnabled {
 		loc := d.ep.Dialect.TableLocator(b.target.Path)
@@ -614,6 +654,11 @@ type checkpointItem struct {
 	PipeFiles     []fileRecord
 	Version       string
 	EncryptionKey string
+
+	// Used by bindings streaming via the high-performance streaming API.
+	SdkSchema string     `json:",omitempty"`
+	SdkPipe   string     `json:",omitempty"`
+	SdkChunks []sdkChunk `json:",omitempty"`
 }
 
 type checkpoint = map[string]*checkpointItem
@@ -636,6 +681,10 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 		}
 		if converted, err := b.target.ConvertAll(it.Key, it.Values, it.RawJSON); err != nil {
 			return nil, fmt.Errorf("converting Store: %w", err)
+		} else if b.sdk {
+			if err := d.sdkStreamManager.writeRow(ctx, it.Binding, converted); err != nil {
+				return nil, fmt.Errorf("encoding Store to SDK stream for resource %s: %w", b.target.Path, err)
+			}
 		} else if b.streaming {
 			if err := d.streamManager.writeRow(ctx, it.Binding, converted); err != nil {
 				return nil, fmt.Errorf("encoding Store to stream for resource %s: %w", b.target.Path, err)
@@ -661,21 +710,48 @@ func (d *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 }
 
 func (d *transactor) buildDriverCheckpoint(ctx context.Context, runtimeCheckpoint *protocol.Checkpoint) (json.RawMessage, error) {
+	// The "base token" only really needs to be sufficiently random that it
+	// doesn't collide with the prior or next transaction's value. Deriving
+	// it from the runtime checkpoint is not absolutely necessary, but it's
+	// convenient to make testing outputs consistent.
+	var baseToken string
+	if d.streamManager != nil || d.sdkStreamManager != nil {
+		if mcp, err := runtimeCheckpoint.Marshal(); err != nil {
+			return nil, fmt.Errorf("marshalling checkpoint: %w", err)
+		} else {
+			baseToken = fmt.Sprintf("%016x", xxhash.Sum64(mcp))
+		}
+	}
+
 	streamBlobs := make(map[int][]*blobMetadata)
 	keys := make(map[int]string)
 	if d.streamManager != nil {
-		// The "base token" only really needs to be sufficiently random that it
-		// doesn't collide with the prior or next transaction's value. Deriving
-		// it from the runtime checkpoint is not absolutely necessary, but it's
-		// convenient to make testing outputs consistent.
-		if mcp, err := runtimeCheckpoint.Marshal(); err != nil {
-			return nil, fmt.Errorf("marshalling checkpoint: %w", err)
-		} else if streamBlobs, keys, err = d.streamManager.flush(fmt.Sprintf("%016x", xxhash.Sum64(mcp))); err != nil {
+		var err error
+		if streamBlobs, keys, err = d.streamManager.flush(baseToken); err != nil {
 			return nil, fmt.Errorf("flushing stream manager: %w", err)
 		}
 	}
 
+	sdkChunks := make(map[int][]sdkChunk)
+	if d.sdkStreamManager != nil {
+		var err error
+		if sdkChunks, err = d.sdkStreamManager.flush(ctx, baseToken); err != nil {
+			return nil, fmt.Errorf("flushing SDK stream manager: %w", err)
+		}
+	}
+
 	for idx, b := range d.bindings {
+		if b.sdk {
+			if chunks, ok := sdkChunks[idx]; ok {
+				d.cp[b.target.StateKey] = &checkpointItem{
+					SdkSchema: b.sdkSchema,
+					SdkPipe:   b.sdkPipe,
+					SdkChunks: chunks,
+				}
+			}
+			continue
+		}
+
 		if b.streaming {
 			if blobs, ok := streamBlobs[idx]; ok {
 				d.cp[b.target.StateKey] = &checkpointItem{
@@ -906,6 +982,20 @@ func (d *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 
 				return nil
 			})
+		} else if len(item.SdkChunks) > 0 {
+			if d.sdkStreamManager == nil {
+				return nil, fmt.Errorf("checkpoint for %s contains chunks of the high-performance streaming API, but it is not active; is the snowpipe_streaming_sdk feature flag still enabled?", path)
+			}
+			group.Go(func() error {
+				d.be.StartedResourceCommit(path)
+				if err := d.sdkStreamManager.write(groupCtx, item.SdkSchema, item.SdkPipe, item.SdkChunks); err != nil {
+					return fmt.Errorf("writing SDK streaming chunks for %s: %w", path, err)
+				}
+				d.be.FinishedResourceCommit(path)
+
+				return nil
+			})
+
 		} else if len(item.StreamBlobs) > 0 {
 			group.Go(func() error {
 				d.be.StartedResourceCommit(path)

--- a/materialize-snowflake/stream_sdk.go
+++ b/materialize-snowflake/stream_sdk.go
@@ -1,0 +1,448 @@
+package main
+
+import (
+	"context"
+	stdsql "database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/google/uuid"
+	"github.com/klauspost/pgzip"
+	log "github.com/sirupsen/logrus"
+	"github.com/segmentio/encoding/json"
+
+	"github.com/estuary/connectors/go/encrow"
+)
+
+// sdkChunkSizeLimit bounds the uncompressed size of a single chunk of NDJSON
+// rows, since the append-rows endpoint limits the size of a single request.
+// Requests are sent gzip-compressed, so the on-the-wire size will be
+// considerably smaller than this.
+const sdkChunkSizeLimit = 3_500_000
+
+// sdkChunk describes one durable chunk of NDJSON rows from a transaction. It
+// is persisted in the driver checkpoint so that a crashed commit can be
+// replayed: the chunk bytes are read from the local file when it still exists,
+// or retrieved from the internal stage otherwise.
+type sdkChunk struct {
+	StageDir  string `json:"stage_dir"`  // internal stage directory, e.g. "uuid"
+	FileName  string `json:"file_name"`  // chunk file name within the directory
+	LocalPath string `json:"local_path"` // local copy of the chunk file
+	Token     string `json:"token"`      // offset token registering this chunk
+}
+
+// sdkTableStream is the per-binding state of a channel of a table's default
+// streaming pipe.
+type sdkTableStream struct {
+	schema string // stored (translated) schema name
+	pipe   string // stored pipe name
+	fields []string
+	shape  *encrow.Shape
+
+	continuationToken string
+	// lastCommitted mirrors the channel's last committed offset token as of
+	// the most recent open or confirmed write.
+	lastCommitted *string
+	// errorRows is the channel's error-row count baseline, used to detect rows
+	// that the server parsed but refused to ingest.
+	errorRows int
+
+	// Local chunk accumulation for the current transaction.
+	dir     string
+	chunkN  int
+	current *sdkChunkWriter
+	chunks  []sdkChunk
+}
+
+// sdkChunkWriter writes gzipped NDJSON rows to a local file while tracking the
+// uncompressed size for chunking decisions.
+type sdkChunkWriter struct {
+	file         *os.File
+	gz           *pgzip.Writer
+	uncompressed int
+	buf          []byte
+}
+
+func newSdkChunkWriter(path string) (*sdkChunkWriter, error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("creating chunk file: %w", err)
+	}
+	return &sdkChunkWriter{file: file, gz: pgzip.NewWriter(file)}, nil
+}
+
+func (w *sdkChunkWriter) writeRow(shape *encrow.Shape, row []any) error {
+	var err error
+	w.buf = w.buf[:0]
+	if w.buf, err = shape.Encode(w.buf, row); err != nil {
+		return fmt.Errorf("encoding row: %w", err)
+	}
+	w.buf = append(w.buf, '\n')
+
+	if _, err := w.gz.Write(w.buf); err != nil {
+		return fmt.Errorf("writing row: %w", err)
+	}
+	w.uncompressed += len(w.buf)
+
+	return nil
+}
+
+func (w *sdkChunkWriter) close() error {
+	if err := w.gz.Close(); err != nil {
+		return fmt.Errorf("closing gzip writer: %w", err)
+	} else if err := w.file.Close(); err != nil {
+		return fmt.Errorf("closing chunk file: %w", err)
+	}
+	return nil
+}
+
+// sdkStreamManager orchestrates Snowpipe Streaming over the high-performance
+// REST API. Rows are accumulated into local NDJSON chunk files during Store and
+// made durable by PUTing them to the connector's internal stage before the
+// driver checkpoint referencing them is built. The chunks are appended to each
+// binding's channel during Acknowledge, using "base:n" offset tokens so that
+// chunks already committed by a prior, interrupted attempt are skipped.
+type sdkStreamManager struct {
+	c           *sdkStreamClient
+	db          *stdsql.DB
+	channelName string
+	tempdir     string
+	streams     map[int]*sdkTableStream
+}
+
+func newSdkStreamManager(cfg *config, materialization string, account string, keyBegin uint32, db *stdsql.DB) (*sdkStreamManager, error) {
+	c, err := newSdkStreamClient(cfg, account)
+	if err != nil {
+		return nil, fmt.Errorf("newSdkStreamClient: %w", err)
+	}
+
+	return &sdkStreamManager{
+		c:           c,
+		db:          db,
+		channelName: channelName(materialization, keyBegin),
+		tempdir:     os.TempDir(),
+		streams:     make(map[int]*sdkTableStream),
+	}, nil
+}
+
+// defaultPipeName is the name of the streaming pipe that Snowflake
+// automatically creates for a table at first ingest.
+func defaultPipeName(tableName string) string {
+	return tableName + "-STREAMING"
+}
+
+func (m *sdkStreamManager) addBinding(ctx context.Context, schema string, tableName string, columnNames []string, target sql.Table) error {
+	pipe := defaultPipeName(tableName)
+
+	res, err := m.c.openChannel(ctx, schema, pipe, m.channelName)
+	if err != nil {
+		return fmt.Errorf("openChannel: %w", err)
+	}
+
+	m.streams[target.Binding] = &sdkTableStream{
+		schema:            schema,
+		pipe:              pipe,
+		fields:            columnNames,
+		shape:             newSdkShape(columnNames),
+		continuationToken: res.NextContinuationToken,
+		lastCommitted:     res.ChannelStatus.LastCommittedOffsetToken,
+		errorRows:         res.ChannelStatus.RowsErrorCount,
+	}
+
+	log.WithFields(log.Fields{
+		"schema":        schema,
+		"pipe":          pipe,
+		"channel":       m.channelName,
+		"lastCommitted": res.ChannelStatus.LastCommittedOffsetToken,
+	}).Info("opened streaming channel")
+
+	return nil
+}
+
+func newSdkShape(fields []string) *encrow.Shape {
+	shape := encrow.NewShape(fields)
+	// Pre-serialized JSON from the runtime is trusted as-is, and values are
+	// not HTML-escaped, matching how rows are encoded for staged files.
+	shape.SetFlags(json.TrustRawMessage)
+	shape.SetSkipNulls(true)
+	return shape
+}
+
+func (m *sdkStreamManager) writeRow(ctx context.Context, binding int, row []any) error {
+	stream, ok := m.streams[binding]
+	if !ok {
+		return fmt.Errorf("no stream for binding %d", binding)
+	}
+
+	if stream.current == nil {
+		if stream.dir == "" {
+			if err := m.startTransaction(ctx, stream); err != nil {
+				return fmt.Errorf("starting transaction: %w", err)
+			}
+		}
+		w, err := newSdkChunkWriter(filepath.Join(stream.dir, fmt.Sprintf("%06d.ndjson.gz", stream.chunkN)))
+		if err != nil {
+			return err
+		}
+		stream.current = w
+	}
+
+	if err := stream.current.writeRow(stream.shape, row); err != nil {
+		return err
+	}
+
+	if stream.current.uncompressed >= sdkChunkSizeLimit {
+		if err := m.finishChunk(ctx, stream); err != nil {
+			return fmt.Errorf("finishing chunk: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// startTransaction initializes the local scratch directory for a binding's
+// chunks of the current transaction, named by a fresh UUID that also serves as
+// the chunk directory within the internal stage.
+func (m *sdkStreamManager) startTransaction(ctx context.Context, stream *sdkTableStream) error {
+	id := uuid.NewString()
+	dir := filepath.Join(m.tempdir, id)
+	if err := os.Mkdir(dir, 0700); err != nil {
+		return fmt.Errorf("creating scratch directory: %w", err)
+	}
+	stream.dir = dir
+	stream.chunkN = 0
+	stream.chunks = nil
+
+	return nil
+}
+
+// finishChunk closes the current chunk file and PUTs it to the internal stage,
+// making it durable for commit replay.
+func (m *sdkStreamManager) finishChunk(ctx context.Context, stream *sdkTableStream) error {
+	if stream.current == nil {
+		return nil
+	}
+	if err := stream.current.close(); err != nil {
+		return err
+	}
+	stream.current = nil
+
+	stageDir := filepath.Base(stream.dir)
+	fileName := fmt.Sprintf("%06d.ndjson.gz", stream.chunkN)
+	localPath := filepath.Join(stream.dir, fileName)
+
+	query := fmt.Sprintf(
+		`PUT file://%s @flow_v1/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=GZIP OVERWRITE=TRUE;`,
+		localPath, stageDir,
+	)
+	// Retry a few times on errors since there are occasionally transient
+	// network errors when running PUT queries.
+	for attempt := 1; ; attempt++ {
+		var source, target, sourceSize, targetSize, sourceCompression, targetCompression, status, message string
+		err := m.db.QueryRowContext(ctx, query).Scan(&source, &target, &sourceSize, &targetSize, &sourceCompression, &targetCompression, &status, &message)
+		if err == nil {
+			break
+		} else if attempt > 3 {
+			return fmt.Errorf("PUT chunk to stage: %w", err)
+		}
+		log.WithError(err).WithField("attempt", attempt).Info("retrying PUT of chunk to stage")
+		time.Sleep(time.Duration(attempt) * time.Second)
+	}
+
+	stream.chunks = append(stream.chunks, sdkChunk{
+		StageDir:  stageDir,
+		FileName:  fileName,
+		LocalPath: localPath,
+	})
+	stream.chunkN++
+
+	return nil
+}
+
+// flush finalizes all bindings' chunks for the transaction, assigning offset
+// tokens "baseToken:0", "baseToken:1", ... per binding, and returns the chunk
+// descriptors to be persisted in the driver checkpoint.
+func (m *sdkStreamManager) flush(ctx context.Context, baseToken string) (map[int][]sdkChunk, error) {
+	out := make(map[int][]sdkChunk)
+	for binding, stream := range m.streams {
+		if err := m.finishChunk(ctx, stream); err != nil {
+			return nil, fmt.Errorf("finishing chunk: %w", err)
+		}
+		if len(stream.chunks) == 0 {
+			continue
+		}
+		for i := range stream.chunks {
+			stream.chunks[i].Token = blobToken(baseToken, i)
+		}
+		out[binding] = stream.chunks
+		stream.chunks = nil
+		stream.dir = ""
+	}
+
+	return out, nil
+}
+
+// write appends a transaction's chunks to the channel of the table identified
+// by schema and pipe, skipping chunks whose offset tokens the channel has
+// already committed, and returns once the channel reports the final chunk's
+// token as durably committed. All chunks must be for the same binding.
+func (m *sdkStreamManager) write(ctx context.Context, schema string, pipe string, chunks []sdkChunk) error {
+	var stream *sdkTableStream
+	for _, s := range m.streams {
+		if s.schema == schema && s.pipe == pipe {
+			stream = s
+			break
+		}
+	}
+	if stream == nil {
+		return fmt.Errorf("unknown stream for pipe %s.%s", schema, pipe)
+	}
+
+	logger := log.WithFields(log.Fields{
+		"schema": schema,
+		"pipe":   pipe,
+	})
+	ctx = WithLogger(ctx, logger)
+
+	var finalToken string
+	for _, chunk := range chunks {
+		finalToken = chunk.Token
+		if shouldWrite, err := shouldWriteNextToken(ctx, chunk.Token, stream.lastCommitted); err != nil {
+			return fmt.Errorf("shouldWriteNextToken: %w", err)
+		} else if !shouldWrite {
+			continue
+		}
+
+		rows, err := m.chunkBytes(ctx, chunk)
+		if err != nil {
+			return fmt.Errorf("reading chunk %s: %w", chunk.FileName, err)
+		}
+
+		next, err := m.c.appendRows(ctx, schema, pipe, m.channelName, stream.continuationToken, chunk.Token, rows)
+		if err != nil {
+			return fmt.Errorf("appendRows: %w", err)
+		}
+		stream.continuationToken = next
+		token := chunk.Token
+		stream.lastCommitted = &token
+	}
+
+	if err := m.waitForTokenCommitted(ctx, stream, finalToken); err != nil {
+		return err
+	}
+
+	return m.cleanupChunks(ctx, chunks)
+}
+
+// chunkBytes returns the gzipped NDJSON bytes of a chunk, reading the local
+// file when present or retrieving the durable copy from the internal stage
+// when replaying a commit after a restart.
+func (m *sdkStreamManager) chunkBytes(ctx context.Context, chunk sdkChunk) ([]byte, error) {
+	if b, err := os.ReadFile(chunk.LocalPath); err == nil {
+		return b, nil
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading local chunk: %w", err)
+	}
+
+	dir, err := os.MkdirTemp(m.tempdir, "sdk-chunk-restore")
+	if err != nil {
+		return nil, fmt.Errorf("creating restore directory: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	query := fmt.Sprintf(`GET @flow_v1/%s/%s file://%s;`, chunk.StageDir, chunk.FileName, dir)
+	var file, size, status, message string
+	if err := m.db.QueryRowContext(ctx, query).Scan(&file, &size, &status, &message); err != nil {
+		return nil, fmt.Errorf("GET chunk from stage: %w", err)
+	} else if status != "DOWNLOADED" {
+		return nil, fmt.Errorf("GET chunk from stage: unexpected status %q: %s", status, message)
+	}
+
+	return os.ReadFile(filepath.Join(dir, chunk.FileName))
+}
+
+// waitForTokenCommitted polls the channel status until the given offset token
+// is reported as durably committed. It also fails loudly if the server reports
+// rows that could not be ingested, since those rows would otherwise be
+// silently dropped.
+func (m *sdkStreamManager) waitForTokenCommitted(ctx context.Context, stream *sdkTableStream, token string) error {
+	logger := Logger(ctx)
+	maxBackoff := 2 * time.Second
+	backoff := 100 * time.Millisecond
+	ts := time.Now()
+	for n := 1; ; n++ {
+		statuses, err := m.c.channelStatus(ctx, stream.schema, stream.pipe, []string{m.channelName})
+		if err != nil {
+			if !errors.Is(err, ErrTemporary) {
+				return err
+			}
+			logger.WithField("attempt", n).WithError(err).Info("temporary error getting channel status")
+		} else if status, ok := statuses[m.channelName]; !ok {
+			return fmt.Errorf("channel %q missing from status response", m.channelName)
+		} else if status.RowsErrorCount > stream.errorRows {
+			return fmt.Errorf(
+				"channel %q reports %d rows that could not be ingested: %s",
+				m.channelName, status.RowsErrorCount-stream.errorRows, deref(status.LastErrorMessage),
+			)
+		} else if status.LastCommittedOffsetToken != nil && *status.LastCommittedOffsetToken == token {
+			break
+		}
+
+		if n%10 == 0 {
+			logger.WithFields(log.Fields{
+				"attempt": n,
+				"token":   token,
+			}).Info("channel offset token not yet committed")
+		}
+
+		if time.Since(ts) > 5*time.Minute {
+			return fmt.Errorf("channel offset token not committed: max retries reached")
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxBackoff)
+	}
+
+	logger.WithFields(log.Fields{
+		"token": token,
+		"took":  time.Since(ts).String(),
+	}).Info("channel offset token committed")
+
+	return nil
+}
+
+// cleanupChunks removes the durable staged copies and local files of a
+// transaction's chunks once their data is committed.
+func (m *sdkStreamManager) cleanupChunks(ctx context.Context, chunks []sdkChunk) error {
+	dirs := make(map[string]struct{})
+	for _, chunk := range chunks {
+		dirs[chunk.StageDir] = struct{}{}
+		if chunk.LocalPath != "" {
+			os.Remove(chunk.LocalPath)
+			os.Remove(filepath.Dir(chunk.LocalPath)) // succeeds only once empty
+		}
+	}
+
+	for dir := range dirs {
+		if _, err := m.db.ExecContext(ctx, fmt.Sprintf(`REMOVE @flow_v1/%s;`, dir)); err != nil {
+			return fmt.Errorf("removing staged chunks: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/materialize-snowflake/stream_sdk.go
+++ b/materialize-snowflake/stream_sdk.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	sql "github.com/estuary/connectors/materialize-sql"
 	"github.com/google/uuid"
 	"github.com/klauspost/pgzip"
-	log "github.com/sirupsen/logrus"
 	"github.com/segmentio/encoding/json"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/estuary/connectors/go/encrow"
 )
@@ -111,7 +112,11 @@ type sdkStreamManager struct {
 	db          *stdsql.DB
 	channelName string
 	tempdir     string
-	streams     map[int]*sdkTableStream
+
+	// mu guards streams, which commit replays of concurrent Acknowledge
+	// checkpoint items may add to via ensureStream.
+	mu      sync.Mutex
+	streams map[int]*sdkTableStream
 }
 
 func newSdkStreamManager(cfg *config, materialization string, account string, keyBegin uint32, db *stdsql.DB) (*sdkStreamManager, error) {
@@ -133,6 +138,45 @@ func newSdkStreamManager(cfg *config, materialization string, account string, ke
 // automatically creates for a table at first ingest.
 func defaultPipeName(tableName string) string {
 	return tableName + "-STREAMING"
+}
+
+// ensureStream returns the stream of the channel of the pipe, opening the
+// channel if needed. Checkpoint replay can reference a pipe with no stream
+// opened by addBinding, such as when the SDK streaming feature flag was
+// turned off with a transaction's chunks still pending.
+func (m *sdkStreamManager) ensureStream(ctx context.Context, schema string, pipe string) (*sdkTableStream, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, s := range m.streams {
+		if s.schema == schema && s.pipe == pipe {
+			return s, nil
+		}
+	}
+
+	res, err := m.c.openChannel(ctx, schema, pipe, m.channelName)
+	if err != nil {
+		return nil, fmt.Errorf("openChannel: %w", err)
+	}
+	stream := &sdkTableStream{
+		schema:            schema,
+		pipe:              pipe,
+		continuationToken: res.NextContinuationToken,
+		lastCommitted:     res.ChannelStatus.LastCommittedOffsetToken,
+		errorRows:         res.ChannelStatus.RowsErrorCount,
+	}
+	// Key by a binding number that no real binding uses, since this stream
+	// exists only to replay a checkpoint.
+	m.streams[-1-len(m.streams)] = stream
+
+	log.WithFields(log.Fields{
+		"schema":        schema,
+		"pipe":          pipe,
+		"channel":       m.channelName,
+		"lastCommitted": res.ChannelStatus.LastCommittedOffsetToken,
+	}).Info("opened streaming channel for checkpoint replay")
+
+	return stream, nil
 }
 
 func (m *sdkStreamManager) addBinding(ctx context.Context, schema string, tableName string, columnNames []string, target sql.Table) error {
@@ -291,15 +335,9 @@ func (m *sdkStreamManager) flush(ctx context.Context, baseToken string) (map[int
 // already committed, and returns once the channel reports the final chunk's
 // token as durably committed. All chunks must be for the same binding.
 func (m *sdkStreamManager) write(ctx context.Context, schema string, pipe string, chunks []sdkChunk) error {
-	var stream *sdkTableStream
-	for _, s := range m.streams {
-		if s.schema == schema && s.pipe == pipe {
-			stream = s
-			break
-		}
-	}
-	if stream == nil {
-		return fmt.Errorf("unknown stream for pipe %s.%s", schema, pipe)
+	stream, err := m.ensureStream(ctx, schema, pipe)
+	if err != nil {
+		return fmt.Errorf("ensuring stream for pipe %s.%s: %w", schema, pipe, err)
 	}
 
 	logger := log.WithFields(log.Fields{

--- a/materialize-snowflake/stream_sdk.go
+++ b/materialize-snowflake/stream_sdk.go
@@ -347,7 +347,9 @@ func (m *sdkStreamManager) write(ctx context.Context, schema string, pipe string
 	ctx = WithLogger(ctx, logger)
 
 	var finalToken string
+	txnTokens := make(map[string]bool, len(chunks))
 	for _, chunk := range chunks {
+		txnTokens[chunk.Token] = true
 		finalToken = chunk.Token
 		if shouldWrite, err := shouldWriteNextToken(ctx, chunk.Token, stream.lastCommitted); err != nil {
 			return fmt.Errorf("shouldWriteNextToken: %w", err)
@@ -369,7 +371,7 @@ func (m *sdkStreamManager) write(ctx context.Context, schema string, pipe string
 		stream.lastCommitted = &token
 	}
 
-	if err := m.waitForTokenCommitted(ctx, stream, finalToken); err != nil {
+	if err := m.waitForTokenCommitted(ctx, stream, finalToken, txnTokens); err != nil {
 		return err
 	}
 
@@ -406,8 +408,11 @@ func (m *sdkStreamManager) chunkBytes(ctx context.Context, chunk sdkChunk) ([]by
 // waitForTokenCommitted polls the channel status until the given offset token
 // is reported as durably committed. It also fails loudly if the server reports
 // rows that could not be ingested, since those rows would otherwise be
-// silently dropped.
-func (m *sdkStreamManager) waitForTokenCommitted(ctx context.Context, stream *sdkTableStream, token string) error {
+// silently dropped: the channel's error-row count is compared against this
+// session's baseline, and the channel's last error offset is compared against
+// txnTokens, which detects rejected rows of this transaction even after a
+// restart has reset the session baseline.
+func (m *sdkStreamManager) waitForTokenCommitted(ctx context.Context, stream *sdkTableStream, token string, txnTokens map[string]bool) error {
 	logger := Logger(ctx)
 	maxBackoff := 2 * time.Second
 	backoff := 100 * time.Millisecond
@@ -425,6 +430,11 @@ func (m *sdkStreamManager) waitForTokenCommitted(ctx context.Context, stream *sd
 			return fmt.Errorf(
 				"channel %q reports %d rows that could not be ingested: %s",
 				m.channelName, status.RowsErrorCount-stream.errorRows, deref(status.LastErrorMessage),
+			)
+		} else if status.LastErrorOffsetUpperBound != nil && txnTokens[*status.LastErrorOffsetUpperBound] {
+			return fmt.Errorf(
+				"channel %q reports rows of this transaction (offset %s) that could not be ingested: %s",
+				m.channelName, *status.LastErrorOffsetUpperBound, deref(status.LastErrorMessage),
 			)
 		} else if status.LastCommittedOffsetToken != nil && *status.LastCommittedOffsetToken == token {
 			break

--- a/materialize-snowflake/stream_sdk_datatypes_test.go
+++ b/materialize-snowflake/stream_sdk_datatypes_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	stdsql "database/sql"
+	"encoding/json"
+	"testing"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSdkStreamDatatypes streams one row of each column type that the
+// connector maps and verifies the server-side parse of the NDJSON values.
+func TestSdkStreamDatatypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx := context.Background()
+	cfg := mustGetCfg(t)
+
+	dsn, err := cfg.toURI(true, "")
+	require.NoError(t, err)
+	db, err := stdsql.Open("snowflake", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var accountName string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName))
+
+	cleanup := func() {
+		db.ExecContext(ctx, "DROP TABLE IF EXISTS SDK_TYPES_TEST;")
+	}
+	defer cleanup()
+	cleanup()
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE SDK_TYPES_TEST (
+		I INTEGER, F FLOAT, B BOOLEAN, T TEXT, V VARIANT, D DATE, TS TIMESTAMP_LTZ, BIN BINARY
+	);`)
+	require.NoError(t, err)
+
+	table := sql.Table{TableShape: sql.TableShape{Binding: 0}, Identifier: `SDK_TYPES_TEST`}
+	columnNames := []string{"I", "F", "B", "T", "V", "D", "TS", "BIN"}
+
+	sm, err := newSdkStreamManager(&cfg, "testing-sdk-types", accountName, 0, db)
+	require.NoError(t, err)
+	require.NoError(t, sm.addBinding(ctx, cfg.Schema, "SDK_TYPES_TEST", columnNames, table))
+
+	require.NoError(t, sm.writeRow(ctx, 0, []any{
+		int64(42),
+		3.14,
+		true,
+		"hello",
+		json.RawMessage(`{"a": [1, 2], "b": "c"}`),
+		"2024-01-02",
+		"2024-01-02T03:04:05Z",
+		"aGVsbG8=", // "hello" in base64, as the runtime delivers binary values
+	}))
+	chunks, err := sm.flush(ctx, "types-token")
+	require.NoError(t, err)
+	require.NoError(t, sm.write(ctx, cfg.Schema, defaultPipeName("SDK_TYPES_TEST"), chunks[0]))
+
+	var i int64
+	var f float64
+	var b bool
+	var text, variant, date, timestamp, binary string
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT
+		I, F, B, T, TO_JSON(V), TO_VARCHAR(D, 'YYYY-MM-DD'),
+		TO_VARCHAR(CONVERT_TIMEZONE('UTC', TS), 'YYYY-MM-DD"T"HH24:MI:SSTZH:TZM'),
+		TO_VARCHAR(BIN, 'UTF-8')
+		FROM SDK_TYPES_TEST`).Scan(&i, &f, &b, &text, &variant, &date, &timestamp, &binary))
+
+	require.Equal(t, int64(42), i)
+	require.Equal(t, 3.14, f)
+	require.Equal(t, true, b)
+	require.Equal(t, "hello", text)
+	require.Equal(t, `{"a":[1,2],"b":"c"}`, variant)
+	require.Equal(t, "2024-01-02", date)
+	require.Equal(t, "2024-01-02T03:04:05Z", timestamp)
+	require.Equal(t, "hello", binary)
+}

--- a/materialize-snowflake/stream_sdk_http.go
+++ b/materialize-snowflake/stream_sdk_http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -153,9 +154,16 @@ func (c *sdkStreamClient) authorize(ctx context.Context) (string, string, error)
 	return c.ingestHost, c.scopedToken, nil
 }
 
+// quotedPathIdent renders an identifier for use as a URL path segment. The
+// endpoints parse path segments as SQL identifiers, uppercasing unquoted ones,
+// so identifiers are always double-quoted to preserve their exact stored form.
+func quotedPathIdent(ident string) string {
+	return url.PathEscape(`"` + strings.ReplaceAll(ident, `"`, `""`) + `"`)
+}
+
 func (c *sdkStreamClient) pipeURL(ingestHost, schema, pipe string) string {
 	return fmt.Sprintf("%s://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s",
-		c.scheme, ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe))
+		c.scheme, ingestHost, quotedPathIdent(c.database), quotedPathIdent(schema), quotedPathIdent(pipe))
 }
 
 // openChannel creates or re-opens a channel of the pipe, returning the
@@ -213,7 +221,7 @@ func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel,
 		SetResult(&out).
 		SetError(apiErr).
 		Post(fmt.Sprintf("%s://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows",
-			c.scheme, ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe), url.PathEscape(channel)))
+			c.scheme, ingestHost, quotedPathIdent(c.database), quotedPathIdent(schema), quotedPathIdent(pipe), url.PathEscape(channel)))
 	if err != nil {
 		return "", fmt.Errorf("appending rows to channel %q: %w", channel, err)
 	} else if !res.IsSuccess() {

--- a/materialize-snowflake/stream_sdk_http.go
+++ b/materialize-snowflake/stream_sdk_http.go
@@ -188,10 +188,10 @@ func (c *sdkStreamClient) openChannel(ctx context.Context, schema, pipe, channel
 	return &out, nil
 }
 
-// appendRows sends a batch of NDJSON-encoded rows. The batch is buffered
-// durably only once a subsequent channel status reports offsetToken (or a
-// later token) as committed.
-func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel, continuationToken, offsetToken string, rows []byte) (string, error) {
+// appendRows sends a batch of gzip-compressed NDJSON-encoded rows. The batch
+// is buffered durably only once a subsequent channel status reports
+// offsetToken (or a later token) as committed.
+func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel, continuationToken, offsetToken string, gzippedRows []byte) (string, error) {
 	ingestHost, token, err := c.authorize(ctx)
 	if err != nil {
 		return "", err
@@ -204,11 +204,12 @@ func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel,
 		SetHeader("Authorization", "Bearer "+token).
 		SetHeader("Accept", "application/json").
 		SetHeader("Content-Type", "application/x-ndjson").
+		SetHeader("Content-Encoding", "gzip").
 		SetQueryParams(map[string]string{
 			"continuationToken": continuationToken,
 			"offsetToken":       offsetToken,
 		}).
-		SetBody(rows).
+		SetBody(gzippedRows).
 		SetResult(&out).
 		SetError(apiErr).
 		Post(fmt.Sprintf("%s://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows",

--- a/materialize-snowflake/stream_sdk_http.go
+++ b/materialize-snowflake/stream_sdk_http.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"resty.dev/v3"
+)
+
+// sdkChannelStatus is the per-channel status reported by the open-channel and
+// bulk-channel-status endpoints of the high-performance streaming API.
+type sdkChannelStatus struct {
+	StatusCode                string  `json:"channel_status_code"`
+	LastCommittedOffsetToken  *string `json:"last_committed_offset_token"`
+	DatabaseName              string  `json:"database_name"`
+	SchemaName                string  `json:"schema_name"`
+	PipeName                  string  `json:"pipe_name"`
+	ChannelName               string  `json:"channel_name"`
+	RowsInserted              int     `json:"rows_inserted"`
+	RowsParsed                int     `json:"rows_parsed"`
+	RowsErrorCount            int     `json:"rows_error_count"`
+	LastErrorOffsetUpperBound *string `json:"last_error_offset_upper_bound"`
+	LastErrorMessage          *string `json:"last_error_message"`
+	LastErrorTimestampMs      *int64  `json:"last_error_timestamp_ms"`
+}
+
+type sdkOpenChannelResponse struct {
+	NextContinuationToken string           `json:"next_continuation_token"`
+	ChannelStatus         sdkChannelStatus `json:"channel_status"`
+}
+
+type sdkAppendRowsResponse struct {
+	StatusCode            int    `json:"status_code"`
+	Message               string `json:"message"`
+	NextContinuationToken string `json:"next_continuation_token"`
+}
+
+type sdkBulkChannelStatusResponse struct {
+	ChannelStatuses map[string]sdkChannelStatus `json:"channel_statuses"`
+}
+
+// sdkApiError is the error document returned by the high-performance streaming
+// API, e.g. {"code": "391902", "message": "..."}.
+type sdkApiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+
+	httpStatus int
+}
+
+func (e *sdkApiError) Error() string {
+	return fmt.Sprintf("%s (code %s, http %d)", e.Message, e.Code, e.httpStatus)
+}
+
+func (e *sdkApiError) Unwrap() error {
+	// Server-side and throttling errors are worth retrying; anything else is a
+	// misconfiguration or a permanent refusal.
+	if e.httpStatus >= 500 || e.httpStatus == http.StatusTooManyRequests {
+		return ErrTemporary
+	}
+	return ErrPermanent
+}
+
+// sdkStreamClient talks to the Snowpipe Streaming high-performance REST API.
+// Account-level endpoints (hostname discovery and scoped token exchange) go to
+// the configured account host, while channel and ingestion endpoints go to the
+// account's discovered ingest host.
+type sdkStreamClient struct {
+	r        *resty.Client
+	host     string
+	key      *rsa.PrivateKey
+	user     string
+	account  string
+	database string
+
+	mu          sync.Mutex
+	ingestHost  string
+	scopedToken string
+	expiry      time.Time
+}
+
+func newSdkStreamClient(cfg *config, account string) (*sdkStreamClient, error) {
+	key, err := cfg.Credentials.ParsePrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	return &sdkStreamClient{
+		r:        resty.New(),
+		host:     cfg.Host,
+		key:      key,
+		user:     cfg.Credentials.User,
+		account:  account,
+		database: cfg.Database,
+	}, nil
+}
+
+// authorize returns the ingest host and a scoped token for it, performing
+// hostname discovery and token exchange as needed. Scoped tokens are derived
+// from a key-pair JWT and share its lifetime, so both are refreshed together.
+func (c *sdkStreamClient) authorize(ctx context.Context) (string, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if time.Until(c.expiry).Minutes() >= 5 && c.ingestHost != "" {
+		return c.ingestHost, c.scopedToken, nil
+	}
+
+	jwt, expiry, err := generateJWTToken(c.key, c.user, c.account)
+	if err != nil {
+		return "", "", err
+	}
+
+	if c.ingestHost == "" {
+		res, err := c.r.NewRequest().
+			WithContext(ctx).
+			SetHeader("Authorization", "Bearer "+jwt).
+			SetHeader("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT").
+			SetHeader("Accept", "application/json").
+			Get("https://" + c.host + "/v2/streaming/hostname")
+		if err != nil {
+			return "", "", fmt.Errorf("discovering ingest hostname: %w", err)
+		} else if !res.IsSuccess() {
+			return "", "", fmt.Errorf("discovering ingest hostname: %s: %s", res.Status(), res.String())
+		}
+		c.ingestHost = res.String()
+	}
+
+	res, err := c.r.NewRequest().
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+jwt).
+		SetFormData(map[string]string{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"scope":      c.ingestHost,
+		}).
+		Post("https://" + c.host + "/oauth/token")
+	if err != nil {
+		return "", "", fmt.Errorf("exchanging scoped token: %w", err)
+	} else if !res.IsSuccess() {
+		return "", "", fmt.Errorf("exchanging scoped token: %s: %s", res.Status(), res.String())
+	}
+
+	c.scopedToken = res.String()
+	c.expiry = expiry
+
+	return c.ingestHost, c.scopedToken, nil
+}
+
+func (c *sdkStreamClient) pipeURL(ingestHost, schema, pipe string) string {
+	return fmt.Sprintf("https://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s",
+		ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe))
+}
+
+// openChannel creates or re-opens a channel of the pipe, returning the
+// continuation token for the next append and the channel's last committed
+// offset token, which is nil for a brand-new channel.
+func (c *sdkStreamClient) openChannel(ctx context.Context, schema, pipe, channel string) (*sdkOpenChannelResponse, error) {
+	ingestHost, token, err := c.authorize(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out sdkOpenChannelResponse
+	apiErr := &sdkApiError{}
+	res, err := c.r.NewRequest().
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+token).
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/json").
+		SetBody(`{}`).
+		SetResult(&out).
+		SetError(apiErr).
+		Put(c.pipeURL(ingestHost, schema, pipe) + "/channels/" + url.PathEscape(channel))
+	if err != nil {
+		return nil, fmt.Errorf("opening channel %q: %w", channel, err)
+	} else if !res.IsSuccess() {
+		apiErr.httpStatus = res.StatusCode()
+		return nil, fmt.Errorf("opening channel %q: %w", channel, apiErr)
+	}
+
+	return &out, nil
+}
+
+// appendRows sends a batch of NDJSON-encoded rows. The batch is buffered
+// durably only once a subsequent channel status reports offsetToken (or a
+// later token) as committed.
+func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel, continuationToken, offsetToken string, rows []byte) (string, error) {
+	ingestHost, token, err := c.authorize(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var out sdkAppendRowsResponse
+	apiErr := &sdkApiError{}
+	res, err := c.r.NewRequest().
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+token).
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/x-ndjson").
+		SetQueryParams(map[string]string{
+			"continuationToken": continuationToken,
+			"offsetToken":       offsetToken,
+		}).
+		SetBody(rows).
+		SetResult(&out).
+		SetError(apiErr).
+		Post(fmt.Sprintf("https://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows",
+			ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe), url.PathEscape(channel)))
+	if err != nil {
+		return "", fmt.Errorf("appending rows to channel %q: %w", channel, err)
+	} else if !res.IsSuccess() {
+		apiErr.httpStatus = res.StatusCode()
+		return "", fmt.Errorf("appending rows to channel %q: %w", channel, apiErr)
+	}
+
+	return out.NextContinuationToken, nil
+}
+
+// channelStatus reports the current status of the named channels of the pipe.
+func (c *sdkStreamClient) channelStatus(ctx context.Context, schema, pipe string, channels []string) (map[string]sdkChannelStatus, error) {
+	ingestHost, token, err := c.authorize(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var out sdkBulkChannelStatusResponse
+	apiErr := &sdkApiError{}
+	res, err := c.r.NewRequest().
+		WithContext(ctx).
+		SetHeader("Authorization", "Bearer "+token).
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/json").
+		SetBody(map[string]any{"channel_names": channels}).
+		SetResult(&out).
+		SetError(apiErr).
+		Post(c.pipeURL(ingestHost, schema, pipe) + ":bulk-channel-status")
+	if err != nil {
+		return nil, fmt.Errorf("getting channel status for pipe %q: %w", pipe, err)
+	} else if !res.IsSuccess() {
+		apiErr.httpStatus = res.StatusCode()
+		return nil, fmt.Errorf("getting channel status for pipe %q: %w", pipe, apiErr)
+	}
+
+	return out.ChannelStatuses, nil
+}

--- a/materialize-snowflake/stream_sdk_http.go
+++ b/materialize-snowflake/stream_sdk_http.go
@@ -72,6 +72,7 @@ func (e *sdkApiError) Unwrap() error {
 // account's discovered ingest host.
 type sdkStreamClient struct {
 	r        *resty.Client
+	scheme   string // "https", except in tests
 	host     string
 	key      *rsa.PrivateKey
 	user     string
@@ -92,6 +93,7 @@ func newSdkStreamClient(cfg *config, account string) (*sdkStreamClient, error) {
 
 	return &sdkStreamClient{
 		r:        resty.New(),
+		scheme:   "https",
 		host:     cfg.Host,
 		key:      key,
 		user:     cfg.Credentials.User,
@@ -122,7 +124,7 @@ func (c *sdkStreamClient) authorize(ctx context.Context) (string, string, error)
 			SetHeader("Authorization", "Bearer "+jwt).
 			SetHeader("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT").
 			SetHeader("Accept", "application/json").
-			Get("https://" + c.host + "/v2/streaming/hostname")
+			Get(c.scheme + "://" + c.host + "/v2/streaming/hostname")
 		if err != nil {
 			return "", "", fmt.Errorf("discovering ingest hostname: %w", err)
 		} else if !res.IsSuccess() {
@@ -138,7 +140,7 @@ func (c *sdkStreamClient) authorize(ctx context.Context) (string, string, error)
 			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
 			"scope":      c.ingestHost,
 		}).
-		Post("https://" + c.host + "/oauth/token")
+		Post(c.scheme + "://" + c.host + "/oauth/token")
 	if err != nil {
 		return "", "", fmt.Errorf("exchanging scoped token: %w", err)
 	} else if !res.IsSuccess() {
@@ -152,8 +154,8 @@ func (c *sdkStreamClient) authorize(ctx context.Context) (string, string, error)
 }
 
 func (c *sdkStreamClient) pipeURL(ingestHost, schema, pipe string) string {
-	return fmt.Sprintf("https://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s",
-		ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe))
+	return fmt.Sprintf("%s://%s/v2/streaming/databases/%s/schemas/%s/pipes/%s",
+		c.scheme, ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe))
 }
 
 // openChannel creates or re-opens a channel of the pipe, returning the
@@ -209,8 +211,8 @@ func (c *sdkStreamClient) appendRows(ctx context.Context, schema, pipe, channel,
 		SetBody(rows).
 		SetResult(&out).
 		SetError(apiErr).
-		Post(fmt.Sprintf("https://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows",
-			ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe), url.PathEscape(channel)))
+		Post(fmt.Sprintf("%s://%s/v2/streaming/data/databases/%s/schemas/%s/pipes/%s/channels/%s/rows",
+			c.scheme, ingestHost, url.PathEscape(c.database), url.PathEscape(schema), url.PathEscape(pipe), url.PathEscape(channel)))
 	if err != nil {
 		return "", fmt.Errorf("appending rows to channel %q: %w", channel, err)
 	} else if !res.IsSuccess() {

--- a/materialize-snowflake/stream_sdk_http_test.go
+++ b/materialize-snowflake/stream_sdk_http_test.go
@@ -213,14 +213,15 @@ func TestSdkStreamClientErrors(t *testing.T) {
 func TestSdkWaitForTokenCommitted(t *testing.T) {
 	ctx := context.Background()
 
-	makeStatus := func(committed *string, errorRows int) map[string]any {
+	makeStatus := func(committed *string, errorRows int, errorOffset *string) map[string]any {
 		return map[string]any{
 			"channel_statuses": map[string]any{
 				"CH": map[string]any{
-					"channel_status_code":         "SUCCESS",
-					"last_committed_offset_token": committed,
-					"rows_error_count":            errorRows,
-					"last_error_message":          "row was rejected",
+					"channel_status_code":           "SUCCESS",
+					"last_committed_offset_token":   committed,
+					"rows_error_count":              errorRows,
+					"last_error_offset_upper_bound": errorOffset,
+					"last_error_message":            "row was rejected",
 				},
 			},
 		}
@@ -235,9 +236,9 @@ func TestSdkWaitForTokenCommitted(t *testing.T) {
 		{
 			name: "committed after polling",
 			responses: []map[string]any{
-				makeStatus(nil, 0),
-				makeStatus(strptr("base:0"), 0),
-				makeStatus(strptr("base:1"), 0),
+				makeStatus(nil, 0, nil),
+				makeStatus(strptr("base:0"), 0, nil),
+				makeStatus(strptr("base:1"), 0, nil),
 			},
 			check: func(t *testing.T, err error) {
 				require.NoError(t, err)
@@ -246,11 +247,23 @@ func TestSdkWaitForTokenCommitted(t *testing.T) {
 		{
 			name: "error rows fail loudly",
 			responses: []map[string]any{
-				makeStatus(nil, 2),
+				makeStatus(nil, 2, nil),
 			},
 			check: func(t *testing.T, err error) {
 				require.ErrorContains(t, err, "2 rows that could not be ingested")
 				require.ErrorContains(t, err, "row was rejected")
+			},
+		},
+		{
+			name: "error offset of this transaction fails even with reset baseline",
+			responses: []map[string]any{
+				// The committed token covers the transaction and the error-row
+				// count matches the (restart-reset) baseline, but the error
+				// offset names one of this transaction's tokens.
+				makeStatus(strptr("base:1"), 0, strptr("base:1")),
+			},
+			check: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "rows of this transaction (offset base:1) that could not be ingested")
 			},
 		},
 	}
@@ -273,7 +286,7 @@ func TestSdkWaitForTokenCommitted(t *testing.T) {
 
 			m := &sdkStreamManager{c: c, channelName: "CH"}
 			stream := &sdkTableStream{schema: "TEST_SCHEMA", pipe: "TBL-STREAMING"}
-			tt.check(t, m.waitForTokenCommitted(ctx, stream, "base:1"))
+			tt.check(t, m.waitForTokenCommitted(ctx, stream, "base:1", map[string]bool{"base:0": true, "base:1": true}))
 		})
 	}
 }

--- a/materialize-snowflake/stream_sdk_http_test.go
+++ b/materialize-snowflake/stream_sdk_http_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"resty.dev/v3"
+)
+
+func newTestSdkClient(t *testing.T, mux *http.ServeMux) (*sdkStreamClient, *httptest.Server) {
+	t.Helper()
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	pkey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	return &sdkStreamClient{
+		r:        resty.New().SetDisableWarn(true),
+		scheme:   "http",
+		host:     u.Host,
+		key:      pkey,
+		user:     "TEST_USER",
+		account:  "TEST_ACCOUNT",
+		database: "TEST_DB",
+	}, ts
+}
+
+func TestSdkStreamClient(t *testing.T) {
+	ctx := context.Background()
+
+	var appendedBodies [][]byte
+	var appendedTokens []string
+	committed := new(string)
+
+	mux := http.NewServeMux()
+	var serverHost string
+	mux.HandleFunc("GET /v2/streaming/hostname", func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+		require.Equal(t, "KEYPAIR_JWT", r.Header.Get("X-Snowflake-Authorization-Token-Type"))
+		w.Write([]byte(serverHost))
+	})
+	mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", r.Form.Get("grant_type"))
+		require.Equal(t, serverHost, r.Form.Get("scope"))
+		w.Write([]byte("scoped-token"))
+	})
+	mux.HandleFunc("PUT /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer scoped-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"next_continuation_token": "0_1",
+			"channel_status": map[string]any{
+				"channel_status_code":         "SUCCESS",
+				"last_committed_offset_token": nil,
+				"rows_error_count":            0,
+			},
+		})
+	})
+	mux.HandleFunc("POST /v2/streaming/data/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH/rows", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "application/x-ndjson", r.Header.Get("Content-Type"))
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		appendedBodies = append(appendedBodies, body)
+		appendedTokens = append(appendedTokens, r.URL.Query().Get("offsetToken"))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status_code":             0,
+			"message":                 "Data buffered",
+			"next_continuation_token": fmt.Sprintf("0_%d", len(appendedTokens)+1),
+		})
+	})
+	mux.HandleFunc("POST /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING:bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ChannelNames []string `json:"channel_names"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, []string{"CH"}, req.ChannelNames)
+		// Report the most recently appended token as committed.
+		if len(appendedTokens) > 0 {
+			*committed = appendedTokens[len(appendedTokens)-1]
+		}
+		var tok *string
+		if *committed != "" {
+			tok = committed
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"channel_statuses": map[string]any{
+				"CH": map[string]any{
+					"channel_status_code":         "SUCCESS",
+					"last_committed_offset_token": tok,
+					"rows_error_count":            0,
+				},
+			},
+		})
+	})
+
+	c, ts := newTestSdkClient(t, mux)
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	serverHost = u.Host
+
+	open, err := c.openChannel(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH")
+	require.NoError(t, err)
+	require.Equal(t, "0_1", open.NextContinuationToken)
+	require.Nil(t, open.ChannelStatus.LastCommittedOffsetToken)
+
+	next, err := c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", open.NextContinuationToken, "base:0", []byte(`{"A": 1}`+"\n"))
+	require.NoError(t, err)
+	require.Equal(t, "0_2", next)
+
+	next, err = c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", next, "base:1", []byte(`{"A": 2}`+"\n"))
+	require.NoError(t, err)
+	require.Equal(t, "0_3", next)
+
+	require.Equal(t, []string{"base:0", "base:1"}, appendedTokens)
+	require.Equal(t, [][]byte{[]byte(`{"A": 1}` + "\n"), []byte(`{"A": 2}` + "\n")}, appendedBodies)
+
+	statuses, err := c.channelStatus(ctx, "TEST_SCHEMA", "TBL-STREAMING", []string{"CH"})
+	require.NoError(t, err)
+	require.Equal(t, "base:1", *statuses["CH"].LastCommittedOffsetToken)
+}
+
+func TestSdkStreamClientErrors(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		status int
+		check  func(t *testing.T, err error)
+	}{
+		{
+			name:   "permanent",
+			status: http.StatusBadRequest,
+			check: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, ErrPermanent)
+				require.ErrorContains(t, err, "no such pipe")
+			},
+		},
+		{
+			name:   "temporary server error",
+			status: http.StatusServiceUnavailable,
+			check: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, ErrTemporary)
+			},
+		},
+		{
+			name:   "temporary throttle",
+			status: http.StatusTooManyRequests,
+			check: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, ErrTemporary)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var serverHost string
+			mux.HandleFunc("GET /v2/streaming/hostname", func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(serverHost))
+			})
+			mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("scoped-token"))
+			})
+			mux.HandleFunc("PUT /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				json.NewEncoder(w).Encode(map[string]any{"code": "390404", "message": "no such pipe"})
+			})
+
+			c, ts := newTestSdkClient(t, mux)
+			u, err := url.Parse(ts.URL)
+			require.NoError(t, err)
+			serverHost = u.Host
+
+			_, err = c.openChannel(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH")
+			tt.check(t, err)
+		})
+	}
+}
+
+func TestSdkWaitForTokenCommitted(t *testing.T) {
+	ctx := context.Background()
+
+	makeStatus := func(committed *string, errorRows int) map[string]any {
+		return map[string]any{
+			"channel_statuses": map[string]any{
+				"CH": map[string]any{
+					"channel_status_code":         "SUCCESS",
+					"last_committed_offset_token": committed,
+					"rows_error_count":            errorRows,
+					"last_error_message":          "row was rejected",
+				},
+			},
+		}
+	}
+	strptr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name      string
+		responses []map[string]any
+		check     func(t *testing.T, err error)
+	}{
+		{
+			name: "committed after polling",
+			responses: []map[string]any{
+				makeStatus(nil, 0),
+				makeStatus(strptr("base:0"), 0),
+				makeStatus(strptr("base:1"), 0),
+			},
+			check: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "error rows fail loudly",
+			responses: []map[string]any{
+				makeStatus(nil, 2),
+			},
+			check: func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "2 rows that could not be ingested")
+				require.ErrorContains(t, err, "row was rejected")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var call int
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING:bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
+				res := tt.responses[min(call, len(tt.responses)-1)]
+				call++
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(res)
+			})
+
+			c, _ := newTestSdkClient(t, mux)
+			c.ingestHost = c.host
+			c.scopedToken = "scoped-token"
+			c.expiry = time.Now().Add(time.Hour)
+
+			m := &sdkStreamManager{c: c, channelName: "CH"}
+			stream := &sdkTableStream{schema: "TEST_SCHEMA", pipe: "TBL-STREAMING"}
+			tt.check(t, m.waitForTokenCommitted(ctx, stream, "base:1"))
+		})
+	}
+}

--- a/materialize-snowflake/stream_sdk_http_test.go
+++ b/materialize-snowflake/stream_sdk_http_test.go
@@ -62,7 +62,7 @@ func TestSdkStreamClient(t *testing.T) {
 		require.Equal(t, serverHost, r.Form.Get("scope"))
 		w.Write([]byte("scoped-token"))
 	})
-	mux.HandleFunc("PUT /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /v2/streaming/databases/\"TEST_DB\"/schemas/\"TEST_SCHEMA\"/pipes/\"TBL-STREAMING\"/channels/CH", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer scoped-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
@@ -74,7 +74,7 @@ func TestSdkStreamClient(t *testing.T) {
 			},
 		})
 	})
-	mux.HandleFunc("POST /v2/streaming/data/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH/rows", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v2/streaming/data/databases/\"TEST_DB\"/schemas/\"TEST_SCHEMA\"/pipes/\"TBL-STREAMING\"/channels/CH/rows", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "application/x-ndjson", r.Header.Get("Content-Type"))
 		require.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
 		gz, err := gzip.NewReader(r.Body)
@@ -90,7 +90,7 @@ func TestSdkStreamClient(t *testing.T) {
 			"next_continuation_token": fmt.Sprintf("0_%d", len(appendedTokens)+1),
 		})
 	})
-	mux.HandleFunc("POST /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING:bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /v2/streaming/databases/\"TEST_DB\"/schemas/\"TEST_SCHEMA\"/pipes/\"TBL-STREAMING\":bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			ChannelNames []string `json:"channel_names"`
 		}
@@ -193,7 +193,7 @@ func TestSdkStreamClientErrors(t *testing.T) {
 			mux.HandleFunc("POST /oauth/token", func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("scoped-token"))
 			})
-			mux.HandleFunc("PUT /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("PUT /v2/streaming/databases/\"TEST_DB\"/schemas/\"TEST_SCHEMA\"/pipes/\"TBL-STREAMING\"/channels/CH", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tt.status)
 				json.NewEncoder(w).Encode(map[string]any{"code": "390404", "message": "no such pipe"})
@@ -272,7 +272,7 @@ func TestSdkWaitForTokenCommitted(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var call int
 			mux := http.NewServeMux()
-			mux.HandleFunc("POST /v2/streaming/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING:bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("POST /v2/streaming/databases/\"TEST_DB\"/schemas/\"TEST_SCHEMA\"/pipes/\"TBL-STREAMING\":bulk-channel-status", func(w http.ResponseWriter, r *http.Request) {
 				res := tt.responses[min(call, len(tt.responses)-1)]
 				call++
 				w.Header().Set("Content-Type", "application/json")

--- a/materialize-snowflake/stream_sdk_http_test.go
+++ b/materialize-snowflake/stream_sdk_http_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -73,8 +76,11 @@ func TestSdkStreamClient(t *testing.T) {
 	})
 	mux.HandleFunc("POST /v2/streaming/data/databases/TEST_DB/schemas/TEST_SCHEMA/pipes/TBL-STREAMING/channels/CH/rows", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "application/x-ndjson", r.Header.Get("Content-Type"))
-		body := make([]byte, r.ContentLength)
-		r.Body.Read(body)
+		require.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+		gz, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		body, err := io.ReadAll(gz)
+		require.NoError(t, err)
 		appendedBodies = append(appendedBodies, body)
 		appendedTokens = append(appendedTokens, r.URL.Query().Get("offsetToken"))
 		w.Header().Set("Content-Type", "application/json")
@@ -120,11 +126,20 @@ func TestSdkStreamClient(t *testing.T) {
 	require.Equal(t, "0_1", open.NextContinuationToken)
 	require.Nil(t, open.ChannelStatus.LastCommittedOffsetToken)
 
-	next, err := c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", open.NextContinuationToken, "base:0", []byte(`{"A": 1}`+"\n"))
+	gzipped := func(s string) []byte {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err := gz.Write([]byte(s))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+		return buf.Bytes()
+	}
+
+	next, err := c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", open.NextContinuationToken, "base:0", gzipped(`{"A": 1}`+"\n"))
 	require.NoError(t, err)
 	require.Equal(t, "0_2", next)
 
-	next, err = c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", next, "base:1", []byte(`{"A": 2}`+"\n"))
+	next, err = c.appendRows(ctx, "TEST_SCHEMA", "TBL-STREAMING", "CH", next, "base:1", gzipped(`{"A": 2}`+"\n"))
 	require.NoError(t, err)
 	require.Equal(t, "0_3", next)
 

--- a/materialize-snowflake/stream_sdk_test.go
+++ b/materialize-snowflake/stream_sdk_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	stdsql "database/sql"
+	"os"
+	"testing"
+
+	sql "github.com/estuary/connectors/materialize-sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSdkStreamManager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx := context.Background()
+
+	cfg := mustGetCfg(t)
+
+	dsn, err := cfg.toURI(true, "")
+	require.NoError(t, err)
+
+	db, err := stdsql.Open("snowflake", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var accountName string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName))
+
+	verify := func(t *testing.T, query string, want [][]any) {
+		t.Helper()
+
+		rows, err := db.Query(query)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		require.NoError(t, err)
+
+		var got [][]any
+		for rows.Next() {
+			var data = make([]any, len(cols))
+			var ptrs = make([]any, len(cols))
+			for i := range data {
+				ptrs[i] = &data[i]
+			}
+			require.NoError(t, rows.Scan(ptrs...))
+			got = append(got, data)
+		}
+
+		require.Equal(t, want, got)
+	}
+
+	table := sql.Table{
+		TableShape: sql.TableShape{
+			Binding: 0,
+		},
+		Identifier: `SDK_STREAM_TEST`,
+	}
+	columnNames := []string{"KEY", "FIRSTCOL", "SECONDCOL"}
+
+	cleanup := func(t *testing.T) {
+		t.Helper()
+		_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS SDK_STREAM_TEST;")
+	}
+	defer cleanup(t)
+
+	cleanup(t)
+	_, err = db.ExecContext(ctx, `CREATE TABLE SDK_STREAM_TEST (key TEXT, firstcol TEXT, secondcol TEXT);`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, createStageSQL)
+	require.NoError(t, err)
+
+	pipe := defaultPipeName("SDK_STREAM_TEST")
+
+	sm, err := newSdkStreamManager(&cfg, "testing-sdk", accountName, 0, db)
+	require.NoError(t, err)
+	require.NoError(t, sm.addBinding(ctx, cfg.Schema, "SDK_STREAM_TEST", columnNames, table))
+
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"key1", "hello1", "world1"}))
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"key2", "hello2", "world2"}))
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"key3", "hello3", "world3"}))
+	chunks, err := sm.flush(ctx, "the-token-1")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(chunks))
+	require.Equal(t, 1, len(chunks[0]))
+
+	require.NoError(t, sm.write(ctx, cfg.Schema, pipe, chunks[0]))
+
+	verify(t, "SELECT * FROM SDK_STREAM_TEST ORDER BY key", [][]any{
+		{"key1", "hello1", "world1"},
+		{"key2", "hello2", "world2"},
+		{"key3", "hello3", "world3"},
+	})
+
+	// Writing the same chunks again is a no-op: their tokens are already
+	// committed by the channel.
+	require.NoError(t, sm.write(ctx, cfg.Schema, pipe, chunks[0]))
+
+	verify(t, "SELECT * FROM SDK_STREAM_TEST ORDER BY key", [][]any{
+		{"key1", "hello1", "world1"},
+		{"key2", "hello2", "world2"},
+		{"key3", "hello3", "world3"},
+	})
+
+	// Simulate a commit replay after a restart: a second transaction's chunks
+	// are made durable, but the connector restarts before appending them. The
+	// local chunk files are gone, so the replay retrieves the durable copies
+	// from the internal stage.
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"key4", "hello4", "world4"}))
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"key5", "hello5", "world5"}))
+	chunks, err = sm.flush(ctx, "the-token-2")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(chunks[0]))
+	for _, chunk := range chunks[0] {
+		require.NoError(t, os.Remove(chunk.LocalPath))
+	}
+
+	sm, err = newSdkStreamManager(&cfg, "testing-sdk", accountName, 0, db)
+	require.NoError(t, err)
+	require.NoError(t, sm.addBinding(ctx, cfg.Schema, "SDK_STREAM_TEST", columnNames, table))
+
+	require.NoError(t, sm.write(ctx, cfg.Schema, pipe, chunks[0]))
+
+	verify(t, "SELECT * FROM SDK_STREAM_TEST ORDER BY key", [][]any{
+		{"key1", "hello1", "world1"},
+		{"key2", "hello2", "world2"},
+		{"key3", "hello3", "world3"},
+		{"key4", "hello4", "world4"},
+		{"key5", "hello5", "world5"},
+	})
+
+	// Replaying through the restarted manager is also a no-op.
+	require.NoError(t, sm.write(ctx, cfg.Schema, pipe, chunks[0]))
+
+	verify(t, "SELECT * FROM SDK_STREAM_TEST ORDER BY key", [][]any{
+		{"key1", "hello1", "world1"},
+		{"key2", "hello2", "world2"},
+		{"key3", "hello3", "world3"},
+		{"key4", "hello4", "world4"},
+		{"key5", "hello5", "world5"},
+	})
+}

--- a/materialize-snowflake/stream_sdk_test.go
+++ b/materialize-snowflake/stream_sdk_test.go
@@ -143,3 +143,58 @@ func TestSdkStreamManager(t *testing.T) {
 		{"key5", "hello5", "world5"},
 	})
 }
+
+// TestSdkStreamCaseSensitiveIdentifiers confirms the SDK streaming path works
+// with quoted, case-sensitive table and column names, whose stored identifiers
+// are not simply uppercased.
+func TestSdkStreamCaseSensitiveIdentifiers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	ctx := context.Background()
+	cfg := mustGetCfg(t)
+
+	dsn, err := cfg.toURI(true, "")
+	require.NoError(t, err)
+	db, err := stdsql.Open("snowflake", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var accountName string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT CURRENT_ACCOUNT()").Scan(&accountName))
+
+	const tableName = `Sdk Mixed-Case`
+	cleanup := func() {
+		db.ExecContext(ctx, `DROP TABLE IF EXISTS "Sdk Mixed-Case";`)
+	}
+	defer cleanup()
+	cleanup()
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE "Sdk Mixed-Case" ("Key col" TEXT, "value:Col" TEXT);`)
+	require.NoError(t, err)
+
+	table := sql.Table{TableShape: sql.TableShape{Binding: 0}, Identifier: `"Sdk Mixed-Case"`}
+	columnNames := []string{"Key col", "value:Col"}
+
+	sm, err := newSdkStreamManager(&cfg, "testing-sdk-case", accountName, 0, db)
+	require.NoError(t, err)
+	require.NoError(t, sm.addBinding(ctx, cfg.Schema, tableName, columnNames, table))
+
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"k1", "v1"}))
+	require.NoError(t, sm.writeRow(ctx, 0, []any{"k2", "v2"}))
+	chunks, err := sm.flush(ctx, "case-token")
+	require.NoError(t, err)
+	require.NoError(t, sm.write(ctx, cfg.Schema, defaultPipeName(tableName), chunks[0]))
+
+	rows, err := db.QueryContext(ctx, `SELECT "Key col", "value:Col" FROM "Sdk Mixed-Case" ORDER BY "Key col"`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var got [][]string
+	for rows.Next() {
+		var k, v string
+		require.NoError(t, rows.Scan(&k, &v))
+		got = append(got, []string{k, v})
+	}
+	require.Equal(t, [][]string{{"k1", "v1"}, {"k2", "v2"}}, got)
+}


### PR DESCRIPTION
**Description:**

Adds a fifth write path to materialize-snowflake: Snowpipe Streaming over the high-performance REST API (`/v2/streaming`, the protocol behind Snowflake's current streaming SDKs), as an alternate to the existing hand-rolled BDEC streaming for delta-updates + JWT bindings. Closes #4324.

- Gated by new feature flag `snowpipe_streaming_sdk` (default **off**) and only activates on the v2 runtime (detected via `Open.sealed_config_json`, populated only by runtime-next); otherwise falls back to the existing streaming cascade.
- `Store` writes gzipped NDJSON chunks and PUTs them to the existing `@flow_v1` internal stage for durability; `Acknowledge` appends chunks to the table's auto-created default pipe (`<TABLE>-STREAMING`) with `base:n` offset tokens, skipping already-committed chunks — same exactly-once model as the existing streaming path, with GET-from-stage recovery after a restart.
- No BDEC/Parquet encoding, no client-side encryption, no cloud-bucket blob management on this path.
- Bumps `estuary/flow` to a master pseudo-version for `Open.SealedConfigJson`.

**Workflow steps:**

Opt in per materialization by adding `snowpipe_streaming_sdk` to `advanced.feature_flags` on a task running on the v2 runtime, with key-pair (JWT) auth and delta-updates bindings. Existing paths are unchanged; flag off (default) preserves current behavior exactly.

**Documentation links affected:**

None yet; flag is internal/opt-in.

**Notes for reviewers:**

- Durable-append happens in `Acknowledge` (not `StartCommit`) because channel appends cannot be aborted: appending before the runtime checkpoint is durable would duplicate rows on crash replay. Staged chunks + offset-token dedup preserve exactly-once, mirroring `stream.go`'s design.
- Verified live against the test account: lifecycle/replay/restart-recovery (`stream_sdk_test.go`), datatype round-trips incl. VARIANT and BINARY (`stream_sdk_datatypes_test.go`), plus httptest unit coverage. Full existing suite passes with zero snapshot changes.
