### PR TITLE
materialize-clickhouse: fail clearly when hard-delete table lacks _is_deleted

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-07-17
 
 ### Fixed
+- Replaced a cryptic `No such column _is_deleted` (code 16) crash loop with a clear, actionable error when hard delete is enabled but a standard-updates table is missing the connector's internal `_is_deleted` column (for example, a pre-created table adopted by the materialization, or a table created before hard delete was enabled). The error explains that the table must be recreated by backfilling the binding, or that hard delete should be disabled.
 - Fixed a permanent restart loop with the error `ALTER of key column ... is not safe because it can change the representation of primary key` (code 524) that occurred when a table's sorting-key or partition-key column was no longer part of the materialization's field selection. Such columns are now left unchanged instead of being made nullable, which ClickHouse forbids for key columns.
 
 ## 2026-07-15

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -321,7 +321,62 @@ func newTransactor(
 		}
 	}
 
+	if cfg.HardDelete {
+		for _, b := range t.bindings {
+			if b.target.DeltaUpdates {
+				continue
+			}
+			if err = t.requireIsDeletedColumn(ctx, b); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return t, nil
+}
+
+// requireIsDeletedColumn fails with a clear, actionable error when a
+// standard-updates target table exists but lacks the connector-internal
+// _is_deleted column that hard-delete mode depends on.
+//
+// With hard delete enabled, renderTemplates bakes an `INSERT ... (_is_deleted)`
+// into every standard-updates store, and the persistent stage table is created
+// `AS` the target -- so a target without the column makes every Store fail with a
+// cryptic ClickHouse "No such column _is_deleted in table ..." (code 16), which
+// crash-loops the task and blocks all of its bindings (issue #4834). Because
+// _is_deleted is purely internal (never a Flow projection), the Apply diffing can
+// never add it, so a table adopted via allow_existing_tables_for_new_bindings (or
+// created before hard delete was enabled) can never acquire it on its own.
+// Surface the problem plainly at session start rather than as that exception, and
+// deliberately do not attempt to add the column: an in-place ALTER cannot restore
+// the ReplacingMergeTree engine's _is_deleted cleanup argument, so the table must
+// be recreated by the connector to get correct hard-delete semantics.
+func (t *transactor) requireIsDeletedColumn(ctx context.Context, b *binding) error {
+	var total, hasIsDeleted uint64
+	if err := t.store.conn.QueryRow(ctx,
+		"SELECT count(), countIf(name = '_is_deleted') FROM system.columns WHERE database = currentDatabase() AND table = ?",
+		b.target.Path[0],
+	).Scan(&total, &hasIsDeleted); err != nil {
+		return fmt.Errorf("checking for _is_deleted column in %s: %w", b.target.Identifier, err)
+	}
+
+	// total == 0: the table does not exist yet, so Apply will create it with the
+	// column. hasIsDeleted > 0: the column is already present.
+	if total == 0 || hasIsDeleted > 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"table %s is missing the required _is_deleted column. This materialization has hard delete "+
+			"enabled, which requires an internal _is_deleted column (UInt8) on every standard-updates "+
+			"table: the connector materializes each table as a ReplacingMergeTree that uses _is_deleted "+
+			"to remove rows deleted in the source. This table exists without that column -- it was "+
+			"pre-created, or hard delete was enabled after the table was created -- so the connector "+
+			"cannot store to it. To resolve this, either backfill this binding (increment its backfill "+
+			"counter) so the connector re-creates the table with the correct schema, or disable hard "+
+			"delete for this materialization",
+		b.target.Identifier,
+	)
 }
 
 type binding struct {

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -593,6 +593,104 @@ func TestPrepareNewTransactor(t *testing.T) {
 	txn.Destroy()
 }
 
+// TestNewTransactorRejectsMissingIsDeletedColumn verifies that a standard-updates
+// binding materializing to a pre-existing table that lacks the connector-internal
+// _is_deleted column fails at session start with a clear, actionable error rather
+// than crash-looping every Store with a cryptic ClickHouse "No such column
+// _is_deleted" (code 16). Regression test for issue #4834.
+func TestNewTransactorRejectsMissingIsDeletedColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ensureDockerUp(t)
+
+	var cfg = testConfig()
+	cfg.HardDelete = true
+	var ctx = t.Context()
+	var dialect = clickHouseDialect(cfg.Database)
+	var tpls = renderTemplates(dialect, cfg.HardDelete)
+	var ep = &sql.Endpoint[config]{Config: cfg, Dialect: dialect}
+	var be = &m.BindingEvents{}
+	var open = pm.Request_Open{Range: &pf.RangeSpec{}}
+
+	db := clickhouse.OpenDB(cfg.newClickhouseOptions())
+	defer db.Close()
+
+	t.Run("rejects adopted table without _is_deleted", func(t *testing.T) {
+		var tableName = "test_missing_is_deleted"
+		var table = buildTestTable(t, dialect, tableName)
+
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		// A table adopted via allow_existing_tables_for_new_bindings that was
+		// pre-created WITHOUT the connector's internal _is_deleted column.
+		_, err := db.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE %s (
+				id String,
+				value Nullable(String),
+				`+"`_meta/op`"+` String,
+				flow_published_at DateTime64(6, 'UTC'),
+				flow_document String
+			) ENGINE = ReplacingMergeTree(flow_published_at)
+			ORDER BY (id)`,
+			dialect.Identifier(tableName),
+		))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		})
+
+		_, err = newTransactor(ctx, "test", nil, ep, sql.Fence{}, []sql.Table{table}, open, nil, be)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "_is_deleted")
+		require.ErrorContains(t, err, tableName)
+	})
+
+	t.Run("accepts table created with _is_deleted", func(t *testing.T) {
+		var tableName = "test_present_is_deleted"
+		var table = buildTestTable(t, dialect, tableName)
+
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		createSQL, err := sql.RenderTableTemplate(table, tpls.createTargetTable)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, createSQL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		})
+
+		txn, err := newTransactor(ctx, "test", nil, ep, sql.Fence{}, []sql.Table{table}, open, nil, be)
+		require.NoError(t, err)
+		txn.Destroy()
+	})
+
+	t.Run("ignores delta-updates binding without _is_deleted", func(t *testing.T) {
+		var tableName = "test_delta_no_is_deleted"
+		var table = buildTestTable(t, dialect, tableName)
+		table.DeltaUpdates = true
+
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		_, err := db.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE %s (
+				id String,
+				value Nullable(String),
+				`+"`_meta/op`"+` String,
+				flow_published_at DateTime64(6, 'UTC'),
+				flow_document String
+			) ENGINE = MergeTree()
+			ORDER BY (id)`,
+			dialect.Identifier(tableName),
+		))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
+		})
+
+		txn, err := newTransactor(ctx, "test", nil, ep, sql.Fence{}, []sql.Table{table}, open, nil, be)
+		require.NoError(t, err)
+		txn.Destroy()
+	})
+}
+
 // TestHardDeleteTombstone verifies that delete rows with _meta/op="d"
 // (which infer _is_deleted=1 via the MATERIALIZED expression) are hidden by FINAL.
 func TestHardDeleteTombstone(t *testing.T) {


### PR DESCRIPTION
**Regression?**

No. Related to #4829/#4830 (same task) but a distinct failure mode.

**Description:**

Fixes #4834. When hard delete is enabled, a standard-updates table missing the connector-internal `_is_deleted` column (a pre-created/adopted table, or one created before hard delete was enabled) crash-looped every `Store` with a cryptic `No such column _is_deleted` (code 16), blocking the whole task one binding at a time.

`_is_deleted` is purely internal (never a Flow projection), so Apply diffing can never add it. Rather than work around it (an in-place `ALTER` can't restore the `ReplacingMergeTree` cleanup arg, so it'd silently break hard-delete semantics), `newTransactor` now detects the gap at session start and exits with a clear, actionable error naming the table.

**Workflow steps:**

On a hard-delete materialization, if a standard-updates target lacks `_is_deleted`, the task fails with a message telling the user to backfill the binding (recreate the table correctly) or disable hard delete — instead of a code-16 crash loop.

**Notes for reviewers:**

- Check lives in `newTransactor` — the earliest connector-local hook with the binding's `DeltaUpdates` flag, `HardDelete` config, and a live conn; there's no per-connector Apply hook for non-diffed existing tables.
- Skips delta-updates bindings and not-yet-existing tables (Apply creates those with the column).
- TDD: commit 1 = failing test, commit 2 = fix. Unit + data-path suite green. `TestIntegration` fails only on a local flowctl auth error, unrelated to this change.

**Checklist:**

- [x] CHANGELOG.md updated.
