### PR TITLE
materialize-postgres: parameterize fence update to avoid pg_stat_statements bloat

### DIFF
--- a/materialize-postgres/.snapshots/TestSQLGeneration
+++ b/materialize-postgres/.snapshots/TestSQLGeneration
@@ -329,19 +329,12 @@ limit 1
 --- End Fence Install ---
 
 --- Begin Fence Update ---
-DO $$
-BEGIN
-	UPDATE path."to".checkpoints
-		SET   checkpoint = 'AAECAwQFBgcICQ=='
-		WHERE materialization = 'some/Materialization'
-		AND   key_begin = 1122867
-		AND   key_end   = 4293844428
-		AND   fence     = 123;
-
-	IF NOT FOUND THEN
-		RAISE 'This instance was fenced off by another';
-	END IF;
-END $$;
+UPDATE path."to".checkpoints
+	SET   checkpoint = $1
+	WHERE materialization = $2
+	AND   key_begin = $3
+	AND   key_end   = $4
+	AND   fence     = $5;
 --- End Fence Update ---
 
 --- Begin createTargetTable [jsonb contentMediaType] ---

--- a/materialize-postgres/CHANGELOG.md
+++ b/materialize-postgres/CHANGELOG.md
@@ -1,5 +1,10 @@
 # materialize-postgres
 
+## 2026-07-20
+
+### Fixed
+- Checkpoint fence updates are now issued as a parameterized `UPDATE` instead of a `DO` block with the checkpoint inlined as a literal. Because a `DO` block is a utility statement whose body cannot be normalized, every commit previously created a distinct `pg_stat_statements` entry, which could exhaust `pg_stat_statements.max` and cause `LWLock:pg_stat_statements` contention on the destination. The parameterized statement collapses into a single normalized entry.
+
 ## v4, 2022-11-30
 
 This version includes breaking changes to materialized table columns. These will provide more

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -678,8 +679,10 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 			return nil, m.FinishedOperation(fmt.Errorf("evaluating fence template: %w", err))
 		}
 
-		// Add the update to the fence as the last statement in the batch.
-		batch.Queue(fenceUpdate.String())
+		// Add the update to the fence as the last statement in the batch. It is
+		// parameterized so that Postgres' pg_stat_statements collapses every
+		// commit into a single normalized entry rather than one per checkpoint.
+		batch.Queue(fenceUpdate.String(), fenceUpdateArgs(d.store.fence)...)
 
 		results := txn.SendBatch(ctx, &batch)
 
@@ -690,9 +693,13 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 			}
 		}
 
-		// The fence update is always the last operation in the batch.
-		if _, err := results.Exec(); err != nil {
+		// The fence update is always the last operation in the batch. A single
+		// affected row confirms this instance still owns the fence; anything
+		// else means we were fenced off by another instance.
+		if tag, err := results.Exec(); err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("updating flow checkpoint: %w", err))
+		} else if tag.RowsAffected() != 1 {
+			return nil, m.FinishedOperation(fmt.Errorf("this instance was fenced off by another"))
 		} else if err = results.Close(); err != nil {
 			return nil, m.FinishedOperation(fmt.Errorf("results.Close(): %w", err))
 		}
@@ -705,6 +712,20 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 
 		return nil, nil
 	}, nil
+}
+
+// fenceUpdateArgs returns the positional bind parameters ($1..$5) for the
+// parameterized updateFence statement, in the order the template references
+// them. The checkpoint is stored as standard base64 text, matching how
+// installFence writes it.
+func fenceUpdateArgs(fence sql.Fence) []any {
+	return []any{
+		base64.StdEncoding.EncodeToString(fence.Checkpoint),
+		fence.Materialization.String(),
+		fence.KeyBegin,
+		fence.KeyEnd,
+		fence.Fence,
+	}
 }
 
 func (d *transactor) Destroy() {

--- a/materialize-postgres/driver_test.go
+++ b/materialize-postgres/driver_test.go
@@ -82,12 +82,23 @@ func TestIntegration(t *testing.T) {
 			"testdata/fence.flow.yaml",
 			makeResourceFn,
 			testTemplates.createTargetTable,
-			func(ctx context.Context, client sql.Client, fence sql.Fence) error {
+			func(ctx context.Context, c sql.Client, fence sql.Fence) error {
 				var fenceUpdate strings.Builder
 				if err := testTemplates.updateFence.Execute(&fenceUpdate, fence); err != nil {
 					return fmt.Errorf("evaluating fence template: %w", err)
 				}
-				return client.ExecStatements(ctx, []string{fenceUpdate.String()})
+				// The fence update is parameterized, so it must be executed with
+				// bind arguments rather than as a plain statement, mirroring the
+				// driver's own fenced-off detection via RowsAffected.
+				res, err := c.(*client).db.ExecContext(ctx, fenceUpdate.String(), fenceUpdateArgs(fence)...)
+				if err != nil {
+					return fmt.Errorf("updating fence: %w", err)
+				} else if rows, err := res.RowsAffected(); err != nil {
+					return fmt.Errorf("fetching fence update rows: %w", err)
+				} else if rows != 1 {
+					return fmt.Errorf("this instance was fenced off by another")
+				}
+				return nil
 			},
 		)
 	})

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -436,12 +436,10 @@ limit 1
 ;
 {{ end }}
 
--- Templated parameterized update of the fence checkpoint. The bind parameters
--- ($1..$5) are supplied by fenceUpdateArgs. Emitting this as ordinary DML with
--- placeholders (rather than a DO block with inlined literals) lets Postgres'
--- pg_stat_statements collapse every commit into a single normalized entry; a
--- DO block is a utility statement whose body cannot be normalized, so each
--- unique checkpoint would otherwise create a distinct entry. The fenced-off
+-- Update the fence checkpoint. The bind parameters ($1..$5) are supplied by
+-- fenceUpdateArgs. This must stay parameterized rather than inlining the
+-- checkpoint as a literal, so that pg_stat_statements collapses every commit
+-- into a single normalized entry instead of one per checkpoint. The fenced-off
 -- check is performed in Go via the reported RowsAffected.
 
 {{ define "updateFence" }}

--- a/materialize-postgres/sqlgen.go
+++ b/materialize-postgres/sqlgen.go
@@ -436,20 +436,21 @@ limit 1
 ;
 {{ end }}
 
-{{ define "updateFence" }}
-DO $$
-BEGIN
-	UPDATE {{ Identifier $.TablePath }}
-		SET   checkpoint = {{ Literal (Base64Std $.Checkpoint) }}
-		WHERE materialization = {{ Literal $.Materialization.String }}
-		AND   key_begin = {{ $.KeyBegin }}
-		AND   key_end   = {{ $.KeyEnd }}
-		AND   fence     = {{ $.Fence }};
+-- Templated parameterized update of the fence checkpoint. The bind parameters
+-- ($1..$5) are supplied by fenceUpdateArgs. Emitting this as ordinary DML with
+-- placeholders (rather than a DO block with inlined literals) lets Postgres'
+-- pg_stat_statements collapse every commit into a single normalized entry; a
+-- DO block is a utility statement whose body cannot be normalized, so each
+-- unique checkpoint would otherwise create a distinct entry. The fenced-off
+-- check is performed in Go via the reported RowsAffected.
 
-	IF NOT FOUND THEN
-		RAISE 'This instance was fenced off by another';
-	END IF;
-END $$;
+{{ define "updateFence" }}
+UPDATE {{ Identifier $.TablePath }}
+	SET   checkpoint = $1
+	WHERE materialization = $2
+	AND   key_begin = $3
+	AND   key_end   = $4
+	AND   fence     = $5;
 {{ end }}
 `)
 


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Fixes #4841. The Postgres fence update was a `DO` block, which is a utility statement that `pg_stat_statements` can't normalize — so every commit's inlined checkpoint became a distinct entry. This switches it to an ordinary parameterized `UPDATE`, which collapses into a single normalized entry.

**Workflow steps:**

No user-facing workflow change. The materialization behaves identically; only the SQL issued for the checkpoint fence update changes.

**Documentation links affected:**

None.

**Notes for reviewers:**

- The fenced-off check that `RAISE` performed inside the `DO` block now happens in Go via `RowsAffected`. This mirrors what `materialize-redshift` and `materialize-sql`'s `StdUpdateFence` already do — Postgres was the outlier.
- The checkpoint is still stored as base64 text (same as `installFence` writes), so it's backwards compatible with existing checkpoint rows.
- `TestIntegration` (including the fencing test) passes locally.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
