### PR TITLE
source-sqlserver: Support SMALLDATETIME as backfill keys

### DIFF
--- a/go/capture/sqlserver/datatypes/datatypes.go
+++ b/go/capture/sqlserver/datatypes/datatypes.go
@@ -283,7 +283,7 @@ func EncodeKeyFDB(key, ktype any) (tuple.TupleElement, error) {
 	switch key := key.(type) {
 	case time.Time:
 		switch ktype {
-		case "datetime":
+		case "datetime", "smalldatetime":
 			return key.Format(DatetimeKeyEncoding), nil
 		default:
 			return key.Format(SortableRFC3339Nano), nil

--- a/go/capture/sqlserver/tests/datatypes.go
+++ b/go/capture/sqlserver/tests/datatypes.go
@@ -291,6 +291,11 @@ func testScanKeyTypes(t *testing.T, setup testSetupFunc) {
 			"('1991-08-31T12:34:54.333', 'Data 1')",
 			"('2000-01-01T01:01:01', 'Data 2')",
 		}},
+		{"SmallDateTime", "SMALLDATETIME", []string{
+			"('1991-08-31T12:34:00', 'Data 0')",
+			"('1991-08-31T12:35:00', 'Data 1')",
+			"('2000-01-01T01:01:00', 'Data 2')",
+		}},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
 			var db, tc = setup(t)

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-SmallDateTime
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-SmallDateTime
@@ -1,0 +1,67 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_SmallDateTime_196778 (k SMALLDATETIME PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_SmallDateTime_196778 VALUES ('1991-08-31T12:34:00', 'Data 0'), ('1991-08-31T12:35:00', 'Data 1'), ('2000-01-01T01:01:00', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:35:00Z",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:00Z",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_SmallDateTime_196778": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-SmallDateTime
+++ b/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-SmallDateTime
@@ -1,0 +1,73 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_SmallDateTime_196778 (k SMALLDATETIME PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_SmallDateTime_196778 VALUES ('1991-08-31T12:34:00', 'Data 0'), ('1991-08-31T12:35:00', 'Data 1'), ('2000-01-01T01:01:00', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:35:00Z",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_smalldatetime_196778",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_SmallDateTime_196778"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:00Z",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_SmallDateTime_196778": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+


### PR DESCRIPTION
**Regression?**

No

**Description:**

`SMALLDATETIME` key columns were serialized into backfill resume keys as RFC3339 strings with nanosecond precision and a timezone suffix, which SQL Server cannot convert back to `SMALLDATETIME`. Any keyed backfill of such a table failed with "Conversion failed when converting character string to smalldatetime data type" when resuming after its first chunk.

Apply the timezone-free key encoding already used for `DATETIME` keys, and add a `SMALLDATETIME` case to the shared scan-key tests. This fixes both `source-sqlserver` and `source-sqlserver-ct` via the shared datatypes package. Captures already stuck on a bad persisted cursor will need their backfill restarted after upgrading.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
