### PR TITLE
source-dynamics-365-finance-and-operations: additional debug logging

### DIFF
--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -137,7 +137,13 @@ async def get_timestamp_folders(
         if path.isDirectory and is_datetime_format(path.name):
             timestamp_folders.append(path.name)
 
-    return sorted(timestamp_folders, key=str_to_dt)
+    sorted_timestamp_folders = sorted(timestamp_folders, key=str_to_dt)
+
+    client.log.debug("Found timestamp folders", {
+        "timestamp folders": sorted_timestamp_folders
+    })
+
+    return sorted_timestamp_folders
 
 
 @alru_cache(maxsize=1, ttl=CACHE_TTL)


### PR DESCRIPTION
**Regression?**

No.

**Description:**

When troubleshooting captures that hit 404 errors when reading a `model.json` or `.csv` file that _should_ exist since we were able to list the timestamp folder previously, it'd be good to know if the list of timestamp folders is consistent across runs or if Azure is deleting timestamp folders as part of some data retention policy. This debug log will help us figure out if that's the case.