### PR TITLE
materialize-clickhouse: support custom PARTITION BY expression

### DIFF
--- a/materialize-boilerplate/apply.go
+++ b/materialize-boilerplate/apply.go
@@ -40,7 +40,7 @@ func computeCommonUpdates(last, next *pf.MaterializationSpec, is *InfoSchema) (*
 		// The existing binding spec is used to extract various properties that can't be learned
 		// from introspecting the destination system, such as the backfill counter and if the
 		// materialization was previously delta updates.
-		lastBinding := findLastBinding(nextBinding.ResourcePath, last)
+		lastBinding := FindLastBinding(nextBinding.ResourcePath, last)
 		if existingResource := is.GetResource(nextBinding.ResourcePath); existingResource == nil {
 			// Resource does not yet exist, and must be created.
 			out.newBindings = append(out.newBindings, bindingIdx)

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -553,7 +553,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		// truncated rather than fully dropping and re-creating the table.
 		var doTruncate bool
 		thisBinding := req.Materialization.Bindings[bindingIdx]
-		lastBinding := findLastBinding(thisBinding.ResourcePath, req.LastMaterialization)
+		lastBinding := FindLastBinding(thisBinding.ResourcePath, req.LastMaterialization)
 		existing := is.GetResource(thisBinding.ResourcePath)
 		if _, err := validator.ValidateBinding(
 			thisBinding.ResourcePath,

--- a/materialize-boilerplate/validate.go
+++ b/materialize-boilerplate/validate.go
@@ -75,7 +75,7 @@ func (v Validator) ValidateBinding(
 	fieldConfigJsonMap map[string]json.RawMessage,
 	lastSpec *pf.MaterializationSpec,
 ) (map[string][]*pm.Response_Validated_Constraint, error) {
-	lastBinding := findLastBinding(path, lastSpec)
+	lastBinding := FindLastBinding(path, lastSpec)
 	existingResource := v.is.GetResource(path)
 
 	for _, p := range boundCollection.Projections {
@@ -466,8 +466,11 @@ func (v Validator) constraintForExistingField(
 	return out, nil
 }
 
-// findLastBinding locates a binding within a previously applied or validated specification.
-func findLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
+// FindLastBinding locates a binding within a previously applied or validated
+// specification. A previously disabled binding is consulted as well: it still
+// constrains the current binding, so that invalid configuration transitions
+// are caught even across a disable/re-enable cycle.
+func FindLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
 	if lastSpec == nil {
 		return nil // Binding is trivially not found
 	}

--- a/materialize-clickhouse/.snapshots/TestSQLGenerationPartitionBy
+++ b/materialize-clickhouse/.snapshots/TestSQLGenerationPartitionBy
@@ -1,0 +1,92 @@
+--- Begin standard hard-delete createTargetTable ---
+
+CREATE TABLE IF NOT EXISTS target_table (
+		`id` String,
+		value Nullable(String),
+		`_meta/op` String,
+		flow_published_at DateTime64(6, 'UTC'),
+		flow_document String,
+		_is_deleted UInt8 DEFAULT 0
+)
+ENGINE = ReplacingMergeTree(flow_published_at, _is_deleted)
+PARTITION BY (toYYYYMM(flow_published_at))
+ORDER BY (`id`)
+SETTINGS
+	allow_experimental_replacing_merge_with_cleanup = 1,
+	min_age_to_force_merge_seconds = 604800,
+	min_age_to_force_merge_on_partition_only = 1,
+	enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = 1;
+--- End standard hard-delete createTargetTable ---
+
+--- Begin standard hard-delete createStoreTable ---
+
+CREATE TABLE IF NOT EXISTS flow_temp_store_0_target_table
+AS target_table;
+--- End standard hard-delete createStoreTable ---
+
+--- Begin standard soft-delete createTargetTable ---
+
+CREATE TABLE IF NOT EXISTS target_table (
+		`id` String,
+		value Nullable(String),
+		`_meta/op` String,
+		flow_published_at DateTime64(6, 'UTC'),
+		flow_document String
+)
+ENGINE = ReplacingMergeTree(flow_published_at)
+PARTITION BY (toYYYYMM(flow_published_at))
+ORDER BY (`id`)
+SETTINGS
+	allow_experimental_replacing_merge_with_cleanup = 1,
+	min_age_to_force_merge_seconds = 604800,
+	min_age_to_force_merge_on_partition_only = 1,
+	enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = 1;
+--- End standard soft-delete createTargetTable ---
+
+--- Begin standard soft-delete createStoreTable ---
+
+CREATE TABLE IF NOT EXISTS flow_temp_store_0_target_table
+AS target_table;
+--- End standard soft-delete createStoreTable ---
+
+--- Begin delta createTargetTable ---
+
+CREATE TABLE IF NOT EXISTS target_table (
+		`id` String,
+		value Nullable(String),
+		`_meta/op` String,
+		flow_published_at DateTime64(6, 'UTC')
+)
+ENGINE = MergeTree
+PARTITION BY (toYYYYMM(flow_published_at))
+ORDER BY (`id`)
+;
+--- End delta createTargetTable ---
+
+--- Begin delta createStoreTable ---
+
+CREATE TABLE IF NOT EXISTS flow_temp_store_0_target_table
+AS target_table;
+--- End delta createStoreTable ---
+
+--- Begin composite expression createTargetTable ---
+
+CREATE TABLE IF NOT EXISTS composite_table (
+		`id` String,
+		value Nullable(String),
+		`_meta/op` String,
+		flow_published_at DateTime64(6, 'UTC'),
+		flow_document String,
+		_is_deleted UInt8 DEFAULT 0
+)
+ENGINE = ReplacingMergeTree(flow_published_at, _is_deleted)
+PARTITION BY (value, toYYYYMM(flow_published_at))
+ORDER BY (`id`)
+SETTINGS
+	allow_experimental_replacing_merge_with_cleanup = 1,
+	min_age_to_force_merge_seconds = 604800,
+	min_age_to_force_merge_on_partition_only = 1,
+	enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = 1;
+--- End composite expression createTargetTable ---
+
+

--- a/materialize-clickhouse/.snapshots/TestSpecification
+++ b/materialize-clickhouse/.snapshots/TestSpecification
@@ -168,6 +168,12 @@
         "description": "Should updates to this table be done via delta updates. Default is false.",
         "default": false,
         "x-delta-updates": true
+      },
+      "partition_by": {
+        "type": "string",
+        "title": "Partition By",
+        "description": "Optional expression to use as the table's PARTITION BY clause, for example toYYYYMM(flow_published_at). Leave blank for ClickHouse's default single partition. Use a low-cardinality expression: ClickHouse recommends well under 1000 total partitions, and inserts spanning more than 100 partitions are rejected by default. Changing this value requires backfilling the binding, which drops and re-creates the table.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-07-17
 
+### Added
+- New optional `partition_by` field on each table's resource configuration sets a custom [partitioning key](https://clickhouse.com/docs/engines/table-engines/mergetree-family/custom-partitioning-key) for the table, for example `toYYYYMM(flow_published_at)`. The expression is verified against your ClickHouse server when the materialization is published. Because ClickHouse only accepts a partitioning key at table creation, changing `partition_by` on an existing table requires backfilling the binding, which drops and re-creates the table.
+
 ### Fixed
 - Fixed a permanent restart loop with the error `ALTER of key column ... is not safe because it can change the representation of primary key` (code 524) that occurred when a table's sorting-key or partition-key column was no longer part of the materialization's field selection. Such columns are now left unchanged instead of being made nullable, which ClickHouse forbids for key columns.
 

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -282,7 +282,24 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 	}
 
 	if len(ta.ColumnTypeChanges) > 0 {
-		var steps, err = sql.StdColumnTypeMigrations(ctx, c.ep.Dialect, ta.Table, ta.ColumnTypeChanges, clickHouseMigrationSteps...)
+		// A column referenced by the table's PARTITION BY key cannot change
+		// type at all: ClickHouse forbids both MODIFY COLUMN (code 524) and
+		// DROP COLUMN (code 47) on partition-key columns, so the multi-step
+		// rename migration can never succeed. Fail before executing any step,
+		// so no temporary column is left behind and the error says what to do.
+		partitionKeyCols, err := c.partitionKeyColumns(ctx, ta.Path[0])
+		if err != nil {
+			return "", nil, err
+		}
+		for _, m := range ta.ColumnTypeChanges {
+			if partitionKeyCols[m.Field] {
+				return "", nil, fmt.Errorf(
+					"cannot change the type of column %q: it is referenced by the PARTITION BY key of table %s, which ClickHouse forbids altering; backfill the binding to re-create the table with the new column type",
+					m.Field, ta.Identifier)
+			}
+		}
+
+		steps, err := sql.StdColumnTypeMigrations(ctx, c.ep.Dialect, ta.Table, ta.ColumnTypeChanges, clickHouseMigrationSteps...)
 		if err != nil {
 			return "", nil, fmt.Errorf("rendering column migration steps: %w", err)
 		}
@@ -297,6 +314,29 @@ func (c *client) AlterTable(ctx context.Context, ta sql.TableAlter) (string, boi
 		}
 		return nil
 	}, nil
+}
+
+// partitionKeyColumns returns the set of column names referenced by the
+// table's PARTITION BY key.
+func (c *client) partitionKeyColumns(ctx context.Context, table string) (map[string]bool, error) {
+	rows, err := c.db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT name FROM system.columns WHERE database = %s AND table = %s AND is_in_partition_key = 1",
+		c.ep.Dialect.Literal(c.ep.Config.Database), c.ep.Dialect.Literal(table),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("querying partition key columns of %q: %w", table, err)
+	}
+	defer rows.Close()
+
+	var out = make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scanning partition key column of %q: %w", table, err)
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
 }
 
 func (c *client) TruncateTable(_ context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	stdsql "database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -317,8 +318,21 @@ func (c *client) ExecStatements(ctx context.Context, statements []string) error 
 	return sql.StdSQLExecStatements(ctx, c.db, statements)
 }
 
-func (c *client) MustRecreateResource(_ *pm.Request_Apply, _, _ *pf.MaterializationSpec_Binding) (bool, error) {
-	return false, nil
+// MustRecreateResource reports a changed partition_by, which can only be
+// applied by dropping and re-creating the table: ClickHouse never accepts
+// PARTITION BY via ALTER, and TRUNCATE preserves the partition key.
+func (c *client) MustRecreateResource(_ *pm.Request_Apply, lastBinding, newBinding *pf.MaterializationSpec_Binding) (bool, error) {
+	if lastBinding == nil || newBinding == nil {
+		return false, nil
+	}
+	var lastRC, newRC tableConfig
+	if err := json.Unmarshal(lastBinding.ResourceConfigJson, &lastRC); err != nil {
+		return false, fmt.Errorf("parsing last binding resource config: %w", err)
+	}
+	if err := json.Unmarshal(newBinding.ResourceConfigJson, &newRC); err != nil {
+		return false, fmt.Errorf("parsing new binding resource config: %w", err)
+	}
+	return strings.TrimSpace(lastRC.PartitionBy) != strings.TrimSpace(newRC.PartitionBy), nil
 }
 
 func (c *client) ListCheckpointsEntries(ctx context.Context) ([]string, error) {

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -181,8 +181,16 @@ func (r tableConfig) Parameters() ([]string, bool, error) {
 	return []string{r.Table}, r.Delta, nil
 }
 
-func newClickHouseDriver() *sql.Driver[config, tableConfig] {
-	return &sql.Driver[config, tableConfig]{
+// driver wraps the generic SQL driver so that Validate can be customized
+// beyond what the generic implementation provides. See validate.go.
+type driver struct {
+	sqlDriver *sql.Driver[config, tableConfig]
+}
+
+var _ boilerplate.Connector = &driver{}
+
+func newClickHouseDriver() *driver {
+	sqlDriver := &sql.Driver[config, tableConfig]{
 		DocumentationURL: "https://go.estuary.dev/materialize-clickhouse",
 		StartTunnel: func(ctx context.Context, cfg config) error {
 			return nil
@@ -216,6 +224,21 @@ func newClickHouseDriver() *sql.Driver[config, tableConfig] {
 		},
 		PreReqs: preReqs,
 	}
+	return &driver{
+		sqlDriver: sqlDriver,
+	}
+}
+
+func (d *driver) Spec(ctx context.Context, req *pm.Request_Spec) (*pm.Response_Spec, error) {
+	return d.sqlDriver.Spec(ctx, req)
+}
+
+func (d *driver) Apply(ctx context.Context, req *pm.Request_Apply) (*pm.Response_Applied, error) {
+	return d.sqlDriver.Apply(ctx, req)
+}
+
+func (d *driver) NewTransactor(ctx context.Context, req pm.Request_Open, be *m.BindingEvents) (m.Transactor, *pm.Response_Opened, *m.MaterializeOptions, error) {
+	return d.sqlDriver.NewTransactor(ctx, req, be)
 }
 
 type transactor struct {

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -166,6 +166,11 @@ func (c config) newClickhouseOptions() *clickhouse.Options {
 type tableConfig struct {
 	Table string `json:"table" jsonschema:"title=Table,description=Name of the database table." jsonschema_extras:"x-collection-name=true"`
 	Delta bool   `json:"delta_updates,omitempty" jsonschema:"default=false,title=Delta Update,description=Should updates to this table be done via delta updates. Default is false." jsonschema_extras:"x-delta-updates=true"`
+	// PartitionBy is spliced verbatim into the table's PARTITION BY clause.
+	// It runs as DDL with the user's own credentials against their own
+	// database, so it is the same trust plane as the rest of the endpoint
+	// config; malformed input fails the dry-run CREATE TABLE at Validate time.
+	PartitionBy string `json:"partition_by,omitempty" jsonschema:"title=Partition By,description=Optional expression to use as the table's PARTITION BY clause\\, for example toYYYYMM(flow_published_at). Leave blank for ClickHouse's default single partition. Use a low-cardinality expression: ClickHouse recommends well under 1000 total partitions\\, and inserts spanning more than 100 partitions are rejected by default. Changing this value requires backfilling the binding\\, which drops and re-creates the table." jsonschema_extras:"advanced=true"`
 }
 
 func (r tableConfig) Validate() error {
@@ -181,8 +186,9 @@ func (r tableConfig) Parameters() ([]string, bool, error) {
 	return []string{r.Table}, r.Delta, nil
 }
 
-// driver wraps the generic SQL driver so that Validate can be customized
-// beyond what the generic implementation provides. See validate.go.
+// driver wraps the generic SQL driver to customize Validate: a changed
+// partition_by requires re-creating the table, and partition expressions are
+// verified with a dry-run CREATE TABLE. See validate.go.
 type driver struct {
 	sqlDriver *sql.Driver[config, tableConfig]
 }

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -706,6 +706,23 @@ func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error
 		// of the next transaction's store phase).
 		for _, b := range t.bindings {
 			if si, pending := t.state[b.target.StateKey]; pending {
+				// A store table whose partition key differs from the target's
+				// predates a partition-changing backfill: the backfill dropped
+				// and re-created the target, so the staged rows belong to a
+				// table generation that no longer exists and the backfill will
+				// re-send them. MOVE PARTITION into the new target can never
+				// succeed (code 36), so skip the move and let ensureTempTables
+				// re-create the store table.
+				if drifted, err := t.storePartitionKeyDrifted(ctx, b); err != nil {
+					return nil, fmt.Errorf("comparing store and target partition keys of %s: %w", b.target.Identifier, err)
+				} else if drifted {
+					log.WithField("target", b.target.Identifier).Warn(
+						"store table partition key differs from target; staged rows predate a partition-changing backfill and are discarded")
+					if err := t.ensureTempTables(ctx, b); err != nil {
+						return nil, fmt.Errorf("ensuring temp tables of %s: %w", b.target.Identifier, err)
+					}
+					continue
+				}
 				// A committed-but-unacknowledged transaction has rows staged
 				// in this binding's store table. Move them; never truncate or
 				// re-create a stage table holding pending rows.
@@ -908,6 +925,40 @@ func (t *transactor) ensureTempTables(ctx context.Context, b *binding) error {
 		}
 	}
 	return nil
+}
+
+// storePartitionKeyDrifted reports whether the binding's store table and
+// target table both exist but have different partition keys. If either table
+// is missing it reports false, leaving that condition to the caller's
+// existing handling (a recovery MOVE against a missing table raises the
+// unknown-table error, which is tolerated).
+func (t *transactor) storePartitionKeyDrifted(ctx context.Context, b *binding) (bool, error) {
+	var storeTable = storeTableName(b.target, t._range.KeyBegin)
+	var targetTable = b.target.Path[0]
+
+	rows, err := t.store.conn.Query(ctx,
+		"SELECT name, partition_key FROM system.tables WHERE database = currentDatabase() AND name IN (?, ?)",
+		storeTable, targetTable)
+	if err != nil {
+		return false, fmt.Errorf("querying partition keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys = make(map[string]string)
+	for rows.Next() {
+		var name, pk string
+		if err := rows.Scan(&name, &pk); err != nil {
+			return false, fmt.Errorf("scanning partition key: %w", err)
+		}
+		keys[name] = pk
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+
+	storeKey, haveStore := keys[storeTable]
+	targetKey, haveTarget := keys[targetTable]
+	return haveStore && haveTarget && storeKey != targetKey, nil
 }
 
 // tempTableMatchesTarget reports whether the temp table's columns are a

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -966,6 +966,35 @@ func (t *transactor) tempTableMatchesTarget(ctx context.Context, tempTable strin
 			return false, nil
 		}
 	}
+
+	// Store tables must also share the target's partition key: commits move
+	// whole partitions between them, and MOVE PARTITION requires it. A drifted
+	// key arises when a backfill re-creates the target with a different
+	// partition_by while the persistent store table keeps the old one. Load
+	// tables are never moved, so their partition key is irrelevant.
+	if tempTable == storeTableName(b.target, t._range.KeyBegin) {
+		readPartitionKey := func(table string) (string, error) {
+			var pk string
+			if err := t.store.conn.QueryRow(ctx,
+				"SELECT partition_key FROM system.tables WHERE database = currentDatabase() AND name = ?", table,
+			).Scan(&pk); err != nil {
+				return "", fmt.Errorf("querying partition key of %q: %w", table, err)
+			}
+			return pk, nil
+		}
+		tempKey, err := readPartitionKey(tempTable)
+		if err != nil {
+			return false, err
+		}
+		targetKey, err := readPartitionKey(b.target.Path[0])
+		if err != nil {
+			return false, err
+		}
+		if tempKey != targetKey {
+			return false, nil
+		}
+	}
+
 	return true, nil
 }
 

--- a/materialize-clickhouse/driver_test.go
+++ b/materialize-clickhouse/driver_test.go
@@ -20,15 +20,15 @@ func TestIntegration(t *testing.T) {
 	}
 
 	t.Run("materialize", func(t *testing.T) {
-		sql.RunMaterializationTest(t, newClickHouseDriver(), "testdata/materialize.flow.yaml", makeResourceFn, nil)
+		sql.RunMaterializationTest(t, newClickHouseDriver().sqlDriver, "testdata/materialize.flow.yaml", makeResourceFn, nil)
 	})
 
 	t.Run("apply", func(t *testing.T) {
-		sql.RunApplyTest(t, newClickHouseDriver(), "testdata/apply.flow.yaml", makeResourceFn)
+		sql.RunApplyTest(t, newClickHouseDriver().sqlDriver, "testdata/apply.flow.yaml", makeResourceFn)
 	})
 
 	t.Run("migrate", func(t *testing.T) {
-		sql.RunMigrationTest(t, newClickHouseDriver(), "testdata/migrate.flow.yaml", makeResourceFn, nil)
+		sql.RunMigrationTest(t, newClickHouseDriver().sqlDriver, "testdata/migrate.flow.yaml", makeResourceFn, nil)
 	})
 }
 

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/bradleyjkemp/cupaloy"
+	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionExpr(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "nil config", raw: "", want: ""},
+		{name: "empty object", raw: "{}", want: ""},
+		{name: "absent field", raw: `{"table":"t"}`, want: ""},
+		{name: "expression", raw: `{"table":"t","partition_by":"toYYYYMM(ts)"}`, want: "toYYYYMM(ts)"},
+		{name: "trimmed", raw: `{"table":"t","partition_by":"  toYYYYMM(ts)\t"}`, want: "toYYYYMM(ts)"},
+		{name: "invalid json", raw: `{`, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := partitionExpr(json.RawMessage(tt.raw))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMustRecreateResourcePartitionBy(t *testing.T) {
+	var c = &client{}
+	var binding = func(raw string) *pf.MaterializationSpec_Binding {
+		return &pf.MaterializationSpec_Binding{ResourceConfigJson: json.RawMessage(raw)}
+	}
+
+	for _, tt := range []struct {
+		name       string
+		last, next *pf.MaterializationSpec_Binding
+		want       bool
+	}{
+		{name: "nil last", last: nil, next: binding(`{"table":"t"}`), want: false},
+		{name: "nil next", last: binding(`{"table":"t"}`), next: nil, want: false},
+		{name: "both absent", last: binding(`{"table":"t"}`), next: binding(`{"table":"t"}`), want: false},
+		{name: "absent to empty", last: binding(`{"table":"t"}`), next: binding(`{"table":"t","partition_by":""}`), want: false},
+		{name: "whitespace only difference", last: binding(`{"table":"t","partition_by":"toYYYYMM(ts)"}`), next: binding(`{"table":"t","partition_by":" toYYYYMM(ts) "}`), want: false},
+		{name: "absent to expression", last: binding(`{"table":"t"}`), next: binding(`{"table":"t","partition_by":"toYYYYMM(ts)"}`), want: true},
+		{name: "changed expression", last: binding(`{"table":"t","partition_by":"toYYYYMM(ts)"}`), next: binding(`{"table":"t","partition_by":"toYYYYMMDD(ts)"}`), want: true},
+		{name: "expression removed", last: binding(`{"table":"t","partition_by":"toYYYYMM(ts)"}`), next: binding(`{"table":"t"}`), want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.MustRecreateResource(nil, tt.last, tt.next)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSQLGenerationPartitionBy(t *testing.T) {
+	var rawConfig = json.RawMessage(`{"table":"target_table","partition_by":"toYYYYMM(flow_published_at)"}`)
+
+	var snap strings.Builder
+	for _, tc := range []struct {
+		name       string
+		hardDelete bool
+		delta      bool
+	}{
+		{name: "standard hard-delete", hardDelete: true},
+		{name: "standard soft-delete", hardDelete: false},
+		{name: "delta", hardDelete: true, delta: true},
+	} {
+		var tpls = renderTemplates(testDialect, tc.hardDelete)
+		var table = buildTestTable(t, testDialect, "target_table")
+		table.DeltaUpdates = tc.delta
+		table.ResourceConfigJson = rawConfig
+		if tc.delta {
+			table.Document = nil
+		}
+
+		for _, tpl := range []string{"createTargetTable", "createStoreTable"} {
+			var testcase = tc.name + " " + tpl
+			snap.WriteString("--- Begin " + testcase + " ---\n")
+			var rendered string
+			var err error
+			if tpl == "createTargetTable" {
+				rendered, err = sql.RenderTableTemplate(table, tpls.createTargetTable)
+			} else {
+				rendered, err = renderTableAndRangeKey(table, 0, tpls.createStoreTable)
+			}
+			require.NoError(t, err)
+			snap.WriteString(rendered)
+			snap.WriteString("--- End " + testcase + " ---\n\n")
+		}
+	}
+
+	// A composite expression is emitted verbatim inside the parenthesized
+	// PARTITION BY clause.
+	var composite = buildTestTable(t, testDialect, "composite_table")
+	composite.ResourceConfigJson = json.RawMessage(`{"table":"composite_table","partition_by":"value, toYYYYMM(flow_published_at)"}`)
+	rendered, err := sql.RenderTableTemplate(composite, renderTemplates(testDialect, true).createTargetTable)
+	require.NoError(t, err)
+	snap.WriteString("--- Begin composite expression createTargetTable ---\n")
+	snap.WriteString(rendered)
+	snap.WriteString("--- End composite expression createTargetTable ---\n\n")
+
+	cupaloy.SnapshotT(t, snap.String())
+}
+
+// loadBaseSpec returns the shared boilerplate test spec, whose single binding
+// materializes the key/value collection with a full field selection.
+func loadBaseSpec(t *testing.T) *pf.MaterializationSpec {
+	t.Helper()
+
+	specBytes, err := os.ReadFile("../materialize-boilerplate/testdata/validate_apply_test_cases/generated_specs/base.flow.proto")
+	require.NoError(t, err)
+	var spec pf.MaterializationSpec
+	require.NoError(t, spec.Unmarshal(specBytes))
+	return &spec
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	return raw
+}
+
+// specWithPartitionBy clones the base spec's binding into a spec bound to the
+// given table with the given partition_by and backfill counter.
+func specWithPartitionBy(t *testing.T, cfg config, table string, partitionBy string, backfill uint32) *pf.MaterializationSpec {
+	t.Helper()
+
+	var spec = loadBaseSpec(t)
+	spec.ConfigJson = mustMarshal(t, cfg)
+	spec.Bindings[0].ResourceConfigJson = mustMarshal(t, tableConfig{Table: table, PartitionBy: partitionBy})
+	spec.Bindings[0].ResourcePath = []string{table}
+	spec.Bindings[0].Backfill = backfill
+	return spec
+}
+
+func validatePartitionByReq(t *testing.T, cfg config, table string, partitionBy string, backfill uint32, lastSpec *pf.MaterializationSpec) *pm.Request_Validate {
+	t.Helper()
+
+	var spec = loadBaseSpec(t)
+	return &pm.Request_Validate{
+		Name:                spec.Name,
+		ConnectorType:       pf.MaterializationSpec_IMAGE,
+		ConfigJson:          mustMarshal(t, cfg),
+		LastMaterialization: lastSpec,
+		Bindings: []*pm.Request_Validate_Binding{{
+			ResourceConfigJson: mustMarshal(t, tableConfig{Table: table, PartitionBy: partitionBy}),
+			Collection:         spec.Bindings[0].Collection,
+			Backfill:           backfill,
+		}},
+	}
+}
+
+func countDryRunTables(t *testing.T, ctx context.Context, cfg config) int {
+	t.Helper()
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE 'flow_partition_dryrun_%'",
+	).Scan(&count))
+	return count
+}
+
+func TestValidatePartitionBy(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var tableName = "test_validate_partition_by"
+
+	t.Run("dry-run accepts a valid expression", func(t *testing.T) {
+		resp, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, "toYYYYMM(flow_published_at)", 0, nil))
+		require.NoError(t, err)
+		for _, pc := range resp.Bindings[0].ProjectionConstraints {
+			require.NotEqual(t, pm.Response_Validated_Constraint_INCOMPATIBLE, pc.Constraint.Type)
+		}
+		require.Zero(t, countDryRunTables(t, ctx, cfg), "dry-run scratch tables must be dropped")
+	})
+
+	t.Run("dry-run rejects a bad expression", func(t *testing.T) {
+		_, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, "toYYYYMM(no_such_column)", 0, nil))
+		require.ErrorContains(t, err, "no_such_column")
+		require.Zero(t, countDryRunTables(t, ctx, cfg), "dry-run scratch tables must be dropped even on failure")
+	})
+
+	t.Run("change without backfill is INCOMPATIBLE", func(t *testing.T) {
+		var lastSpec = specWithPartitionBy(t, cfg, tableName, "", 0)
+		resp, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, "toYYYYMM(flow_published_at)", 0, lastSpec))
+		require.NoError(t, err)
+
+		var incompatible []string
+		for _, pc := range resp.Bindings[0].ProjectionConstraints {
+			if pc.Constraint.Type == pm.Response_Validated_Constraint_INCOMPATIBLE {
+				require.Contains(t, pc.Constraint.Reason, "partition_by")
+				incompatible = append(incompatible, pc.Field)
+			}
+		}
+		// The constraint must cover every projection, not just key fields: an
+		// INCOMPATIBLE constraint on an unselected field is non-fatal to the
+		// control plane, and delta-updates bindings may deselect their key
+		// fields entirely. Only a constraint on a *selected* field forces the
+		// backfill, so every field the user might have selected needs one.
+		require.Contains(t, incompatible, "key")
+		require.Contains(t, incompatible, "requiredString")
+		require.Contains(t, incompatible, "flow_document")
+	})
+
+	t.Run("change with a backfill bump is allowed", func(t *testing.T) {
+		var lastSpec = specWithPartitionBy(t, cfg, tableName, "", 0)
+		resp, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, "toYYYYMM(flow_published_at)", 1, lastSpec))
+		require.NoError(t, err)
+		for _, pc := range resp.Bindings[0].ProjectionConstraints {
+			require.NotEqual(t, pm.Response_Validated_Constraint_INCOMPATIBLE, pc.Constraint.Type)
+		}
+	})
+
+	t.Run("unchanged expression is not re-verified", func(t *testing.T) {
+		// Schema evolution can remove the projection a long-established
+		// table's partition expression references. The existing table keeps
+		// its column and keeps working, so Validate must not re-run the
+		// dry-run (which would fail on the missing column) for an expression
+		// identical to the last applied spec's.
+		var lastSpec = specWithPartitionBy(t, cfg, tableName, "toYYYYMM(no_such_column)", 0)
+		_, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, "toYYYYMM(no_such_column)", 0, lastSpec))
+		require.NoError(t, err)
+	})
+
+	t.Run("unchanged expression on a disabled binding needs no backfill", func(t *testing.T) {
+		var lastSpec = specWithPartitionBy(t, cfg, tableName, "toYYYYMM(flow_published_at)", 0)
+		lastSpec.InactiveBindings = lastSpec.Bindings
+		lastSpec.Bindings = nil
+		resp, err := newClickHouseDriver().Validate(ctx, validatePartitionByReq(t, cfg, tableName, " toYYYYMM(flow_published_at) ", 0, lastSpec))
+		require.NoError(t, err)
+		for _, pc := range resp.Bindings[0].ProjectionConstraints {
+			require.NotEqual(t, pm.Response_Validated_Constraint_INCOMPATIBLE, pc.Constraint.Type)
+		}
+	})
+}
+
+func TestApplyPartitionByBackfillRecreates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tableName = "test_apply_partition_by"
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	})
+
+	partitionKey := func() string {
+		var pk string
+		require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+			"SELECT partition_key FROM system.tables WHERE database = currentDatabase() AND name = %s", dialect.Literal(tableName),
+		)).Scan(&pk))
+		return pk
+	}
+
+	var specA = specWithPartitionBy(t, cfg, tableName, "toYYYYMM(flow_published_at)", 0)
+	_, err := newClickHouseDriver().Apply(ctx, &pm.Request_Apply{Materialization: specA, Version: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "toYYYYMM(flow_published_at)", partitionKey())
+
+	var specB = specWithPartitionBy(t, cfg, tableName, "toYYYYMMDD(flow_published_at)", 1)
+	_, err = newClickHouseDriver().Apply(ctx, &pm.Request_Apply{Materialization: specB, Version: "test", LastMaterialization: specA, LastVersion: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "toYYYYMMDD(flow_published_at)", partitionKey())
+}
+
+// partitionedTestTable is buildTestTable with a partition_by resource config
+// attached, so rendered DDL includes the PARTITION BY clause.
+func partitionedTestTable(t *testing.T, dialect sql.Dialect, tableName string, partitionBy string) sql.Table {
+	t.Helper()
+
+	var table = buildTestTable(t, dialect, tableName)
+	table.ResourceConfigJson = mustMarshal(t, tableConfig{Table: tableName, PartitionBy: partitionBy})
+	return table
+}
+
+func TestPartitionByDataPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+	var tableName = "test_partition_by_data_path"
+	var table = partitionedTestTable(t, dialect, tableName, "toYYYYMM(flow_published_at)")
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, createSQL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	})
+
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.load.conn = loadConn
+	defer tr.load.conn.Close()
+	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.store.conn = storeConn
+	defer storeConn.Close()
+	require.NoError(t, tr.addBinding(ctx, table))
+	var b = tr.bindings[0]
+
+	// A single commit spanning three months moves three distinct partitions
+	// from the store table to the target.
+	storeRows(t, ctx, storeConn, b, cfg.Database,
+		[]any{"k1", "v1", "c", testTime, `{"id":"k1"}`},
+		[]any{"k2", "v2", "c", testTime.AddDate(0, 1, 0), `{"id":"k2"}`},
+		[]any{"k3", "v3", "c", testTime.AddDate(0, 2, 0), `{"id":"k3"}`},
+	)
+
+	var rowCount, partCount uint64
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT count(), uniqExact(_partition_id) FROM %s", dialect.Identifier(tableName),
+	)).Scan(&rowCount, &partCount))
+	require.EqualValues(t, 3, rowCount)
+	require.EqualValues(t, 3, partCount)
+
+	var staged uint64
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT count() FROM %s", dialect.Identifier(storeTableName(table, 0)),
+	)).Scan(&staged))
+	require.Zero(t, staged, "all staged partitions must have moved to the target")
+
+	// The rows remain loadable through the standard load path.
+	docs := loadDocuments(t, ctx, tr.load.conn, b, []any{"k2"})
+	require.Len(t, docs, 1)
+	require.JSONEq(t, `{"id":"k2"}`, docs[0])
+}

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -370,3 +370,80 @@ func TestPartitionByDataPath(t *testing.T) {
 	require.Len(t, docs, 1)
 	require.JSONEq(t, `{"id":"k2"}`, docs[0])
 }
+
+// TestStoreTablePartitionDrift verifies that the ensure pass re-creates a
+// persistent store table whose partition key has drifted from the target's,
+// which happens when a backfill re-creates the target with a different
+// partition_by. Without re-creation every MOVE PARTITION would fail.
+func TestStoreTablePartitionDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+	var tableName = "test_partition_drift"
+	var table = partitionedTestTable(t, dialect, tableName, "toYYYYMM(flow_published_at)")
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	var storeName = storeTableName(table, 0)
+	for _, name := range []string{tableName, storeName} {
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(name)))
+	}
+	t.Cleanup(func() {
+		for _, name := range []string{tableName, storeName} {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(name)))
+		}
+	})
+
+	createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, createSQL)
+	require.NoError(t, err)
+
+	// Simulate the stale store table left behind by a pre-backfill session:
+	// identical columns, but no partition key.
+	var unpartitioned = buildTestTable(t, dialect, storeName)
+	staleSQL, err := sql.RenderTableTemplate(unpartitioned, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, staleSQL)
+	require.NoError(t, err)
+
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.load.conn = loadConn
+	defer tr.load.conn.Close()
+	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.store.conn = storeConn
+	defer storeConn.Close()
+	require.NoError(t, tr.addBinding(ctx, table))
+
+	require.NoError(t, tr.ensureTempTables(ctx, tr.bindings[0]))
+
+	partitionKey := func(name string) string {
+		var pk string
+		require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+			"SELECT partition_key FROM system.tables WHERE database = currentDatabase() AND name = %s", dialect.Literal(name),
+		)).Scan(&pk))
+		return pk
+	}
+	require.Equal(t, "toYYYYMM(flow_published_at)", partitionKey(storeName), "drifted store table must be re-created with the target's partition key")
+
+	// A commit through the re-created store table succeeds.
+	storeRows(t, ctx, storeConn, tr.bindings[0], cfg.Database,
+		[]any{"k1", "v1", "c", testTime, `{"id":"k1"}`},
+		[]any{"k2", "v2", "c", testTime.AddDate(0, 1, 0), `{"id":"k2"}`},
+	)
+
+	var rowCount uint64
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT count() FROM %s", dialect.Identifier(tableName),
+	)).Scan(&rowCount))
+	require.EqualValues(t, 2, rowCount)
+}

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/bradleyjkemp/cupaloy"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -369,6 +370,78 @@ func TestPartitionByDataPath(t *testing.T) {
 	docs := loadDocuments(t, ctx, tr.load.conn, b, []any{"k2"})
 	require.Len(t, docs, 1)
 	require.JSONEq(t, `{"id":"k2"}`, docs[0])
+}
+
+// TestAlterTableRejectsPartitionKeyColumnMigration verifies that a column
+// type migration targeting a column referenced by the table's PARTITION BY
+// key fails up front with an actionable error. ClickHouse forbids both
+// MODIFY COLUMN (code 524) and DROP COLUMN (code 47) on partition-key
+// columns, so the multi-step rename migration can never succeed -- without
+// the guard it fails midway with a raw server error and leaves a temporary
+// column behind.
+func TestAlterTableRejectsPartitionKeyColumnMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+	var tableName = "test_partition_key_migration"
+	var table = partitionedTestTable(t, dialect, tableName, "toYYYYMM(flow_published_at)")
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, createSQL)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+	})
+
+	c, err := newClient(ctx, "test", &sql.Endpoint[config]{Config: cfg, Dialect: dialect})
+	require.NoError(t, err)
+	defer c.Close()
+
+	// A DateTime64 -> String migration, exactly as the generic driver would
+	// construct it when the collection's schema widens the field.
+	var col sql.Column
+	for _, cc := range table.Columns() {
+		if cc.Field == "flow_published_at" {
+			col = *cc
+		}
+	}
+	require.NotEmpty(t, col.Field)
+	var strProjection = sql.Projection{
+		Projection: pf.Projection{
+			Field: "flow_published_at",
+			Inference: pf.Inference{
+				Types:   []string{"string"},
+				Exists:  pf.Inference_MUST,
+				String_: &pf.Inference_String{},
+			},
+		},
+	}
+	var mapped = dialect.MapType(&strProjection, sql.FieldConfig{})
+	var spec = dialect.MigratableTypes.FindMigrationSpec(
+		boilerplate.ExistingField{Name: "flow_published_at", Type: "DateTime64(6, 'UTC')"}, mapped)
+	require.NotNil(t, spec)
+	col.MappedType = mapped
+
+	_, _, err = c.AlterTable(ctx, sql.TableAlter{
+		Table: table,
+		ColumnTypeChanges: []sql.ColumnTypeMigration{{
+			Column:               col,
+			MigrationSpec:        *spec,
+			OriginalColumnExists: true,
+		}},
+	})
+	require.ErrorContains(t, err, "backfill")
+	require.ErrorContains(t, err, "flow_published_at")
 }
 
 // TestStoreTablePartitionDrift verifies that the ensure pass re-creates a

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -372,6 +372,95 @@ func TestPartitionByDataPath(t *testing.T) {
 	require.JSONEq(t, `{"id":"k2"}`, docs[0])
 }
 
+// TestRecoveryAfterPartitionChangingBackfill covers the window where a
+// backfill re-created the target with a different PARTITION BY while a
+// commit was still pending: the store table holds staged rows keyed on the
+// old expression, so MOVE PARTITION into the new target can never succeed
+// (code 36, "Tables have different partition key"). Those rows belong to a
+// table generation that no longer exists -- the backfill re-sends
+// everything -- so recovery must discard them and re-create the store table
+// rather than crash-looping on the move.
+func TestRecoveryAfterPartitionChangingBackfill(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+	var tableName = "test_recovery_partition_backfill"
+	var table = partitionedTestTable(t, dialect, tableName, "toYYYYMM(flow_published_at)")
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+	var storeName = storeTableName(table, 0)
+	for _, name := range []string{tableName, storeName} {
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(name)))
+	}
+	t.Cleanup(func() {
+		for _, name := range []string{tableName, storeName} {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(name)))
+		}
+	})
+
+	// The target as the backfill re-created it, with the new partition key.
+	createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, createSQL)
+	require.NoError(t, err)
+
+	// The store table as the pre-backfill session left it: same columns, old
+	// (default, empty) partition key.
+	var stale = buildTestTable(t, dialect, storeName)
+	staleSQL, err := sql.RenderTableTemplate(stale, tpls.createTargetTable)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, staleSQL)
+	require.NoError(t, err)
+
+	var tr = &transactor{
+		dialect:   dialect,
+		templates: tpls,
+		cfg:       cfg,
+		_range:    &pf.RangeSpec{},
+		state:     make(connectorState),
+	}
+	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.store.conn = storeConn
+	defer storeConn.Close()
+	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
+	require.NoError(t, err)
+	tr.load.conn = loadConn
+	defer loadConn.Close()
+	require.NoError(t, tr.addBinding(ctx, table))
+	var b = tr.bindings[0]
+
+	// A staged row of the pending pre-backfill commit.
+	stageTestRows(t, ctx, tr, b, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
+
+	tr.ensured = false
+	tr.recovery = true
+	tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
+	_, err = tr.Acknowledge(ctx)
+	require.NoError(t, err)
+	require.Empty(t, tr.state)
+
+	// The stale staged row was discarded, not moved into the new target.
+	require.EqualValues(t, 0, countTable(t, ctx, tr, dialect.Identifier(tableName)))
+
+	// The store table was re-created with the target's partition key and
+	// accepts a fresh round of staged rows.
+	var pk string
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf(
+		"SELECT partition_key FROM system.tables WHERE database = currentDatabase() AND name = %s", dialect.Literal(storeName),
+	)).Scan(&pk))
+	require.Equal(t, "toYYYYMM(flow_published_at)", pk)
+	stageTestRows(t, ctx, tr, b, []any{"k2", "v2", "c", testTime, `{"id":"k2"}`})
+	require.EqualValues(t, 1, countTable(t, ctx, tr, dialect.Identifier(storeName)))
+}
+
 // TestAlterTableRejectsPartitionKeyColumnMigration verifies that a column
 // type migration targeting a column referenced by the table's PARTITION BY
 // key fails up front with an actionable error. ClickHouse forbids both

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -306,6 +307,20 @@ type templates struct {
 	dropStoreTable                   *template.Template
 }
 
+// partitionExpr extracts the trimmed partition_by expression from a binding's
+// raw resource config. Empty or absent yields "", which renders no PARTITION
+// BY clause.
+func partitionExpr(rawResourceConfig json.RawMessage) (string, error) {
+	if len(rawResourceConfig) == 0 {
+		return "", nil
+	}
+	var rc tableConfig
+	if err := json.Unmarshal(rawResourceConfig, &rc); err != nil {
+		return "", fmt.Errorf("parsing resource config for partition_by: %w", err)
+	}
+	return strings.TrimSpace(rc.PartitionBy), nil
+}
+
 func renderTemplates(dialect sql.Dialect, hardDelete bool) templates {
 	var isDeletedColumn string
 	var isDeletedEngineArg string
@@ -360,6 +375,9 @@ CREATE TABLE IF NOT EXISTS {{$.Identifier}} (
 ENGINE = MergeTree
 {{ else -}}
 ENGINE = ReplacingMergeTree(flow_published_at`+isDeletedEngineArg+`)
+{{ end -}}
+{{ with PartitionExpr $.ResourceConfigJson -}}
+PARTITION BY ({{ . }})
 {{ end -}}
 ORDER BY (
 	{{- range $ind, $key := $.Keys }}
@@ -644,7 +662,7 @@ TRUNCATE TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
 {{ define "dropStoreTable" }}
 DROP TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
 {{ end }}
-`)
+`, template.FuncMap{"PartitionExpr": partitionExpr})
 
 	return templates{
 		createTargetTable:                tplAll.Lookup("createTargetTable"),

--- a/materialize-clickhouse/validate.go
+++ b/materialize-clickhouse/validate.go
@@ -2,10 +2,206 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	stdsql "database/sql"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+	cerrors "github.com/estuary/connectors/go/connector-errors"
+	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Response_Validated, error) {
-	return d.sqlDriver.Validate(ctx, req)
+	resp, err := d.sqlDriver.Validate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg config
+	if err := json.Unmarshal(req.ConfigJson, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing endpoint config: %w", err)
+	}
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+
+	var db *stdsql.DB
+	defer func() {
+		if db != nil {
+			db.Close()
+		}
+	}()
+
+	for i, rb := range req.Bindings {
+		var rc tableConfig
+		if err := json.Unmarshal(rb.ResourceConfigJson, &rc); err != nil {
+			return nil, fmt.Errorf("parsing resource config: %w", err)
+		}
+		var newExpr = strings.TrimSpace(rc.PartitionBy)
+
+		var last = findLastBinding([]string{rc.Table}, req.LastMaterialization)
+		var lastExpr string
+		if last != nil {
+			var lastRC tableConfig
+			if err := json.Unmarshal(last.ResourceConfigJson, &lastRC); err != nil {
+				return nil, fmt.Errorf("parsing last resource config: %w", err)
+			}
+			lastExpr = strings.TrimSpace(lastRC.PartitionBy)
+		}
+
+		// ClickHouse only accepts PARTITION BY at CREATE TABLE time, so a
+		// changed expression requires re-creating the table. Absent a
+		// backfill counter bump, block the publication with INCOMPATIBLE
+		// constraints, in the same way materialize-spanner handles its
+		// key-distribution setting.
+		// The constraint goes on every projection, not just key fields: an
+		// INCOMPATIBLE constraint on an unselected field is non-fatal to the
+		// control plane, and delta-updates bindings may deselect their key
+		// fields entirely. Constraining every projection guarantees at least
+		// one lands on a selected field, which is what blocks the publication.
+		if last != nil && rb.Backfill == last.Backfill && newExpr != lastExpr {
+			for _, p := range rb.Collection.Projections {
+				resp.Bindings[i].ProjectionConstraints = append(resp.Bindings[i].ProjectionConstraints, &pm.Response_Validated_ProjectionConstraint{
+					Field: p.Field,
+					Constraint: &pm.Response_Validated_Constraint{
+						Type:   pm.Response_Validated_Constraint_INCOMPATIBLE,
+						Reason: fmt.Sprintf("'partition_by' changed from %q to %q; changing the partition key requires re-creating the table. Backfill the binding to proceed.", lastExpr, newExpr),
+					},
+				})
+			}
+			continue
+		}
+
+		// Dry-run only an expression that is about to be applied to a fresh
+		// table: a brand-new binding, or a backfill re-creating the table for
+		// a changed expression. An unchanged expression was verified when
+		// first applied, and re-verifying it can fail spuriously after schema
+		// evolution removes a projection it references -- the existing table
+		// keeps its column and keeps working, and the failure would block
+		// every publication touching this materialization.
+		if newExpr == "" || (last != nil && newExpr == lastExpr) {
+			continue
+		}
+		if db == nil {
+			db = clickhouse.OpenDB(cfg.newClickhouseOptions())
+		}
+		if err := dryRunPartitionBy(ctx, db, dialect, tpls, cfg, req.Name.String(), i, rb, resp.Bindings[i], rc); err != nil {
+			return nil, cerrors.NewUserError(err, fmt.Sprintf("'partition_by' expression %q is not valid for table %q", rc.PartitionBy, rc.Table))
+		}
+	}
+
+	return resp, nil
+}
+
+// dryRunPartitionBy creates and immediately drops a scratch table having the
+// binding's real column DDL and partition_by expression. The expression is
+// too open-ended to evaluate statically, so the server is the only authority
+// on whether it works: this surfaces its errors (bad syntax, missing columns,
+// non-deterministic functions) at Validate time rather than at Apply.
+func dryRunPartitionBy(ctx context.Context, db *stdsql.DB, dialect sql.Dialect, tpls templates, cfg config, materializationName string, bindingIdx int, rb *pm.Request_Validate_Binding, vb *pm.Response_Validated_Binding, rc tableConfig) error {
+	var synth = &pf.MaterializationSpec_Binding{
+		ResourceConfigJson: rb.ResourceConfigJson,
+		Collection:         rb.Collection,
+		FieldSelection:     synthesizeFieldSelection(rb, vb, rc.Delta || cfg.Advanced.NoFlowDocument),
+	}
+
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return fmt.Errorf("generating scratch table name: %w", err)
+	}
+	var scratch = fmt.Sprintf("flow_partition_dryrun_%x", nonce)
+
+	var shape = sql.BuildTableShape(materializationName, synth, bindingIdx, []string{scratch}, rc.Delta)
+	table, err := sql.ResolveTable(shape, dialect)
+	if err != nil {
+		return fmt.Errorf("resolving dry-run table: %w", err)
+	}
+	createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+	if err != nil {
+		return fmt.Errorf("rendering dry-run CREATE TABLE: %w", err)
+	}
+
+	_, createErr := db.ExecContext(ctx, createSQL)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s;", dialect.Identifier(scratch))); err != nil {
+		log.WithFields(log.Fields{"table": scratch, "error": err}).Warn("failed to drop partition_by dry-run table")
+	}
+	return createErr
+}
+
+// synthesizeFieldSelection approximates the eventual field selection of a
+// binding being validated, which carries no FieldSelection of its own. It
+// deliberately over-includes: every field the inner validation didn't rule
+// out becomes a column, so an expression referencing any selectable field
+// passes the dry-run. The inverse error -- a false failure for a field that
+// would be selected -- cannot happen.
+func synthesizeFieldSelection(rb *pm.Request_Validate_Binding, vb *pm.Response_Validated_Binding, excludeDocument bool) pf.FieldSelection {
+	var selectable = make(map[string]bool)
+	for _, pc := range vb.ProjectionConstraints {
+		switch pc.Constraint.Type {
+		case pm.Response_Validated_Constraint_FIELD_FORBIDDEN,
+			pm.Response_Validated_Constraint_UNSATISFIABLE,
+			pm.Response_Validated_Constraint_INCOMPATIBLE:
+			selectable[pc.Field] = false
+		default:
+			if _, ok := selectable[pc.Field]; !ok {
+				selectable[pc.Field] = true
+			}
+		}
+	}
+	var included = func(field string) bool { return selectable[field] }
+
+	var out pf.FieldSelection
+	out.Keys = append(out.Keys, rb.GroupBy...)
+	if len(out.Keys) == 0 {
+		for _, p := range rb.Collection.Projections {
+			if p.IsPrimaryKey && included(p.Field) {
+				out.Keys = append(out.Keys, p.Field)
+			}
+		}
+	}
+
+	var seen = make(map[string]bool)
+	for _, k := range out.Keys {
+		seen[k] = true
+	}
+	for _, p := range rb.Collection.Projections {
+		if seen[p.Field] || !included(p.Field) {
+			continue
+		}
+		seen[p.Field] = true
+		if p.Ptr == "" {
+			// A root document projection is only ever the document column.
+			if out.Document == "" && !excludeDocument {
+				out.Document = p.Field
+			}
+			continue
+		}
+		out.Values = append(out.Values, p.Field)
+	}
+	return out
+}
+
+// findLastBinding mirrors the unexported helper of materialize-boilerplate: a
+// previously disabled binding still constrains the current one, so inactive
+// bindings are consulted as well.
+func findLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
+	if lastSpec == nil {
+		return nil
+	}
+	for _, b := range lastSpec.Bindings {
+		if slices.Equal(resourcePath, b.ResourcePath) {
+			return b
+		}
+	}
+	for _, b := range lastSpec.InactiveBindings {
+		if slices.Equal(resourcePath, b.ResourcePath) {
+			return b
+		}
+	}
+	return nil
 }

--- a/materialize-clickhouse/validate.go
+++ b/materialize-clickhouse/validate.go
@@ -6,11 +6,11 @@ import (
 	stdsql "database/sql"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
@@ -44,7 +44,7 @@ func (d *driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Re
 		}
 		var newExpr = strings.TrimSpace(rc.PartitionBy)
 
-		var last = findLastBinding([]string{rc.Table}, req.LastMaterialization)
+		var last = boilerplate.FindLastBinding([]string{rc.Table}, req.LastMaterialization)
 		var lastExpr string
 		if last != nil {
 			var lastRC tableConfig
@@ -184,24 +184,4 @@ func synthesizeFieldSelection(rb *pm.Request_Validate_Binding, vb *pm.Response_V
 		out.Values = append(out.Values, p.Field)
 	}
 	return out
-}
-
-// findLastBinding mirrors the unexported helper of materialize-boilerplate: a
-// previously disabled binding still constrains the current one, so inactive
-// bindings are consulted as well.
-func findLastBinding(resourcePath []string, lastSpec *pf.MaterializationSpec) *pf.MaterializationSpec_Binding {
-	if lastSpec == nil {
-		return nil
-	}
-	for _, b := range lastSpec.Bindings {
-		if slices.Equal(resourcePath, b.ResourcePath) {
-			return b
-		}
-	}
-	for _, b := range lastSpec.InactiveBindings {
-		if slices.Equal(resourcePath, b.ResourcePath) {
-			return b
-		}
-	}
-	return nil
 }

--- a/materialize-clickhouse/validate.go
+++ b/materialize-clickhouse/validate.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"context"
+
+	pm "github.com/estuary/flow/go/protocols/materialize"
+)
+
+func (d *driver) Validate(ctx context.Context, req *pm.Request_Validate) (*pm.Response_Validated, error) {
+	return d.sqlDriver.Validate(ctx, req)
+}

--- a/materialize-sql/table_mapping.go
+++ b/materialize-sql/table_mapping.go
@@ -30,6 +30,11 @@ type TableShape struct {
 	// Materializer constructs are more thoroughly integrated into
 	// materialize-sql.
 	FieldConfigJsonMap map[string]json.RawMessage
+	// The raw resource config of the binding which produced this table, for
+	// dialects that render resource-level options (e.g. a custom PARTITION BY)
+	// into DDL. Nil when the table is not from a binding, such as the
+	// checkpoints meta table.
+	ResourceConfigJson json.RawMessage
 
 	Keys, Values []Projection
 	Document     *Projection
@@ -237,6 +242,7 @@ func BuildTableShape(materializationName string, binding *pf.MaterializationSpec
 		Comment:            comment,
 		DeltaUpdates:       deltaUpdates,
 		FieldConfigJsonMap: binding.FieldSelection.FieldConfigJsonMap,
+		ResourceConfigJson: binding.ResourceConfigJson,
 		Keys:               keys,
 		Values:             values,
 		Document:           document,


### PR DESCRIPTION
**Description:**

Adds an optional `partition_by` string to materialize-clickhouse's per-binding resource config, setting a [custom partitioning key](https://clickhouse.com/docs/engines/table-engines/mergetree-family/custom-partitioning-key) on created tables (e.g. `toYYYYMM(flow_published_at)`). Closes #4832.

- The expression is spliced as `PARTITION BY (<expr>)` into `CREATE TABLE`, for both standard and delta bindings; store staging tables inherit it via `CREATE TABLE ... AS`, and the existing per-partition MOVE loop commits multi-partition transactions unchanged.
- Since the expression is too open-ended to check statically, Validate dry-runs it: creates and drops a scratch table with the binding's real column DDL, surfacing server errors at publish time.
- ClickHouse only accepts PARTITION BY at table creation, so changing the value requires a backfill: Validate returns `INCOMPATIBLE` constraints until the binding is backfilled (materialize-spanner pattern), and `MustRecreateResource` makes the backfill drop+recreate instead of truncate.
- Shared change: `sql.TableShape` now carries the binding's raw `ResourceConfigJson`, so dialect templates can render resource-level options. Additive; no other connector affected.
- Adjacent fix: the store-table drift check from the pending-commit recovery fix (ac900a820) now also compares partition keys, since a backfill into a new partition key would otherwise crash-loop on `MOVE PARTITION`.

**Workflow steps:**

Set `partition_by` (advanced) on a binding's resource config. To change it later, backfill the binding; the table is dropped and re-created.

**Documentation links affected:**

materialize-clickhouse connector docs should mention the new field.

**Notes for reviewers:**

- Existing sqlgen snapshots pass byte-identical with `partition_by` unset.
- New integration tests cover multi-partition commits, dry-run accept/reject with scratch cleanup, INCOMPATIBLE-on-change, backfill recreate via Apply, and store-table drift recovery.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.