### PR TITLE
source-postgres: restrict table-detail catalog queries to requested schemas

### DIFF
--- a/source-postgres/.snapshots/TestDiscoveryCrossSchemaIsolation
+++ b/source-postgres/.snapshots/TestDiscoveryCrossSchemaIsolation
@@ -1,0 +1,283 @@
+sql> CREATE SCHEMA IF NOT EXISTS otherschema
+sql> GRANT USAGE ON SCHEMA otherschema TO flow_capture
+sql> CREATE TABLE test.discoverycrossschemaisolation_568126 (k1 INTEGER PRIMARY KEY, foo TEXT)
+sql> CREATE TABLE otherschema.tbl568126 (
+		k2 TEXT PRIMARY KEY,
+		bar INTEGER,
+		gen INTEGER GENERATED ALWAYS AS (bar + 1) STORED
+	)
+sql> GRANT SELECT ON ALL TABLES IN SCHEMA otherschema TO flow_capture
+sql> CREATE UNIQUE INDEX decoy_idx568126 ON otherschema.tbl568126 (bar)
+sql> COMMENT ON COLUMN otherschema.tbl568126.bar IS 'should never appear'
+=== Discover: Discover Tables ===
+{
+  "recommendedName": "otherschema/tbl568126",
+  "resourceConfig": {
+    "namespace": "otherschema",
+    "stream": "tbl568126"
+  },
+  "documentSchema": {
+    "$defs": {
+      "OtherschemaTbl568126": {
+        "type": "object",
+        "required": [
+          "k2"
+        ],
+        "$anchor": "OtherschemaTbl568126",
+        "properties": {
+          "bar": {
+            "description": "should never appear (source type: int4)",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "k2": {
+            "type": "string",
+            "description": "(source type: non-nullable text)"
+          }
+        }
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "_meta": {
+              "properties": {
+                "op": {
+                  "const": "d"
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "reduce": {
+            "delete": true,
+            "strategy": "merge"
+          }
+        },
+        "else": {
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "type": "object",
+            "required": [
+              "op",
+              "source"
+            ],
+            "properties": {
+              "before": {
+                "$ref": "#OtherschemaTbl568126",
+                "description": "Record state immediately before this change was applied.",
+                "reduce": {
+                  "strategy": "firstWriteWins"
+                }
+              },
+              "op": {
+                "enum": [
+                  "c",
+                  "d",
+                  "u"
+                ],
+                "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+              },
+              "source": {
+                "properties": {
+                  "ts_ms": {
+                    "type": "integer",
+                    "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema (namespace) of the event."
+                  },
+                  "snapshot": {
+                    "type": "boolean",
+                    "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table of the event."
+                  },
+                  "loc": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                  },
+                  "txid": {
+                    "type": "integer",
+                    "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "schema",
+                  "table",
+                  "loc"
+                ]
+              }
+            },
+            "reduce": {
+              "strategy": "merge"
+            }
+          }
+        }
+      },
+      {
+        "$ref": "#OtherschemaTbl568126"
+      }
+    ],
+    "x-infer-schema": true
+  },
+  "key": [
+    "/k2"
+  ]
+}
+{
+  "recommendedName": "test/discoverycrossschemaisolation_568126",
+  "resourceConfig": {
+    "namespace": "test",
+    "stream": "discoverycrossschemaisolation_568126"
+  },
+  "documentSchema": {
+    "$defs": {
+      "TestDiscoverycrossschemaisolation_568126": {
+        "type": "object",
+        "required": [
+          "k1"
+        ],
+        "$anchor": "TestDiscoverycrossschemaisolation_568126",
+        "properties": {
+          "foo": {
+            "description": "(source type: text)",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "k1": {
+            "type": "integer",
+            "description": "(source type: non-nullable int4)"
+          }
+        }
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "_meta": {
+              "properties": {
+                "op": {
+                  "const": "d"
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "reduce": {
+            "delete": true,
+            "strategy": "merge"
+          }
+        },
+        "else": {
+          "reduce": {
+            "strategy": "merge"
+          }
+        },
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "type": "object",
+            "required": [
+              "op",
+              "source"
+            ],
+            "properties": {
+              "before": {
+                "$ref": "#TestDiscoverycrossschemaisolation_568126",
+                "description": "Record state immediately before this change was applied.",
+                "reduce": {
+                  "strategy": "firstWriteWins"
+                }
+              },
+              "op": {
+                "enum": [
+                  "c",
+                  "d",
+                  "u"
+                ],
+                "description": "Change operation type: 'c' Create/Insert, 'u' Update, 'd' Delete."
+              },
+              "source": {
+                "properties": {
+                  "ts_ms": {
+                    "type": "integer",
+                    "description": "Unix timestamp (in millis) at which this event was recorded by the database."
+                  },
+                  "schema": {
+                    "type": "string",
+                    "description": "Database schema (namespace) of the event."
+                  },
+                  "snapshot": {
+                    "type": "boolean",
+                    "description": "Snapshot is true if the record was produced from an initial table backfill and unset if produced from the replication log."
+                  },
+                  "table": {
+                    "type": "string",
+                    "description": "Database table of the event."
+                  },
+                  "loc": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array",
+                    "maxItems": 3,
+                    "minItems": 3,
+                    "description": "Location of this WAL event as [last Commit.EndLSN; event LSN; current Begin.FinalLSN]. See https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html"
+                  },
+                  "txid": {
+                    "type": "integer",
+                    "description": "The 32-bit transaction ID assigned by Postgres to the commit which produced this change."
+                  }
+                },
+                "type": "object",
+                "required": [
+                  "schema",
+                  "table",
+                  "loc"
+                ]
+              }
+            },
+            "reduce": {
+              "strategy": "merge"
+            }
+          }
+        }
+      },
+      {
+        "$ref": "#TestDiscoverycrossschemaisolation_568126"
+      }
+    ],
+    "x-infer-schema": true
+  },
+  "key": [
+    "/k1"
+  ]
+}
+

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -37,19 +37,26 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 	if err != nil {
 		return nil, fmt.Errorf("unable to list database tables: %w", err)
 	}
-	columns, err := getColumns(ctx, db.conn)
+
+	// Restrict subsequent catalog queries to just the schemas containing requested
+	// tables. On databases with very large catalogs (hundreds of thousands of tables)
+	// the unfiltered queries can return millions of rows, which is both slow and can
+	// exhaust connector memory.
+	var schemas = distinctSchemas(requested)
+
+	columns, err := getColumns(ctx, db.conn, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list database columns: %w", err)
 	}
-	primaryKeys, err := getPrimaryKeys(ctx, db.conn)
+	primaryKeys, err := getPrimaryKeys(ctx, db.conn, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list database primary keys: %w", err)
 	}
-	secondaryIndexes, err := getSecondaryIndexes(ctx, db.conn)
+	secondaryIndexes, err := getSecondaryIndexes(ctx, db.conn, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list database secondary indexes: %w", err)
 	}
-	generatedColumns, err := getGeneratedColumns(ctx, db.conn)
+	generatedColumns, err := getGeneratedColumns(ctx, db.conn, schemas)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if !errors.As(err, &pgErr) || pgErr.Code != "42703" {
@@ -63,7 +70,7 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 
 	// Column descriptions just add a bit of user-friendliness. They're so unimportant
 	// that failure to list them shouldn't even be a fatal error.
-	columnDescriptions, err := getColumnDescriptions(ctx, db.conn)
+	columnDescriptions, err := getColumnDescriptions(ctx, db.conn, schemas)
 	if err != nil {
 		logrus.WithField("err", err).Warn("error fetching column descriptions")
 	}
@@ -452,6 +459,29 @@ func getTables(ctx context.Context, conn *pgxpool.Pool, selectedSchemas []string
 	return tables, rows.Err()
 }
 
+// distinctSchemas returns the distinct schema names of the provided tables.
+func distinctSchemas(tables []sqlcapture.TableID) []string {
+	var seen = make(map[string]bool)
+	var schemas []string
+	for _, t := range tables {
+		if !seen[t.Schema] {
+			seen[t.Schema] = true
+			schemas = append(schemas, t.Schema)
+		}
+	}
+	return schemas
+}
+
+// schemaFilter returns a SQL predicate (and matching query arguments) which
+// restricts the named schema column to the provided list of schemas, or an
+// empty predicate when no schemas are specified.
+func schemaFilter(column string, schemas []string) (string, []any) {
+	if len(schemas) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("AND %s = ANY($1)", column), []any{schemas}
+}
+
 const queryDiscoverColumns = `
   SELECT nc.nspname as table_schema,
          c.relname as table_name,
@@ -471,12 +501,14 @@ const queryDiscoverColumns = `
 	  AND a.attnum > 0
 	  AND NOT a.attisdropped
 	  AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))
+	  %s
 	ORDER BY nc.nspname, c.relname, a.attnum;`
 
-func getColumns(ctx context.Context, conn *pgxpool.Pool) ([]sqlcapture.ColumnInfo, error) {
+func getColumns(ctx context.Context, conn *pgxpool.Pool, schemas []string) ([]sqlcapture.ColumnInfo, error) {
 	logrus.Debug("listing all columns in the database")
+	var filter, args = schemaFilter("nc.nspname", schemas)
 	var columns []sqlcapture.ColumnInfo
-	var rows, err = conn.Query(ctx, queryDiscoverColumns)
+	var rows, err = conn.Query(ctx, fmt.Sprintf(queryDiscoverColumns, filter), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -717,6 +749,7 @@ const queryDiscoverPrimaryKeys = `
       JOIN pg_catalog.pg_index i ON (a.attrelid = i.indrelid)
       JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)
     WHERE i.indisprimary
+	  %s
   ) result
   WHERE result.A_ATTNUM = (result.KEYS).x
   ORDER BY result.table_name, result.pk_name, result.key_seq;
@@ -726,10 +759,11 @@ const queryDiscoverPrimaryKeys = `
 // primary keys. Table names are fully qualified as "<schema>.<name>", and
 // primary keys are represented as a list of column names, in the order that
 // they form the table's primary key.
-func getPrimaryKeys(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID][]string, error) {
+func getPrimaryKeys(ctx context.Context, conn *pgxpool.Pool, schemas []string) (map[sqlcapture.StreamID][]string, error) {
 	logrus.Debug("listing all primary-key columns in the database")
+	var filter, args = schemaFilter("n.nspname", schemas)
 	var keys = make(map[sqlcapture.StreamID][]string)
-	var rows, err = conn.Query(ctx, queryDiscoverPrimaryKeys)
+	var rows, err = conn.Query(ctx, fmt.Sprintf(queryDiscoverPrimaryKeys, filter), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -765,18 +799,20 @@ FROM (
 	   JOIN pg_catalog.pg_attribute a ON (a.attrelid = tc.oid)
   WHERE ix.indisunique AND ix.indexprs IS NULL AND tc.relkind = 'r'
     AND NOT ix.indisprimary
+	%s
   ORDER BY tc.relname, ic.relname
 ) r
 WHERE r.column_number = (r.index_keys).x
 ORDER BY r.table_schema, r.table_name, r.index_name, (r.index_keys).n
 `
 
-func getSecondaryIndexes(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID]map[string][]string, error) {
+func getSecondaryIndexes(ctx context.Context, conn *pgxpool.Pool, schemas []string) (map[sqlcapture.StreamID]map[string][]string, error) {
 	logrus.Debug("listing secondary indexes")
 	// Run the 'list secondary indexes' query and aggregate results into
 	// a `map[StreamID]map[IndexName][]ColumnName`
 	var streamIndexColumns = make(map[sqlcapture.StreamID]map[string][]string)
-	var rows, err = conn.Query(ctx, queryDiscoverSecondaryIndices)
+	var filter, args = schemaFilter("tn.nspname", schemas)
+	var rows, err = conn.Query(ctx, fmt.Sprintf(queryDiscoverSecondaryIndices, filter), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -810,12 +846,14 @@ const queryListGeneratedColumns = `
 	JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
 	JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 	WHERE a.attgenerated = 's'
+	  %s
 	ORDER BY n.nspname, c.relname, a.attname;
 `
 
-func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID][]string, error) {
+func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool, schemas []string) (map[sqlcapture.StreamID][]string, error) {
 	logrus.Debug("listing generated columns")
-	var rows, err = conn.Query(ctx, queryListGeneratedColumns)
+	var filter, args = schemaFilter("n.nspname", schemas)
+	var rows, err = conn.Query(ctx, fmt.Sprintf(queryListGeneratedColumns, filter), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error querying generated columns: %w", err)
 	}
@@ -842,9 +880,10 @@ const queryColumnDescriptions = `
 		    isc.table_schema,
 			isc.table_name,
 			isc.column_name,
-			pg_catalog.col_description(format('"%s"."%s"',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) description
+			pg_catalog.col_description(format('"%%s"."%%s"',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) description
 		FROM information_schema.columns isc
 		WHERE isc.table_schema NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron', 'pglogical')
+		  %s
 	) as descriptions WHERE description != '';
 `
 
@@ -855,9 +894,10 @@ type columnDescription struct {
 	Description string
 }
 
-func getColumnDescriptions(ctx context.Context, conn *pgxpool.Pool) ([]columnDescription, error) {
+func getColumnDescriptions(ctx context.Context, conn *pgxpool.Pool, schemas []string) ([]columnDescription, error) {
+	var filter, args = schemaFilter("isc.table_schema", schemas)
 	var descriptions []columnDescription
-	var rows, err = conn.Query(ctx, queryColumnDescriptions)
+	var rows, err = conn.Query(ctx, fmt.Sprintf(queryColumnDescriptions, filter), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}

--- a/source-postgres/discovery_test.go
+++ b/source-postgres/discovery_test.go
@@ -4,7 +4,10 @@ import (
 	"regexp"
 	"testing"
 
+
 	"github.com/bradleyjkemp/cupaloy"
+        "github.com/estuary/connectors/sqlcapture" 
+        "github.com/stretchr/testify/require"
 )
 
 func TestDiscoveryComplex(t *testing.T) {
@@ -112,4 +115,38 @@ func TestFloatKeyDiscovery(t *testing.T) {
 	tc.Discover("Discover Tables")
 	tc.Run("Capture", transactionCountBaseline+1)
 	cupaloy.SnapshotT(t, tc.Transcript.String())
+}
+
+func TestDiscoveryCrossSchemaIsolation(t *testing.T) {
+	var db, tc = blackboxTestSetup(t)
+
+	db.Exec(t, `CREATE SCHEMA IF NOT EXISTS otherschema`)
+	db.Exec(t, `GRANT USAGE ON SCHEMA otherschema TO flow_capture`)
+	t.Cleanup(func() { db.Exec(t, `DROP SCHEMA IF EXISTS otherschema CASCADE`) })
+
+	db.CreateTable(t, `<NAME>`, `(k1 INTEGER PRIMARY KEY, foo TEXT)`)
+	db.Exec(t, `CREATE TABLE otherschema.tbl<ID> (
+		k2 TEXT PRIMARY KEY,
+		bar INTEGER,
+		gen INTEGER GENERATED ALWAYS AS (bar + 1) STORED
+	)`)
+	db.Exec(t, `GRANT SELECT ON ALL TABLES IN SCHEMA otherschema TO flow_capture`)
+	db.Exec(t, `CREATE UNIQUE INDEX decoy_idx<ID> ON otherschema.tbl<ID> (bar)`)
+	db.Exec(t, `COMMENT ON COLUMN otherschema.tbl<ID>.bar IS 'should never appear'`)
+
+	tc.DiscoverFull("Discover Tables")
+	cupaloy.SnapshotT(t, tc.Transcript.String())
+}
+
+func TestSchemaFilterHelpers(t *testing.T) {
+	var filter, args = schemaFilter("nc.nspname", nil)
+	require.Equal(t, "", filter)
+	require.Nil(t, args)
+
+	filter, args = schemaFilter("nc.nspname", []string{"a", "b"})
+	require.Equal(t, "AND nc.nspname = ANY($1)", filter)
+	require.Equal(t, []any{[]string{"a", "b"}}, args)
+
+	require.Equal(t, []string{"a", "b"},
+		distinctSchemas([]sqlcapture.TableID{{Schema: "a"}, {Schema: "b"}, {Schema: "a"}}))
 }


### PR DESCRIPTION
## Problem

While setting up replication against a database with ~500k tables, the capture shard OOM-killed (SIGKILL ~10s after connect) on every startup, crash-looping indefinitely.

`DiscoverTableDetails` runs five catalog queries with no schema filtering — `getColumns`, `getPrimaryKeys`, `getSecondaryIndexes`, `getGeneratedColumns`, and `getColumnDescriptions` — then filters to the requested tables in memory. On this database the column query alone returns **3.2M rows** (confirmed via `pg_stat_activity`, stuck in `ClientWrite`), which exhausts connector memory before filtering ever happens. `discover_schemas` doesn't help since it only applies to `getTables`.

## Fix

Every caller of `DiscoverTableDetails` already passes an explicit list of requested tables. This change derives the distinct schema set from that list and pushes it into all five queries as an `AND <schema_col> = ANY($1)` predicate.

- Capture startup / Apply / Validate pass bound tables only → queries scoped to the bound schemas (in our case, 180 tables in one schema instead of 3.2M rows across 14k schemas).
- Full discovery passes all listed tables → all schemas present → results unchanged.
- Empty requested list → empty predicate → queries identical to before.

One incidental change: `queryColumnDescriptions` now passes through `fmt.Sprintf`, so its pre-existing SQL-level `format('"%s"."%s"', ...)` literals are escaped to `%%s`.

No config or schema changes; behavior is identical except for the reduced result sets.

## Impact

Measured on the affected production database (~500k tables, ~742k `pg_class` rows, ~6M `pg_attribute` rows), column discovery query (`queryDiscoverColumns`), warm cache:

| | Unfiltered (before) | Schema-filtered (after, `ANY('{public}')`, 180 tables) |
|---|---|---|
| Rows returned | 3,201,318 | 1,899 |
| Execution time | 2,812 ms | 34 ms |
| Shared buffers touched | 121,010 | 24,213 |
| Connector memory | All rows materialized → shard OOM (SIGKILL) at every capture startup | Negligible |