### PR TITLE
materialize-s3-iceberg: self-heal manifest lists with null partitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.17.3
 	github.com/tidwall/sjson v1.2.5
+	github.com/twmb/avro v1.7.2
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
 	go.mongodb.org/mongo-driver v1.17.7
@@ -258,7 +259,6 @@ require (
 	github.com/substrait-io/substrait-protobuf/go v0.85.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/twmb/avro v1.7.2 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-07-15
+
+### Fixed
+- Tables affected by a manifest-list encoding defect in a previous connector
+  release are now repaired automatically when the materialization starts up.
+  The defect could cause external query engines to reject a table's current
+  snapshot (Redshift Spectrum: `Wrong type in Avro file. Field: partitions`)
+  or to silently return NULL values for affected rows (Athena). No action is
+  needed; the connector logs a warning for each table it repairs.

--- a/materialize-s3-iceberg/catalog.go
+++ b/materialize-s3-iceberg/catalog.go
@@ -332,16 +332,32 @@ func (c *catalog) populateInfoSchema(ctx context.Context, is *boilerplate.InfoSc
 	return nil
 }
 
-// tablePaths returns the registered storage path for each resource path in a
-// list, in the same order as the input.
-func (c *catalog) tablePaths(ctx context.Context, resourcePaths [][]string) ([]string, error) {
+// tableInfo is the per-table state read from the catalog at Open: the
+// registered storage location, the current snapshot's manifest list path
+// (empty when the table has no snapshots yet), and whether the table is
+// unpartitioned.
+type tableInfo struct {
+	location      string
+	manifestList  string
+	unpartitioned bool
+}
+
+// tableInfos returns the tableInfo for each resource path in a list, in the
+// same order as the input.
+func (c *catalog) tableInfos(ctx context.Context, resourcePaths [][]string) ([]tableInfo, error) {
 	idents := make([]icebergtable.Identifier, len(resourcePaths))
 	for i, p := range resourcePaths {
 		idents[i] = p
 	}
-	out := make([]string, len(idents))
+	out := make([]tableInfo, len(idents))
 	if err := c.forEachTable(ctx, idents, func(idx int, tbl *icebergtable.Table) error {
-		out[idx] = tbl.Location()
+		out[idx] = tableInfo{
+			location:      tbl.Location(),
+			unpartitioned: tbl.Spec().IsUnpartitioned(),
+		}
+		if snap := tbl.CurrentSnapshot(); snap != nil {
+			out[idx].manifestList = snap.ManifestList
+		}
 		return nil
 	}); err != nil {
 		return nil, err

--- a/materialize-s3-iceberg/driver.go
+++ b/materialize-s3-iceberg/driver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/invopop/jsonschema"
 	iso8601 "github.com/senseyeio/duration"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 var featureFlagDefaults = map[string]bool{
@@ -572,18 +573,43 @@ func (d *materialization) NewTransactor(
 		})
 	}
 
-	tablePaths, err := d.catalog.tablePaths(ctx, resourcePaths)
+	tableInfos, err := d.catalog.tableInfos(ctx, resourcePaths)
 	if err != nil {
 		return nil, fmt.Errorf("looking up table paths: %w", err)
 	}
 
 	for idx := range bindings {
-		bindings[idx].catalogTablePath = tablePaths[idx]
+		bindings[idx].catalogTablePath = tableInfos[idx].location
 	}
 
 	s3store, err := filesink.NewS3Store(ctx, d.cfg.s3StoreConfig())
 	if err != nil {
 		return nil, fmt.Errorf("creating s3 store: %w", err)
+	}
+
+	// Heal manifest lists corrupted by iceberg-go v0.6.0 (issue #4816) before
+	// any transactions run. Open is the one point where this is race-free: the
+	// connector is each table's sole appender, and a concurrent external
+	// rewrite (e.g. a compaction) only makes the repair moot — the check runs
+	// again on the next Open. The repair is sound only for unpartitioned
+	// tables, where null and empty partition summaries are semantically
+	// identical; a bound pre-existing partitioned table may legitimately carry
+	// null summaries, so it is left alone.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for idx := range bindings {
+		if !tableInfos[idx].unpartitioned {
+			continue
+		}
+		g.Go(func() error {
+			if err := repairManifestListNullPartitions(gctx, s3store.Client(), d.cfg.Bucket, tableInfos[idx].manifestList); err != nil {
+				return fmt.Errorf("repairing manifest list of table %q: %w", pathToFQN(bindings[idx].path), err)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return &transactor{
@@ -605,12 +631,12 @@ func (d *materialization) CleanupTestTask(ctx context.Context, taskName string) 
 }
 
 func (d *materialization) SnapshotTestResource(ctx context.Context, path []string) ([]string, [][]any, error) {
-	tablePaths, err := d.catalog.tablePaths(ctx, [][]string{path})
+	tableInfos, err := d.catalog.tableInfos(ctx, [][]string{path})
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting table path for %s.%s: %w", path[0], path[1], err)
 	}
 
-	tableLocation := tablePaths[0]
+	tableLocation := tableInfos[0].location
 	if tableLocation == "" {
 		return nil, nil, nil
 	}

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"github.com/twmb/avro/ocf"
 )
 
 const (
@@ -154,6 +155,10 @@ func TestIntegration(t *testing.T) {
 		runCheckpointFenceRegression(t, cfg)
 	})
 
+	t.Run("manifest-null-partitions-regression", func(t *testing.T) {
+		runManifestListNullPartitionsRegression(t, cfg)
+	})
+
 	// Migration test is skipped because Iceberg does not support the type
 	// migrations exercised by the test (e.g. long→string).
 	//t.Run("migrate", func(t *testing.T) {
@@ -206,6 +211,10 @@ func TestIntegrationGlue(t *testing.T) {
 
 	t.Run("checkpoint-fence-regression", func(t *testing.T) {
 		runCheckpointFenceRegression(t, cfg)
+	})
+
+	t.Run("manifest-null-partitions-regression", func(t *testing.T) {
+		runManifestListNullPartitionsRegression(t, cfg)
 	})
 }
 
@@ -412,6 +421,217 @@ func runCheckpointFenceRegression(t *testing.T, cfg config) {
 		}
 	}
 	require.ElementsMatch(t, []string{first, second}, livePaths)
+}
+
+// runManifestListNullPartitionsRegression reproduces issue #4816. iceberg-go
+// v0.6.0 re-encoded a present-but-empty `partitions` field summary in the
+// manifest list as the Avro null union branch whenever a commit inherited
+// manifests from a prior snapshot (apache/iceberg-go#1309); strict readers
+// such as Redshift Spectrum reject those files, and Athena can silently
+// return NULLs. The upstream fix (apache/iceberg-go#1464) stops writing new
+// nulls but preserves decoded nulls, so a manifest list corrupted during the
+// exposure window re-corrupts every subsequent commit and never heals on its
+// own — this test demonstrates that propagation against the fixed dependency.
+//
+// Every table this connector creates is unpartitioned, so for our tables a
+// null `partitions` in the current manifest list is unambiguous corruption,
+// and normalizing it to an empty array cannot change query results. Opening
+// the materialization must repair the current snapshot's manifest list in
+// place: all entries decode with a present `partitions` array, the embedded
+// writer schema is byte-identical, and the set of live data files is
+// untouched.
+func runManifestListNullPartitionsRegression(t *testing.T, cfg config) {
+	ctx := context.Background()
+
+	const materialization = "acmeCo/tests/regression"
+
+	rt := newRegressionTable(t, ctx, cfg, "manifest_null_partitions_regression",
+		iceberg.NestedField{ID: 1, Name: "v", Type: iceberg.PrimitiveTypes.String, Required: false}, nil)
+
+	vCol := writer.ParquetSchemaElement{Name: "v", DataType: writer.LogicalTypeString, Required: false}
+	first := rt.uploadParquet(t, ctx, vCol, "one")
+	require.NoError(t, rt.cat.appendFiles(ctx, materialization, rt.ident,
+		[]string{first}, "", "checkpoint-1"))
+
+	cleanNulls, cleanTotal, cleanSchema := readManifestListPartitions(t, rt.getObject(t, ctx, rt.currentManifestListKey(t, ctx)))
+	require.Zero(t, cleanNulls)
+	require.Equal(t, 1, cleanTotal)
+
+	corruptManifestListPartitions(t, ctx, rt)
+
+	nulls, total, corruptSchema := readManifestListPartitions(t, rt.getObject(t, ctx, rt.currentManifestListKey(t, ctx)))
+	require.Equal(t, total, nulls, "fixture: every manifest-list entry must carry null partitions")
+	require.Equal(t, string(cleanSchema), string(corruptSchema), "fixture: corruption must not change the writer schema")
+
+	// The next commit inherits the corrupted entry: decode of the null branch
+	// yields a nil partition list that the fixed writer deliberately leaves
+	// null, so the new manifest list is corrupted too. This is the propagation
+	// that makes the corruption permanent without an explicit repair.
+	second := rt.uploadParquet(t, ctx, vCol, "two")
+	require.NoError(t, rt.cat.appendFiles(ctx, materialization, rt.ident,
+		[]string{second}, "checkpoint-1", "checkpoint-2"))
+
+	key := rt.currentManifestListKey(t, ctx)
+	nulls, total, corruptSchema = readManifestListPartitions(t, rt.getObject(t, ctx, key))
+	require.Positive(t, nulls, "corruption must propagate to the next commit's manifest list")
+	require.Equal(t, 2, total)
+
+	// Opening the materialization runs the connector's per-table startup path,
+	// which is where issue #4816's self-heal must repair the current manifest
+	// list before any transactions run.
+	mat, err := newMaterialization(ctx, materialization, cfg, map[string]bool{})
+	require.NoError(t, err)
+	_, err = mat.NewTransactor(ctx,
+		pm.Request_Open{Materialization: &pf.MaterializationSpec{Name: pf.Materialization(materialization)}},
+		mboilerplate.InfoSchema{},
+		[]mboilerplate.MappedBinding[config, resource, mappedType]{
+			{MaterializationSpec_Binding: pf.MaterializationSpec_Binding{ResourcePath: rt.ident}},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	healedNulls, healedTotal, healedSchema := readManifestListPartitions(t, rt.getObject(t, ctx, key))
+	require.Zero(t, healedNulls, "opening the materialization must heal null partitions in the current manifest list")
+	require.Equal(t, total, healedTotal)
+	require.Equal(t, string(corruptSchema), string(healedSchema), "the repair must re-encode with the file's own writer schema")
+
+	// The repaired table must still be fully readable, with exactly the two
+	// appended files live.
+	tbl, err := rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	fs, err := tbl.FS(ctx)
+	require.NoError(t, err)
+	manifests, err := tbl.CurrentSnapshot().Manifests(fs)
+	require.NoError(t, err)
+	var livePaths []string
+	for _, m := range manifests {
+		for entry, err := range m.Entries(fs, true) {
+			require.NoError(t, err)
+			livePaths = append(livePaths, entry.DataFile().FilePath())
+		}
+	}
+	require.ElementsMatch(t, []string{first, second}, livePaths)
+
+	// A clean manifest list is left untouched by subsequent Opens. Any
+	// rewrite is byte-detectable because the OCF sync marker is freshly
+	// randomized on every encode.
+	before := rt.getObject(t, ctx, key)
+	_, err = mat.NewTransactor(ctx,
+		pm.Request_Open{Materialization: &pf.MaterializationSpec{Name: pf.Materialization(materialization)}},
+		mboilerplate.InfoSchema{},
+		[]mboilerplate.MappedBinding[config, resource, mappedType]{
+			{MaterializationSpec_Binding: pf.MaterializationSpec_Binding{ResourcePath: rt.ident}},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, before, rt.getObject(t, ctx, key), "a second Open must not rewrite a clean manifest list")
+}
+
+// currentManifestListKey returns the S3 object key of the table's current
+// snapshot's manifest list.
+func (rt *regressionTable) currentManifestListKey(t *testing.T, ctx context.Context) string {
+	t.Helper()
+
+	tbl, err := rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	return strings.TrimPrefix(snap.ManifestList, "s3://"+rt.cfg.Bucket+"/")
+}
+
+func (rt *regressionTable) getObject(t *testing.T, ctx context.Context, key string) []byte {
+	t.Helper()
+
+	out, err := rt.s3client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(rt.cfg.Bucket),
+		Key:    aws.String(key),
+	})
+	require.NoError(t, err)
+	defer out.Body.Close()
+	data, err := io.ReadAll(out.Body)
+	require.NoError(t, err)
+	return data
+}
+
+// readManifestListPartitions decodes a raw manifest-list Avro file and counts
+// entries whose `partitions` field is the null union branch, alongside the
+// file's embedded writer schema. iceberg-go's ManifestFile.Partitions()
+// cannot be used for this: it returns an empty slice for both the null and
+// the present-but-empty encoding, and the distinction between those two is
+// exactly what issue #4816 is about. Decoding each record generically into a
+// map surfaces it — the null branch decodes to a nil interface, while a
+// present (possibly empty) array is non-nil.
+func readManifestListPartitions(t *testing.T, data []byte) (nullPartitions, total int, schemaJSON []byte) {
+	t.Helper()
+
+	rd, err := ocf.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rd.Close()
+	schemaJSON = bytes.Clone(rd.Metadata()["avro.schema"])
+	for {
+		var rec map[string]any
+		if err := rd.Decode(&rec); errors.Is(err, io.EOF) {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+		total++
+		if rec["partitions"] == nil {
+			nullPartitions++
+		}
+	}
+	return nullPartitions, total, schemaJSON
+}
+
+// corruptManifestListPartitions rewrites the current snapshot's manifest list
+// in place with every entry's `partitions` field encoded as the Avro null
+// union branch, recreating on disk what iceberg-go v0.6.0 wrote during the
+// issue #4816 exposure window. The entries are rebuilt through the public
+// ManifestBuilder without setting a partition list: the fixed writer
+// normalizes only a present-but-nil list, so a genuinely absent one still
+// encodes as null. The manifest list is referenced by exact path with no
+// checksum, so overwriting the object needs no catalog commit.
+func corruptManifestListPartitions(t *testing.T, ctx context.Context, rt *regressionTable) {
+	t.Helper()
+
+	tbl, err := rt.cat.cat.LoadTable(ctx, rt.ident)
+	require.NoError(t, err)
+	snap := tbl.CurrentSnapshot()
+	require.NotNil(t, snap)
+	key := strings.TrimPrefix(snap.ManifestList, "s3://"+rt.cfg.Bucket+"/")
+
+	entries, err := iceberg.ReadManifestList(bytes.NewReader(rt.getObject(t, ctx, key)))
+	require.NoError(t, err)
+
+	corrupted := make([]iceberg.ManifestFile, 0, len(entries))
+	for _, m := range entries {
+		b := iceberg.NewManifestFile(m.Version(), m.FilePath(), m.Length(), m.PartitionSpecID(), m.SnapshotID()).
+			Content(m.ManifestContent()).
+			SequenceNum(m.SequenceNum(), m.MinSequenceNum()).
+			AddedFiles(m.AddedDataFiles()).
+			ExistingFiles(m.ExistingDataFiles()).
+			DeletedFiles(m.DeletedDataFiles()).
+			AddedRows(m.AddedRows()).
+			ExistingRows(m.ExistingRows()).
+			DeletedRows(m.DeletedRows())
+		if km := m.KeyMetadata(); km != nil {
+			b = b.KeyMetadata(km)
+		}
+		corrupted = append(corrupted, b.Build())
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(tbl.Metadata().Version(), &buf,
+		snap.SnapshotID, snap.ParentSnapshotID, &snap.SequenceNumber, 0, corrupted))
+
+	_, err = rt.s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(rt.cfg.Bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(buf.Bytes()),
+	})
+	require.NoError(t, err)
 }
 
 // TestNormalizeLegacyCredentials guards the parity with the removed Python

--- a/materialize-s3-iceberg/manifest_repair.go
+++ b/materialize-s3-iceberg/manifest_repair.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	log "github.com/sirupsen/logrus"
+	"github.com/twmb/avro/ocf"
+)
+
+// repairManifestListNullPartitions heals the corruption described in issue
+// #4816: iceberg-go v0.6.0 encoded present-but-empty `partitions` field
+// summaries in manifest lists as the Avro null union branch, which strict
+// readers such as Redshift Spectrum reject, and later iceberg-go versions
+// re-encode a decoded null as null on every commit, so the corruption
+// propagates forward indefinitely.
+//
+// Every table this connector creates is unpartitioned, so a null
+// `partitions` in the current manifest list is unambiguous corruption: for
+// an unpartitioned table, null and empty summaries are semantically
+// identical, and normalizing cannot change query results. Revisit that
+// invariant if partitioned-table support ever lands.
+//
+// The repair rewrites the object in place, which needs no catalog commit
+// because a manifest list is referenced by exact path with no checksum. It
+// is race-free at Open: the connector is the table's sole appender, and a
+// concurrent external rewrite only makes the repair moot. Once one clean
+// manifest list exists, subsequent commits inherit present-empty arrays and
+// stay clean, so the check degrades to a single GET per table per Open.
+func repairManifestListNullPartitions(ctx context.Context, s3client *s3.Client, bucket, manifestList string) error {
+	if manifestList == "" {
+		// The table has no snapshots, so there is nothing to heal.
+		return nil
+	}
+
+	prefix := "s3://" + bucket + "/"
+	if !strings.HasPrefix(manifestList, prefix) {
+		// An adopted pre-existing table's metadata can live outside the
+		// configured bucket (or use another URI scheme). The repair is
+		// opportunistic, so an unreachable manifest list is skipped rather
+		// than failing the task's Open.
+		log.WithFields(log.Fields{
+			"manifestList": manifestList,
+			"bucket":       bucket,
+		}).Warn("skipping manifest-list repair of a table outside the configured bucket")
+		return nil
+	}
+	key := strings.TrimPrefix(manifestList, prefix)
+
+	out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("reading manifest list %q: %w", manifestList, err)
+	}
+	data, err := io.ReadAll(out.Body)
+	out.Body.Close()
+	if err != nil {
+		return fmt.Errorf("reading manifest list %q: %w", manifestList, err)
+	}
+
+	repaired, healed, err := healNullPartitions(data)
+	if err != nil {
+		return fmt.Errorf("repairing manifest list %q: %w", manifestList, err)
+	}
+	if healed == 0 {
+		return nil
+	}
+
+	if _, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(repaired),
+	}); err != nil {
+		return fmt.Errorf("writing repaired manifest list %q: %w", manifestList, err)
+	}
+
+	log.WithFields(log.Fields{
+		"manifestList": manifestList,
+		"entries":      healed,
+	}).Warn("repaired manifest list entries with null partition summaries (issue #4816)")
+
+	return nil
+}
+
+// healNullPartitions decodes an Avro manifest list generically, replaces
+// each null `partitions` value with an empty array, and re-encodes with the
+// file's own embedded writer schema, codec, and metadata, so the union
+// branch is the only thing that changes. The generic map decode is required:
+// iceberg-go's ManifestFile.Partitions() returns an empty slice for both the
+// null and the present-but-empty encoding, and round-tripping through its
+// typed reader/writer would substitute the current library's schema for the
+// file's own. Returns the rewritten file and the number of entries healed;
+// the rewritten bytes are nil when that count is zero.
+func healNullPartitions(data []byte) ([]byte, int, error) {
+	rd, err := ocf.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, 0, fmt.Errorf("opening avro file: %w", err)
+	}
+	defer rd.Close()
+
+	var records []map[string]any
+	var healed int
+	for {
+		var rec map[string]any
+		if err := rd.Decode(&rec); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, 0, fmt.Errorf("decoding entry: %w", err)
+		}
+		// The two-value lookup keeps a schema without a `partitions` field —
+		// where the single-value form also yields nil — out of the healed
+		// count, since "healing" it would rewrite the file on every Open.
+		if v, ok := rec["partitions"]; ok && v == nil {
+			rec["partitions"] = []any{}
+			healed++
+		}
+		records = append(records, rec)
+	}
+	if healed == 0 {
+		return nil, 0, nil
+	}
+
+	meta := rd.Metadata()
+	userMeta := make(map[string][]byte, len(meta))
+	for k, v := range meta {
+		// The writer emits the avro.* keys itself and rejects them as user
+		// metadata.
+		if !strings.HasPrefix(k, "avro.") {
+			userMeta[k] = v
+		}
+	}
+
+	opts := []ocf.WriterOpt{
+		// Preserve the file's schema JSON byte-for-byte rather than letting
+		// the writer emit the canonical form of the parsed schema.
+		ocf.WithSchema(string(meta["avro.schema"])),
+		ocf.WithMetadata(userMeta),
+	}
+	codec, err := codecByName(string(meta["avro.codec"]))
+	if err != nil {
+		return nil, 0, err
+	}
+	if codec != nil {
+		opts = append(opts, ocf.WithCodec(codec))
+	}
+
+	var buf bytes.Buffer
+	w, err := ocf.NewWriter(&buf, rd.Schema(), opts...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("opening avro writer: %w", err)
+	}
+	for _, rec := range records {
+		if err := w.Encode(rec); err != nil {
+			return nil, 0, fmt.Errorf("encoding entry: %w", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, 0, fmt.Errorf("closing avro writer: %w", err)
+	}
+
+	return buf.Bytes(), healed, nil
+}
+
+func codecByName(name string) (ocf.Codec, error) {
+	switch name {
+	case "", "null":
+		return nil, nil
+	case "deflate":
+		return ocf.DeflateCodec(-1), nil
+	case "snappy":
+		return ocf.SnappyCodec(), nil
+	// "zstandard" is the Avro spec's on-disk avro.codec name (Iceberg's
+	// write.avro.compression-codec table property spells it "zstd", but that
+	// is translated before it reaches the file header).
+	case "zstandard":
+		return ocf.ZstdCodec(nil, nil)
+	default:
+		return nil, fmt.Errorf("unsupported avro codec %q", name)
+	}
+}

--- a/materialize-s3-iceberg/manifest_repair_test.go
+++ b/materialize-s3-iceberg/manifest_repair_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	icebergcatalog "github.com/apache/iceberg-go/catalog"
+	icebergtable "github.com/apache/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/avro"
+	"github.com/twmb/avro/ocf"
+)
+
+// writeManifestListFixture builds a two-entry manifest list of the given
+// format version: entry one carries the null `partitions` union branch that
+// iceberg-go v0.6.0 wrote for inherited manifests, entry two the
+// present-but-empty encoding of a healthy unpartitioned commit.
+func writeManifestListFixture(t *testing.T, version int) []byte {
+	t.Helper()
+
+	corrupt := iceberg.NewManifestFile(version, "s3://bucket/metadata/m1.avro", 111, 0, 1).
+		AddedFiles(1).AddedRows(10)
+	clean := iceberg.NewManifestFile(version, "s3://bucket/metadata/m2.avro", 222, 0, 2).
+		AddedFiles(2).AddedRows(20).
+		Partitions([]iceberg.FieldSummary{})
+
+	var seq *int64
+	if version != 1 {
+		corrupt = corrupt.SequenceNum(1, 1)
+		clean = clean.SequenceNum(2, 2)
+		s := int64(2)
+		seq = &s
+	}
+
+	parent := int64(1)
+	var buf bytes.Buffer
+	require.NoError(t, iceberg.WriteManifestList(version, &buf, 2, &parent, seq, 0,
+		[]iceberg.ManifestFile{corrupt.Build(), clean.Build()}))
+	return buf.Bytes()
+}
+
+// readOCFRecords generically decodes every record of an Avro OCF alongside
+// its header metadata.
+func readOCFRecords(t *testing.T, data []byte) ([]map[string]any, map[string][]byte) {
+	t.Helper()
+
+	rd, err := ocf.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rd.Close()
+
+	var recs []map[string]any
+	for {
+		var rec map[string]any
+		if err := rd.Decode(&rec); errors.Is(err, io.EOF) {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+		recs = append(recs, rec)
+	}
+	return recs, rd.Metadata()
+}
+
+// transcodeOCF rewrites an OCF with a different codec, preserving its schema
+// and metadata, so codec variants of a fixture can be synthesized.
+func transcodeOCF(t *testing.T, data []byte, codec ocf.Codec) []byte {
+	t.Helper()
+
+	rd, err := ocf.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rd.Close()
+
+	meta := rd.Metadata()
+	userMeta := map[string][]byte{}
+	for k, v := range meta {
+		if !strings.HasPrefix(k, "avro.") {
+			userMeta[k] = v
+		}
+	}
+
+	var buf bytes.Buffer
+	w, err := ocf.NewWriter(&buf, rd.Schema(),
+		ocf.WithSchema(string(meta["avro.schema"])),
+		ocf.WithMetadata(userMeta),
+		ocf.WithCodec(codec))
+	require.NoError(t, err)
+	for {
+		var rec map[string]any
+		if err := rd.Decode(&rec); errors.Is(err, io.EOF) {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+		require.NoError(t, w.Encode(rec))
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// withoutPartitions returns copies of the records with the `partitions` key
+// removed, for asserting that a repair changed nothing else.
+func withoutPartitions(recs []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(recs))
+	for i, rec := range recs {
+		c := make(map[string]any, len(rec))
+		for k, v := range rec {
+			if k != "partitions" {
+				c[k] = v
+			}
+		}
+		out[i] = c
+	}
+	return out
+}
+
+func TestHealNullPartitions(t *testing.T) {
+	for _, version := range []int{1, 2} {
+		t.Run(map[int]string{1: "v1", 2: "v2"}[version], func(t *testing.T) {
+			data := writeManifestListFixture(t, version)
+
+			beforeRecs, beforeMeta := readOCFRecords(t, data)
+			require.Len(t, beforeRecs, 2)
+			require.Nil(t, beforeRecs[0]["partitions"])
+			require.NotNil(t, beforeRecs[1]["partitions"])
+
+			repaired, healed, err := healNullPartitions(data)
+			require.NoError(t, err)
+			require.Equal(t, 1, healed)
+
+			afterRecs, afterMeta := readOCFRecords(t, repaired)
+			require.Len(t, afterRecs, 2)
+			for _, rec := range afterRecs {
+				require.NotNil(t, rec["partitions"])
+			}
+			require.Equal(t, withoutPartitions(beforeRecs), withoutPartitions(afterRecs),
+				"the repair must change nothing but the partitions union branch")
+			require.Equal(t, beforeMeta["avro.schema"], afterMeta["avro.schema"],
+				"the repair must preserve the writer schema byte-for-byte")
+			require.Equal(t, beforeMeta["avro.codec"], afterMeta["avro.codec"])
+			for k, v := range beforeMeta {
+				if !strings.HasPrefix(k, "avro.") {
+					require.Equal(t, v, afterMeta[k], "metadata key %q must be preserved", k)
+				}
+			}
+		})
+	}
+
+	t.Run("clean file is a no-op", func(t *testing.T) {
+		data := writeManifestListFixture(t, 2)
+		clean, healed, err := healNullPartitions(data)
+		require.NoError(t, err)
+		require.Equal(t, 1, healed)
+
+		repaired, healed, err := healNullPartitions(clean)
+		require.NoError(t, err)
+		require.Zero(t, healed)
+		require.Nil(t, repaired)
+	})
+
+	t.Run("absent partitions field is not healed", func(t *testing.T) {
+		schema := avro.MustParse(`{"type":"record","name":"r","fields":[{"name":"x","type":"long"}]}`)
+		var buf bytes.Buffer
+		w, err := ocf.NewWriter(&buf, schema)
+		require.NoError(t, err)
+		require.NoError(t, w.Encode(map[string]any{"x": int64(1)}))
+		require.NoError(t, w.Close())
+
+		repaired, healed, err := healNullPartitions(buf.Bytes())
+		require.NoError(t, err)
+		require.Zero(t, healed)
+		require.Nil(t, repaired)
+	})
+
+	t.Run("codecs are preserved", func(t *testing.T) {
+		for name, codec := range map[string]ocf.Codec{
+			"snappy":    ocf.SnappyCodec(),
+			"zstandard": ocf.MustZstdCodec(nil, nil),
+		} {
+			data := transcodeOCF(t, writeManifestListFixture(t, 2), codec)
+
+			repaired, healed, err := healNullPartitions(data)
+			require.NoError(t, err)
+			require.Equal(t, 1, healed)
+
+			afterRecs, afterMeta := readOCFRecords(t, repaired)
+			require.Equal(t, name, string(afterMeta["avro.codec"]))
+			for _, rec := range afterRecs {
+				require.NotNil(t, rec["partitions"])
+			}
+		}
+	})
+
+	t.Run("unknown codec errors", func(t *testing.T) {
+		_, err := codecByName("lzo")
+		require.Error(t, err)
+	})
+}
+
+// fakeLoadCatalog serves constructed tables from LoadTable; the embedded
+// interface panics if any other method is called.
+type fakeLoadCatalog struct {
+	icebergcatalog.Catalog
+	tables map[string]*icebergtable.Table
+}
+
+func (f *fakeLoadCatalog) LoadTable(_ context.Context, ident icebergtable.Identifier) (*icebergtable.Table, error) {
+	return f.tables[ident[len(ident)-1]], nil
+}
+
+func newFakeTable(t *testing.T, spec *iceberg.PartitionSpec) *icebergtable.Table {
+	t.Helper()
+
+	schema := iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "v", Type: iceberg.PrimitiveTypes.String})
+	md, err := icebergtable.NewMetadata(schema, spec, icebergtable.UnsortedSortOrder, "s3://bucket/loc", nil)
+	require.NoError(t, err)
+	return icebergtable.New(icebergtable.Identifier{"ns", "tbl"}, md, "s3://bucket/loc/metadata/v1.json", nil, nil)
+}
+
+// TestTableInfosPartitionGate pins the flag that gates the issue #4816
+// manifest-list repair: it must be true only for unpartitioned tables, since
+// a partitioned table may legitimately carry null partition summaries.
+func TestTableInfosPartitionGate(t *testing.T) {
+	partSpec := iceberg.NewPartitionSpec(iceberg.PartitionField{
+		SourceIDs: []int{1}, FieldID: 1000, Name: "v", Transform: iceberg.IdentityTransform{},
+	})
+	c := &catalog{cfg: &config{}, locationStyle: NestedLocationStyle, cat: &fakeLoadCatalog{
+		tables: map[string]*icebergtable.Table{
+			"unpart": newFakeTable(t, nil),
+			"part":   newFakeTable(t, &partSpec),
+		},
+	}}
+
+	infos, err := c.tableInfos(context.Background(), [][]string{{"ns", "unpart"}, {"ns", "part"}})
+	require.NoError(t, err)
+	require.True(t, infos[0].unpartitioned)
+	require.False(t, infos[1].unpartitioned)
+	// A table with no snapshots has no manifest list to repair.
+	require.Empty(t, infos[0].manifestList)
+}


### PR DESCRIPTION
**Regression?**

Yes — heals data corruption introduced by the iceberg-go v0.6.0 adoption in #4347 (apache/iceberg-go#1309). The write path was fixed in #4809, but manifest lists corrupted during the exposure window re-corrupt every subsequent commit and never heal on their own. Closes #4816.

**Description:**

Self-heal manifest lists whose `partitions` field summaries were encoded as the Avro null union branch, which strict readers (e.g. Redshift Spectrum) reject. On Open, for each bound table: GET the current snapshot's manifest list; if any entry has null `partitions`, flip it to an empty array and re-encode with the file's own embedded writer schema, codec, and metadata; PUT back to the same key (no catalog commit needed). Otherwise no-op. All tables this connector creates are unpartitioned, so null ⇒ corruption, and normalizing cannot change query results.

Commit 1 is a failing regression test that reproduces the corruption and its propagation; commit 2 is the fix.

**Workflow steps:**

None — the repair runs automatically at task startup and logs a warning per healed manifest list. Once one clean manifest list exists the check degrades to a single GET per table per Open, and the code can be removed after a fleet re-scan is clean.

**Documentation links affected:**

None.

**Notes for reviewers:**

- The generic Avro map round-trip is deliberate: `ManifestFile.Partitions()` cannot distinguish null from present-but-empty, and iceberg-go's typed writer would substitute its own schema for the file's. The test asserts the writer schema is byte-identical after repair.
- Verified against both the Polaris REST and AWS Glue integration suites (all subtests green, no snapshot drift).

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
