### PR TITLE
source-postgres: Improved discovery filters

### DIFF
--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -408,6 +408,20 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/credentials/azure_client_id` | Azure Client ID | Azure App Registration Client ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 | `/credentials/azure_tenant_id` | Azure Tenant ID | Azure Tenant ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object | |
+| `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. Combined as a union with the `Discovery Schema Selection` setting under Advanced Options. | string array | |
+| `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array | |
+| `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array | |
+| `/discoveryFilters/discover_unpublished_tables` | Discover Unpublished Tables | When set, the capture discovers all tables, including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options. | boolean | |
+
 ##### Advanced options
 
 | Property | Title | Description | Type | Required/Default |

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -143,6 +143,20 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/credentials/azure_client_id` | Azure Client ID | Azure App Registration Client ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 | `/credentials/azure_tenant_id` | Azure Tenant ID | Azure Tenant ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object | |
+| `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. Combined as a union with the `Discovery Schema Selection` setting under Advanced Options. | string array | |
+| `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array | |
+| `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array | |
+| `/discoveryFilters/discover_unpublished_tables` | Discover Unpublished Tables | When set, the capture discovers all tables, including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options. | boolean | |
+
 ##### Advanced options
 
 | Property | Title | Description | Type | Required/Default |

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -230,6 +230,20 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
 | `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
 
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object | |
+| `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. Combined as a union with the `Discovery Schema Selection` setting under Advanced Options. | string array | |
+| `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array | |
+| `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array | |
+| `/discoveryFilters/discover_unpublished_tables` | Discover Unpublished Tables | When set, the capture discovers all tables, including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options. | boolean | |
+
 ##### Advanced options
 
 | Property | Title | Description | Type | Required/Default |

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -164,6 +164,20 @@ See [connectors](../../../../concepts/connectors.md#using-connectors) to learn m
 | `/credentials/gcp_service_account_to_impersonate` | GCP Service Account | GCP service account email for Cloud SQL IAM authentication. | string | Required for `GCPIAM` auth |
 | `/credentials/gcp_workload_identity_pool_audience` | Workload Identity Pool Audience | GCP workload identity pool audience. The format should be similar to: `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider`. | string | Required for `GCPIAM` auth |
 
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object | |
+| `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. Combined as a union with the `Discovery Schema Selection` setting under Advanced Options. | string array | |
+| `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array | |
+| `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array | |
+| `/discoveryFilters/discover_unpublished_tables` | Discover Unpublished Tables | When set, the capture discovers all tables, including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options. | boolean | |
+
 ##### Advanced options
 
 | Property | Title | Description | Type | Required/Default |

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
@@ -181,6 +181,20 @@ See [connectors](../../../../concepts/connectors.md#using-connectors) to learn m
 | `/credentials/azure_client_id` | Azure Client ID | Azure App Registration Client ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 | `/credentials/azure_tenant_id` | Azure Tenant ID | Azure Tenant ID for Azure Active Directory authentication. | string | Required for `AzureIAM` auth |
 
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object | |
+| `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. Combined as a union with the `Discovery Schema Selection` setting under Advanced Options. | string array | |
+| `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array | |
+| `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array | |
+| `/discoveryFilters/discover_unpublished_tables` | Discover Unpublished Tables | When set, the capture discovers all tables, including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options. | boolean | |
+
 ##### Advanced options
 
 | Property | Title | Description | Type | Required/Default |

--- a/source-postgres/.snapshots/TestSchemaWhitelist-Default
+++ b/source-postgres/.snapshots/TestSchemaWhitelist-Default
@@ -1,0 +1,4 @@
+sql> CREATE TABLE test.schemawhitelist_default_880405 (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/schemawhitelist_default_880405
+

--- a/source-postgres/.snapshots/TestSchemaWhitelist-Excluded
+++ b/source-postgres/.snapshots/TestSchemaWhitelist-Excluded
@@ -1,0 +1,3 @@
+sql> CREATE TABLE test.schemawhitelist_excluded_533051 (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+

--- a/source-postgres/.snapshots/TestSchemaWhitelist-IncludeViaAdvanced
+++ b/source-postgres/.snapshots/TestSchemaWhitelist-IncludeViaAdvanced
@@ -1,0 +1,4 @@
+sql> CREATE TABLE test.schemawhitelist_includeviaadvanced_595331 (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/schemawhitelist_includeviaadvanced_595331
+

--- a/source-postgres/.snapshots/TestSchemaWhitelist-IncludeViaFilters
+++ b/source-postgres/.snapshots/TestSchemaWhitelist-IncludeViaFilters
@@ -1,0 +1,4 @@
+sql> CREATE TABLE test.schemawhitelist_includeviafilters_799069 (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/schemawhitelist_includeviafilters_799069
+

--- a/source-postgres/.snapshots/TestSchemaWhitelist-UnionOfBoth
+++ b/source-postgres/.snapshots/TestSchemaWhitelist-UnionOfBoth
@@ -1,0 +1,4 @@
+sql> CREATE TABLE test.schemawhitelist_unionofboth_162969 (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/schemawhitelist_unionofboth_162969
+

--- a/source-postgres/.snapshots/TestSpec
+++ b/source-postgres/.snapshots/TestSpec
@@ -150,6 +150,43 @@
         "x-iam-auth": true,
         "x-iam-azure-scope": "https://ossrdbms-aad.database.windows.net/.default"
       },
+      "discoveryFilters": {
+        "properties": {
+          "include_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Include Schemas",
+            "description": "If specified only tables in the listed schemas will be discovered. Combined as a union with the 'Discovery Schema Selection' setting under Advanced Options."
+          },
+          "exclude_schemas": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Exclude Schemas",
+            "description": "Tables in the listed schemas will be excluded from discovery."
+          },
+          "table_patterns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Table Patterns",
+            "description": "If specified only tables matching at least one of these glob patterns will be discovered. A pattern containing a '.' matches against the qualified 'schema.table' name. A pattern without a '.' matches the unqualified table name in any schema. Use '*' or '?' as wildcards."
+          },
+          "discover_unpublished_tables": {
+            "type": "boolean",
+            "title": "Discover Unpublished Tables",
+            "description": "When set the capture will discover all tables including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Discovery Filters",
+        "description": "Options that restrict which tables are visible to discovery."
+      },
       "advanced": {
         "properties": {
           "publicationName": {

--- a/source-postgres/.snapshots/TestTablePatterns-AlphaOnly
+++ b/source-postgres/.snapshots/TestTablePatterns-AlphaOnly
@@ -1,0 +1,8 @@
+sql> CREATE TABLE test.tp_798083_alpha_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_798083_beta_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_798083_alpha_log (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_798083_beta_log (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/tp_798083_alpha_evt
+acmeCo/test_capture/test/tp_798083_alpha_log
+

--- a/source-postgres/.snapshots/TestTablePatterns-Default
+++ b/source-postgres/.snapshots/TestTablePatterns-Default
@@ -1,0 +1,10 @@
+sql> CREATE TABLE test.tp_893091_alpha_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_893091_beta_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_893091_alpha_log (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_893091_beta_log (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/tp_893091_alpha_evt
+acmeCo/test_capture/test/tp_893091_alpha_log
+acmeCo/test_capture/test/tp_893091_beta_evt
+acmeCo/test_capture/test/tp_893091_beta_log
+

--- a/source-postgres/.snapshots/TestTablePatterns-EventsOnly
+++ b/source-postgres/.snapshots/TestTablePatterns-EventsOnly
@@ -1,0 +1,8 @@
+sql> CREATE TABLE test.tp_126238_alpha_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_126238_beta_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_126238_alpha_log (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_126238_beta_log (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/tp_126238_alpha_evt
+acmeCo/test_capture/test/tp_126238_beta_evt
+

--- a/source-postgres/.snapshots/TestTablePatterns-NoMatch
+++ b/source-postgres/.snapshots/TestTablePatterns-NoMatch
@@ -1,0 +1,6 @@
+sql> CREATE TABLE test.tp_375199_alpha_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_375199_beta_evt (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_375199_alpha_log (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.tp_375199_beta_log (id INTEGER PRIMARY KEY, data TEXT)
+=== Discover: Discover Tables ===
+

--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-07-21
+
+### Added
+- New "Discovery Filters" configuration section which controls the set of
+  tables visible to discovery. Where these filters overlap with existing
+  Advanced Options, the settings are combined as a union.
+
+### Changed
+- Discovery fetches per-table metadata in chunks, so discovery of databases with
+  very large numbers of tables no longer times out or exhausts memory.
+
 ## 2026-07-20
 
 ### Fixed

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -15,98 +15,133 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// discoveryChunkSize is the number of tables per chunk in DiscoverTableDetails.
+const discoveryChunkSize = 100
+
+// tableIDsInClause builds a parenthesized list of pgx-style row-constructor
+// placeholders and the corresponding argument slice, suitable for use in a
+// query predicate of the form `WHERE (table_schema, table_name) IN (...)`.
+//
+// Verified empirically that PostgreSQL plans this row-constructor form as a
+// BitmapOr of per-tuple index probes on the relevant catalog index, so this
+// should be efficient even on massive catalogs.
+func tableIDsInClause(tables []sqlcapture.TableID) (string, []any) {
+	var placeholders = make([]string, len(tables))
+	var args = make([]any, 0, len(tables)*2)
+	for i, t := range tables {
+		placeholders[i] = fmt.Sprintf("($%d, $%d)", 2*i+1, 2*i+2)
+		args = append(args, t.Schema, t.Table)
+	}
+	return strings.Join(placeholders, ", "), args
+}
+
 // ListTables returns identifiers for all tables visible for capture after the
 // connector's configured discovery filters are applied.
 func (db *postgresDatabase) ListTables(ctx context.Context) ([]sqlcapture.TableID, error) {
-	var tables, err = getTables(ctx, db.conn, db.config.Advanced.DiscoverSchemas, db.config.Advanced.CaptureAsPartitions)
+	tables, err := listTables(ctx, db.conn, db.config.Advanced.DiscoverSchemas, db.config.Advanced.CaptureAsPartitions)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list database tables: %w", err)
+		return nil, err
 	}
-	var ids = make([]sqlcapture.TableID, 0, len(tables))
-	for _, table := range tables {
-		ids = append(ids, sqlcapture.TableID{Schema: table.Schema, Table: table.Name})
+
+	// Exclude the watermarks table from discovery. The connector may write to
+	// it during backfills but it should never be surfaced as a bindable source.
+	var watermarks = db.WatermarksTable()
+	tables = slices.DeleteFunc(tables, func(t sqlcapture.TableID) bool {
+		return sqlcapture.JoinStreamID(t.Schema, t.Table) == watermarks
+	})
+
+	// Exclude tables not in the configured publication unless the user has
+	// explicitly opted in to discovering them.
+	if !db.config.Advanced.DiscoverUnpublishedTables {
+		publicationStatus, err := listPublishedTables(ctx, db.conn, db.config.Advanced.PublicationName)
+		if err != nil {
+			return nil, err
+		}
+		tables = slices.DeleteFunc(tables, func(t sqlcapture.TableID) bool {
+			return !publicationStatus[sqlcapture.JoinStreamID(t.Schema, t.Table)]
+		})
 	}
-	return ids, nil
+
+	return tables, nil
 }
 
-// DiscoverTableDetails queries the database for detailed schema information
-// about the specified tables.
+// DiscoverTableDetails queries the database for detailed schema information about
+// the specified tables. The per-table metadata queries are chunked into batches.
 func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested []sqlcapture.TableID) (map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, error) {
-	// Get lists of all tables, columns and primary keys in the database
-	var tables, err = getTables(ctx, db.conn, db.config.Advanced.DiscoverSchemas, db.config.Advanced.CaptureAsPartitions)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list database tables: %w", err)
-	}
-	columns, err := getColumns(ctx, db.conn)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list database columns: %w", err)
-	}
-	primaryKeys, err := getPrimaryKeys(ctx, db.conn)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list database primary keys: %w", err)
-	}
-	secondaryIndexes, err := getSecondaryIndexes(ctx, db.conn)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list database secondary indexes: %w", err)
-	}
-	generatedColumns, err := getGeneratedColumns(ctx, db.conn)
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if !errors.As(err, &pgErr) || pgErr.Code != "42703" {
-			// Failure is expected on pre-12 versions of PostgreSQL which don't have
-			// the 'attgenerated' column. Other errors should still be logged but
-			// also probably don't warrant a fatal error.
-			logrus.WithError(err).Warn("unable to list database generated columns")
-		}
-		generatedColumns = make(map[sqlcapture.StreamID][]string) // Empty map makes downstream logic simpler
-	}
-
-	// Column descriptions just add a bit of user-friendliness. They're so unimportant
-	// that failure to list them shouldn't even be a fatal error.
-	columnDescriptions, err := getColumnDescriptions(ctx, db.conn)
-	if err != nil {
-		logrus.WithField("err", err).Warn("error fetching column descriptions")
-	}
-
-	// Aggregate column and primary key information into DiscoveryInfo structs
-	// using a map from fully-qualified "<schema>.<name>" table names to
-	// the corresponding DiscoveryInfo.
-	var tableDetails = make(map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, len(tables))
-	for _, table := range tables {
-		tableDetails[sqlcapture.JoinStreamID(table.Schema, table.Name)] = table
-	}
 	var tableMap = make(map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, len(requested))
-	for _, req := range requested {
-		var streamID = sqlcapture.JoinStreamID(req.Schema, req.Table)
-		var table, ok = tableDetails[streamID]
-		if !ok {
-			continue // Requested table is not present in the database or was excluded by the connector's discovery filters.
+	for i := 0; i < len(requested); i += discoveryChunkSize {
+		var end = min(i+discoveryChunkSize, len(requested))
+		if err := db.extendTableDetails(ctx, tableMap, requested[i:end]); err != nil {
+			return nil, err
 		}
-		if streamID == db.WatermarksTable() {
-			// We want to exclude the watermarks table from the output bindings, but we still discover it
-			table.OmitBinding = true
+	}
+
+	// Determine whether the database sorts the keys of each table in a
+	// predictable order or not. The term "predictable" here specifically
+	// means "able to be reproduced using bytewise lexicographic ordering of
+	// the serialized row keys generated by this connector".
+	for _, info := range tableMap {
+		for _, colName := range info.PrimaryKey {
+			if !predictableColumnOrder(info.Columns[colName].DataType) {
+				info.UnpredictableKeyOrdering = true
+			}
 		}
+	}
+
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		for id, info := range tableMap {
+			logrus.WithFields(logrus.Fields{
+				"stream":     id,
+				"keyColumns": info.PrimaryKey,
+			}).Debug("discovered table")
+		}
+	}
+
+	return tableMap, nil
+}
+
+// extendTableDetails runs the per-chunk discovery queries (tables, columns,
+// column descriptions, primary keys, generated columns, secondary indexes) for
+// one batch of requested tables and merges the results into dst.
+func (db *postgresDatabase) extendTableDetails(ctx context.Context, dst map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, requested []sqlcapture.TableID) error {
+	tables, err := getTables(ctx, db.conn, requested)
+	if err != nil {
+		return fmt.Errorf("unable to list database tables: %w", err)
+	}
+	for _, table := range tables {
+		var streamID = sqlcapture.JoinStreamID(table.Schema, table.Name)
 		table.UseSchemaInference = db.featureFlags["use_schema_inference"]
 		table.EmitSourcedSchemas = db.featureFlags["emit_sourced_schemas"]
-		tableMap[streamID] = table
+		dst[streamID] = table
+	}
+
+	columns, err := getColumns(ctx, db.conn, requested)
+	if err != nil {
+		return fmt.Errorf("unable to list database columns: %w", err)
 	}
 	for _, column := range columns {
 		var streamID = sqlcapture.JoinStreamID(column.TableSchema, column.TableName)
-		var info, ok = tableMap[streamID]
+		var info, ok = dst[streamID]
 		if !ok {
 			continue
 		}
-
 		if info.Columns == nil {
 			info.Columns = make(map[string]sqlcapture.ColumnInfo)
 		}
 		info.Columns[column.Name] = column
 		info.ColumnNames = append(info.ColumnNames, column.Name)
-		tableMap[streamID] = info
+		dst[streamID] = info
+	}
+
+	// Column descriptions just add a bit of user-friendliness. They're so unimportant
+	// that failure to list them shouldn't even be a fatal error.
+	columnDescriptions, err := getColumnDescriptions(ctx, db.conn, requested)
+	if err != nil {
+		logrus.WithField("err", err).Warn("error fetching column descriptions")
 	}
 	for _, desc := range columnDescriptions {
 		var streamID = sqlcapture.JoinStreamID(desc.TableSchema, desc.TableName)
-		if info, ok := tableMap[streamID]; ok {
+		if info, ok := dst[streamID]; ok {
 			if column, ok := info.Columns[desc.ColumnName]; ok {
 				logrus.WithFields(logrus.Fields{
 					"table":  streamID,
@@ -117,14 +152,16 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 				column.Description = &description
 				info.Columns[desc.ColumnName] = column
 			}
-			tableMap[streamID] = info
+			dst[streamID] = info
 		}
 	}
 
+	primaryKeys, err := getPrimaryKeys(ctx, db.conn, requested)
+	if err != nil {
+		return fmt.Errorf("unable to list database primary keys: %w", err)
+	}
 	for streamID, key := range primaryKeys {
-		// The `getColumns()` query implements the "exclude system schemas" logic,
-		// so here we ignore primary key information for tables we don't care about.
-		var info, ok = tableMap[streamID]
+		var info, ok = dst[streamID]
 		if !ok {
 			continue
 		}
@@ -133,15 +170,29 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 			"key":   key,
 		}).Trace("queried primary key")
 		info.PrimaryKey = key
-		tableMap[streamID] = info
+		dst[streamID] = info
 	}
 
-	// Add generated columns information
-	for streamID, table := range tableMap {
-		if details, ok := table.ExtraDetails.(*postgresTableDiscoveryDetails); ok {
-			details.GeneratedColumns = generatedColumns[streamID]
+	generatedColumns, err := getGeneratedColumns(ctx, db.conn, requested)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "42703" {
+			// Failure is expected on pre-12 versions of PostgreSQL which don't have
+			// the 'attgenerated' column. Other errors should still be logged but
+			// also probably don't warrant a fatal error.
+			logrus.WithError(err).Warn("unable to list database generated columns")
 		}
-		for _, columnName := range generatedColumns[streamID] {
+		generatedColumns = nil
+	}
+	for streamID, columnNames := range generatedColumns {
+		var table, ok = dst[streamID]
+		if !ok {
+			continue
+		}
+		if details, ok := table.ExtraDetails.(*postgresTableDiscoveryDetails); ok {
+			details.GeneratedColumns = columnNames
+		}
+		for _, columnName := range columnNames {
 			logrus.WithFields(logrus.Fields{
 				"table":  streamID,
 				"column": columnName,
@@ -154,8 +205,12 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 
 	// For tables which have no primary key but have a valid secondary index,
 	// fill in that secondary index as the 'primary key' for our purposes.
+	secondaryIndexes, err := getSecondaryIndexes(ctx, db.conn, requested)
+	if err != nil {
+		return fmt.Errorf("unable to list database secondary indexes: %w", err)
+	}
 	for streamID, indexColumns := range secondaryIndexes {
-		var info, ok = tableMap[streamID]
+		var info, ok = dst[streamID]
 		if !ok || info.PrimaryKey != nil {
 			continue
 		}
@@ -194,41 +249,7 @@ func (db *postgresDatabase) DiscoverTableDetails(ctx context.Context, requested 
 		}
 	}
 
-	// Determine whether the database sorts the keys of a each table in a
-	// predictable order or not. The term "predictable" here specifically
-	// means "able to be reproduced using bytewise lexicographic ordering of
-	// the serialized row keys generated by this connector".
-	for _, info := range tableMap {
-		for _, colName := range info.PrimaryKey {
-			if !predictableColumnOrder(info.Columns[colName].DataType) {
-				info.UnpredictableKeyOrdering = true
-			}
-		}
-	}
-
-	// Filter discovery to only published tables unless explicitly configured otherwise.
-	if !db.config.Advanced.DiscoverUnpublishedTables {
-		publicationStatus, err := listPublishedTables(ctx, db.conn, db.config.Advanced.PublicationName)
-		if err != nil {
-			return nil, err
-		}
-		for streamID, info := range tableMap {
-			if !publicationStatus[streamID] {
-				info.OmitBinding = true
-			}
-		}
-	}
-
-	if logrus.IsLevelEnabled(logrus.DebugLevel) {
-		for id, info := range tableMap {
-			logrus.WithFields(logrus.Fields{
-				"stream":     id,
-				"keyColumns": info.PrimaryKey,
-			}).Debug("discovered table")
-		}
-	}
-
-	return tableMap, nil
+	return nil
 }
 
 // Returns true if the bytewise lexicographic ordering of serialized row keys for
@@ -402,10 +423,14 @@ type postgresTableDiscoveryDetails struct {
 	GeneratedColumns []string // List of the names of generated columns in this table, in no particular order.
 }
 
-func getTables(ctx context.Context, conn *pgxpool.Pool, selectedSchemas []string, captureAsPartitions bool) ([]*sqlcapture.DiscoveryInfo, error) {
+// listTables performs the raw enumeration query of all tables in the database,
+// optionally restricted to a list of specified schemas. System schemas and
+// temporary or unlogged tables are always excluded.
+func listTables(ctx context.Context, conn *pgxpool.Pool, selectedSchemas []string, captureAsPartitions bool) ([]sqlcapture.TableID, error) {
 	logrus.Debug("listing all tables in the database")
 
 	var query = new(strings.Builder)
+	var args []any
 	fmt.Fprintf(query, "SELECT n.nspname, c.relname")
 	fmt.Fprintf(query, "  FROM pg_catalog.pg_class c")
 	fmt.Fprintf(query, "  JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)")
@@ -420,63 +445,89 @@ func getTables(ctx context.Context, conn *pgxpool.Pool, selectedSchemas []string
 		fmt.Fprintf(query, "    AND NOT c.relispartition")
 		fmt.Fprintf(query, "    AND c.relkind IN ('r', 'p')") // Both ordinary and partitioned tables
 	}
+	if len(selectedSchemas) > 0 {
+		args = append(args, selectedSchemas)
+		fmt.Fprintf(query, "    AND n.nspname = ANY($%d)", len(args))
+	}
 	fmt.Fprintf(query, ";")
 
-	var tables []*sqlcapture.DiscoveryInfo
-	var rows, err = conn.Query(ctx, query.String())
+	var rows, err = conn.Query(ctx, query.String(), args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
 	defer rows.Close()
+	var tables []sqlcapture.TableID
 	for rows.Next() {
 		var tableSchema, tableName string
 		if err := rows.Scan(&tableSchema, &tableName); err != nil {
 			return nil, fmt.Errorf("error scanning result row: %w", err)
 		}
-		var omitBinding = false
-		if len(selectedSchemas) > 0 && !slices.Contains(selectedSchemas, tableSchema) {
-			logrus.WithFields(logrus.Fields{
-				"schema": tableSchema,
-				"table":  tableName,
-			}).Debug("table in filtered schema")
-			omitBinding = true
+		tables = append(tables, sqlcapture.TableID{Schema: tableSchema, Table: tableName})
+	}
+	return tables, rows.Err()
+}
+
+// getTables fetches table-level discovery metadata for a specific set of
+// tables.
+func getTables(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) ([]*sqlcapture.DiscoveryInfo, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(
+		`SELECT n.nspname, c.relname`+
+			`  FROM pg_catalog.pg_class c`+
+			`  JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)`+
+			`  WHERE (n.nspname, c.relname) IN (%s);`, inClause)
+
+	var rows, err = conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing query: %w", err)
+	}
+	defer rows.Close()
+	var tables []*sqlcapture.DiscoveryInfo
+	for rows.Next() {
+		var tableSchema, tableName string
+		if err := rows.Scan(&tableSchema, &tableName); err != nil {
+			return nil, fmt.Errorf("error scanning result row: %w", err)
 		}
 		tables = append(tables, &sqlcapture.DiscoveryInfo{
 			Schema:       tableSchema,
 			Name:         tableName,
 			BaseTable:    true, // PostgreSQL discovery queries only ever list 'BASE TABLE' entities
-			OmitBinding:  omitBinding,
 			ExtraDetails: &postgresTableDiscoveryDetails{},
 		})
 	}
 	return tables, rows.Err()
 }
 
-const queryDiscoverColumns = `
-  SELECT nc.nspname as table_schema,
-         c.relname as table_name,
-		 a.attnum as ordinal_position,
-		 a.attname as column_name,
-		 NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,
-		 COALESCE(bt.typname, t.typname) AS udt_name,
-		 t.typtype::text AS typtype,
-		 a.atttypmod-4 as char_max_length
-	FROM pg_catalog.pg_attribute a
-	JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
-	JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
-	JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid
-	LEFT JOIN (pg_catalog.pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)
-	       ON t.typtype = 'd'::"char" AND t.typbasetype = bt.oid
-    WHERE NOT pg_is_other_temp_schema(nc.oid)
-	  AND a.attnum > 0
-	  AND NOT a.attisdropped
-	  AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char", 'p'::"char"]))
-	ORDER BY nc.nspname, c.relname, a.attnum;`
+func getColumns(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) ([]sqlcapture.ColumnInfo, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(`
+	  SELECT nc.nspname as table_schema,
+	         c.relname as table_name,
+			 a.attnum as ordinal_position,
+			 a.attname as column_name,
+			 NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,
+			 COALESCE(bt.typname, t.typname) AS udt_name,
+			 t.typtype::text AS typtype,
+			 a.atttypmod-4 as char_max_length
+		FROM pg_catalog.pg_attribute a
+		JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
+		JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+		JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid
+		LEFT JOIN (pg_catalog.pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)
+		       ON t.typtype = 'd'::"char" AND t.typbasetype = bt.oid
+	    WHERE (nc.nspname, c.relname) IN (%s)
+	      AND a.attnum > 0
+		  AND NOT a.attisdropped
+		ORDER BY nc.nspname, c.relname, a.attnum;`, inClause)
 
-func getColumns(ctx context.Context, conn *pgxpool.Pool) ([]sqlcapture.ColumnInfo, error) {
-	logrus.Debug("listing all columns in the database")
 	var columns []sqlcapture.ColumnInfo
-	var rows, err = conn.Query(ctx, queryDiscoverColumns)
+	var rows, err = conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -700,36 +751,41 @@ func (t postgresCompositeType) JSONSchema(isColumnNullable, isPrimaryKey bool, f
 	return colSchema.toType(), nil
 }
 
-// Query copied from pgjdbc's method PgDatabaseMetaData.getPrimaryKeys() with
-// the always-NULL `TABLE_CAT` column omitted.
-//
-// See: https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2134
-const queryDiscoverPrimaryKeys = `
-  SELECT result.TABLE_SCHEM, result.TABLE_NAME, result.COLUMN_NAME, result.KEY_SEQ
-  FROM (
-    SELECT n.nspname AS TABLE_SCHEM,
-      ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME,
-      (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, ci.relname AS PK_NAME,
-      information_schema._pg_expandarray(i.indkey) AS KEYS, a.attnum AS A_ATTNUM
-    FROM pg_catalog.pg_class ct
-      JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
-      JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
-      JOIN pg_catalog.pg_index i ON (a.attrelid = i.indrelid)
-      JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)
-    WHERE i.indisprimary
-  ) result
-  WHERE result.A_ATTNUM = (result.KEYS).x
-  ORDER BY result.table_name, result.pk_name, result.key_seq;
-`
-
 // getPrimaryKeys queries the database to produce a map from table names to
 // primary keys. Table names are fully qualified as "<schema>.<name>", and
 // primary keys are represented as a list of column names, in the order that
 // they form the table's primary key.
-func getPrimaryKeys(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID][]string, error) {
-	logrus.Debug("listing all primary-key columns in the database")
+//
+// Query adapted from pgjdbc's method PgDatabaseMetaData.getPrimaryKeys() with
+// the always-NULL `TABLE_CAT` column omitted and a (schema, table) IN-clause
+// added to keep per-chunk response size bounded.
+//
+// See: https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgDatabaseMetaData.java#L2134
+func getPrimaryKeys(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) (map[sqlcapture.StreamID][]string, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(`
+	  SELECT result.TABLE_SCHEM, result.TABLE_NAME, result.COLUMN_NAME, result.KEY_SEQ
+	  FROM (
+	    SELECT n.nspname AS TABLE_SCHEM,
+	      ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME,
+	      (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, ci.relname AS PK_NAME,
+	      information_schema._pg_expandarray(i.indkey) AS KEYS, a.attnum AS A_ATTNUM
+	    FROM pg_catalog.pg_class ct
+	      JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)
+	      JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)
+	      JOIN pg_catalog.pg_index i ON (a.attrelid = i.indrelid)
+	      JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)
+	    WHERE i.indisprimary AND (n.nspname, ct.relname) IN (%s)
+	  ) result
+	  WHERE result.A_ATTNUM = (result.KEYS).x
+	  ORDER BY result.table_name, result.pk_name, result.key_seq;
+	`, inClause)
+
 	var keys = make(map[sqlcapture.StreamID][]string)
-	var rows, err = conn.Query(ctx, queryDiscoverPrimaryKeys)
+	var rows, err = conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -749,34 +805,37 @@ func getPrimaryKeys(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.Str
 	return keys, rows.Err()
 }
 
-const queryDiscoverSecondaryIndices = `
-SELECT r.table_schema, r.table_name, r.index_name, (r.index_keys).n, r.column_name
-FROM (
-  SELECT tn.nspname AS table_schema,
-         tc.relname AS table_name,
-	     ic.relname AS index_name,
-	     information_schema._pg_expandarray(ix.indkey) AS index_keys,
-		 a.attnum AS column_number,
-		 a.attname AS column_name
-  FROM pg_catalog.pg_index ix
-       JOIN pg_catalog.pg_class ic ON (ic.oid = ix.indexrelid)
-	   JOIN pg_catalog.pg_class tc ON (tc.oid = ix.indrelid)
-	   JOIN pg_catalog.pg_namespace tn ON (tn.oid = tc.relnamespace)
-	   JOIN pg_catalog.pg_attribute a ON (a.attrelid = tc.oid)
-  WHERE ix.indisunique AND ix.indexprs IS NULL AND tc.relkind = 'r'
-    AND NOT ix.indisprimary
-  ORDER BY tc.relname, ic.relname
-) r
-WHERE r.column_number = (r.index_keys).x
-ORDER BY r.table_schema, r.table_name, r.index_name, (r.index_keys).n
-`
+func getSecondaryIndexes(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) (map[sqlcapture.StreamID]map[string][]string, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(`
+	SELECT r.table_schema, r.table_name, r.index_name, (r.index_keys).n, r.column_name
+	FROM (
+	  SELECT tn.nspname AS table_schema,
+	         tc.relname AS table_name,
+		     ic.relname AS index_name,
+		     information_schema._pg_expandarray(ix.indkey) AS index_keys,
+			 a.attnum AS column_number,
+			 a.attname AS column_name
+	  FROM pg_catalog.pg_index ix
+	       JOIN pg_catalog.pg_class ic ON (ic.oid = ix.indexrelid)
+		   JOIN pg_catalog.pg_class tc ON (tc.oid = ix.indrelid)
+		   JOIN pg_catalog.pg_namespace tn ON (tn.oid = tc.relnamespace)
+		   JOIN pg_catalog.pg_attribute a ON (a.attrelid = tc.oid)
+	  WHERE ix.indisunique AND ix.indexprs IS NULL AND tc.relkind = 'r'
+	    AND NOT ix.indisprimary
+	    AND (tn.nspname, tc.relname) IN (%s)
+	  ORDER BY tc.relname, ic.relname
+	) r
+	WHERE r.column_number = (r.index_keys).x
+	ORDER BY r.table_schema, r.table_name, r.index_name, (r.index_keys).n
+	`, inClause)
 
-func getSecondaryIndexes(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID]map[string][]string, error) {
-	logrus.Debug("listing secondary indexes")
-	// Run the 'list secondary indexes' query and aggregate results into
-	// a `map[StreamID]map[IndexName][]ColumnName`
+	// Aggregate results into a `map[StreamID]map[IndexName][]ColumnName`.
 	var streamIndexColumns = make(map[sqlcapture.StreamID]map[string][]string)
-	var rows, err = conn.Query(ctx, queryDiscoverSecondaryIndices)
+	var rows, err = conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
@@ -802,20 +861,23 @@ func getSecondaryIndexes(ctx context.Context, conn *pgxpool.Pool) (map[sqlcaptur
 	return streamIndexColumns, rows.Err()
 }
 
-const queryListGeneratedColumns = `
-	SELECT n.nspname AS table_schema,
-       c.relname AS table_name,
-       a.attname AS column_name
-	FROM pg_catalog.pg_attribute a
-	JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
-	JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-	WHERE a.attgenerated = 's'
-	ORDER BY n.nspname, c.relname, a.attname;
-`
+func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) (map[sqlcapture.StreamID][]string, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(`
+		SELECT n.nspname AS table_schema,
+	       c.relname AS table_name,
+	       a.attname AS column_name
+		FROM pg_catalog.pg_attribute a
+		JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+		JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+		WHERE a.attgenerated = 's' AND (n.nspname, c.relname) IN (%s)
+		ORDER BY n.nspname, c.relname, a.attname;
+	`, inClause)
 
-func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool) (map[sqlcapture.StreamID][]string, error) {
-	logrus.Debug("listing generated columns")
-	var rows, err = conn.Query(ctx, queryListGeneratedColumns)
+	var rows, err = conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("error querying generated columns: %w", err)
 	}
@@ -836,18 +898,6 @@ func getGeneratedColumns(ctx context.Context, conn *pgxpool.Pool) (map[sqlcaptur
 	return generatedColumns, nil
 }
 
-const queryColumnDescriptions = `
-    SELECT * FROM (
-		SELECT
-		    isc.table_schema,
-			isc.table_name,
-			isc.column_name,
-			pg_catalog.col_description(format('"%s"."%s"',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) description
-		FROM information_schema.columns isc
-		WHERE isc.table_schema NOT IN ('pg_catalog', 'pg_internal', 'information_schema', 'catalog_history', 'cron', 'pglogical')
-	) as descriptions WHERE description != '';
-`
-
 type columnDescription struct {
 	TableSchema string
 	TableName   string
@@ -855,9 +905,25 @@ type columnDescription struct {
 	Description string
 }
 
-func getColumnDescriptions(ctx context.Context, conn *pgxpool.Pool) ([]columnDescription, error) {
+func getColumnDescriptions(ctx context.Context, conn *pgxpool.Pool, requested []sqlcapture.TableID) ([]columnDescription, error) {
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	var inClause, args = tableIDsInClause(requested)
+	var query = fmt.Sprintf(`
+	    SELECT * FROM (
+			SELECT
+			    isc.table_schema,
+				isc.table_name,
+				isc.column_name,
+				pg_catalog.col_description(format('"%%s"."%%s"',isc.table_schema,isc.table_name)::regclass::oid,isc.ordinal_position) description
+			FROM information_schema.columns isc
+			WHERE (isc.table_schema, isc.table_name) IN (%s)
+		) as descriptions WHERE description != '';
+	`, inClause)
+
 	var descriptions []columnDescription
-	var rows, err = conn.Query(ctx, queryColumnDescriptions)
+	var rows, err = conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}

--- a/source-postgres/discovery.go
+++ b/source-postgres/discovery.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/estuary/connectors/go/tableglob"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/invopop/jsonschema"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -17,6 +18,62 @@ import (
 
 // discoveryChunkSize is the number of tables per chunk in DiscoverTableDetails.
 const discoveryChunkSize = 100
+
+type discoveryFilters struct {
+	IncludeSchemas            []string `json:"include_schemas,omitempty" jsonschema:"title=Include Schemas,description=If specified only tables in the listed schemas will be discovered. Combined as a union with the 'Discovery Schema Selection' setting under Advanced Options."`
+	ExcludeSchemas            []string `json:"exclude_schemas,omitempty" jsonschema:"title=Exclude Schemas,description=Tables in the listed schemas will be excluded from discovery."`
+	TablePatterns             []string `json:"table_patterns,omitempty"  jsonschema:"title=Table Patterns,description=If specified only tables matching at least one of these glob patterns will be discovered. A pattern containing a '.' matches against the qualified 'schema.table' name. A pattern without a '.' matches the unqualified table name in any schema. Use '*' or '?' as wildcards."`
+	DiscoverUnpublishedTables bool     `json:"discover_unpublished_tables,omitempty" jsonschema:"title=Discover Unpublished Tables,description=When set the capture will discover all tables including those not currently in the publication. Combined as a union with the equivalent setting under Advanced Options."`
+}
+
+// Validate checks that the configured discovery filters are well-formed. The
+// only thing that can actually be invalid here is a malformed table pattern.
+func (f *discoveryFilters) Validate() error {
+	for _, raw := range f.TablePatterns {
+		if _, err := tableglob.Compile(raw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// apply filters the input table list by the configured exclude-schemas and
+// table patterns. The include-schemas list is intentionally not consulted
+// here: it is expected to have already been pushed into the listTables query.
+func (f *discoveryFilters) apply(tables []sqlcapture.TableID) ([]sqlcapture.TableID, error) {
+	var patterns = make([]*tableglob.Pattern, 0, len(f.TablePatterns))
+	for _, raw := range f.TablePatterns {
+		var p, err = tableglob.Compile(raw)
+		if err != nil {
+			return nil, err
+		}
+		patterns = append(patterns, p)
+	}
+	var excluded = make(map[string]struct{}, len(f.ExcludeSchemas))
+	for _, schema := range f.ExcludeSchemas {
+		excluded[schema] = struct{}{}
+	}
+	var filtered = make([]sqlcapture.TableID, 0, len(tables))
+	for _, t := range tables {
+		if _, ok := excluded[t.Schema]; ok {
+			continue
+		}
+		if len(patterns) > 0 && !matchesAnyPattern(patterns, t) {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered, nil
+}
+
+func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool {
+	for _, p := range patterns {
+		if p.MatchTable(t.Schema, t.Table) {
+			return true
+		}
+	}
+	return false
+}
 
 // tableIDsInClause builds a parenthesized list of pgx-style row-constructor
 // placeholders and the corresponding argument slice, suitable for use in a
@@ -38,9 +95,19 @@ func tableIDsInClause(tables []sqlcapture.TableID) (string, []any) {
 // ListTables returns identifiers for all tables visible for capture after the
 // connector's configured discovery filters are applied.
 func (db *postgresDatabase) ListTables(ctx context.Context) ([]sqlcapture.TableID, error) {
-	tables, err := listTables(ctx, db.conn, db.config.Advanced.DiscoverSchemas, db.config.Advanced.CaptureAsPartitions)
+	// Union the new DiscoveryFilters.IncludeSchemas with the legacy
+	// Advanced.DiscoverSchemas whitelist and push the result into listTables.
+	var includeSchemas = slices.Concat(db.config.DiscoveryFilters.IncludeSchemas, db.config.Advanced.DiscoverSchemas)
+	slices.Sort(includeSchemas)
+	includeSchemas = slices.Compact(includeSchemas)
+
+	tables, err := listTables(ctx, db.conn, includeSchemas, db.config.Advanced.CaptureAsPartitions)
 	if err != nil {
 		return nil, err
+	}
+	tables, err = db.config.DiscoveryFilters.apply(tables)
+	if err != nil {
+		return nil, fmt.Errorf("error applying discovery filters: %w", err)
 	}
 
 	// Exclude the watermarks table from discovery. The connector may write to
@@ -51,8 +118,10 @@ func (db *postgresDatabase) ListTables(ctx context.Context) ([]sqlcapture.TableI
 	})
 
 	// Exclude tables not in the configured publication unless the user has
-	// explicitly opted in to discovering them.
-	if !db.config.Advanced.DiscoverUnpublishedTables {
+	// explicitly opted in to discovering them. The new DiscoveryFilters setting
+	// and the legacy Advanced one are OR'd together for back-compat.
+	var discoverUnpublished = db.config.Advanced.DiscoverUnpublishedTables || db.config.DiscoveryFilters.DiscoverUnpublishedTables
+	if !discoverUnpublished {
 		publicationStatus, err := listPublishedTables(ctx, db.conn, db.config.Advanced.PublicationName)
 		if err != nil {
 			return nil, err

--- a/source-postgres/discovery_test.go
+++ b/source-postgres/discovery_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiscoveryComplex(t *testing.T) {
@@ -112,4 +116,213 @@ func TestFloatKeyDiscovery(t *testing.T) {
 	tc.Discover("Discover Tables")
 	tc.Run("Capture", transactionCountBaseline+1)
 	cupaloy.SnapshotT(t, tc.Transcript.String())
+}
+
+// TestDiscoveryFiltersApply exercises the post-query filtering logic for various
+// combinations of exclude-schemas and table patterns. The include-schemas list
+// is not covered here, since it is pushed into the listTables query rather than
+// handled by apply().
+func TestDiscoveryFiltersApply(t *testing.T) {
+	var input = []sqlcapture.TableID{
+		{Schema: "a", Table: "users"},
+		{Schema: "a", Table: "users_evt"},
+		{Schema: "a", Table: "events_log"},
+		{Schema: "b", Table: "users"},
+		{Schema: "b", Table: "users_evt"},
+		{Schema: "internal", Table: "secret"},
+	}
+	var cases = []struct {
+		name     string
+		filters  discoveryFilters
+		expected []sqlcapture.TableID
+	}{
+		{
+			name:     "Passthrough",
+			filters:  discoveryFilters{},
+			expected: input,
+		},
+		{
+			name:    "ExcludeOneSchema",
+			filters: discoveryFilters{ExcludeSchemas: []string{"internal"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "a", Table: "users_evt"},
+				{Schema: "a", Table: "events_log"},
+				{Schema: "b", Table: "users"},
+				{Schema: "b", Table: "users_evt"},
+			},
+		},
+		{
+			name:    "ExcludeMultipleSchemas",
+			filters: discoveryFilters{ExcludeSchemas: []string{"internal", "b"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "a", Table: "users_evt"},
+				{Schema: "a", Table: "events_log"},
+			},
+		},
+		{
+			// A literal basename pattern matches only the exact table name,
+			// proving that patterns are implicitly anchored. The "users_evt"
+			// tables must not be included by the "users" pattern.
+			name:    "BasenameLiteral",
+			filters: discoveryFilters{TablePatterns: []string{"users"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "b", Table: "users"},
+			},
+		},
+		{
+			name:    "BasenameWildcard",
+			filters: discoveryFilters{TablePatterns: []string{"*_evt"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users_evt"},
+				{Schema: "b", Table: "users_evt"},
+			},
+		},
+		{
+			name:    "MultiplePatternsOR",
+			filters: discoveryFilters{TablePatterns: []string{"users", "secret"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "b", Table: "users"},
+				{Schema: "internal", Table: "secret"},
+			},
+		},
+		{
+			// A pattern containing a '.' is qualified and matches against
+			// schema and table independently.
+			name:    "QualifiedLiteral",
+			filters: discoveryFilters{TablePatterns: []string{"a.users"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+			},
+		},
+		{
+			name:    "QualifiedWildcardTable",
+			filters: discoveryFilters{TablePatterns: []string{"a.*"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "a", Table: "users_evt"},
+				{Schema: "a", Table: "events_log"},
+			},
+		},
+		{
+			name:    "QualifiedWildcardSchema",
+			filters: discoveryFilters{TablePatterns: []string{"*.users"}},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users"},
+				{Schema: "b", Table: "users"},
+			},
+		},
+		{
+			name: "ExcludeAndPattern",
+			filters: discoveryFilters{
+				ExcludeSchemas: []string{"b"},
+				TablePatterns:  []string{"*_evt", "events_*"},
+			},
+			expected: []sqlcapture.TableID{
+				{Schema: "a", Table: "users_evt"},
+				{Schema: "a", Table: "events_log"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got, err = tc.filters.apply(input)
+			if err != nil {
+				t.Fatalf("apply() unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("apply() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestDiscoveryFiltersValidate checks that malformed table patterns are caught
+// at config-validation time.
+func TestDiscoveryFiltersValidate(t *testing.T) {
+	var cases = []struct {
+		name    string
+		filters discoveryFilters
+		wantErr bool
+	}{
+		{"Empty", discoveryFilters{}, false},
+		{"GoodPatterns", discoveryFilters{TablePatterns: []string{"foo", "bar_*", "a.b"}}, false},
+		{"EmptyTableComponent", discoveryFilters{TablePatterns: []string{"foo."}}, true},
+		{"TrailingBackslash", discoveryFilters{TablePatterns: []string{`foo\`}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err = tc.filters.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestTablePatterns exercises end-to-end discovery against a live database with
+// various TablePatterns configurations.
+func TestTablePatterns(t *testing.T) {
+	var runSubcase = func(t *testing.T, patterns []string) {
+		var db, tc = blackboxTestSetup(t)
+		var id = uniqueTableID(t)
+		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_alpha_evt", testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)
+		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_beta_evt", testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)
+		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_alpha_log", testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)
+		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_beta_log", testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)
+		if patterns != nil {
+			require.NoError(t, tc.Capture.EditConfig("discoveryFilters.table_patterns", patterns))
+		}
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	}
+
+	t.Run("Default", func(t *testing.T) { runSubcase(t, nil) })
+	t.Run("EventsOnly", func(t *testing.T) { runSubcase(t, []string{"*_evt"}) })
+	t.Run("AlphaOnly", func(t *testing.T) { runSubcase(t, []string{"*_alpha_evt", "*_alpha_log"}) })
+	t.Run("NoMatch", func(t *testing.T) { runSubcase(t, []string{"nonexistent"}) })
+}
+
+// TestSchemaWhitelist exercises the schema include filter, including the union
+// between the legacy Advanced.DiscoverSchemas and the new
+// DiscoveryFilters.IncludeSchemas option.
+func TestSchemaWhitelist(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		var db, tc = blackboxTestSetup(t)
+		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	})
+	t.Run("IncludeViaAdvanced", func(t *testing.T) {
+		var db, tc = blackboxTestSetup(t)
+		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+		require.NoError(t, tc.Capture.EditConfig("advanced.discover_schemas", []string{testSchemaName}))
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	})
+	t.Run("IncludeViaFilters", func(t *testing.T) {
+		var db, tc = blackboxTestSetup(t)
+		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{testSchemaName}))
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	})
+	t.Run("Excluded", func(t *testing.T) {
+		var db, tc = blackboxTestSetup(t)
+		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+		require.NoError(t, tc.Capture.EditConfig("advanced.discover_schemas", []string{"nonexistent_schema"}))
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	})
+	t.Run("UnionOfBoth", func(t *testing.T) {
+		var db, tc = blackboxTestSetup(t)
+		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+		require.NoError(t, tc.Capture.EditConfig("advanced.discover_schemas", []string{"nonexistent_schema"}))
+		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{testSchemaName}))
+		tc.Discover("Discover Tables")
+		cupaloy.SnapshotT(t, tc.Transcript.String())
+	})
 }

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -121,7 +121,9 @@ type Config struct {
 	Database    string            `json:"database" jsonschema:"default=postgres,description=Logical database name to capture from." jsonschema_extras:"order=2"`
 	HistoryMode bool              `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=3"`
 	Credentials *credentialConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=4,x-iam-auth=true,x-iam-azure-scope=https://ossrdbms-aad.database.windows.net/.default"`
-	Advanced    advancedConfig    `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
+
+	DiscoveryFilters discoveryFilters `json:"discoveryFilters,omitempty" jsonschema:"title=Discovery Filters,description=Options that restrict which tables are visible to discovery."`
+	Advanced         advancedConfig   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 
 	NetworkTunnel *tunnelConfig `json:"networkTunnel,omitempty" jsonschema:"title=Network Tunnel,description=Connect to your system through an SSH server that acts as a bastion host for your network."`
 }
@@ -295,6 +297,9 @@ func (c *Config) Validate() error {
 		if _, err := time.ParseDuration(c.Advanced.StatementTimeout); err != nil {
 			return fmt.Errorf("invalid statement timeout %q: %w", c.Advanced.StatementTimeout, err)
 		}
+	}
+	if err := c.DiscoveryFilters.Validate(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
**Description:**

Makes source-postgres discovery operations more efficient when discovering a subset of tables from a massive catalog, and introduces the planned "Discovery Filters" config section as described in https://github.com/estuary/connectors/issues/4476 to make it easier for users to configure captures which only discover some of the available tables.

**Workflow steps:**

No user action is required if they're happy with the existing advanced config option for schema whitelisting. If desired users can instead use the new "Discovery Filters" config section. For now both sets of options are merged in the appropriate ways, eventually we will migrate and deprecate the legacy advanced-option properties.

**Documentation links affected:**

Docs edits are in the PR, I'll see about syncing those over to the Flow repo.

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
