### PR TITLE
materialize-bigquery: strip policy tags from temp table schema

### DIFF
--- a/materialize-bigquery/CHANGELOG.md
+++ b/materialize-bigquery/CHANGELOG.md
@@ -1,4 +1,14 @@
 # materialize-bigquery
 
+## 2026-07-18
+
+### Fixed
+- Fixed a permanent `403 Access Denied: ... does not have permission to access policy
+  tag ... on column flow_temp_table_N.cN` error when materializing to tables that use
+  BigQuery column-level security (policy tags). The connector's internal staging table
+  no longer inherits policy tags from destination columns; BigQuery enforced access
+  control on that staging table regardless of the service account's Fine-Grained
+  Reader grants, so no permissioning change could resolve the error.
+
 ## v1, 2022-07-27
 - Beginning of changelog.

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -196,13 +196,25 @@ func schemaForCols(cols []*sql.Column, fieldSchemas map[string]*bigquery.FieldSc
 			return nil, fmt.Errorf("could not find metadata for field '%s'", col.Field)
 		}
 
+		// Copy the field schema rather than reusing the destination table's, both to avoid
+		// mutating the caller's view of the destination schema and so that modifications made
+		// here never leak back to BigQuery via the temp/external table definition.
+		tempSchema := *schema
+
 		// Use a placeholder value instead of the actual field name for the external table schema.
 		// This allows for materialized tables to use "Flexible column names", which is not yet
 		// supported by external tables. A similar placeholder is used in the generated SQL queries
 		// to match this.
-		schema.Name = fmt.Sprintf("c%d", idx)
+		tempSchema.Name = fmt.Sprintf("c%d", idx)
 
-		s = append(s, schema)
+		// Never carry the destination column's policy tags onto the temp/external table:
+		// BigQuery enforces column-level security on the query-scoped external table itself,
+		// and Fine-Grained Reader grants do not extend to it, so a tagged temp column fails
+		// with a 403 that no customer permissioning can fix. See
+		// https://github.com/estuary/connectors/issues/4833.
+		tempSchema.PolicyTags = nil
+
+		s = append(s, &tempSchema)
 	}
 
 	return s, nil

--- a/materialize-bigquery/transactor_test.go
+++ b/materialize-bigquery/transactor_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaForColsStripsPolicyTags(t *testing.T) {
+	makeCol := func(field string) *sql.Column {
+		return &sql.Column{Projection: sql.Projection{Projection: pf.Projection{Field: field}}}
+	}
+
+	fieldSchemas := map[string]*bigquery.FieldSchema{
+		"id": {Name: "id", Type: bigquery.StringFieldType, Required: true},
+		"birthday": {
+			Name: "birthday",
+			Type: bigquery.DateFieldType,
+			PolicyTags: &bigquery.PolicyTagList{
+				Names: []string{"projects/p/locations/us/taxonomies/1/policyTags/2"},
+			},
+		},
+	}
+
+	got, err := schemaForCols([]*sql.Column{makeCol("id"), makeCol("birthday")}, fieldSchemas)
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	require.Equal(t, "c0", got[0].Name)
+	require.Equal(t, "c1", got[1].Name)
+	require.Equal(t, bigquery.StringFieldType, got[0].Type)
+	require.Equal(t, bigquery.DateFieldType, got[1].Type)
+
+	// The temp/external table schema must never carry the destination
+	// column's policy tags: BigQuery enforces column-level security on the
+	// query-scoped external table itself, and Fine-Grained Reader grants do
+	// not extend to it (https://github.com/estuary/connectors/issues/4833).
+	for _, f := range got {
+		require.Nil(t, f.PolicyTags, "field %s must not carry policy tags", f.Name)
+	}
+
+	// The destination table's field schemas must not be mutated: loadSchema
+	// and storeSchema are both built from the same map, and the caller's view
+	// of the destination schema should remain intact.
+	require.Equal(t, "id", fieldSchemas["id"].Name)
+	require.Equal(t, "birthday", fieldSchemas["birthday"].Name)
+	require.NotNil(t, fieldSchemas["birthday"].PolicyTags)
+}


### PR DESCRIPTION
**Description:**

Fixes #4833. `materialize-bigquery`'s temp/external table schema reused the destination table's `*bigquery.FieldSchema` structs, so destination columns' `PolicyTags` (column-level security) leaked into the query-scoped external table used for Load/Store. BigQuery enforces policy tags on that ephemeral table, and Fine-Grained Reader grants do not extend to query-scoped external tables — confirmed by live repro — so materializations into policy-tagged tables failed permanently with `403 Access Denied ... on column flow_temp_table_N.cN`, unfixable by customer permissioning.

`schemaForCols` now copies each field schema (also fixing in-place mutation of the destination schema) and strips `PolicyTags`.

**Workflow steps:**

No user-facing changes; materializations into tables with policy-tagged columns now work when the service account has Fine-Grained Reader on the destination columns' tags.

**Documentation links affected:**

None.

**Notes for reviewers:**

- Two-commit TDD shape: failing regression test, then fix.
- Repro validated in `estuary-theatre` (taxonomy + enforced policy tag fixture, left in place): tagged external-table schema 403s even with Fine-Grained Reader; stripped schema succeeds, including a connector-shaped MERGE into a real policy-tagged destination.
- Full `TestIntegration` suite passes with no snapshot changes (suite now takes ~10.5m; needs `-timeout` above the Go default).

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
