### PR TITLE
estuary-cdk: render %-style log args via getMessage in LogFormatter

### DIFF
--- a/estuary-cdk/estuary_cdk/logger.py
+++ b/estuary-cdk/estuary_cdk/logger.py
@@ -37,7 +37,7 @@ class LogFormatter(logging.Formatter):
         elif record.stack_info:
             fields["stack"] = self.formatStack(record.stack_info).splitlines()
 
-        return OpsLog(level=record.levelname, msg=record.msg, fields=fields).model_dump_json()
+        return OpsLog(level=record.levelname, msg=record.getMessage(), fields=fields).model_dump_json()
 
 
 # Boolean log field set to True on log lines we aggregate across the whole

--- a/estuary-cdk/estuary_cdk/logger.py
+++ b/estuary-cdk/estuary_cdk/logger.py
@@ -37,7 +37,11 @@ class LogFormatter(logging.Formatter):
         elif record.stack_info:
             fields["stack"] = self.formatStack(record.stack_info).splitlines()
 
-        return OpsLog(level=record.levelname, msg=record.getMessage(), fields=fields).model_dump_json()
+        try:
+            msg = record.getMessage()
+        except Exception:
+            msg = str(record.msg)  # fall back to raw template on malformed %-args
+        return OpsLog(level=record.levelname, msg=msg, fields=fields).model_dump_json()
 
 
 # Boolean log field set to True on log lines we aggregate across the whole

--- a/estuary-cdk/tests/test_logger.py
+++ b/estuary-cdk/tests/test_logger.py
@@ -26,3 +26,16 @@ def test_fstring_message_unchanged():
         "flow", logging.INFO, __file__, 1, "already formatted", None, None
     )
     assert _fmt(r)["msg"] == "already formatted"
+
+
+def test_malformed_percent_args_fall_back_to_raw_template():
+    # Several connectors pass a context dict positionally (e.g.
+    # log.info(f"...", {"errors": ...})). When the (already-rendered) message
+    # contains a stray '%', getMessage() would raise on `msg % args`; we must
+    # fall back to the raw template rather than let logging drop the line.
+    r = logging.LogRecord(
+        "flow", logging.INFO, __file__, 1,
+        "query failed: LIKE '%x%'", ({"errors": ["boom"]},), None,
+    )
+    out = _fmt(r)
+    assert out["msg"] == "query failed: LIKE '%x%'"

--- a/estuary-cdk/tests/test_logger.py
+++ b/estuary-cdk/tests/test_logger.py
@@ -1,0 +1,28 @@
+import json
+import logging
+
+from estuary_cdk.logger import LogFormatter
+
+
+def _fmt(record: logging.LogRecord) -> dict:
+    return json.loads(LogFormatter().format(record))
+
+
+def test_percent_args_are_rendered():
+    # Lazy %-style logging (as used by gunicorn and much of the stdlib) must be
+    # interpolated into `msg`, not emitted as a raw template.
+    r = logging.LogRecord(
+        "flow", logging.INFO, __file__, 1, "pid: %s", (1234,), None
+    )
+    out = _fmt(r)
+    assert out["msg"] == "pid: 1234"
+    # Raw args are still retained as a structured field.
+    assert out["fields"]["args"] == [1234]  # pydantic serializes the tuple to a JSON array
+
+
+def test_fstring_message_unchanged():
+    # An already-formatted message with no args passes through verbatim.
+    r = logging.LogRecord(
+        "flow", logging.INFO, __file__, 1, "already formatted", None, None
+    )
+    assert _fmt(r)["msg"] == "already formatted"


### PR DESCRIPTION
## Problem

`LogFormatter.format` in `estuary-cdk/estuary_cdk/logger.py` builds the emitted `msg` from `record.msg` (the raw format template) instead of `record.getMessage()`. `record.args` are stashed into a separate `fields["args"]` and never applied to the human-readable message.

Result: any log call using lazy `%`-style formatting comes through with the literal placeholder. Seen in production from gunicorn's internal logger inside source-netsuite's `query_server`:

```
Booting worker with pid: %s
```

which surfaced verbatim in a customer's task-failure alert (wrapped as `completeRecovery: store.RestoreCheckpoint: Booting worker with pid: %s`).

## Scope

Affects every Python connector on estuary-cdk. The connectors' own code mostly uses f-strings (so `record.args` is empty and `record.msg` is already complete), which is why it went unnoticed. Any dependency that logs with `%`-args (gunicorn, much of the stdlib ecosystem) renders with raw placeholders.

## Fix

Use `record.getMessage()` for the emitted `msg`. It applies `record.args` when present and returns `record.msg` unchanged when args is empty, so f-string callers are unaffected (no regression). `fields["args"]` is left in place for structured logging.

## Note

estuary-cdk is a shared library with no per-connector `CHANGELOG.md`. If the docs-changelog-check flags this, it's a false positive for a shared-lib change — apply `docs-check-skip`.
