### PR TITLE
ci: fix docs-changelog-check SIGPIPE on large diffs

### DIFF
--- a/.github/workflows/docs-changelog-check.yaml
+++ b/.github/workflows/docs-changelog-check.yaml
@@ -90,11 +90,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           # Bounded diff of connector code for the model, skipping files
-          # that are large or mechanical.
+          # that are large or mechanical. Write the full diff to a file and
+          # truncate from there rather than piping straight into `head -c`:
+          # when the diff exceeds the cap, `head` closes the pipe and `git
+          # diff` dies with SIGPIPE (141), which `pipefail` would turn into a
+          # step failure. Reading the cap from a regular file avoids that.
           git diff "$BASE_SHA" "$HEAD_SHA" -- $CONNECTORS \
             ':(exclude)**/go.sum' ':(exclude)**/poetry.lock' ':(exclude)**/uv.lock' \
             ':(exclude)**/*.snapshot' ':(exclude)**/testdata/**' ':(exclude)**/snapshots/**' \
-            | head -c 180000 > /tmp/connector.diff
+            > /tmp/connector.full.diff
+          head -c 180000 /tmp/connector.full.diff > /tmp/connector.diff
           echo "Diff size for review: $(wc -c < /tmp/connector.diff) bytes"
 
       - name: Ask Claude whether docs / changelog updates are warranted


### PR DESCRIPTION
**Regression?**

No.

**Description:**

The docs/CHANGELOG check piped `git diff` straight into `head -c 180000` under `set -o pipefail`. When a PR's connector diff exceeds the 180 KB cap, `head` closes the pipe once it has read enough, `git diff` dies with SIGPIPE (exit 141), and `pipefail` propagates that as a step failure - so the check crashed on exactly the large PRs it was meant to review (e.g. a new connector), before it could render any verdict.

Write the full diff to a file and truncate by reading that file instead. `head` reading a regular file never signals the producer, so `git diff` completes normally. The 180 KB cap on what the model sees is unchanged.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
