### PR TITLE
ci: docs-changelog-check tolerates bare-object model verdicts

### DIFF
--- a/.github/workflows/docs-changelog-check.yaml
+++ b/.github/workflows/docs-changelog-check.yaml
@@ -155,10 +155,12 @@ jobs:
             exit 0
           fi
 
-          # Extract the JSON array, tolerating stray fences.
+          # Extract the JSON array, tolerating stray fences and a bare
+          # object (the model sometimes drops the array wrapper when only
+          # one connector changed).
           jq -r '.content[0].text' /tmp/response.json \
             | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//' \
-            | jq -c '.' > /tmp/verdict.json
+            | jq -c 'if type == "array" then . else [.] end' > /tmp/verdict.json
           echo "Verdict:"
           jq '.' /tmp/verdict.json
 


### PR DESCRIPTION
**Regression?**

No.

**Description:**

With a single changed connector the model sometimes returns one JSON object instead of the requested one-element array, which broke the compare step's `jq -c '.[]'` iteration. Normalize the verdict to an array at extraction time.

**Notes for reviewers:**

Here's a CI run where the verdict was a single object instead of an object inside an array: https://github.com/estuary/connectors/actions/runs/29711083684/job/88254973105?pr=4839.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
