### PR TITLE
Reconcile connector docs against flow/site drift (first pass)

### DIFF
--- a/docs/reference/Connectors/README.md
+++ b/docs/reference/Connectors/README.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Browse Estuary's capture and materialization connectors. Reference configuration details to create customized data flows.
 ---
 
 # Connectors

--- a/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
+++ b/docs/reference/Connectors/capture-connectors/HubSpot-real-time.md
@@ -1,3 +1,7 @@
+---
+description: Keep HubSpot CRM and marketing data fresh in downstream systems with Estuary, from contacts and deals to tickets, workflows, and custom objects.
+---
+
 # HubSpot ( Real-Time )
 
 This connector captures data from HubSpot into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Set up Estuary's MariaDB capture connector with CDC, binlog configuration, replication permissions, and backfill and time zone settings.
 ---
 
 # MariaDB
@@ -40,8 +41,10 @@ To meet these requirements, do the following:
 
 1. Create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture IDENTIFIED BY 'secret';

--- a/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Set up Estuary's Amazon RDS for MariaDB capture connector with CDC, binlog configuration, replication permissions, and backfill and time zone settings.
 ---
 
 # Amazon RDS for MariaDB

--- a/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
@@ -1,3 +1,7 @@
+---
+description: Capture Amazon DocumentDB's MongoDB-compatible collections with Estuary's connector, using either change stream or batch capture modes.
+---
+
 # Amazon DocumentDB
 
 This connector captures data from your Amazon DocumentDB collections into Estuary collections.
@@ -75,7 +79,7 @@ Amazon DocumentDB source connector.
 | `/pollSchedule`         | Default Batch Collection Polling Schedule                          | When and how often to poll batch collections. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset                                                                 | string  |                  |
 | `/advanced/maxAwaitTime` | Max Await Time | Maximum time to wait for new change stream events before returning an empty batch. Defaults to 1 second. Accepts a Go duration string like '10s'. | string |  |
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
-| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled. | boolean |  |
+| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
 
 #### Bindings

--- a/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
@@ -1,3 +1,7 @@
+---
+description: Capture Azure Cosmos DB's MongoDB-compatible collections with Estuary's connector, using either change feeds or batch capture mode.
+---
+
 # Azure CosmosDB
 
 This connector captures data from your Azure Cosmos DB collections into Estuary collections.
@@ -87,7 +91,7 @@ Azure Cosmos DB source connector.
 | `/pollSchedule`         | Default Batch Collection Polling Schedule                          | When and how often to poll batch collections. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset                                                                 | string  |                  |
 | `/advanced/maxAwaitTime` | Max Await Time | Maximum time to wait for new change stream events before returning an empty batch. Defaults to 1 second. Accepts a Go duration string like '10s'. | string |  |
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
-| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled. | boolean |  |
+| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
 
 #### Bindings

--- a/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
@@ -1,3 +1,7 @@
+---
+description: Stream MongoDB collections with Estuary using change streams or fall back to a batch capture mode. Configure cursor fields, batch polling schedules, and SSH tunneling.
+---
+
 # MongoDB
 
 This connector captures data from your MongoDB collections into Estuary collections.
@@ -103,7 +107,7 @@ MongoDB source connector.
 | `/pollSchedule`         | Default Batch Collection Polling Schedule                          | When and how often to poll batch collections. Accepts a Go duration string like '5m' or '6h' for frequency-based polling or a string like 'daily at 12:34Z' to poll at a specific time (specified in UTC) every day. Defaults to '24h' if unset                                                                 | string  |                  |
 | `/advanced/maxAwaitTime` | Max Await Time | Maximum time to wait for new change stream events before returning an empty batch. Defaults to 1 second. Accepts a Go duration string like '10s'. | string |  |
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
-| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled. | boolean |  |
+| `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
 
 #### Bindings

--- a/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Set up Estuary's MySQL capture connector with CDC, binlog configuration, and time zone settings using self-hosted and cloud platform guides.
 ---
 
 # MySQL
@@ -54,8 +55,10 @@ To meet these requirements, follow the steps for your hosting type.
 
 1. Create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 ```sql
 CREATE USER IF NOT EXISTS flow_capture
@@ -149,8 +152,10 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 3. Using [MySQL workbench](https://docs.microsoft.com/en-us/azure/mysql/single-server/connect-workbench) or your preferred client,
    create the `flow_capture` user with replication permission, and the ability to read all tables.
 
-The `SELECT` permission can be restricted to just the tables that need to be
-captured, but automatic discovery requires `information_schema` access as well.
+Grant `SELECT` on all tables or restrict it to the tables to be captured. `SELECT`
+permissions must be at the table level, not the column level. Automatic discovery also
+requires `information_schema` access. To keep specific columns, such as sensitive fields,
+out of the capture, use [redaction](/features/redaction.md) rather than column-level grants.
 
 :::tip
 Your username must be specified in the format `username@servername`.

--- a/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Capture Amazon RDS MySQL changes with Estuary’s CDC connector. Guide includes binlog setup, capturing from read replicas, and backfill considerations.
 ---
 
 # Amazon RDS for MySQL

--- a/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Capture MySQL changes from Google Cloud SQL instances with Estuary’s CDC connector. Setup guide includes binlog handling, read replicas, and backfills.
 ---
 
 # Google Cloud SQL for MySQL

--- a/docs/reference/Connectors/capture-connectors/MySQL/mysql-batch.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/mysql-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the MySQL Batch Query connector to capture tables, views, and custom SQL queries with configurable polling schedules, cursors, and SSH tunneling.
+---
+
 # MySQL Batch Query Connector
 
 This connector captures data from MySQL databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/MySQL/singlestore-batch.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/singlestore-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the SingleStore Batch Query connector to capture tables, views, and custom SQL queries with configurable polling schedules, cursors, and SSH tunneling.
+---
+
 # SingleStore Batch Query Connector
 
 This connector captures data from SingleStore into Estuary collections by periodically executing queries and translating

--- a/docs/reference/Connectors/capture-connectors/OracleDB/OracleDB.md
+++ b/docs/reference/Connectors/capture-connectors/OracleDB/OracleDB.md
@@ -1,3 +1,7 @@
+---
+description: Capture OracleDB changes into Estuary with LogMiner for container or non-container databases. Setup guidance includes configuring dictionary modes and SCN tuning.
+---
+
 import ReactPlayer from "react-player";
 
 # OracleDB

--- a/docs/reference/Connectors/capture-connectors/OracleDB/oracle-batch.md
+++ b/docs/reference/Connectors/capture-connectors/OracleDB/oracle-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the Oracle Batch Query connector to capture tables, views, and custom SQL queries with configurable polling schedules, cursors, and SSH tunneling.
+---
+
 # Oracle Batch Query Connector
 
 This connector captures data from Oracle databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Set up Estuary's PostgreSQL capture connector with CDC, logical replication, and proper permissions using self-hosted and cloud platform guides.
 ---
 
 import ReactPlayer from "react-player";

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 6
+description: Capture Supabase updates with Estuary's CDC connector. Setup guide includes logical replication, WAL handling, replication slots, publications, watermarks tables, and backfills.
 ---
+
 # Supabase
 
 This connector uses change data capture (CDC) to continuously capture updates in a Supabase PostgreSQL database into one or more Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Capture Amazon RDS PostgreSQL changes with Estuary's CDC connector. Setup guide includes logical replication, WAL handling, replication slots, publications, watermarks tables, and backfills.
 ---
 
 # Amazon RDS for PostgreSQL

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Capture PostgreSQL changes from Google Cloud SQL instances with Estuary’s CDC connector. Setup guide includes logical replication, WAL handling, replication slots, publications, watermarks tables, and backfills.
 ---
 
 # Google Cloud SQL for PostgreSQL

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
@@ -1,3 +1,7 @@
+---
+description: Capture Neon PostgreSQL data with Estuary's CDC connector. Setup guide includes logical replication, WAL handling, replication slots, publications, watermarks tables, and backfills.
+---
+
 # Neon PostgreSQL
 
 Neon's logical replication feature allows you to replicate data from your Neon Postgres database to external destinations.

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/postgres-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the PostgreSQL Batch Query connector to capture tables, views, and custom SQL queries with configurable polling schedules, cursors, and SSH tunneling.
+---
+
 # PostgreSQL Batch Query Connector
 
 This connector captures data from PostgreSQL databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/README.md
+++ b/docs/reference/Connectors/capture-connectors/README.md
@@ -1,3 +1,7 @@
+---
+description: Browse Estuary's list of capture connectors for databases, SaaS apps, files, streams, and APIs, with complete configuration details.
+---
+
 # Capture Connectors
 
 Estuary's available capture connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.

--- a/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Capture Amazon RDS SQL Server changes with Estuary’s CDC connector. Setup guide includes database/table CDC setup, permissions, SSH tunneling, and DDL handling.
 ---
 
 # Amazon RDS for SQL Server

--- a/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Capture SQL Server changes from Google Cloud SQL instances with Estuary’s CDC connector. Setup guide includes database/table CDC setup, permissions, SSH tunneling, and DDL handling.
 ---
 
 # Google Cloud SQL for SQL Server

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the SQL Server Batch Query connector to capture tables, views, and custom SQL queries with configurable cursors, polling schedules, and SSH tunneling.
+---
+
 # SQL Server Batch Query Connector
 
 This connector captures data from SQL Server databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Capture SQL Server updates with the Change Tracking connector. Includes setup guides for self-hosted and cloud instances.
 ---
 
 # Microsoft SQL Server (Change Tracking)

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Set up Estuary's Microsoft SQL Server CDC connector with automatic capture instance management and change table cleanup using self-hosted and cloud platform guides.
 ---
 
 # Microsoft SQL Server

--- a/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-native.md
+++ b/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-native.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's Salesforce connector to capture Salesforce standard and custom objects. Supports formula field handling, custom fields, and multiple authentication methods.
+---
+
 # Salesforce
 
 This connector captures data from Salesforce objects into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/ada.md
+++ b/docs/reference/Connectors/capture-connectors/ada.md
@@ -1,3 +1,7 @@
+---
+description: Sync Ada bot data into Estuary, including articles, conversations, messages, sources, tags, and platform integrations.
+---
+
 # Ada
 
 This connector captures data from [Ada](https://www.ada.cx/) into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/aircall.md
+++ b/docs/reference/Connectors/capture-connectors/aircall.md
@@ -1,3 +1,6 @@
+---
+description: Use the Aircall connector to capture calls, contacts, numbers, tags, users, teams, and webhooks, using an Aircall App ID and token.
+---
 
 # Aircall
 

--- a/docs/reference/Connectors/capture-connectors/airtable-native.md
+++ b/docs/reference/Connectors/capture-connectors/airtable-native.md
@@ -1,3 +1,7 @@
+---
+description: Capture Airtable bases and tables with Estuary's connector, using an Airtable access token. Supports formula fields with refresh schedules and incremental updates.
+---
+
 # Airtable
 
 This connector captures data from Airtable into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/alloydb.md
+++ b/docs/reference/Connectors/capture-connectors/alloydb.md
@@ -1,3 +1,6 @@
+---
+description: Capture AlloyDB table updates with Estuary's CDC connector. Setup guide for logical decoding, replication slots, publications, watermarks tables, and SSH tunneling.
+---
 
 # AlloyDB
 

--- a/docs/reference/Connectors/capture-connectors/alpaca.md
+++ b/docs/reference/Connectors/capture-connectors/alpaca.md
@@ -1,3 +1,6 @@
+---
+description: Ingest Alpaca stock trade data into Estuary using both historical and real-time updates. Configure stock symbols, feed settings, and backfills.
+---
 
 # Alpaca
 

--- a/docs/reference/Connectors/capture-connectors/amazon-ads.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-ads.md
@@ -1,3 +1,6 @@
+---
+description: Centralize Amazon Ads reporting in Estuary with profiles, sponsored campaigns, ad groups, keywords, and report streams, using OAuth2.
+---
 
 # Amazon Ads
 
@@ -19,7 +22,7 @@ The following data resources are supported:
 * [Sponsored display ad groups](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Ad%20groups)
 * [Sponsored display ad campaigns](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Campaigns)
 * [Sponsored display product ads](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Product%20ads)
-* [ Sponsored display report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Reports)
+* [Sponsored display report stream](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Reports)
 * [Sponsored display targetings](https://advertising.amazon.com/API/docs/en-us/sponsored-display/3-0/openapi#/Targeting)
 * [Sponsored product ad groups](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Ad%20groups)
 * [Sponsored product ads](https://advertising.amazon.com/API/docs/en-us/sponsored-products/2-0/openapi#/Product%20ads)

--- a/docs/reference/Connectors/capture-connectors/amazon-dynamodb.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-dynamodb.md
@@ -1,3 +1,7 @@
+---
+description: Stream DynamoDB table updates into Estuary using DynamoDB Streams. Supports automatic table discovery and backfills, with guides for permissions and settings.
+---
+
 # Amazon DynamoDB
 
 This connector uses DynamoDB streams to continuously capture updates from DynamoDB tables into one or more Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/amazon-kinesis.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-kinesis.md
@@ -1,3 +1,6 @@
+---
+description: Capture JSON records from Amazon Kinesis streams with Estuary's connector, using an IAM user with Kinesis permissions.
+---
 
 # Amazon Kinesis
 

--- a/docs/reference/Connectors/capture-connectors/amazon-s3.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-s3.md
@@ -1,4 +1,6 @@
-
+---
+description: Capture files from Amazon S3 buckets or specific bucket prefixes into Estuary. Configure IAM access, bucket policies, and parser settings related to file format and compression.
+---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docs/reference/Connectors/capture-connectors/amazon-sqs.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-sqs.md
@@ -1,4 +1,6 @@
-
+---
+description: Capture Amazon SQS messages into Estuary, using AWS IAM secret and access keys, with deletion configuration.
+---
 
 # Amazon SQS
 

--- a/docs/reference/Connectors/capture-connectors/amplitude.md
+++ b/docs/reference/Connectors/capture-connectors/amplitude.md
@@ -1,3 +1,6 @@
+---
+description: Use the Amplitude connector to capture analytics data in Estuary, including active users, annotations, cohorts, and events, using API key authentication.
+---
 
 # Amplitude
 

--- a/docs/reference/Connectors/capture-connectors/apache-kafka.md
+++ b/docs/reference/Connectors/capture-connectors/apache-kafka.md
@@ -1,3 +1,7 @@
+---
+description: Capture Kafka topic data formatted as Avro, Protobuf, or JSON messages in Estuary. Supports schema registry configuration, multiple SASL mechanisms, and AWS MSK IAM authentication.
+---
+
 # Apache Kafka
 
 This connector captures streaming data from Apache Kafka topics.

--- a/docs/reference/Connectors/capture-connectors/apple-app-store.md
+++ b/docs/reference/Connectors/capture-connectors/apple-app-store.md
@@ -1,3 +1,6 @@
+---
+description: Pull Apple App Store data into Estuary, including customer reviews and analytics reports for installs, sessions, and crashes.
+---
 
 # Apple App Store
 

--- a/docs/reference/Connectors/capture-connectors/appsflyer.md
+++ b/docs/reference/Connectors/capture-connectors/appsflyer.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's AppsFlyer connector for real-time mobile marketing data, including installs, in-app events, and postbacks, using a combination of webhook and API streams.
+---
+
 # AppsFlyer
 
 This connector captures data from [AppsFlyer](https://www.appsflyer.com/) into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/asana.md
+++ b/docs/reference/Connectors/capture-connectors/asana.md
@@ -1,3 +1,6 @@
+---
+description: Pull Asana workspace and project data into Estuary, including tasks, portfolios, teams, and users. Authenticate using OAuth or a personal access token.
+---
 
 # Asana
 

--- a/docs/reference/Connectors/capture-connectors/ashby.md
+++ b/docs/reference/Connectors/capture-connectors/ashby.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's Ashby connector with an Ashby API key to sync recruiting data like candidates, applications, interviews, jobs, offers, openings, and users.
+---
+
 # Ashby
 
 This connector captures data from Ashby into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/azure-blob-storage.md
+++ b/docs/reference/Connectors/capture-connectors/azure-blob-storage.md
@@ -1,3 +1,7 @@
+---
+description: Capture Azure Blob Storage files with Estuary's connector, with configuration options for regex filters, parser settings, and file formats.
+---
+
 # Azure Blob Storage
 
 This connector captures data from an Azure Blob Storage Account.

--- a/docs/reference/Connectors/capture-connectors/bigquery-batch.md
+++ b/docs/reference/Connectors/capture-connectors/bigquery-batch.md
@@ -1,3 +1,7 @@
+---
+description: Run BigQuery batch captures with Estuary's connector. Configure periodic SQL queries, service accounts, cursor columns, and poll intervals.
+---
+
 # BigQuery Batch Query Connector
 
 This connector captures data from BigQuery into Estuary collections by periodically

--- a/docs/reference/Connectors/capture-connectors/bing-ads.md
+++ b/docs/reference/Connectors/capture-connectors/bing-ads.md
@@ -1,3 +1,6 @@
+---
+description: Centralize Bing Ads reporting in Estuary with accounts, campaigns, ad groups, ads, and performance reports. Configure OAuth2, start date, and lookback windows.
+---
 
 # Bing Ads
 

--- a/docs/reference/Connectors/capture-connectors/braintree.md
+++ b/docs/reference/Connectors/capture-connectors/braintree.md
@@ -1,3 +1,7 @@
+---
+description: Track Braintree payment data in Estuary, including customers, transactions, disputes, subscriptions, and merchant accounts.
+---
+
 # Braintree
 
 This connector captures data from Braintree into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/braze.md
+++ b/docs/reference/Connectors/capture-connectors/braze.md
@@ -1,3 +1,6 @@
+---
+description: Capture Braze engagement data with the connector, including campaigns, canvases, events, cards, segments, and analytics, using a Braze API key and endpoint URL.
+---
 
 # Braze
 

--- a/docs/reference/Connectors/capture-connectors/brevo.md
+++ b/docs/reference/Connectors/capture-connectors/brevo.md
@@ -1,3 +1,6 @@
+---
+description: Capture Brevo contacts data with Estuary's connector, including attributes and lists, using API key authentication and a configurable start date.
+---
 
 # Brevo
 

--- a/docs/reference/Connectors/capture-connectors/calendly.md
+++ b/docs/reference/Connectors/capture-connectors/calendly.md
@@ -1,3 +1,7 @@
+---
+description: Capture Calendly scheduling data in Estuary, including event invitees, event types, scheduled events, and groups, using an access token.
+---
+
 # Calendly
 
 This connector captures data from Calendly into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/chargebee-native.md
+++ b/docs/reference/Connectors/capture-connectors/chargebee-native.md
@@ -1,3 +1,7 @@
+---
+description: Track Chargebee subscription and billing data in Estuary, including customers, invoices, transactions, and orders, using a Chargebee API key.
+---
+
 # Chargebee Native
 
 This connector captures data from Chargebee into Estuary collections in real-time. It is a native implementation that provides enhanced performance and reliability compared to the third-party connector.

--- a/docs/reference/Connectors/capture-connectors/confluence.md
+++ b/docs/reference/Connectors/capture-connectors/confluence.md
@@ -1,3 +1,6 @@
+---
+description: Use the Confluence connector to capture pages, spaces, blog posts, groups, and audits with an Atlassian API token, email, and domain.
+---
 
 # Confluence
 

--- a/docs/reference/Connectors/capture-connectors/criteo.md
+++ b/docs/reference/Connectors/capture-connectors/criteo.md
@@ -1,3 +1,6 @@
+---
+description: Build Criteo ad data flows in Estuary with advertisers, ad sets, audiences, campaigns, and customized reports.
+---
 
 # Criteo
 

--- a/docs/reference/Connectors/capture-connectors/datadog-ingest.md
+++ b/docs/reference/Connectors/capture-connectors/datadog-ingest.md
@@ -1,3 +1,6 @@
+---
+description: Turn Datadog webhook deliveries into Estuary collections with the HTTP Ingest connector. Configure custom paths and authentication.
+---
 
 # Datadog HTTP Ingest (Webhook)
 

--- a/docs/reference/Connectors/capture-connectors/datadog.md
+++ b/docs/reference/Connectors/capture-connectors/datadog.md
@@ -1,3 +1,7 @@
+---
+description: Use the Datadog connector to capture RUM and logs data in Estuary, using a Datadog access token and application key.
+---
+
 # Datadog
 
 This connector captures data from [Datadog](https://docs.datadoghq.com/api/latest) into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/db2-batch.md
+++ b/docs/reference/Connectors/capture-connectors/db2-batch.md
@@ -1,3 +1,7 @@
+---
+description: Run IBM Db2 batch captures with Estuary's connector using periodic queries. Configure polling schedules, SSH tunneling, and query templates.
+---
+
 # IBM Db2 Batch Query Connector
 
 This connector captures data from IBM Db2 databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/dropbox.md
+++ b/docs/reference/Connectors/capture-connectors/dropbox.md
@@ -1,3 +1,7 @@
+---
+description: Read Dropbox folder files with Estuary's connector using OAuth2 with configuration options for regex filters and parser settings related to file and compression formats.
+---
+
 # Dropbox
 
 This connector captures data from a Dropbox account into an Estuary collection.

--- a/docs/reference/Connectors/capture-connectors/dynamics-365-finance-and-operations.md
+++ b/docs/reference/Connectors/capture-connectors/dynamics-365-finance-and-operations.md
@@ -1,3 +1,7 @@
+---
+description: Use the Dynamics 365 Finance and Operations connector to capture CSV exports from Synapse Link into Estuary.
+---
+
 # Microsoft Dynamics 365 Finance and Operations
 
 This connector captures data from [Microsoft Dynamics 365 Finance and Operations](https://www.microsoft.com/en-us/dynamics-365) into Estuary collections. It does so by capturing data exported to Azure Data Lake Storage via [Azure Synapse Link for Dataverse](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/azure-synapse-link-select-fno-data).

--- a/docs/reference/Connectors/capture-connectors/exchange-rates.md
+++ b/docs/reference/Connectors/capture-connectors/exchange-rates.md
@@ -1,3 +1,6 @@
+---
+description: Capture daily currency rates with the Exchange Rates API connector. Configure a base currency, weekend handling, and start date.
+---
 
 # Exchange Rates API
 

--- a/docs/reference/Connectors/capture-connectors/facebook-marketing-native.md
+++ b/docs/reference/Connectors/capture-connectors/facebook-marketing-native.md
@@ -1,3 +1,6 @@
+---
+description: Analyze Meta ad performance with Estuary's Facebook Ads connector for campaigns, ad sets, creatives, and insights. Configure OAuth2 or access token authentication.
+---
 
 # Facebook Ads (Meta)
 

--- a/docs/reference/Connectors/capture-connectors/freshdesk.md
+++ b/docs/reference/Connectors/capture-connectors/freshdesk.md
@@ -1,3 +1,6 @@
+---
+description: Use the Freshdesk connector to capture support data, like tickets, contacts, agents, companies, SLA policies, and solution articles.
+---
 
 # Freshdesk
 

--- a/docs/reference/Connectors/capture-connectors/front.md
+++ b/docs/reference/Connectors/capture-connectors/front.md
@@ -1,3 +1,7 @@
+---
+description: Sync Front customer communication data with Estuary, including channels, contacts, conversations, events, inboxes, tags, and teams.
+---
+
 # Front
 
 This connector captures data from Front into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/gainsight-nxt.md
+++ b/docs/reference/Connectors/capture-connectors/gainsight-nxt.md
@@ -1,3 +1,7 @@
+---
+description: Capture Gainsight NXT customer success data in real time with Estuary, including companies, users, CTAs, and activity timelines.
+---
+
 # Gainsight NXT
 
 This connector captures data from [Gainsight NXT](https://www.gainsight.com/), a customer success platform. It uses Gainsight's REST API to capture data in real-time.
@@ -15,7 +19,7 @@ The exceptions are `activity_timelines` and `companies` streams, which use their
 | [`call_to_actions`](<https://support.gainsight.com/gainsight_nxt/04Cockpit_and_Playbooks/00Cockpit_Horizon_Experience/Cockpit_API_Documentation/Call_To_Action_(CTA)_API_Documentation#Fetch_CTA_API>) | incremental  | ModifiedDate     | `/v1/data/objects/query/call_to_action` |
 | [`companies`](https://support.gainsight.com/gainsight_nxt/API_and_Developer_Docs/Company_and_Relationship_API/Company_API_Documentation#Read_API)                                                      | incremental  | ModifiedDate     |                                         |
 | [`cs_tasks`](https://support.gainsight.com/gainsight_nxt/API_and_Developer_Docs/Cockpit_API/Task_APIs#Fetch_Task_List_API)                                                                             | incremental  | ModifiedDate     | `/v1/data/objects/query/cs_task`        |
-| `success_plans`                                                                                                                                                                                        | incremental  | ModifiedDate     | `/v1/data/objects/query/cta_grooup`     |
+| `success_plans`                                                                                                                                                                                        | incremental  | ModifiedDate     | `/v1/data/objects/query/cta_group`     |
 | [`users`](https://support.gainsight.com/gainsight_nxt/API_and_Developer_Docs/User_Management_APIs/User_Management_APIs#Fetch_User_Details)                                                             | incremental  | ModifiedDate     | `/v1/data/objects/query/gsuser`         |
 
 ## Prerequisites

--- a/docs/reference/Connectors/capture-connectors/gcs.md
+++ b/docs/reference/Connectors/capture-connectors/gcs.md
@@ -1,3 +1,6 @@
+---
+description: Read files from Google Cloud Storage into Estuary. Configure bucket prefixes, service account access, regex filters, and parser settings.
+---
 
 # Google Cloud Storage
 

--- a/docs/reference/Connectors/capture-connectors/genesys.md
+++ b/docs/reference/Connectors/capture-connectors/genesys.md
@@ -1,3 +1,7 @@
+---
+description: Capture Genesys data with Estuary's connector, including campaigns, conversations, queues, teams, and users, using an OAuth app.
+---
+
 # Genesys
 
 This connector captures data from Genesys into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/github.md
+++ b/docs/reference/Connectors/capture-connectors/github.md
@@ -1,3 +1,6 @@
+---
+description: Sync GitHub repository and organization data with Estuary, including issues, pull requests, commits, releases, workflows, and teams, using OAuth2 or token setup.
+---
 
 # GitHub
 

--- a/docs/reference/Connectors/capture-connectors/gitlab.md
+++ b/docs/reference/Connectors/capture-connectors/gitlab.md
@@ -1,3 +1,6 @@
+---
+description: Configure GitLab data capture from groups and projects to ingest issues, pipelines, commits, jobs, and releases, using OAuth2 or access token authentication.
+---
 
 # GitLab
 

--- a/docs/reference/Connectors/capture-connectors/gladly.md
+++ b/docs/reference/Connectors/capture-connectors/gladly.md
@@ -1,3 +1,7 @@
+---
+description: Sync Gladly agent data with Estuary's connector, including agent availability, agent status, contacts, conversations, customers, and tasks, using API token authentication.
+---
+
 # Gladly
 
 This connector captures data from Gladly into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/gong.md
+++ b/docs/reference/Connectors/capture-connectors/gong.md
@@ -1,3 +1,7 @@
+---
+description: Capture Gong revenue intelligence data with Estuary's connector, including calls, users, and scorecards, using API key authentication. Configure start date and call lookback windows.
+---
+
 # Gong
 
 This connector captures data from Gong into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/google-ads.md
+++ b/docs/reference/Connectors/capture-connectors/google-ads.md
@@ -1,3 +1,6 @@
+---
+description: Connect Google Ads accounts to Estuary for campaign, ad group, keyword, click, and customer data, with support for GAQL queries and OAuth2 authentication.
+---
 
 # Google Ads
 

--- a/docs/reference/Connectors/capture-connectors/google-analytics-4-bigquery-exports.md
+++ b/docs/reference/Connectors/capture-connectors/google-analytics-4-bigquery-exports.md
@@ -1,3 +1,7 @@
+---
+description: Use the GA4 BigQuery Exports connector to capture daily events, users, and pseudonymous users tables with service account authentication.
+---
+
 # Google Analytics 4 Bigquery Exports
 
 This connector captures data from Google Analytics 4 BigQuery exports into

--- a/docs/reference/Connectors/capture-connectors/google-analytics-4.md
+++ b/docs/reference/Connectors/capture-connectors/google-analytics-4.md
@@ -1,3 +1,6 @@
+---
+description: Report GA4 property data in Estuary, including active users, devices, locations, pages, traffic sources, and custom reports, using OAuth or a service account key.
+---
 
 # Google Analytics 4
 

--- a/docs/reference/Connectors/capture-connectors/google-analytics-data-api-native.md
+++ b/docs/reference/Connectors/capture-connectors/google-analytics-data-api-native.md
@@ -1,3 +1,6 @@
+---
+description: Build Google Analytics Data API captures in Estuary with streams for website activity, traffic, and custom reports. Connect via OAuth.
+---
 
 # Google Analytics Data API
 

--- a/docs/reference/Connectors/capture-connectors/google-drive.md
+++ b/docs/reference/Connectors/capture-connectors/google-drive.md
@@ -1,3 +1,7 @@
+---
+description: Read files from Google Drive folders with Estuary's connector, using OAuth2 or service account credentials, with settings for regex filters and parser configuration.
+---
+
 # Google Drive
 
 This connector lets you capture data from your Google Drive account into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/google-firestore.md
+++ b/docs/reference/Connectors/capture-connectors/google-firestore.md
@@ -1,3 +1,6 @@
+---
+description: Stream Firestore documents into Estuary collections with a service account. Configure collection path mapping, discovery options, and backfills.
+---
 
 # Google Firestore
 

--- a/docs/reference/Connectors/capture-connectors/google-play.md
+++ b/docs/reference/Connectors/capture-connectors/google-play.md
@@ -1,3 +1,6 @@
+---
+description: Use Estuary's Google Play connector to capture from monthly reports for crashes, installs, and reviews with Google service account credentials.
+---
 
 # Google Play
 

--- a/docs/reference/Connectors/capture-connectors/google-pubsub.md
+++ b/docs/reference/Connectors/capture-connectors/google-pubsub.md
@@ -1,3 +1,6 @@
+---
+description: Use the Google Cloud Pub/Sub connector to capture messages into Estuary in JSON format, with automatic topic discovery.
+---
 
 # Google Cloud Pub/Sub
 

--- a/docs/reference/Connectors/capture-connectors/google-search-console.md
+++ b/docs/reference/Connectors/capture-connectors/google-search-console.md
@@ -1,3 +1,6 @@
+---
+description: Bring Google Search Console data into Estuary, including search analytics by country, date, device, page, and query, along with sites and sitemaps.
+---
 
 # Google Search Console
 

--- a/docs/reference/Connectors/capture-connectors/google-sheets.md
+++ b/docs/reference/Connectors/capture-connectors/google-sheets.md
@@ -1,3 +1,6 @@
+---
+description: Set up Estuary's Google Sheets connector to capture spreadsheet data using OAuth2 authentication and polling.
+---
 
 # Google Sheets
 

--- a/docs/reference/Connectors/capture-connectors/greenhouse-native.md
+++ b/docs/reference/Connectors/capture-connectors/greenhouse-native.md
@@ -1,3 +1,7 @@
+---
+description: Move Greenhouse recruiting data from the Harvest API into Estuary, including candidates, applications, jobs, offers, interviews, and users.
+---
+
 # Greenhouse
 
 This connector captures data from [Greenhouse](https://www.greenhouse.com/) into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/harvest.md
+++ b/docs/reference/Connectors/capture-connectors/harvest.md
@@ -1,3 +1,6 @@
+---
+description: Connect Harvest to Estuary for time entries, projects, clients, invoices, expenses, tasks, and reports, using an API key for authentication.
+---
 
 # Harvest
 

--- a/docs/reference/Connectors/capture-connectors/http-file.md
+++ b/docs/reference/Connectors/capture-connectors/http-file.md
@@ -1,3 +1,7 @@
+---
+description: Capture data from an HTTP endpoint with the HTTP File connector, including data in Avro, CSV, JSON, Protobuf, or W3C logs format, with the option to configure compression and parser settings.
+---
+
 # HTTP File
 
 This connector captures data from an HTTP endpoint into an Estuary collection.

--- a/docs/reference/Connectors/capture-connectors/http-ingest.md
+++ b/docs/reference/Connectors/capture-connectors/http-ingest.md
@@ -1,3 +1,6 @@
+---
+description: Receive webhook data with the HTTP Ingest connector as JSON payloads. Configure custom paths, CORS, signature verification, and authentication requirements.
+---
 
 # HTTP Ingest (Webhook)
 

--- a/docs/reference/Connectors/capture-connectors/incident-io.md
+++ b/docs/reference/Connectors/capture-connectors/incident-io.md
@@ -1,3 +1,7 @@
+---
+description: Track incident.io operational data in Estuary, including incidents, severities, roles, timestamps, users, and custom fields, using an API key.
+---
+
 # Incident.io
 
 This connector captures data from Incident.io into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/instagram.md
+++ b/docs/reference/Connectors/capture-connectors/instagram.md
@@ -1,3 +1,6 @@
+---
+description: Capture Instagram business data in Estuary from the Graph and Insights APIs, including users, media, stories, and insights. Connect via OAuth.
+---
 
 # Instagram
 

--- a/docs/reference/Connectors/capture-connectors/intercom-ingest.md
+++ b/docs/reference/Connectors/capture-connectors/intercom-ingest.md
@@ -1,3 +1,6 @@
+---
+description: Capture Intercom webhook events with the HTTP Ingest connector. Configure webhook paths, capture query parameters, and set authentication details.
+---
 
 # Intercom HTTP Ingest (Webhook)
 

--- a/docs/reference/Connectors/capture-connectors/intercom-native.md
+++ b/docs/reference/Connectors/capture-connectors/intercom-native.md
@@ -1,3 +1,6 @@
+---
+description: Keep Intercom support and customer data flowing through Estuary, including contacts, companies, conversations, tickets, teams, and tags, using OAuth2 or access token authentication.
+---
 
 # Intercom
 

--- a/docs/reference/Connectors/capture-connectors/iterable-native.md
+++ b/docs/reference/Connectors/capture-connectors/iterable-native.md
@@ -1,3 +1,7 @@
+---
+description: Use the Iterable connector to sync campaigns, events, users, lists, templates, and channels, using API key authentication with backfill schedule configuration.
+---
+
 # Iterable
 
 This connector captures data from Iterable into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/iterate.md
+++ b/docs/reference/Connectors/capture-connectors/iterate.md
@@ -1,3 +1,6 @@
+---
+description: Turn Iterate survey and response data into Estuary collections with the connector, using an API access token. Supports configurable interval schedules.
+---
 
 # Iterate
 

--- a/docs/reference/Connectors/capture-connectors/jira-ingest.md
+++ b/docs/reference/Connectors/capture-connectors/jira-ingest.md
@@ -1,3 +1,6 @@
+---
+description: Capture Jira webhook deliveries with the HTTP Ingest connector. Configure webhook paths, capture query parameters, and set authentication details.
+---
 
 # Jira HTTP Ingest (Webhook)
 

--- a/docs/reference/Connectors/capture-connectors/jira-native.md
+++ b/docs/reference/Connectors/capture-connectors/jira-native.md
@@ -1,3 +1,6 @@
+---
+description: Capture Jira data into Estuary collections, including issues, projects, sprints, users, and workflows.
+---
 
 # Jira
 

--- a/docs/reference/Connectors/capture-connectors/klaviyo-native.md
+++ b/docs/reference/Connectors/capture-connectors/klaviyo-native.md
@@ -1,3 +1,7 @@
+---
+description: Sync Klaviyo marketing data with Estuary, including campaigns, flows, events, lists, profiles, and segments, with API key setup and backfill window settings.
+---
+
 # Klaviyo
 
 This connector captures data from Klaviyo into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/linkedin-ads.md
+++ b/docs/reference/Connectors/capture-connectors/linkedin-ads.md
@@ -1,3 +1,6 @@
+---
+description: Manage LinkedIn Ads data flows in Estuary for accounts, campaigns, creatives, video ads, and ad analytics. Configure account ids and use OAuth2 or an access token for authentication.
+---
 
 # LinkedIn Ads
 

--- a/docs/reference/Connectors/capture-connectors/linkedin-pages.md
+++ b/docs/reference/Connectors/capture-connectors/linkedin-pages.md
@@ -1,4 +1,6 @@
-
+---
+description: Measure LinkedIn Page performance in Estuary with follower stats, share stats, organization lookup, and follower counts using OAuth or an access token.
+---
 
 # LinkedIn Pages
 

--- a/docs/reference/Connectors/capture-connectors/looker.md
+++ b/docs/reference/Connectors/capture-connectors/looker.md
@@ -1,3 +1,7 @@
+---
+description: Bring Looker analytics metadata into Estuary, including dashboards, folders, LookML models, explores, roles, and users.
+---
+
 # Looker
 
 This connector captures data from [Looker](https://cloud.google.com/looker/docs/reference/looker-api/latest) into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/mailchimp.md
+++ b/docs/reference/Connectors/capture-connectors/mailchimp.md
@@ -1,3 +1,6 @@
+---
+description: Sync Mailchimp data with Estuary's connector, including lists, campaigns, and email activity, using a Mailchimp API key.
+---
 
 # Mailchimp
 

--- a/docs/reference/Connectors/capture-connectors/marketo.md
+++ b/docs/reference/Connectors/capture-connectors/marketo.md
@@ -1,3 +1,6 @@
+---
+description: Capture Marketo marketing data with Estuary's connector, including activities, campaigns, leads, lists, and programs, using Marketo developer application credentials.
+---
 
 # Marketo
 

--- a/docs/reference/Connectors/capture-connectors/mixpanel.md
+++ b/docs/reference/Connectors/capture-connectors/mixpanel.md
@@ -1,3 +1,6 @@
+---
+description: Use the Mixpanel connector to capture product analytics data in Estuary, including cohorts, funnels, and annotations.
+---
 
 # MixPanel
 

--- a/docs/reference/Connectors/capture-connectors/monday.md
+++ b/docs/reference/Connectors/capture-connectors/monday.md
@@ -1,3 +1,7 @@
+---
+description: Sync Monday.com work data with Estuary's connector, including boards, items, users, teams, and tags, using API token authentication.
+---
+
 # Monday
 
 This connector captures data from Monday.com into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/navan.md
+++ b/docs/reference/Connectors/capture-connectors/navan.md
@@ -1,3 +1,7 @@
+---
+description: Capture Navan booking data through Estuary's connector using a Navan OAuth application. Supports configurable sync interval settings.
+---
+
 # Navan
 
 This connector captures data from Navan into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/netsuite-suiteanalytics.md
+++ b/docs/reference/Connectors/capture-connectors/netsuite-suiteanalytics.md
@@ -1,3 +1,7 @@
+---
+description: Use the NetSuite SuiteAnalytics connector to load tables, such as Transactions, Reports, and Lists. Setup guide walks through NetSuite connection, special columns, and sync modes.
+---
+
 import ReactPlayer from "react-player";
 
 # NetSuite SuiteAnalytics Connect

--- a/docs/reference/Connectors/capture-connectors/netsuite-suiteql.md
+++ b/docs/reference/Connectors/capture-connectors/netsuite-suiteql.md
@@ -1,3 +1,6 @@
+---
+description: Query NetSuite data with the SuiteQL connector, including accounts, customers, items, and transactions. Setup guide includes NetSuite connection instructions and API limitations.
+---
 
 # Netsuite SuiteQL (Beta)
 

--- a/docs/reference/Connectors/capture-connectors/notion.md
+++ b/docs/reference/Connectors/capture-connectors/notion.md
@@ -1,3 +1,6 @@
+---
+description: Connect Notion to Estuary via OAuth2.0 or access token for blocks, comments, databases, pages, and users data.
+---
 
 # Notion
 

--- a/docs/reference/Connectors/capture-connectors/onedrive.md
+++ b/docs/reference/Connectors/capture-connectors/onedrive.md
@@ -1,3 +1,6 @@
+---
+description: Bring files from a OneDrive folder into Estuary with the connector. Configure path filters and parser settings related to compression and file format.
+---
 
 # OneDrive
 

--- a/docs/reference/Connectors/capture-connectors/outreach.md
+++ b/docs/reference/Connectors/capture-connectors/outreach.md
@@ -1,3 +1,6 @@
+---
+description: Build Outreach sales engagement data flows with Estuary for accounts, calls, mailings, opportunities, prospects, tasks, and users.
+---
 
 # Outreach
 

--- a/docs/reference/Connectors/capture-connectors/paypal-transaction.md
+++ b/docs/reference/Connectors/capture-connectors/paypal-transaction.md
@@ -1,3 +1,6 @@
+---
+description: Use the PayPal Transaction connector to capture balances and transaction history with PayPal developer application credentials. Supports sandbox mode and configurable start date.
+---
 
 # Paypal Transaction
 

--- a/docs/reference/Connectors/capture-connectors/pendo.md
+++ b/docs/reference/Connectors/capture-connectors/pendo.md
@@ -1,3 +1,7 @@
+---
+description: Use the Pendo connector to capture accounts, features, guides, pages, reports, visitors, and events, using API key authentication.
+---
+
 # Pendo
 
 This connector captures data from Pendo into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/pinterest.md
+++ b/docs/reference/Connectors/capture-connectors/pinterest.md
@@ -1,3 +1,6 @@
+---
+description: Use the Pinterest connector to capture boards, pins, ads, campaigns, and analytics, using OAuth2.0 or access token authentication.
+---
 
 # Pinterest
 This connector captures data from Pinterest into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/posthog.md
+++ b/docs/reference/Connectors/capture-connectors/posthog.md
@@ -1,3 +1,7 @@
+---
+description: Use the PostHog connector to capture organizations, projects, persons, cohorts, annotations, events, and feature flags, using API key authentication.
+---
+
 # PostHog
 
 This connector captures data from PostHog into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/qualtrics.md
+++ b/docs/reference/Connectors/capture-connectors/qualtrics.md
@@ -1,3 +1,7 @@
+---
+description: Capture Qualtrics survey data with Estuary's connector, including questions and responses, with sync interval configuration.
+---
+
 # Qualtrics
 
 This connector captures data from Qualtrics surveys into Estuary collections. It supports real-time data synchronization of surveys, survey questions, and survey responses from your Qualtrics account.

--- a/docs/reference/Connectors/capture-connectors/quickbooks.md
+++ b/docs/reference/Connectors/capture-connectors/quickbooks.md
@@ -1,3 +1,7 @@
+---
+description: Capture QuickBooks accounting data with Estuary, including invoices, customers, bills, payments, and vendors, with a simple OAuth connection.
+---
+
 # QuickBooks
 
 This connector captures data from QuickBooks into Estuary collections.
@@ -39,7 +43,29 @@ By default, each resource is mapped to an Estuary collection through a separate 
 
 ## Prerequisites
 
-To set up the QuickBooks source connector, you'll need a [QuickBooks company ID](https://quickbooks.intuit.com/learn-support/en-global/help-article/customer-company-settings/find-quickbooks-online-company-id/L7lp8O9yU_ROW_en).
+This connector authenticates with your own Intuit app. You'll need:
+
+- An [Intuit developer account](https://developer.intuit.com) and an app with access to the QuickBooks Online Accounting API
+- Your app's **client ID** and **client secret**
+- A **refresh token** obtained by authorizing your app against your QuickBooks company
+- Your [QuickBooks company ID](https://quickbooks.intuit.com/learn-support/en-global/help-article/customer-company-settings/find-quickbooks-online-company-id/L7lp8O9yU_ROW_en) (also called the realm ID)
+
+### Create an Intuit app
+
+1. Sign in (or sign up) at the [Intuit Developer Portal](https://developer.intuit.com) and create a new app, granting it the **QuickBooks Online Accounting API** scope (`com.intuit.quickbooks.accounting`).
+2. Your app starts with **Development** keys, which only work against [sandbox companies](https://developer.intuit.com/app/developer/qbo/docs/develop/sandboxes). To capture data from a real QuickBooks company, complete the questionnaire under your app's **Production Settings** to obtain **Production** keys.
+3. In your app's **Keys & credentials** page (under Production Settings for a real company, or Development Settings for a sandbox), note the **Client ID** and **Client Secret**.
+
+### Obtain a refresh token with the OAuth 2.0 Playground
+
+The easiest way to authorize your app and generate a refresh token is Intuit's [OAuth 2.0 Playground](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0-playground):
+
+1. On your app's **Keys & credentials** page, add the playground's redirect URI (`https://developer.intuit.com/v2/OAuth2Playground/RedirectUrl`) to the app's Redirect URIs. Do this for the environment (Production or Development) whose keys you're using.
+2. Open the OAuth 2.0 Playground, select your app and environment, and check the `com.intuit.quickbooks.accounting` scope.
+3. Click **Get authorization code** and authorize the QuickBooks company you want to capture from. The playground displays the company's **realm ID**.
+4. Click **Get tokens**. The response contains your **refresh token**.
+
+Refresh tokens are valid for up to 100 days. That's all the connector needs: it exchanges the refresh token for access tokens on its own, keeping the tokens in your endpoint configuration up to date. Create the capture reasonably soon after generating the refresh token — Intuit issues a replacement refresh token roughly every 24 hours, and only the latest one remains valid.
 
 ## Configuration
 
@@ -50,16 +76,15 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 
 #### Endpoint
 
-| Property                                   | Title                            | Description                                                                                                                                 | Type   | Required/Default     |
-| ------------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------------------- |
-| **`/realm_id`**                            | Company ID                       | ID for the Company to Request Data From                                                                                                     | string | Required             |
-| **`/credentials/access_token`**            | Access Token                     | The access token received from the OAuth app.                                                                                               | string | Required             |
-| **`/credentials/access_token_expires_at`** | Access Token Expiration Datetime | The access token's expiration date and time in the format 2025-04-24T00:00:00Z.                                                             | string | Required             |
-| **`/credentials/client_id`**               | OAuth Client ID                  | The OAuth app's client ID.                                                                                                                  | string | Required             |
-| **`/credentials/client_secret`**           | OAuth Client Secret              | The OAuth app's client secret.                                                                                                              | string | Required             |
-| **`/credentials/credentials_title`**       | Authentication Method            | Name of the credentials set. Set to `OAuth Credentials`.                                                                                    | string | Required             |
-| **`/credentials/refresh_token`**           | Refresh Token                    | The refresh token received from the OAuth app.                                                                                              | string | Required             |
-| `/start_date`                              | Start Date                       | The date from which you'd like to replicate data, in the format YYYY-MM-DDT00:00:00Z. All data modified after this date will be replicated. | string | Default: 30 days ago |
+| Property                             | Title                   | Description                                                                                                                                 | Type    | Required/Default     |
+| ------------------------------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------- |
+| **`/realm_id`**                      | Company ID              | ID for the Company to Request Data From                                                                                                     | string  | Required             |
+| **`/credentials/credentials_title`** | Authentication Method   | Name of the credentials set. Set to `OAuth Credentials`.                                                                                    | string  | Required             |
+| **`/credentials/client_id`**         | Client ID               | Your Intuit app's client ID.                                                                                                                | string  | Required             |
+| **`/credentials/client_secret`**     | Client Secret           | Your Intuit app's client secret.                                                                                                            | string  | Required             |
+| **`/credentials/refresh_token`**     | Refresh Token           | The refresh token received when authorizing your app.                                                                                       | string  | Required             |
+| `/start_date`                        | Start Date              | The date from which you'd like to replicate data, in the format YYYY-MM-DDT00:00:00Z. All data modified after this date will be replicated. | string  | Default: 30 days ago |
+| `/is_sandbox`                        | Use Sandbox Environment | Enable to capture from a QuickBooks sandbox company instead of production.                                                                  | boolean | Default: false       |
 
 #### Bindings
 
@@ -79,8 +104,6 @@ captures:
         config:
           realm_id: <your realm id>
           credentials:
-            access_token: <secret>
-            access_token_expires_at: "2025-04-24T12:00:00Z"
             credentials_title: "OAuth Credentials"
             client_id: <secret>
             client_secret: <secret>

--- a/docs/reference/Connectors/capture-connectors/recharge.md
+++ b/docs/reference/Connectors/capture-connectors/recharge.md
@@ -1,3 +1,7 @@
+---
+description: Use the Recharge connector to sync subscription commerce data, including customers, charges, orders, products, and discounts, using access token authentication.
+---
+
 # Recharge
 
 This connector captures data from Recharge into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/redshift-batch.md
+++ b/docs/reference/Connectors/capture-connectors/redshift-batch.md
@@ -1,3 +1,7 @@
+---
+description: Use the Amazon Redshift batch query connector to capture tables to Estuary. Configure network access, polling schedules, and query templates.
+---
+
 # Amazon Redshift Batch Query Connector
 
 This connector captures data from Amazon Redshift databases into Estuary collections by

--- a/docs/reference/Connectors/capture-connectors/ringcentral.md
+++ b/docs/reference/Connectors/capture-connectors/ringcentral.md
@@ -1,3 +1,7 @@
+---
+description: Capture RingCentral communications data with Estuary's connector, including extensions, contacts, call logs, and messages.
+---
+
 # RingCentral Source Connector
 
 This connector captures data from RingCentral into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/sage-intacct.md
+++ b/docs/reference/Connectors/capture-connectors/sage-intacct.md
@@ -1,3 +1,7 @@
+---
+description: Capture Sage Intacct finance data with Estuary's connector and a Web Services developer license. Supported data resources include customers, vendors, projects, tax details, and items.
+---
+
 # Sage Intacct
 
 This connector captures data from Sage Intacct into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/sendgrid.md
+++ b/docs/reference/Connectors/capture-connectors/sendgrid.md
@@ -1,3 +1,7 @@
+---
+description: Organize SendGrid email marketing data in Estuary, including campaigns, contacts, lists, segments, templates, suppressions, and bounces.
+---
+
 # SendGrid
 
 This connector captures data from SendGrid into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/sentry.md
+++ b/docs/reference/Connectors/capture-connectors/sentry.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's Sentry connector to sync environments, teams, projects, issues, releases, and custom Explore queries, using a Sentry access token.
+---
+
 # Sentry
 
 This connector captures data from Sentry into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/sftp.md
+++ b/docs/reference/Connectors/capture-connectors/sftp.md
@@ -1,3 +1,7 @@
+---
+description: Capture SFTP server files from a directory with Estuary's connector. Supports subdirectory capture, regex filters, and parser settings related to compression and file formats.
+---
+
 # SFTP
 
 This connector captures data from an SFTP server.

--- a/docs/reference/Connectors/capture-connectors/sharepoint.md
+++ b/docs/reference/Connectors/capture-connectors/sharepoint.md
@@ -1,3 +1,7 @@
+---
+description: Read SharePoint document library files into Estuary, with configuration settings for regex path filters, file types, and compression formats.
+---
+
 # SharePoint
 
 This connector captures data from SharePoint document libraries in team sites and communication sites into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/shopify-native.md
+++ b/docs/reference/Connectors/capture-connectors/shopify-native.md
@@ -1,3 +1,6 @@
+---
+description: Capture Shopify store data through the GraphQL Admin API, including orders, customers, products, and inventory. Configure multi-store setup with client credentials or access token authentication.
+---
 
 # Shopify (GraphQL)
 

--- a/docs/reference/Connectors/capture-connectors/slack.md
+++ b/docs/reference/Connectors/capture-connectors/slack.md
@@ -1,3 +1,7 @@
+---
+description: Capture Slack workspace data with Estuary's connector, including channels, members, messages, threads, users, and files.
+---
+
 # Slack
 
 This connector captures data from Slack into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/snapchat.md
+++ b/docs/reference/Connectors/capture-connectors/snapchat.md
@@ -1,3 +1,7 @@
+---
+description: Use the Snapchat Marketing connector to sync ads, campaigns, creatives, media, organizations, segments, and stats.
+---
+
 # Snapchat Marketing
 
 This connector captures data from Snapchat Marketing into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/snowflake.md
+++ b/docs/reference/Connectors/capture-connectors/snowflake.md
@@ -1,3 +1,7 @@
+---
+description: Capture Snowflake table changes with Estuary's CDC connector. Supports JWT authentication, capturing from shared tables, and polling schedule configuration.
+---
+
 # Snowflake CDC Connector
 
 This connector captures change events from source tables in a Snowflake database.

--- a/docs/reference/Connectors/capture-connectors/stripe-realtime.md
+++ b/docs/reference/Connectors/capture-connectors/stripe-realtime.md
@@ -1,3 +1,7 @@
+---
+description: Stream Stripe events and payment data into Estuary with real-time sync and backfills for data consistency. Configure connected accounts and sync start date.
+---
+
 # Stripe Real-time
 
 This connector captures data from [Stripe's API](https://docs.stripe.com/api) into Estuary collections.
@@ -26,6 +30,10 @@ The connector handles several known limitations of the Stripe API:
 - **Inconsistent event generation**: Stripe's Events API may not surface events for certain resource types, even when corresponding webhooks are delivered. This particularly affects account-related resources.
 - **Connected account child streams**: Resources like Persons, ExternalAccountCards, and ExternalBankAccount must be queried through parent account endpoints (e.g., `/v1/accounts/{id}/persons`), requiring per-account queries when capturing connected accounts.
 - **Events API retention**: Stripe retains events for 30 days. While other resources can backfill beyond this window using their own list endpoints, the Events stream is limited to the most recent 30 days regardless of the configured `start_date`. The connector gracefully handles this by treating Stripe's retention expiry as a completed backfill.
+
+:::warning
+The **API Version** advanced configuration field does not apply to the Events stream. Because Stripe fixes an event's `api_version` at creation time and does not re-render events at a requested version, events are always captured in the version under which they were originally generated. Refer to the [official Stripe API documentation](https://docs.stripe.com/api/events/object#event_object-api_version) for more information.
+:::
 
 ### Streams removed by API version
 

--- a/docs/reference/Connectors/capture-connectors/survey-monkey.md
+++ b/docs/reference/Connectors/capture-connectors/survey-monkey.md
@@ -1,3 +1,7 @@
+---
+description: Use the SurveyMonkey connector to sync surveys, pages, questions, and responses, using OAuth or an access token, with caching to handle API limits.
+---
+
 # Survey Monkey
 
 This connector captures data from SurveyMonkey surveys into Estuary collections via the SurveyMonkey API.

--- a/docs/reference/Connectors/capture-connectors/tiktok.md
+++ b/docs/reference/Connectors/capture-connectors/tiktok.md
@@ -1,3 +1,7 @@
+---
+description: Manage TikTok Marketing data with Estuary's connector, including advertisers, campaigns, ads, and audience reports, using OAuth authentication or sandbox tokens.
+---
+
 # TikTok Marketing
 
 This connector captures data from TikTok marketing campaigns and ads into Estuary collections via the [TikTok API for Business](https://ads.tiktok.com/marketing_api/docs). It supports production as well as [sandbox](https://ads.tiktok.com/marketing_api/docs?id=1738855331457026) accounts.

--- a/docs/reference/Connectors/capture-connectors/twilio-ingest.md
+++ b/docs/reference/Connectors/capture-connectors/twilio-ingest.md
@@ -1,9 +1,11 @@
+---
+description: Capture Twilio SendGrid webhook events into Estuary collections. Configure signature verification and webhook paths.
+---
+
 # Twilio SendGrid HTTP Ingest (Webhook)
 
 The Twilio SendGrid HTTP Ingest connector allows you to capture data from _incoming_ HTTP requests from Twilio SendGrid Event Webhooks.
 A common use case is to capture webhook deliveries, turning them into an Estuary collection.
-
-The connector is available for use in the Estuary web application. For local development or open-source workflows, [`ghcr.io/estuary/source-twilio-ingest:dev`](https://ghcr.io/estuary/source-twilio-ingest:dev) provides the latest version of the connector as a Docker image. You can also follow the link in your browser to see past image versions.
 
 ## Usage
 

--- a/docs/reference/Connectors/capture-connectors/twilio.md
+++ b/docs/reference/Connectors/capture-connectors/twilio.md
@@ -1,3 +1,7 @@
+---
+description: Bring Twilio communications data into Estuary, from calls and messages to conversations, recordings, and usage records. Configure with an account SID and auth token.
+---
+
 # Twilio
 
 This connector captures data from Twilio into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/woocommerce.md
+++ b/docs/reference/Connectors/capture-connectors/woocommerce.md
@@ -1,3 +1,6 @@
+---
+description: Sync WooCommerce store data with Estuary's connector, including orders, customers, products, refunds, coupons, and shipping, using a WooCommerce API key and secret.
+---
 
 # WooCommerce
 This connector captures data from WooCommerce into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/youtube-analytics.md
+++ b/docs/reference/Connectors/capture-connectors/youtube-analytics.md
@@ -1,3 +1,7 @@
+---
+description: Use the YouTube Analytics connector to capture channel and playlist reports, including traffic source and demographic data.
+---
+
 # YouTube Analytics
 
 This connector captures data from YouTube Analytics into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/zendesk-chat.md
+++ b/docs/reference/Connectors/capture-connectors/zendesk-chat.md
@@ -1,3 +1,7 @@
+---
+description: Sync Zendesk Chat data with Estuary, including accounts, agents, chats, shortcuts, triggers, and departments, using an access token for authentication.
+---
+
 # Zendesk Chat
 
 This connector captures data from Zendesk into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/zendesk-support-native.md
+++ b/docs/reference/Connectors/capture-connectors/zendesk-support-native.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's Zendesk Support connector to sync support data like tickets, comments, users, organizations, and SLA policies, using OAuth2 or API token authentication.
+---
+
 # Zendesk Support Real-Time
 
 This connector captures data from Zendesk into Estuary collections.

--- a/docs/reference/Connectors/capture-connectors/zoho-crm.md
+++ b/docs/reference/Connectors/capture-connectors/zoho-crm.md
@@ -1,3 +1,7 @@
+---
+description: Use the Zoho CRM connector to capture modules with Zoho's Bulk and COQL APIs for efficient backfills with incremental updates. Supports formula field handling with refresh schedules.
+---
+
 # Zoho CRM
 
 This connector captures data from Zoho CRM modules into Estuary collections.

--- a/docs/reference/Connectors/dekaf/README.md
+++ b/docs/reference/Connectors/dekaf/README.md
@@ -1,3 +1,6 @@
+---
+description: Explore Dekaf integrations that emit Estuary collections as Kafka topics. Find out whether a Dekaf integration or Apache Kafka connector fits your use case.
+---
 
 import Mermaid from '@theme/Mermaid';
 
@@ -33,6 +36,7 @@ Dekaf is compatible with many Kafka consumers. For instructions on integrating w
 - [ClickHouse](../materialization-connectors/Dekaf/clickhouse.md)
 - [Imply Polaris](../materialization-connectors/Dekaf/imply-polaris.md)
 - [Materialize](../materialization-connectors/Dekaf/materialize.md)
+- [RisingWave](../materialization-connectors/Dekaf/risingwave.md)
 - [SingleStore](../materialization-connectors/Dekaf/singlestore.md)
 - [Startree](../materialization-connectors/Dekaf/startree.md)
 - [Tinybird](../materialization-connectors/Dekaf/tinybird.md)

--- a/docs/reference/Connectors/materialization-connectors/BigQuery.md
+++ b/docs/reference/Connectors/materialization-connectors/BigQuery.md
@@ -1,3 +1,6 @@
+---
+description: Use the BigQuery connector to materialize Estuary collections into dataset tables. Supports IAM auth or service account credentials, delta updates, and sync schedules.
+---
 
 # Google BigQuery
 

--- a/docs/reference/Connectors/materialization-connectors/ClickHouse.md
+++ b/docs/reference/Connectors/materialization-connectors/ClickHouse.md
@@ -1,4 +1,6 @@
-
+---
+description: Materialize data collections directly into ClickHouse using the native protocol. Handles hard and soft deletes, merge and delta updates, and sync schedules.
+---
 
 # ClickHouse
 
@@ -103,6 +105,11 @@ materializations:
           table: my_table
         source: ${PREFIX}/${source_collection}
 ```
+
+## Sync Schedule
+
+This connector supports configuring a schedule for sync frequency. You can read
+about how to configure this [here](/reference/materialization-sync-schedule).
 
 ## ReplacingMergeTree and FINAL
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/bytewax.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collections to Bytewax via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # Bytewax
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/clickhouse.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collections into ClickHouse via Kafka-compatible topics and ClickPipes. Estuary acts as the broker and schema registry.
+---
 
 # ClickHouse
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/dekaf.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/dekaf.md
@@ -1,3 +1,7 @@
+---
+description: Use the Dekaf connector to expose Estuary data collections as Kafka-compatible topics with Estuary acting as the broker and schema registry.
+---
+
 import ReactPlayer from "react-player";
 
 # Dekaf

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/imply-polaris.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collections into Imply Polaris via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # Imply Polaris
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/materialize.md
@@ -1,3 +1,6 @@
+---
+description: Send Estuary data collections to Materialize via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # Materialize
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/risingwave.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/risingwave.md
@@ -1,3 +1,7 @@
+---
+description: Materialize Estuary data collections to RisingWave via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
+
 # RisingWave
 
 This connector materializes Estuary collections as Kafka-compatible messages that a RisingWave Kafka consumer can read. [RisingWave](https://www.risingwave.com/) is a cloud-native SQL streaming database that enables real-time data processing and analytics.

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/singlestore.md
@@ -1,3 +1,6 @@
+---
+description: Send Estuary data collections to SingleStore via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # SingleStore
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/startree.md
@@ -1,3 +1,6 @@
+---
+description: Send Estuary data collections to StarTree via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # StarTree
 

--- a/docs/reference/Connectors/materialization-connectors/Dekaf/tinybird.md
+++ b/docs/reference/Connectors/materialization-connectors/Dekaf/tinybird.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collections to Tinybird via Kafka-compatible topics. Configure auth details and topic names while Estuary acts as the broker and schema registry.
+---
 
 # Tinybird
 

--- a/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
+++ b/docs/reference/Connectors/materialization-connectors/Elasticsearch.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data collections into indices in an Elasticsearch cluster. Configure connector authentication, hard deletes, number of replicas, and delta updates.
+---
+
 # Elasticsearch
 
 This connector materializes Estuary collections into indices in an Elasticsearch cluster.

--- a/docs/reference/Connectors/materialization-connectors/Google-sheets.md
+++ b/docs/reference/Connectors/materialization-connectors/Google-sheets.md
@@ -1,4 +1,6 @@
-
+---
+description: Use Estuary's Google Sheets connector to materialize data collections into spreadsheets. Connect with OAuth or service account credentials.
+---
 
 # Google Sheets
 

--- a/docs/reference/Connectors/materialization-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/materialization-connectors/MySQL/amazon-rds-mysql.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Amazon RDS for MySQL database.
+description: Materialize data collections into an Amazon RDS for MySQL database. Estuary's connector supports SSH tunneling, custom create SQL, hard deletes, and delta updates.
 ---
 
 # Amazon RDS for MySQL

--- a/docs/reference/Connectors/materialization-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/docs/reference/Connectors/materialization-connectors/MySQL/google-cloud-sql-mysql.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Google Cloud SQL for MySQL database.
+description: Materialize data collections into a Google Cloud SQL for MySQL database. Estuary's connector supports SSH tunneling, custom create SQL, hard deletes, and delta updates.
 ---
 
 # Google Cloud SQL for MySQL

--- a/docs/reference/Connectors/materialization-connectors/MySQL/mysql.md
+++ b/docs/reference/Connectors/materialization-connectors/MySQL/mysql.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data collections into MySQL with Estuary's connector. Supports self-hosted or cloud database instances, SSH tunneling, custom create SQL, and delta updates.
+---
+
 # MySQL
 
 This connector materializes Estuary collections into tables in a MySQL database.

--- a/docs/reference/Connectors/materialization-connectors/MySQL/singlestore-mysql.md
+++ b/docs/reference/Connectors/materialization-connectors/MySQL/singlestore-mysql.md
@@ -1,3 +1,6 @@
+---
+description: Materialize data collections directly into SingleStore tables. Estuary's connector supports SSL configuration, custom create SQL, and delta updates.
+---
 
 # SingleStore
 

--- a/docs/reference/Connectors/materialization-connectors/PostgreSQL/PostgreSQL.md
+++ b/docs/reference/Connectors/materialization-connectors/PostgreSQL/PostgreSQL.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data collections into PostgreSQL with Estuary's connector. Supports self-hosted or cloud database instances, IAM auth, SSH tunneling, custom create SQL, and delta updates.
+---
+
 # PostgreSQL
 
 This connector materializes Estuary collections into tables in a PostgreSQL database.

--- a/docs/reference/Connectors/materialization-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/docs/reference/Connectors/materialization-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Amazon RDS for PostgreSQL database.
+description: Materialize data collections into an Amazon RDS for PostgreSQL database. Estuary's connector supports IAM auth, SSH tunneling, custom create SQL, hard deletes, and delta updates.
 ---
 
 # Amazon RDS for PostgreSQL

--- a/docs/reference/Connectors/materialization-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/docs/reference/Connectors/materialization-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Google Cloud SQL for PostgreSQL database.
+description: Materialize data collections into a Google Cloud SQL for PostgreSQL database. Estuary's connector supports IAM auth, SSH tunneling, custom create SQL, hard deletes, and delta updates.
 ---
 
 # Google Cloud SQL for PostgreSQL

--- a/docs/reference/Connectors/materialization-connectors/PostgreSQL/supabase.md
+++ b/docs/reference/Connectors/materialization-connectors/PostgreSQL/supabase.md
@@ -1,3 +1,6 @@
+---
+description: Materialize data collections into Supabase with Estuary's connector. Supports IAM auth, SSH tunneling, custom create SQL, hard deletes, and delta updates.
+---
 
 # Supabase
 

--- a/docs/reference/Connectors/materialization-connectors/README.md
+++ b/docs/reference/Connectors/materialization-connectors/README.md
@@ -1,3 +1,7 @@
+---
+description: Browse Estuary's list of materialization connectors for warehouses, databases, data lakes, and streaming destinations with complete configuration details.
+---
+
 # Materialization Connectors
 
 Estuary's available materialization connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.

--- a/docs/reference/Connectors/materialization-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/docs/reference/Connectors/materialization-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Amazon RDS for SQL Server database.
+description: Materialize data collections into an Amazon RDS for SQL Server database. Estuary's connector supports SSH tunneling, IAM authentication, and delta updates.
 ---
 
 # Amazon RDS for SQL Server

--- a/docs/reference/Connectors/materialization-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/docs/reference/Connectors/materialization-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Google Cloud SQL for SQLServer database.
+description: Materialize data collections into a Google Cloud SQL for SQL Server database. Estuary's connector supports SSH tunneling and delta updates.
 ---
 
 # Google Cloud SQL for SQLServer

--- a/docs/reference/Connectors/materialization-connectors/SQLServer/sqlserver.md
+++ b/docs/reference/Connectors/materialization-connectors/SQLServer/sqlserver.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes Estuary collections into tables in a Microsoft SQLServer database.
+description: Materialize data collections into Microsoft SQL Server with Estuary's connector. Supports self-hosted or cloud database instances, SSH tunneling, and delta updates.
 ---
 
 # Microsoft SQLServer

--- a/docs/reference/Connectors/materialization-connectors/SQLite.md
+++ b/docs/reference/Connectors/materialization-connectors/SQLite.md
@@ -1,3 +1,6 @@
+---
+description: Use Estuary's SQLite connector to test out materializing data collections into an ephemeral demo database with no endpoint configuration required.
+---
 
 # SQLite
 

--- a/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -1,3 +1,6 @@
+---
+description: Use the Snowflake connector to materialize Estuary collections into Snowflake tables. Configure delta updates for Snowpipe Streaming, JWT auth, sync schedules, and timestamp types.
+---
 
 import ReactPlayer from "react-player";
 

--- a/docs/reference/Connectors/materialization-connectors/alloydb.md
+++ b/docs/reference/Connectors/materialization-connectors/alloydb.md
@@ -1,3 +1,6 @@
+---
+description: Materialize data collections into AlloyDB with Estuary's connector. Supports IAM auth, SSH tunneling, custom create SQL, hard deletes, and delta updates.
+---
 
 # AlloyDB
 

--- a/docs/reference/Connectors/materialization-connectors/amazon-dynamodb.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-dynamodb.md
@@ -1,4 +1,6 @@
-
+---
+description: Use Estuary's connector to materialize collections into Amazon DynamoDB tables with AWS access key or IAM authentication, and review collection requirements.
+---
 
 # Amazon DynamoDB
 
@@ -20,12 +22,12 @@ To use this connector, you'll need:
   DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/using-identity-based-policies.html)
   in the Amazon docs.
 
-- AWS Credentials.  One of the following types:
+- AWS Credentials. One of the following types:
   - The AWS **access key** and **secret access key** for the user. See the [AWS
     blog](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/)
     for help finding these credentials.
   - To authenticate using an AWS Role, you'll need the **region** and the
-    **role arn**.  Follow the steps in the [AWS IAM
+    **role arn**. Follow the steps in the [AWS IAM
     guide](/guides/iam-auth/aws.md) to setup the role.
 
 ## Collection Requirements

--- a/docs/reference/Connectors/materialization-connectors/amazon-eventbridge.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-eventbridge.md
@@ -1,3 +1,6 @@
+---
+description: Publish Estuary documents as events on an Amazon EventBridge event bus, authenticated with an AWS access key or IAM role. Review payload details and size limits.
+---
 
 # Amazon EventBridge
 

--- a/docs/reference/Connectors/materialization-connectors/amazon-redshift.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-redshift.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data collections into Redshift with Estuary's connector. Configure SSH tunneling, sync schedules, hard deletes, and delta updates.
+---
+
 # Amazon Redshift
 
 This connector materializes Estuary collections into tables in an Amazon Redshift database.

--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-csv.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes delta updates of Estuary collections into files in an S3 bucket per the CSV format described in RFC-4180.
+description: Write delta updates of Estuary collections into an S3 bucket as compressed CSV files. Configure the upload interval, maximum file size, and file path.
 ---
 
 # CSV Files in Amazon S3

--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-parquet.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-parquet.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes delta updates of Estuary collections into an S3 bucket in the Apache Parquet format.
+description: Write delta updates of Estuary collections into an S3 bucket as Apache Parquet files. Configure the upload interval, maximum file size, and file path.
 ---
 
 # Apache Parquet Files in Amazon S3
@@ -24,8 +24,8 @@ To use this connector, you'll need:
 
   When authenticating as user, you'll need the **access key** and **secret access key**. See the
   [AWS blog](https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/) for help finding
-  these credentials.  When authenticating using a role, you'll need the **region** and the **role
-  arn**.  Follow the steps in the [AWS IAM guide](/guides/iam-auth/aws.md) to setup the role.
+  these credentials. When authenticating using a role, you'll need the **region** and the **role
+  arn**. Follow the steps in the [AWS IAM guide](/guides/iam-auth/aws.md) to setup the role.
 
 
 ## Configuration

--- a/docs/reference/Connectors/materialization-connectors/amazon-sns.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-sns.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collection into Amazon Simple Notification Service (SNS) topics in this delta-updates connector.
+---
 
 # Amazon SNS
 

--- a/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data into Iceberg tables. Setup guide includes AWS Glue and other REST catalogs, EMR Serverless Spark jobs, S3 staging, IAM roles, and table maintenance.
+---
+
 # Apache Iceberg
 
 This connector materializes Estuary collections into Iceberg tables. It

--- a/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data into a Bauplan data lake. This variation of Estuary's Apache Iceberg connector uses the Bauplan REST catalog.
+---
+
 # Bauplan
 
 [Bauplan](https://www.bauplan.io) is a serverless data lake platform built natively on Apache Iceberg. It provides a managed REST catalog so you can run SQL and Python queries directly on your Iceberg tables without managing catalog infrastructure yourself.

--- a/docs/reference/Connectors/materialization-connectors/apache-kafka.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-kafka.md
@@ -1,3 +1,7 @@
+---
+description: Materialize Estuary collections into Kafka topics as Avro or JSON messages. Supports schema registries, different SASL mechanisms, and TLS encryption.
+---
+
 # Apache Kafka
 
 This connector materializes Estuary collections into Apache Kafka topics.

--- a/docs/reference/Connectors/materialization-connectors/azure-blob-parquet.md
+++ b/docs/reference/Connectors/materialization-connectors/azure-blob-parquet.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes delta updates of Estuary collections into an Azure Blob Storage container in the Apache Parquet format.
+description: Write delta updates of Estuary collections into an Azure Blob Storage container as Apache Parquet files. Configure the upload interval, maximum file size, and file path.
 ---
 
 # Apache Parquet Files in Azure Blob Storage

--- a/docs/reference/Connectors/materialization-connectors/azure-fabric-warehouse.md
+++ b/docs/reference/Connectors/materialization-connectors/azure-fabric-warehouse.md
@@ -1,3 +1,6 @@
+---
+description: Materialize data collections into tables in a Microsoft Azure Fabric Warehouse. Configure hard delete, delta update, and sync schedule settings.
+---
 
 import ReactPlayer from "react-player";
 

--- a/docs/reference/Connectors/materialization-connectors/databricks.md
+++ b/docs/reference/Connectors/materialization-connectors/databricks.md
@@ -1,3 +1,6 @@
+---
+description: Materialize collections into a Databricks SQL Warehouse with Estuary's connector. Configure delta updates, sync schedules, hard deletes, and custom creation SQL.
+---
 
 import ReactPlayer from "react-player";
 

--- a/docs/reference/Connectors/materialization-connectors/google-bigtable.md
+++ b/docs/reference/Connectors/materialization-connectors/google-bigtable.md
@@ -1,3 +1,7 @@
+---
+description: Use Estuary's Bigtable connector to materialize collections into tables using a Google Cloud service account. Supports IAM auth and hard deletes.
+---
+
 # Google Cloud Bigtable
 
 This connector materializes Estuary collections into tables in a Google Cloud Bigtable instance.

--- a/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
+++ b/docs/reference/Connectors/materialization-connectors/google-gcs-csv.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes delta updates of Estuary collections into files in a GCS bucket per the CSV format described in RFC-4180
+description: Write delta updates of Estuary collections into a GCS bucket as compressed CSV files. Configure the upload interval, maximum file size, and file path.
 ---
 
 # CSV Files in Google GCS

--- a/docs/reference/Connectors/materialization-connectors/google-gcs-parquet.md
+++ b/docs/reference/Connectors/materialization-connectors/google-gcs-parquet.md
@@ -1,5 +1,5 @@
 ---
-description: This connector materializes delta updates of Estuary collections into a GCS bucket in the Apache Parquet format.
+description: Write delta updates of Estuary collections into a GCS bucket as Apache Parquet files. Configure the upload interval, maximum file size, and file path.
 ---
 
 # Apache Parquet Files in Google GCS

--- a/docs/reference/Connectors/materialization-connectors/google-pubsub.md
+++ b/docs/reference/Connectors/materialization-connectors/google-pubsub.md
@@ -1,3 +1,6 @@
+---
+description: Publish Estuary collections to Google Pub/Sub topics. Configure multiplex topics and authenticate with OAuth or service account credentials in this delta updates connector.
+---
 
 # Google Cloud Pub/Sub
 

--- a/docs/reference/Connectors/materialization-connectors/google-spanner.md
+++ b/docs/reference/Connectors/materialization-connectors/google-spanner.md
@@ -1,3 +1,6 @@
+---
+description: Materialize Estuary data collection into Google Spanner tables, with settings to configure hard deletes, custom creation SQL, and optimizations.
+---
 
 # Google Spanner
 

--- a/docs/reference/Connectors/materialization-connectors/http-webhook.md
+++ b/docs/reference/Connectors/materialization-connectors/http-webhook.md
@@ -1,3 +1,7 @@
+---
+description: Send Estuary collection data to HTTP endpoints with the webhook connector. Configure target URLs, custom headers, and relative paths.
+---
+
 # HTTP Webhook
 
 This connector lets you materialize data from Estuary directly to specified HTTP endpoints via webhooks.

--- a/docs/reference/Connectors/materialization-connectors/mongodb.md
+++ b/docs/reference/Connectors/materialization-connectors/mongodb.md
@@ -1,3 +1,7 @@
+---
+description: Materialize Estuary data collections into MongoDB collections. Supports SSH tunneling, delta updates, and hard deletes.
+---
+
 # MongoDB
 
 This connector materializes data from your Estuary collections to your MongoDB collections.

--- a/docs/reference/Connectors/materialization-connectors/motherduck.md
+++ b/docs/reference/Connectors/materialization-connectors/motherduck.md
@@ -1,3 +1,6 @@
+---
+description: Use Estuary's connector to materialize data into MotherDuck tables with options for S3, GCS, or Azure Blob staging, sync schedules, and delta updates.
+---
 
 import ReactPlayer from "react-player";
 
@@ -18,8 +21,8 @@ To use this connector, you'll need:
 
 * A [MotherDuck](https://motherduck.com/) account and [Service
   Token](https://motherduck.com/docs/authenticating-to-motherduck#fetching-the-service-token).
-* An S3 bucket for staging temporary files, or a GCS bucket for staging
-  temporary files.  Cloudflare R2 can also be used via its S3-compatible API.
+* An S3, GCS, or Azure bucket for staging temporary files.
+  Cloudflare R2 can also be used via its S3-compatible API.
   An S3 bucket in `us-east-1` is recommended for best performance and costs,
   since MotherDuck is currently hosted in that region.
 

--- a/docs/reference/Connectors/materialization-connectors/mysql-heatwave.md
+++ b/docs/reference/Connectors/materialization-connectors/mysql-heatwave.md
@@ -1,3 +1,7 @@
+---
+description: Use the MySQL HeatWave connector to materialize collections into Oracle MySQL HeatWave instances. Configure SSH tunneling, SSL mode, hard deletes, and additional creation SQL.
+---
+
 # MySQL HeatWave
 
 This connector lets you materialize data from your Estuary collections directly into Oracle MySQL HeatWave instances.

--- a/docs/reference/Connectors/materialization-connectors/pinecone.md
+++ b/docs/reference/Connectors/materialization-connectors/pinecone.md
@@ -1,3 +1,7 @@
+---
+description: Use the Pinecone connector to materialize Estuary data collections into index namespaces via OpenAI vector embeddings.
+---
+
 # Pinecone
 
 This connector materializes Estuary collections into namespaces in a Pinecone index.

--- a/docs/reference/Connectors/materialization-connectors/slack.md
+++ b/docs/reference/Connectors/materialization-connectors/slack.md
@@ -1,3 +1,7 @@
+---
+description: Deliver Estuary collection data into Slack channels with this connector, and customize sender settings like display name and icon logo.
+---
+
 # Slack
 
 This connector lets you materialize data from Estuary directly into Slack channels.

--- a/docs/reference/Connectors/materialization-connectors/timescaledb.md
+++ b/docs/reference/Connectors/materialization-connectors/timescaledb.md
@@ -1,3 +1,7 @@
+---
+description: Use the TimescaleDB connector to materialize data collections into tables or hypertables, with settings for delta updates, hard deletes, and additional creation SQL.
+---
+
 # TimescaleDB
 
 This connector materializes Estuary collections into tables in a TimescaleDB database.


### PR DESCRIPTION
## What

First reconciliation pass against flow/site's intervening edits since the original doc-copy PR (#4528, 2026-05-20). A second, final pass will run immediately before the actual DNS cutover.

Two commits:
1. **Mechanical**: same bulk SEO `description:` frontmatter sync as estuary/docs (169 files). No other content touched.
2. **Real content drift** (17 files): MariaDB/MySQL grant-scope + redaction guidance, MongoDB/DocumentDB/CosmosDB `exclusiveCollectionFilter` performance caveat, a full QuickBooks OAuth/Intuit-app rewrite, Stripe API-version-vs-Events-stream warning, RisingWave added to the Dekaf integrations list, ClickHouse Sync Schedule section, and several wording fixes.

## One deliberate exception, worth a second pair of eyes

`materialization-connectors/README.md` and `apache-iceberg/apache-iceberg.md` did **not** get a straight copy from flow/site. flow/site's versions have the Dremio content removed, but `git log` confirms Dremio support (#4776, "materialize-iceberg: support Dremio Cloud catalog") and its doc page (#4776's docs commit, "docs: add Dremio Cloud page for the Iceberg materialization") were added directly and only to this repo — flow/site never had it, so this isn't drift to replay, it's this repo legitimately ahead. I only pulled the `description:` frontmatter addition from those two files and left the Dremio bullet/section untouched. Flagging in case anyone reading this has more context than a `git log` search gives me.

## How I verified this

Diffed flow/site's `site/docs/reference/Connectors/` against this repo's `docs/reference/Connectors/` directly (`git archive` + `diff -rq`). Classified every differing file mechanically first before manually reading the 17 that had real content changes. Confirmed no dangling image references.