### PR TITLE
materialize-clickhouse: skip nullable ALTER of sorting/partition-key columns (#4829)

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17
+
+### Fixed
+- Fixed a permanent restart loop with the error `ALTER of key column ... is not safe because it can change the representation of primary key` (code 524) that occurred when a table's sorting-key or partition-key column was no longer part of the materialization's field selection. Such columns are now left unchanged instead of being made nullable, which ClickHouse forbids for key columns.
+
 ## 2026-07-15
 
 ### Fixed

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -249,11 +249,9 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 	var stmts []string
 
 	// ClickHouse forbids changing the type of a sorting-key or partition-key
-	// column (code 524), so such a column can never be widened to Nullable.
-	// It doesn't need to be either: inserts name their columns explicitly, and
-	// a non-nullable column omitted from an insert receives the type's zero
-	// value. Skip these columns rather than crash-looping on an ALTER that can
-	// never succeed.
+	// column (code 524), so such a column cannot be widened to Nullable. It
+	// doesn't need to be: inserts name their columns explicitly, and a
+	// non-nullable column omitted from an insert receives the type's zero value.
 	var dropNotNulls []boilerplate.ExistingField
 	for _, col := range ta.DropNotNulls {
 		if meta, ok := col.Meta.(existingFieldMeta); ok && meta.isKeyColumn {

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -13,11 +13,21 @@ import (
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	log "github.com/sirupsen/logrus"
 )
 
 type client struct {
 	db *stdsql.DB
 	ep *sql.Endpoint[config]
+}
+
+// existingFieldMeta is ClickHouse-specific column metadata attached to
+// boilerplate.ExistingField.Meta by PopulateInfoSchema.
+type existingFieldMeta struct {
+	// isKeyColumn is set for columns in the table's sorting key or partition
+	// key. ClickHouse forbids ALTERing the type of such columns (code 524),
+	// including widening them to Nullable.
+	isKeyColumn bool
 }
 
 func newClient(_ context.Context, materializationName string, ep *sql.Endpoint[config]) (sql.Client, error) {
@@ -73,7 +83,7 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 	// Query columns from system.columns.
 	var colRows *stdsql.Rows
 	colRows, err = c.db.QueryContext(ctx, fmt.Sprintf(
-		"SELECT database, table, name, type, default_expression FROM system.columns WHERE database = %s",
+		"SELECT database, table, name, type, default_expression, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = %s",
 		c.ep.Dialect.Literal(database),
 	))
 	if err != nil {
@@ -83,7 +93,8 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 
 	for colRows.Next() {
 		var dbName, tableName, colName, colType, defaultExpr string
-		if err := colRows.Scan(&dbName, &tableName, &colName, &colType, &defaultExpr); err != nil {
+		var isInSortingKey, isInPartitionKey uint8
+		if err := colRows.Scan(&dbName, &tableName, &colName, &colType, &defaultExpr, &isInSortingKey, &isInPartitionKey); err != nil {
 			return fmt.Errorf("scanning column row: %w", err)
 		}
 
@@ -104,6 +115,7 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 			Nullable:   isNullable,
 			Type:       baseType,
 			HasDefault: defaultExpr != "",
+			Meta:       existingFieldMeta{isKeyColumn: isInSortingKey == 1 || isInPartitionKey == 1},
 		})
 	}
 	if err := colRows.Err(); err != nil {
@@ -235,6 +247,25 @@ var clickHouseMigrationSteps = []sql.ColumnMigrationStep{
 
 func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boilerplate.ActionApplyFn, error) {
 	var stmts []string
+
+	// ClickHouse forbids changing the type of a sorting-key or partition-key
+	// column (code 524), so such a column can never be widened to Nullable.
+	// It doesn't need to be either: inserts name their columns explicitly, and
+	// a non-nullable column omitted from an insert receives the type's zero
+	// value. Skip these columns rather than crash-looping on an ALTER that can
+	// never succeed.
+	var dropNotNulls []boilerplate.ExistingField
+	for _, col := range ta.DropNotNulls {
+		if meta, ok := col.Meta.(existingFieldMeta); ok && meta.isKeyColumn {
+			log.WithFields(log.Fields{
+				"table":  ta.Identifier,
+				"column": col.Name,
+			}).Warn("not making key column nullable because ClickHouse forbids ALTER of sorting-key and partition-key columns")
+			continue
+		}
+		dropNotNulls = append(dropNotNulls, col)
+	}
+	ta.DropNotNulls = dropNotNulls
 
 	if len(ta.AddColumns) > 0 || len(ta.DropNotNulls) > 0 {
 		var alterStmtBuilder strings.Builder

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -247,14 +247,12 @@ func TestTruncateTable(t *testing.T) {
 	require.Equal(t, 0, count)
 }
 
-// TestAlterTableOrphanedSortingKeyColumn is a regression test for
-// https://github.com/estuary/connectors/issues/4829: a pre-existing table
-// (adopted via allow_existing_tables_for_new_bindings) can have non-nullable
-// columns in its ORDER BY key that are not in the current field selection. The
-// boilerplate orphan sweep marks every such column as newly nullable, and
-// AlterTable renders MODIFY COLUMN ... Nullable(...) for it — which ClickHouse
-// forbids for sorting-key columns (code 524), crash-looping the task on every
-// restart. Sorting-key columns must be skipped, while non-key orphaned columns
+// TestAlterTableOrphanedSortingKeyColumn verifies that AlterTable does not make
+// a sorting-key or partition-key column nullable, which ClickHouse forbids for
+// key columns (code 524). A pre-existing table (adopted via
+// allow_existing_tables_for_new_bindings) can have non-nullable key columns that
+// are not in the field selection, which the boilerplate orphan sweep marks as
+// newly nullable. Such columns must be skipped, while non-key orphaned columns
 // must still be widened.
 func TestAlterTableOrphanedSortingKeyColumn(t *testing.T) {
 	if testing.Short() {

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -12,6 +12,7 @@ import (
 	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouseproto "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	m "github.com/estuary/connectors/go/materialize"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -244,6 +245,109 @@ func TestTruncateTable(t *testing.T) {
 	var count int
 	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT count() FROM %s", dialect.Identifier(tableName))).Scan(&count))
 	require.Equal(t, 0, count)
+}
+
+// TestAlterTableOrphanedSortingKeyColumn is a regression test for
+// https://github.com/estuary/connectors/issues/4829: a pre-existing table
+// (adopted via allow_existing_tables_for_new_bindings) can have non-nullable
+// columns in its ORDER BY key that are not in the current field selection. The
+// boilerplate orphan sweep marks every such column as newly nullable, and
+// AlterTable renders MODIFY COLUMN ... Nullable(...) for it — which ClickHouse
+// forbids for sorting-key columns (code 524), crash-looping the task on every
+// restart. Sorting-key columns must be skipped, while non-key orphaned columns
+// must still be widened.
+func TestAlterTableOrphanedSortingKeyColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var ep = &sql.Endpoint[config]{Config: cfg, Dialect: dialect}
+	var tableName = "test_orphaned_sorting_key"
+	var table = buildTestTable(t, dialect, tableName)
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+
+	// The table reflects an older keying of the data: legacy_key participates
+	// in ORDER BY but is no longer part of the collection or field selection,
+	// and orphaned_value is a non-key column that is also no longer selected.
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id String,
+			legacy_key String,
+			orphaned_value String,
+			value Nullable(String),
+			`+"`_meta/op`"+` String,
+			flow_published_at DateTime64(6, 'UTC'),
+			flow_document String,
+			_is_deleted UInt8 DEFAULT 0
+		) ENGINE = ReplacingMergeTree(flow_published_at, _is_deleted)
+		ORDER BY (id, legacy_key)`,
+		dialect.Identifier(tableName),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	})
+
+	c, err := newClient(ctx, "test", ep)
+	require.NoError(t, err)
+	defer c.Close()
+
+	var is = boilerplate.NewInfoSchema(
+		sql.ToLocatePathFn(dialect.TableLocator),
+		dialect.SchemaLocator,
+		dialect.ColumnLocator,
+		dialect.CaseInsensitiveColumns,
+		dialect.CaseInsensitiveResources,
+	)
+	require.NoError(t, c.PopulateInfoSchema(ctx, is, [][]string{{tableName}}))
+	existing := is.GetResource([]string{tableName})
+	require.NotNil(t, existing)
+
+	// Mirror the orphan sweep of materialize-boilerplate's computeBindingUpdate:
+	// every existing non-nullable column that isn't in the field selection is
+	// marked as newly nullable and arrives at AlterTable as a DropNotNulls entry.
+	var inSelection = make(map[string]bool)
+	for _, col := range table.Columns() {
+		inSelection[col.Field] = true
+	}
+	var dropNotNulls []boilerplate.ExistingField
+	var droppedNames []string
+	for _, f := range existing.AllFields() {
+		if !inSelection[f.Name] && !f.Nullable {
+			dropNotNulls = append(dropNotNulls, f)
+			droppedNames = append(droppedNames, f.Name)
+		}
+	}
+	require.ElementsMatch(t, []string{"legacy_key", "orphaned_value"}, droppedNames)
+
+	_, applyFn, err := c.AlterTable(ctx, sql.TableAlter{Table: table, DropNotNulls: dropNotNulls})
+	require.NoError(t, err)
+	require.NoError(t, applyFn(ctx))
+
+	// The sorting-key column must be left untouched, and the non-key orphaned
+	// column must still be widened to Nullable.
+	colTypes := make(map[string]string)
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT name, type FROM system.columns WHERE database = %s AND table = %s",
+		dialect.Literal(cfg.Database), dialect.Literal(tableName),
+	))
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var name, typ string
+		require.NoError(t, rows.Scan(&name, &typ))
+		colTypes[name] = typ
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, "String", colTypes["legacy_key"])
+	require.Equal(t, "Nullable(String)", colTypes["orphaned_value"])
 }
 
 func TestOpenNativeConn(t *testing.T) {


### PR DESCRIPTION
**Description:**

`materialize-clickhouse` could enter a permanent crash-loop (code 524, `ALTER ... is not safe because it can change the representation of primary key`) when applying schema changes to a table whose sorting-key or partition-key column is no longer in the field selection — the connector tried to make that key column `Nullable`, which ClickHouse forbids for key columns. One such binding blocked the entire task. Key columns are now detected via `system.columns` (`is_in_sorting_key` / `is_in_partition_key`) and skipped when dropping NOT NULL; non-key columns are still widened as before. Fixes #4829.

**Workflow steps:**

No user action needed. Affected tasks — typically ones adopting pre-existing tables via `allow_existing_tables_for_new_bindings` — self-recover on restart instead of looping.

**Notes for reviewers:**

Two commits, TDD shape: failing regression test, then the fix. The guard covers both sorting and partition keys (both raise code 524; the partition-key case was verified manually). The test also asserts a non-key orphaned column is still made nullable, so the filter doesn't over-suppress.

**Checklist:**

- [x] `materialize-clickhouse/CHANGELOG.md` updated.