### PR TITLE
source-postgres: Use CREATE_REPLICATION_SLOT

### DIFF
--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## 2026-07-16
+## 2026-07-20
 
 ### Fixed
-- Replication slot creation is exempted from `statement_timeout`, so that slot
-  creation blocks indefinitely rather than timing out when there are long-running
-  transactions open (until they commit and slot creation finishes).
+- Replication slot creation and deletion now use replication protocol commands
+  instead of SQL functions. This avoids holding a transaction snapshot while
+  slot creation blocks waiting for a consistent point.
+
+## 2026-07-16
+
+### Changed
+- Replication slot creation is exempted from `statement_timeout`, slot creation
+  blocks indefinitely rather than timing out in the presence of long-running
+  transactions.
 
 ## 2026-07-14
 

--- a/source-postgres/database.go
+++ b/source-postgres/database.go
@@ -8,6 +8,7 @@ import (
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sirupsen/logrus"
 )
@@ -65,31 +66,28 @@ func listPublishedTables(ctx context.Context, conn *pgxpool.Pool, publicationNam
 	return publicationStatus, nil
 }
 
-// recreateReplicationSlot attempts to drop and then recreate a replication slot with the specified name.
-func recreateReplicationSlot(ctx context.Context, pool *pgxpool.Pool, slotName string) error {
+// recreateReplicationSlot attempts to drop and then recreate a replication slot with
+// the specified name.
+//
+// Slot manipulation is done via replication-protocol commands rather than SQL functions
+// because slot creation can block for a long time waiting for a consistent point, and
+// walsender commands hold no transaction snapshot during that wait.
+func recreateReplicationSlot(ctx context.Context, replConn *pgconn.PgConn, slotName string) error {
 	var logEntry = logrus.WithField("slot", slotName)
 	logEntry.Info("attempting to drop replication slot")
-	if _, err := pool.Exec(ctx, fmt.Sprintf(`SELECT pg_drop_replication_slot('%s');`, slotName)); err != nil {
+	if err := pglogrepl.DropReplicationSlot(ctx, replConn, slotName, pglogrepl.DropReplicationSlotOptions{}); err != nil {
 		// Not a fatal error because we don't want a failure to drop a nonexistent slot
 		// to prevent the subsequent attempt to create it.
 		logEntry.WithField("err", err).Debug("failed to drop replication slot")
 	}
 
 	logEntry.Info("attempting to create replication slot")
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("error opening transaction for replication slot creation: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
-	// Disable statement timeout within this transaction so that long-running transactions
-	// on the server can't cause slot creation to timeout.
-	if _, err := tx.Exec(ctx, `SET LOCAL statement_timeout = 0;`); err != nil {
-		return fmt.Errorf("error disabling statement timeout for replication slot creation: %w", err)
-	} else if _, err := tx.Exec(ctx, fmt.Sprintf(`SELECT pg_create_logical_replication_slot('%s', 'pgoutput');`, slotName)); err != nil {
-		return fmt.Errorf("replication slot %q couldn't be created", slotName)
-	} else if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("error committing replication slot creation: %w", err)
+	// NOEXPORT_SNAPSHOT (legacy syntax, accepted by all supported server versions) skips
+	// exporting a snapshot, which we have no use for.
+	if _, err := pglogrepl.CreateReplicationSlot(ctx, replConn, slotName, "pgoutput", pglogrepl.CreateReplicationSlotOptions{
+		SnapshotAction: "NOEXPORT_SNAPSHOT",
+	}); err != nil {
+		return fmt.Errorf("replication slot %q couldn't be created: %w", slotName, err)
 	}
 	logEntry.Info("created replication slot")
 	return nil

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -221,7 +221,7 @@ func (db *postgresDatabase) ReplicationStream(ctx context.Context, startCursorJS
 			// care about any prior state in the replication slot, and if we're able to drop
 			// it then we also have the necessary permissions to recreate it. Any errors here
 			// aren't fatal, just to be on the safe side.
-			if err := recreateReplicationSlot(ctx, db.conn, slot); err != nil {
+			if err := recreateReplicationSlot(ctx, conn, slot); err != nil {
 				logrus.WithField("err", err).Debug("error recreating replication slot")
 			}
 		}


### PR DESCRIPTION
**Description:**

Modifies the source-postgres replication slot (re)create logic so it uses the `CREATE_REPLICATION_SLOT` (and `DROP_REPLICATION_SLOT`) command over the logical replication connection rather than running a `SELECT pg_create_logical_replication_slot()` query over the query connection.

The motivation here is that the `SELECT` form is still a `SELECT` query and takes a database transaction snapshot which may cause undesired tuple retention when the create itself blocks for a long time due to a long-running transaction on the DB.

This also conveniently sidesteps the whole question of statement timeouts for this one query which we previously exempted.

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
