### PR TITLE
source-zuora: add debug logging for field exportability and export lifecycle

### DIFF
--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -78,7 +78,9 @@ async def discover_object_names(
     catalog = _parse_catalog(
         await http.request(log, url, headers=VERSION_HEADERS)
     )
-    return [obj.name for obj in catalog.objects]
+    names = [obj.name for obj in catalog.objects]
+    log.debug("discovered objects", {"count": len(names), "objects": names})
+    return names
 
 
 def _parse_catalog(response_bytes: bytes) -> DescribeCatalog:
@@ -99,9 +101,25 @@ async def fetch_object_fields(
 ) -> list[str]:
     """Return the exportable field names for a Zuora object."""
     url = f"{base_url}/v1/describe/{object_name}"
-    return _parse_describe_object(
+    described = _parse_describe_object(
         await http.request(log, url, headers=VERSION_HEADERS)
-    ).exportable_field_names
+    )
+    # Field availability in exports is tenant-dependent and describe has been
+    # seen disagreeing with what POST /v1/object/export actually accepts, so
+    # record exactly how each field was classified and why.
+    log.debug(
+        "described object",
+        {
+            "object": object_name,
+            "exportable_fields": described.exportable_field_names,
+            "excluded_fields": {
+                f.name: {"selectable": f.selectable, "contexts": f.contexts}
+                for f in described.fields
+                if not f.is_exportable
+            },
+        },
+    )
+    return described.exportable_field_names
 
 
 def _parse_describe_object(response_bytes: bytes) -> DescribeObject:
@@ -165,7 +183,10 @@ async def _export_window(
     window rather than the opaque Zuora file id.
     """
     max_cursor: datetime | None = None
+    # count drives intermediate checkpoints and resets at each one; total is the
+    # window's whole-lifetime document count, kept separately for the summary log.
     count = 0
+    total = 0
     while True:
         query = build_query(
             object_name, fields, model.CURSOR_FIELD,
@@ -184,6 +205,7 @@ async def _export_window(
                     count = 0
                 yield doc
                 count += 1
+                total += 1
                 if max_cursor is None or cursor > max_cursor:
                     max_cursor = cursor
             break
@@ -195,8 +217,27 @@ async def _export_window(
                     f"[{_format_dt_to_utc(window_start)}, {_format_dt_to_utc(window_end)}) "
                     f"still exceeds Zuora's size limit and cannot be narrowed further"
                 ) from err
+            log.debug(
+                "export exceeded size limit, bisecting window",
+                {
+                    "object": object_name,
+                    "window_start": _format_dt_to_utc(window_start),
+                    "window_end": _format_dt_to_utc(window_end),
+                    "new_window_end": _format_dt_to_utc(mid),
+                },
+            )
             window_end = mid
 
+    log.debug(
+        "export window complete",
+        {
+            "object": object_name,
+            "window_start": _format_dt_to_utc(window_start),
+            "covered_end": _format_dt_to_utc(window_end),
+            "docs": total,
+            "max_cursor": max_cursor.isoformat() if max_cursor is not None else None,
+        },
+    )
     yield _WindowEnd(max_cursor=max_cursor, covered_end=window_end)
 
 
@@ -222,11 +263,25 @@ async def fetch_changes(
             yield item  # a document or an intermediate datetime checkpoint
         elif item.max_cursor is not None:
             # Advance only to just past the last second that held data.
-            yield _second_floor(item.max_cursor) + timedelta(seconds=1)
+            new_cursor = _second_floor(item.max_cursor) + timedelta(seconds=1)
+            log.debug(
+                "advancing cursor just past the last second holding data",
+                {"object": object_name, "cursor": _format_dt_to_utc(new_cursor)},
+            )
+            yield new_cursor
         elif item.covered_end < now:
             # A full-sized window that yielded nothing. Advance past all of it
             # rather than leaving the cursor stuck in the past.
+            log.debug(
+                "empty window, advancing cursor to its end",
+                {"object": object_name, "cursor": _format_dt_to_utc(item.covered_end)},
+            )
             yield item.covered_end
+        else:
+            log.debug(
+                "empty window at the leading edge, cursor unchanged",
+                {"object": object_name, "cursor": _format_dt_to_utc(log_cursor)},
+            )
 
 
 async def fetch_page(
@@ -260,7 +315,13 @@ async def fetch_page(
             # window (covered_end == cutoff) ends on documents so backfill
             # completes without emitting a further page.
             if item.covered_end < cutoff:
+                log.debug(
+                    "backfill window complete, resuming from next page cursor",
+                    {"object": object_name, "next_page": item.covered_end.isoformat()},
+                )
                 yield item.covered_end.isoformat()
+            else:
+                log.debug("backfill reached cutoff", {"object": object_name})
         elif isinstance(item, datetime):
             yield item.isoformat()  # PageCursors are isoformat strings
         else:

--- a/source-zuora/source_zuora/export_manager.py
+++ b/source-zuora/source_zuora/export_manager.py
@@ -126,6 +126,10 @@ class ExportManager:
     async def _submit(self, query: str) -> str:
         url = f"{self.base_url}/v1/object/export"
         payload = {"Format": "csv", "Query": query}
+        # Logged before the request so a submit-time rejection (e.g. a 400 for a
+        # field describe claimed was exportable) sits next to the query that
+        # caused it in the task logs.
+        self.log.debug("submitting export job", {"query": query})
         submit_bytes = await self.http.request(
             self.log, url, method="POST", json=payload, headers=VERSION_HEADERS
         )
@@ -148,8 +152,22 @@ class ExportManager:
 
     async def _poll_until_complete(self, job_id: str) -> str:
         """Poll a submitted job until it completes, returning its file ID."""
-        for _ in range(MAX_POLL_ATTEMPTS):
+        last_status: ExportStatus | None = None
+        for attempt in range(MAX_POLL_ATTEMPTS):
             job = await self._check_job(job_id)
+            # Logged only on transitions (not every poll) so a long-running job
+            # stays visible in the logs without flooding them.
+            if job.Status is not last_status:
+                last_status = job.Status
+                self.log.debug(
+                    "export job status",
+                    {
+                        "job_id": job_id,
+                        "status": job.Status,
+                        "file_id": job.FileId,
+                        "elapsed_s": attempt * POLL_INTERVAL,
+                    },
+                )
             if job.Status is ExportStatus.COMPLETED:
                 if job.FileId is None:
                     raise ExportError(

--- a/source-zuora/tests/test_describe.py
+++ b/source-zuora/tests/test_describe.py
@@ -6,10 +6,14 @@ the `./fields/field` scoping that ignores nested <field>s — logic that the
 spec/capture tests don't touch.
 """
 
+import logging
+
 import pytest
 
 from source_zuora import api
 from source_zuora.models import DescribeField
+
+_LOG = logging.getLogger("test")
 
 
 # --- DescribeField.is_exportable ----------------------------------------------
@@ -138,7 +142,7 @@ class _FakeHTTP:
 @pytest.mark.asyncio
 async def test_describe_object_returns_exportable_field_names():
     http = _FakeHTTP(_DESCRIBE_XML)
-    fields = await api.fetch_object_fields("https://rest.zuora.com", http, None, "Account")
+    fields = await api.fetch_object_fields("https://rest.zuora.com", http, _LOG, "Account")
     assert fields == ["Id", "UpdatedDate"]
     assert http.urls == ["https://rest.zuora.com/v1/describe/Account"]
 
@@ -148,7 +152,7 @@ async def test_describe_requests_pin_api_version_header():
     from source_zuora.shared import ZUORA_API_VERSION
 
     http = _FakeHTTP(_DESCRIBE_XML)
-    await api.fetch_object_fields("https://rest.zuora.com", http, None, "Account")
+    await api.fetch_object_fields("https://rest.zuora.com", http, _LOG, "Account")
     assert http.headers[0].get("Zuora-Version") == ZUORA_API_VERSION
 
 
@@ -156,6 +160,6 @@ async def test_describe_requests_pin_api_version_header():
 async def test_discover_object_names_returns_catalog_names():
     xml = b"<objects><object><name>Account</name></object><object><name>Order</name></object></objects>"
     http = _FakeHTTP(xml)
-    names = await api.discover_object_names("https://rest.zuora.com", http, None)
+    names = await api.discover_object_names("https://rest.zuora.com", http, _LOG)
     assert names == ["Account", "Order"]
     assert http.urls == ["https://rest.zuora.com/v1/describe"]


### PR DESCRIPTION
**Regression?**

No.

**Description:**

These logs should provide some visibility into what's happening inside a connector & help troubleshoot when captures hit issues.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
