### PR TITLE
source-dynamics-365-finance-and-operations: use fallback per-table `model.json` when folder level `model.json` omits the table

### DIFF
--- a/estuary-cdk/estuary_cdk/incremental_csv_processor.py
+++ b/estuary-cdk/estuary_cdk/incremental_csv_processor.py
@@ -68,6 +68,14 @@ class CSVProcessingError(Exception):
         super().__init__(message)
 
 
+# Sentinels for column-count validation. aiocsv's dict reader collects surplus
+# cells under `restkey` and pads short rows with `restval`. Using unique objects
+# for both lets us detect either mismatch without mistaking a genuinely empty
+# field ("") for a missing one.
+_SURPLUS_COLUMNS_KEY = object()
+_MISSING_COLUMN = object()
+
+
 class _AsyncByteReader(aiocsv.protocols.WithAsyncRead):
     """Internal class that handles incremental decoding for aiocsv."""
 
@@ -245,8 +253,34 @@ class IncrementalCSVProcessor(Generic[T]):
         if self.fieldnames is not None:
             reader_kwargs['fieldnames'] = self.fieldnames
 
+        # Route surplus cells and short-row padding to sentinels so a
+        # column-count mismatch is detectable and distinct from an empty field.
+        reader_kwargs['restkey'] = _SURPLUS_COLUMNS_KEY
+        reader_kwargs['restval'] = _MISSING_COLUMN
+
         try:
-            async for row in aiocsv.AsyncDictReader(async_reader, **reader_kwargs):
+            reader = aiocsv.AsyncDictReader(async_reader, **reader_kwargs)
+            async for row in reader:
+                self._validate_column_count(row, reader)
                 yield row
         except csv.Error as e:
             raise CSVProcessingError(f"Failed to parse CSV data: {str(e)}", config=reader_kwargs) from e
+
+    @staticmethod
+    def _validate_column_count(row: dict[Any, Any], reader: "aiocsv.AsyncDictReader") -> None:
+        """Raise CSVProcessingError if `row` has more or fewer columns than the
+        reader's header/fieldnames."""
+        expected = len(reader.fieldnames or [])
+
+        if _SURPLUS_COLUMNS_KEY in row:
+            actual = expected + len(row[_SURPLUS_COLUMNS_KEY])
+            raise CSVProcessingError(
+                f"CSV row {reader.line_num} has {actual} columns but {expected} were expected."
+            )
+
+        missing = sum(1 for value in row.values() if value is _MISSING_COLUMN)
+        if missing:
+            raise CSVProcessingError(
+                f"CSV row {reader.line_num} has {expected - missing} columns but "
+                f"{expected} were expected."
+            )

--- a/estuary-cdk/tests/test_incremental_csv_processor.py
+++ b/estuary-cdk/tests/test_incremental_csv_processor.py
@@ -55,10 +55,12 @@ newline",15.50
 
     def csv_with_special_chars(self, delimiter: str = '|') -> str:
         """CSV with special characters and custom delimiter."""
-        return f"""name{delimiter}age{delimiter}city
-John{delimiter}Product with, comma{delimiter}"Quoted notes"
-Jane{delimiter}Another product{delimiter}Simple notes
-Bob{delimiter}"Quoted product"{delimiter}Notes with {delimiter} delimiter"""
+        return (
+            f"name{delimiter}age{delimiter}city\n"
+            f'John{delimiter}Product with, comma{delimiter}"Quoted notes"\n'
+            f"Jane{delimiter}Another product{delimiter}Simple notes\n"
+            f'Bob{delimiter}"Quoted product"{delimiter}"Notes with {delimiter} delimiter"'
+        )
 
     async def create_byte_chunk_iterator(self, data: str, chunk_size: int = 10, encoding: str = 'utf-8') -> AsyncGenerator[bytes, None]:
         """Helper to create async byte chunk iterator."""
@@ -320,13 +322,60 @@ Fran\xc3\xa7ois,Paris,France
         assert len(rows) == 2  # Empty lines should be filtered out.
 
     @pytest.mark.asyncio
-    async def test_csv_with_inconsistent_fields_is_allowed(self):
-        """Test that CSV with inconsistent field counts is actually allowed by CSV parsers."""
-        # This is actually valid CSV - parsers fill missing fields with None.
-        csv_with_varying_fields = b'name,age,city\nJohn,25,New York\nJane\nBob,35\n,,'
+    async def test_row_with_too_few_columns_raises(self):
+        """A row with fewer columns than the header raises rather than being
+        silently padded with None."""
+        csv_data = b'name,age,city\nJohn,25,New York\nJane,30'
 
         async def csv_iterator():
-            yield csv_with_varying_fields
+            yield csv_data
+
+        processor = IncrementalCSVProcessor(csv_iterator(), BasicRecord)
+
+        with pytest.raises(CSVProcessingError, match="2 columns but 3 were expected"):
+            async for _ in processor:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_row_with_too_many_columns_raises(self):
+        """A row with more columns than the header raises rather than the
+        surplus being silently dropped."""
+        csv_data = b'name,age,city\nJohn,25,New York\nJane,30,LA,extra'
+
+        async def csv_iterator():
+            yield csv_data
+
+        processor = IncrementalCSVProcessor(csv_iterator(), BasicRecord)
+
+        with pytest.raises(CSVProcessingError, match="4 columns but 3 were expected"):
+            async for _ in processor:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_too_few_columns_with_explicit_fieldnames_raises(self):
+        """Validation also applies when fieldnames are supplied for a headerless
+        CSV."""
+        csv_data = b'John,25,New York\nJane,30'
+
+        async def csv_iterator():
+            yield csv_data
+
+        processor = IncrementalCSVProcessor(
+            csv_iterator(), BasicRecord, fieldnames=['name', 'age', 'city']
+        )
+
+        with pytest.raises(CSVProcessingError, match="2 columns but 3 were expected"):
+            async for _ in processor:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_empty_fields_are_not_a_column_count_mismatch(self):
+        """A row of the right width whose fields are empty is valid; empty
+        strings are not treated as missing columns."""
+        csv_data = b'name,age,city\nJohn,,New York\n,,'
+
+        async def csv_iterator():
+            yield csv_data
 
         processor = IncrementalCSVProcessor(csv_iterator(), BasicRecord)
 
@@ -334,12 +383,9 @@ Fran\xc3\xa7ois,Paris,France
         async for row in processor:
             rows.append(row)
 
-        # Should get all rows, including ones with missing fields and empty rows.
-        assert len(rows) == 4
-        assert rows[0].name == "John" and rows[0].age == "25" and rows[0].city == "New York"
-        assert rows[1].name == "Jane" and rows[1].age is None and rows[1].city is None
-        assert rows[2].name == "Bob" and rows[2].age == "35" and rows[2].city is None
-        assert rows[3].name == "" and rows[3].age == "" and rows[3].city == ""
+        assert len(rows) == 2
+        assert rows[0].name == "John" and rows[0].age == "" and rows[0].city == "New York"
+        assert rows[1].name == "" and rows[1].age == "" and rows[1].city == ""
 
     @pytest.mark.asyncio
     async def test_headers_only(self):

--- a/source-dynamics-365-finance-and-operations/CHANGELOG.md
+++ b/source-dynamics-365-finance-and-operations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-17
+
+### Fixed
+- Captures no longer crash when a timestamp folder's `model.json` is present but does not list an entity for a given binding. The connector now falls back to the per-table `model.json` that Synapse Link writes under `Microsoft.Athena.TrickleFeedService/`.
+- CSV rows whose column count doesn't match their table's schema now fail with a clear error instead of being silently padded or truncated, guarding against misaligned reads from a fallback per-table `model.json`.
+
 ## 2026-07-16
 
 ### Fixed

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -52,18 +52,38 @@ SETTLE_DELAY = timedelta(hours=1)
 TransformedRow = dict[str, str | bool | None | dict[str, str]]
 
 
+# Alongside the folder level model.json, D365's Synapse Link export (via its
+# TrickleFeedService) writes a per-table model.json at
+# {timestamp}/{TRICKLE_FEED_SERVICE_DIR}/{table}-model.json. It has the same
+# shape as the folder level model.json but describes a single table, and serves
+# as an fallback when the folder level model.json was written but
+# truncated (see get_table_metadata).
+TRICKLE_FEED_SERVICE_DIR = "Microsoft.Athena.TrickleFeedService"
+
+
 class ModelFormat(StrEnum):
     BYTES = "bytes"
     PYDANTIC = "pydantic"
 
 
-class TimestampFolderModelNotFoundError(Exception):
-    """Raised when a timestamp folder has table CSV data but no folder-level
-    model.json, indicating the folder has not been finalized."""
+class TableSchemaUnavailableError(Exception):
+    """Raised when a timestamp folder has CSV data for a table but no usable
+    schema to read it with. Observed causes, all suspected to be due to
+    aborted/interrupted Synapse Link exports, include:
 
-    def __init__(self, folder: str):
+    - the folder level model.json is absent (404),
+    - the folder level model.json is present but lists no entities, or
+    - neither the folder level model.json (which can be truncated, dropping a
+      lexicographically-ordered tail of entities) nor the table's per-table
+      model.json describes the table.
+    """
+
+    def __init__(self, folder: str, detail: str):
         self.folder = folder
-        super().__init__(f"Timestamp folder {folder} has no model.json.")
+        self.detail = detail
+        super().__init__(
+            f"No usable schema for the table in timestamp folder {folder}: {detail}."
+        )
 
 
 # model.json metadata files are not updated after they're written.
@@ -114,6 +134,21 @@ async def fetch_model_dot_json(
     return raw_bytes
 
 
+def _find_entity(entities: list[dict], table_name: str) -> dict | None:
+    return next((e for e in entities if e["name"] == table_name), None)
+
+
+def _table_metadata_from_entity(entity: dict) -> TableMetadata:
+    return TableMetadata(
+        name=entity["name"],
+        field_names=[attr["name"] for attr in entity["attributes"]],
+        boolean_fields=frozenset(
+            attr["name"] for attr in entity["attributes"]
+            if attr["dataType"] == "boolean"
+        ),
+    )
+
+
 async def get_table_metadata(
     timestamp: str,
     table_name: str,
@@ -121,20 +156,62 @@ async def get_table_metadata(
     log: Logger,
 ) -> TableMetadata:
     raw_bytes = await fetch_model_dot_json(client, log, timestamp)
-    data = orjson.loads(raw_bytes)
+    entities = orjson.loads(raw_bytes).get("entities") or []
 
-    for entity in data["entities"]:
-        if entity["name"] == table_name:
-            return TableMetadata(
-                name=entity["name"],
-                field_names=[attr["name"] for attr in entity["attributes"]],
-                boolean_fields=frozenset(
-                    attr["name"] for attr in entity["attributes"]
-                    if attr["dataType"] == "boolean"
-                ),
-            )
+    entity = _find_entity(entities, table_name)
+    if entity is not None:
+        return _table_metadata_from_entity(entity)
 
-    raise KeyError(f"Table {table_name} not found in timestamp folder {timestamp}.")
+    if not entities:
+        # We haven't observed the case where the folder level model.json
+        # doesn't have _any_ entities present, but I'm not confident it
+        # would be safe to fallback to the per-table model.json under
+        # TRICKLE_FEED_SERVICE_DIR in that situation. Raise so we can
+        # investigate if this happens.
+        raise TableSchemaUnavailableError(
+            timestamp, "folder level model.json lists no entities"
+        )
+
+    # The model.json lists other entities but not this one. It was written but
+    # truncated (entities are emitted in lexicographic order, and an aborted
+    # export can cut the list off partway through). The folder did finalize its
+    # schemas, so fall back to the per-table model.json.
+    return await _get_table_metadata_from_per_table_model_dot_json(
+        timestamp, table_name, client, log
+    )
+
+
+async def _get_table_metadata_from_per_table_model_dot_json(
+    timestamp: str,
+    table_name: str,
+    client: ADLSGen2Client,
+    log: Logger,
+) -> TableMetadata:
+    path = f"{timestamp}/{TRICKLE_FEED_SERVICE_DIR}/{table_name}-model.json"
+    try:
+        raw_bytes = await client.read_file(path)
+    except HTTPError as err:
+        if err.code == 404:
+            raise TableSchemaUnavailableError(
+                timestamp,
+                f"folder level model.json omits table {table_name} and no "
+                f"per-table model.json exists for it",
+            ) from err
+        raise
+
+    entity = _find_entity(orjson.loads(raw_bytes).get("entities") or [], table_name)
+    if entity is None:
+        raise TableSchemaUnavailableError(
+            timestamp, f"per-table model.json for {table_name} does not describe the table"
+        )
+
+    log.info(
+        "The folder level model.json omitted this table. Reading its CSVs with the "
+        "per-table model.json instead.",
+        {"folder": timestamp, "table": table_name, "path": path},
+    )
+
+    return _table_metadata_from_entity(entity)
 
 
 async def get_in_progress_timestamp_folder(
@@ -316,9 +393,10 @@ async def read_csvs_in_folder(
     if not csvs:
         return
 
-    # The folder has CSV data for this table but its model.json is fetched
-    # separately. A 404 here means the folder was never finalized (see
-    # SETTLE_DELAY). We surface it so fetch_changes can decide
+    # The folder has CSV data for this table but its schema is
+    # fetched separately. A 404 means the folder level model.json is missing
+    # entirely. get_table_metadata raises TableSchemaUnavailableError for
+    # the other unusable-schema cases. We surface it so fetch_changes can decide
     # whether to wait for finalization or skip the incomplete folder.
     try:
         table_metadata = await get_table_metadata(
@@ -329,7 +407,9 @@ async def read_csvs_in_folder(
         )
     except HTTPError as err:
         if err.code == 404:
-            raise TimestampFolderModelNotFoundError(folder) from err
+            raise TableSchemaUnavailableError(
+                folder, "folder level model.json is missing"
+            ) from err
         raise
 
     def open_csv(csv: ADLSPathMetadata) -> AsyncGenerator[TransformedRow, None]:
@@ -415,12 +495,12 @@ async def fetch_changes(
             try:
                 async for row in read_csvs_in_folder(folder, table_name, client, log):
                     yield row
-            except TimestampFolderModelNotFoundError:
-                # The folder has table data but no model.json. This folder should
-                # be finalized when the next folder is created, and we use the next
-                # folder to determine if SETTLE_DELAY has elapsed. If so, then we
-                # assume the current folder's export was interrupted/aborted by D365
-                # & the changes shouldn't be replicated.
+            except TableSchemaUnavailableError as err:
+                # The folder has table data but no usable schema for this table.
+                # This folder should be finalized when the next folder is created,
+                # and we use the next folder to determine if SETTLE_DELAY has elapsed.
+                # If so, then we assume the current folder's export was interrupted/aborted
+                # by D365 & the changes shouldn't be replicated.
                 if index + 1 < len(finalized_folders):
                     next_folder = finalized_folders[index + 1]
                 else:
@@ -428,21 +508,21 @@ async def fetch_changes(
 
                 if should_wait_for_finalization(next_folder, datetime.now(tz=UTC)):
                     log.info(
-                        "Timestamp folder has table data but no model.json yet and "
-                        "it may still be finalizing. Will retry on the next sweep.",
-                        {"folder": folder, "table": table_name},
+                        "Timestamp folder has table data but no usable schema yet "
+                        "and it may still be finalizing. Will retry on the next sweep.",
+                        {"folder": folder, "table": table_name, "detail": err.detail},
                     )
                     return
 
-                # The folder had ample time to finalize but still has no
-                # model.json, so it's an incomplete/abandoned folder. Skip it
-                # and advance past it. Its changes are expected to be
-                # re-committed in a later folder.
+                # The folder had ample time to finalize but still has no usable
+                # schema, so it's an incomplete/abandoned folder. Skip it and
+                # advance past it. Its changes are expected to be re-committed in
+                # a later folder.
                 log.warning(
-                    "Skipping timestamp folder with table data but no model.json. "
+                    "Skipping timestamp folder with table data but no usable schema. "
                     "The folder appears incomplete and was never finalized. Its changes "
                     "are expected to be re-committed in a later folder.",
-                    {"folder": folder, "table": table_name},
+                    {"folder": folder, "table": table_name, "detail": err.detail},
                 )
 
             log.debug(f"Read all CSVs in folder. Yielding folder name as new cursor.", {

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -1,12 +1,18 @@
+import logging
 from datetime import timedelta
 from typing import AsyncGenerator, Callable
 
+import orjson
 import pytest
 
+from estuary_cdk.http import HTTPError
 from source_dynamics_365_finance_and_operations.adls_gen2_client import ADLSPathMetadata
 from source_dynamics_365_finance_and_operations.api import (
     SETTLE_DELAY,
+    TRICKLE_FEED_SERVICE_DIR,
+    TableSchemaUnavailableError,
     TransformedRow,
+    get_table_metadata,
     should_wait_for_finalization,
     stream_folder_rows,
     transform_row,
@@ -250,6 +256,99 @@ class TestStreamFolderRows:
         })
         result = await collect(stream_folder_rows(csvs, factory))
         assert [(r["Id"], r["versionnumber"]) for r in result] == [("A", "10")]
+
+
+def entity(name: str) -> dict:
+    """A model.json entity with the standard metadata columns plus one boolean."""
+    return {
+        "$type": "LocalEntity",
+        "name": name,
+        "description": "",
+        "attributes": [
+            {"name": "Id", "dataType": "guid"},
+            {"name": "IsDelete", "dataType": "string"},
+            {"name": "IsActive", "dataType": "boolean"},
+        ],
+    }
+
+
+def model_json(table_names: list[str]) -> bytes:
+    return orjson.dumps({"name": "cdm", "entities": [entity(n) for n in table_names]})
+
+
+class FakeADLSClient:
+    """Serves file bytes by path and raises a 404 HTTPError for anything else,
+    matching how ADLSGen2Client surfaces missing files."""
+
+    def __init__(self, files: dict[str, bytes]):
+        self._files = files
+        self.log = logging.getLogger("test-d365-api")
+
+    async def read_file(self, path: str) -> bytes:
+        if path not in self._files:
+            raise HTTPError("The specified path does not exist.", 404)
+        return self._files[path]
+
+
+class TestGetTableMetadata:
+    """Tests for schema resolution, including the per-table model.json fallback
+    used when a folder-level model.json was written but truncated."""
+
+    TIMESTAMP = "2025-04-11T06.24.48Z"
+    TABLE = "whsworktrans"
+
+    def per_table_path(self) -> str:
+        return f"{self.TIMESTAMP}/{TRICKLE_FEED_SERVICE_DIR}/{self.TABLE}-model.json"
+
+    @pytest.mark.asyncio
+    async def test_uses_folder_level_model_json(self):
+        client = FakeADLSClient({
+            f"{self.TIMESTAMP}/model.json": model_json(["customers", self.TABLE]),
+        })
+        metadata = await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
+        assert metadata.name == self.TABLE
+        assert metadata.field_names == ["Id", "IsDelete", "IsActive"]
+        assert metadata.boolean_fields == frozenset({"IsActive"})
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_per_table_model_json_when_truncated(self):
+        """A truncated folder-level model.json (lists earlier tables but not this
+        one) falls back to the authoritative per-table model.json."""
+        client = FakeADLSClient({
+            f"{self.TIMESTAMP}/model.json": model_json(["customers", "vendinvoicetrans"]),
+            self.per_table_path(): model_json([self.TABLE]),
+        })
+        metadata = await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
+        assert metadata.name == self.TABLE
+        assert metadata.field_names == ["Id", "IsDelete", "IsActive"]
+
+    @pytest.mark.asyncio
+    async def test_raises_when_truncated_and_no_per_table_model_json(self):
+        client = FakeADLSClient({
+            f"{self.TIMESTAMP}/model.json": model_json(["customers", "vendinvoicetrans"]),
+        })
+        with pytest.raises(TableSchemaUnavailableError, match="no per-table model.json"):
+            await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
+
+    @pytest.mark.asyncio
+    async def test_does_not_fall_back_when_folder_model_json_has_no_entities(self):
+        """An empty folder-level model.json means the folder hasn't finalized;
+        we must not trust a per-table model.json even if one exists."""
+        client = FakeADLSClient({
+            f"{self.TIMESTAMP}/model.json": model_json([]),
+            self.per_table_path(): model_json([self.TABLE]),
+        })
+        with pytest.raises(TableSchemaUnavailableError, match="lists no entities"):
+            await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_per_table_model_json_lacks_table(self):
+        client = FakeADLSClient({
+            f"{self.TIMESTAMP}/model.json": model_json(["customers", "vendinvoicetrans"]),
+            self.per_table_path(): model_json(["a_different_table"]),
+        })
+        with pytest.raises(TableSchemaUnavailableError, match="does not describe the table"):
+            await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
 
 
 class TestShouldWaitForFinalization:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes:
- Updating the CDK's `IncrementalCSVProcessor` to raise an exception when there's a column mismatch between a CSV's headers and actual rows.
- Falling back to use `{timestamp}/Microsoft.Athena.TrickleFeedService/{table}-model.json` for table metadata when a timestamp folder's `model.json` is present, lists entities, but omits a given one. I suspect these individual per-table `model.json`s are what feed into the folder level `model.json` - during testing, parsing CSVs with these per-table `model.json`s worked fine & produced rows with all the anticipated columns. I'm not sure why some entities can be missing from the folder level `model.json`, but I suspect it's an unusual situation where Synapse Link almost finished writing everything to the folder level `model.json` but was interrupted for some reason.

See individual commits for more details.

**Notes for reviewers:**

Tested with an account where the folder level `model.json` was missing three entities, causing the capture to fail. The capture now fallsback to the per-table `model.json`s, parses the CSV rows successfully for those entities, and moves on.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
