### PR TITLE
sqlcapture: dump goroutine stacks during long-running streaming cycles

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -1,6 +1,7 @@
 package sqlcapture
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"runtime"
+	"runtime/pprof"
 	"slices"
 	"strings"
 	"sync"
@@ -591,6 +594,7 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	// so the two callers of logProgress never overlap on the shared interval state.
 	var progressDone = make(chan struct{})
 	var progressWG sync.WaitGroup
+	var progressTicks int
 	progressWG.Go(func() {
 		var ticker = time.NewTicker(streamingProgressInterval)
 		defer ticker.Stop()
@@ -601,6 +605,12 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 			case <-ticker.C:
 				logProgress("processing replication events")
 				log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
+				// Dump goroutine stacks on the first tick and every fifth tick thereafter
+				// to help with investigations into potentially stalled captures.
+				if progressTicks%5 == 0 {
+					dumpGoroutineStacks()
+				}
+				progressTicks++
 				if err := c.Database.ReplicationDiagnostics(ctx); err != nil {
 					log.WithField("err", err).Error("replication diagnostics error")
 				}
@@ -649,6 +659,20 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	}
 
 	return nil
+}
+
+// dumpGoroutineStacks emits a full goroutine stack dump when a replication
+// streaming cycle has been running longer than expected.
+func dumpGoroutineStacks() {
+	var buf bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&buf, 2); err != nil {
+		log.WithField("err", err).Warn("failed to capture goroutine stack dump")
+		return
+	}
+	log.WithFields(log.Fields{
+		"goroutines": runtime.NumGoroutine(),
+		"stacks":     buf.String(),
+	}).Warn("goroutine stack dump for long-running replication streaming")
 }
 
 func (c *Capture) handleReplicationEvent(event DatabaseEvent) (int, error) {

--- a/sqlcapture/goroutine_dump_test.go
+++ b/sqlcapture/goroutine_dump_test.go
@@ -1,0 +1,51 @@
+package sqlcapture
+
+import (
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// blockedForStackDumpTest parks a goroutine on a channel receive so that
+// dumpGoroutineStacks has a recognizable, deliberately-blocked goroutine to
+// capture.
+func blockedForStackDumpTest(release <-chan struct{}) {
+	<-release
+}
+
+func TestDumpGoroutineStacks(t *testing.T) {
+	// Capture logrus output via a test hook rather than writing to stderr.
+	var hook = logtest.NewGlobal()
+	defer hook.Reset()
+
+	// Park a goroutine on a channel receive so the dump has a known blocked
+	// stack to find.
+	var release = make(chan struct{})
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		blockedForStackDumpTest(release)
+	}()
+	<-started
+	defer close(release)
+
+	dumpGoroutineStacks()
+
+	var entry = hook.LastEntry()
+	require.NotNil(t, entry, "expected a log entry from dumpGoroutineStacks")
+	require.Equal(t, log.WarnLevel, entry.Level)
+	require.Equal(t, "goroutine stack dump for long-running replication streaming", entry.Message)
+
+	var stacks, ok = entry.Data["stacks"].(string)
+	require.True(t, ok, "expected a 'stacks' string field")
+
+	require.Contains(t, stacks, "goroutine ")
+	require.Contains(t, stacks, "sqlcapture.dumpGoroutineStacks")
+	require.Contains(t, stacks, "sqlcapture.blockedForStackDumpTest")
+	require.Contains(t, stacks, "chan receive")
+
+	require.GreaterOrEqual(t, strings.Count(stacks, "goroutine "), 2)
+}


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've observed a `source-mysql` capture stall for 12+ hours, logging out that replication streaming is taking an unexpectedly long time every so often with suspiciously zero data movement. In this situation, it's difficult to tell from the logs why the capture is apparently stalled. This PR hangs a full goroutine dump off the existing progress ticker on the first tick and every fifth tick thereafter. This should help us investigate stalls even if an operator isn't around to get a goroutine stack dump before the capture is restarted & un-stuck.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
