### PR TITLE
materialize-clickhouse: reconcile store-table schema drift after pending-commit recovery

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-07-15
+
+### Fixed
+- Fixed a permanent restart loop with the error `Tables have different structure` (code 122) that occurred when a table's schema was migrated while a transaction commit was pending. Recovery now updates the staging table to match the migrated table, with no data loss and no manual intervention required.

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -680,24 +680,24 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 				// A committed-but-unacknowledged transaction has rows staged
 				// in this binding's store table. Move them; never truncate or
 				// re-create a stage table holding pending rows.
-				err := t.moveStorePartitionsToTarget(ctx, b, si, true)
-				if err == nil {
-					continue
+				if err := t.moveStorePartitionsToTarget(ctx, b, si, true); err != nil {
+					if !isUnknownTableErr(err) {
+						return nil, fmt.Errorf("recovering stage to target %s: %w", b.target.Identifier, err)
+					}
+					// The store table was dropped out-of-band, so there are no
+					// staged rows left to recover. Fall through to re-create
+					// the temp tables rather than crash-looping on the missing
+					// table; ReplacingMergeTree lets later transactions refresh
+					// the lost rows.
+					log.WithField("target", b.target.Identifier).Warn(
+						"store table missing during recovery; nothing to recover, re-creating temp tables")
 				}
-				if !isUnknownTableErr(err) {
-					return nil, fmt.Errorf("recovering stage to target %s: %w", b.target.Identifier, err)
-				}
-				// The store table was lost out-of-band (e.g. dropped) while the
-				// connector state still recorded a pending commit referencing
-				// it. No staged rows remain to recover -- the same situation as
-				// a commit that fully completed before the previous process
-				// exited -- so fall through to (re-)create the temp tables for
-				// the next transaction instead of crash-looping forever on the
-				// missing table. The pending transaction's rows are
-				// unrecoverable regardless; ReplacingMergeTree lets later
-				// transactions refresh them.
-				log.WithField("target", b.target.Identifier).Warn(
-					"store table missing during recovery; nothing to recover, re-creating temp tables")
+				// A successful recovery move leaves the store table empty, so
+				// falling through to ensureTempTables is safe and reconciles
+				// any target-schema drift that occurred while the commit was
+				// pending. Skipping it would fail the next MOVE PARTITION with
+				// code 122 ("Tables have different structure") -- a permanent
+				// recovery crash-loop (issue #4817).
 			}
 			if err := t.ensureTempTables(ctx, b); err != nil {
 				return nil, fmt.Errorf("ensuring temp tables of %s: %w", b.target.Identifier, err)
@@ -840,8 +840,9 @@ func (t *transactor) moveStorePartitionsToTarget(ctx context.Context, b *binding
 // their schema has drifted from the target's (a migration ran in a prior
 // session -- migrations only happen in the Apply RPC, never while a session
 // is running), and truncated otherwise to discard rows staged by a
-// transaction that never committed. It must never be called for a binding
-// with a pending commit recorded in the connector state.
+// transaction that never committed. It must only be called when the store
+// table holds no staged rows of a pending commit; on the recovery path this
+// is guaranteed by moveStorePartitionsToTarget's post-move emptiness check.
 func (t *transactor) ensureTempTables(ctx context.Context, b *binding) error {
 	ensure := func(createSQL, truncateSQL, dropSQL string, tableName string) error {
 		if err := t.store.conn.Exec(ctx, createSQL); err != nil {

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -1276,6 +1276,44 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.EqualValues(t, 1, countTable(t, ctx, tr, stageName))
 	})
 
+	t.Run("schema drift is reconciled after a trivial pending-commit recovery", func(t *testing.T) {
+		// Reproduces issue #4817. A committed-but-unacknowledged transaction
+		// left pending state behind, but its rows had already been moved to the
+		// target before the prior crash -- so the store table is empty. In the
+		// interim an Apply RPC migrated the target, so the store table's
+		// structure no longer matches. On the first Acknowledge,
+		// moveStorePartitionsToTarget(recovery=true) trivially succeeds against
+		// the empty store table; the drift must still be reconciled so the next
+		// commit's MOVE PARTITION does not fail with code 122 ("Tables have
+		// different structure"), which would otherwise crash-loop recovery
+		// forever.
+		tr, b := newTestTransactor(t, ctx, "test_recovery_drift_pending")
+		require.NoError(t, tr.ensureTempTables(ctx, b))
+		stageName := tr.dialect.Identifier(storeTableName(b.target, 0))
+		targetName := tr.dialect.Identifier("test_recovery_drift_pending")
+
+		// Migrate the target as the Apply RPC would while the commit was
+		// pending; the store table keeps its pre-migration structure.
+		require.NoError(t, tr.store.conn.Exec(ctx,
+			fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s String", targetName, tr.dialect.Identifier("extra"))))
+
+		// Pending state with rows already moved (StoredRows > 0, empty stage):
+		// this is what drives Acknowledge through the trivial recovery move.
+		tr.ensured = false
+		tr.recovery = true
+		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
+		_, err := tr.Acknowledge(ctx)
+		require.NoError(t, err)
+
+		// The next transaction must stage and commit cleanly. On the unfixed
+		// connector the store table is still pre-migration and the move fails
+		// with code 122.
+		stageTestRows(t, ctx, tr, b, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
+		require.NoError(t, tr.moveStorePartitionsToTarget(ctx, b, &stateItem{StoredRows: 1}, false))
+		require.EqualValues(t, 1, countTable(t, ctx, tr, targetName))
+		require.EqualValues(t, 0, countTable(t, ctx, tr, stageName))
+	})
+
 	t.Run("pre-StoredRows checkpoint state recovers without executing persisted SQL", func(t *testing.T) {
 		tr, b := newTestTransactor(t, ctx, "test_recovery_upgrade")
 		require.NoError(t, tr.ensureTempTables(ctx, b))

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -597,10 +597,10 @@ DROP TABLE IF EXISTS {{ template "loadTableName" . }};
 -- because the target table uses ReplacingMergeTree, which deduplicates by ORDER BY
 -- key and flow_published_at version — re-applying a partial commit is idempotent.
 --
--- At session start the store table is truncated when there is no pending commit
--- recorded in the connector state, discarding rows staged by a transaction that
--- never committed. It is dropped and re-created only when its schema has drifted
--- from the target's (a migration ran in a prior session).
+-- At session start, once any pending commit has been recovered, the store table is
+-- truncated, discarding rows staged by a transaction that never committed. It is
+-- dropped and re-created only when its schema has drifted from the target's (a
+-- migration ran in a prior session).
 
 {{ define "storeTableNameIdentifier" -}}
 {{ printf "flow_temp_store_%s_%s" $.RangeKey (index $.Path 0) | ColumnIdentifier }}


### PR DESCRIPTION
**Description:**

Fixes #4817. A `materialize-clickhouse` binding could enter a permanent recovery crash-loop (`code: 122, Tables have different structure`) when the target table was migrated while a commit was pending. The first-Acknowledge recovery loop `continue`d past `ensureTempTables` after a successful recovery move, leaving the persistent store table with its pre-migration structure.

Fix: fall through to `ensureTempTables` instead. A successful recovery move guarantees the store table is empty, so drift reconciliation (drop + re-create) is safe with no data loss.

- Commit 1: failing regression test (fails on `main` with `code: 16, No such column`)
- Commit 2: the fix

**Workflow steps:**

No user-facing change; affected tasks self-heal instead of requiring an operator to drop the drifted store stage table.

**Notes for reviewers:**

TDD shape — the regression test commit demonstrates the failure mode before the fix. Full package suite is green.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
