### PR TITLE
docs: use :::deprecated admonition for deprecated connector notices

### DIFF
--- a/docs/reference/Connectors/capture-connectors/HubSpot.md
+++ b/docs/reference/Connectors/capture-connectors/HubSpot.md
@@ -3,7 +3,7 @@
 
 This connector captures data from a Hubspot account.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [HubSpot connector](/reference/Connectors/capture-connectors/HubSpot-real-time) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-historical-data.md
+++ b/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-historical-data.md
@@ -6,7 +6,7 @@ It uses batch processing and is ideal for syncing your historical Salesforce dat
 [A separate connector is available for real-time Salesforce data capture](./salesforce-real-time.md).
 For help using both connectors in parallel, [contact your Estuary account manager](mailto:info@estuary.dev).
 
-:::warning
+:::deprecated
 This connector is deprecated. Consider using the new [native Salesforce connector](./salesforce-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-real-time.md
+++ b/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-real-time.md
@@ -5,7 +5,7 @@ This connector captures data from Salesforce objects into Estuary collections in
 [A separate connector is available for syncing historical Salesforce data](./salesforce-historical-data.md).
 For help using both connectors in parallel, [contact your Estuary account manager](mailto:info@estuary.dev).
 
-:::warning
+:::deprecated
 This connector is deprecated. Consider using the new [native Salesforce connector](./salesforce-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/airtable.md
+++ b/docs/reference/Connectors/capture-connectors/airtable.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Airtable into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Airtable connector](./airtable-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/amazon-redshift.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-redshift.md
@@ -2,7 +2,7 @@
 
 This connector captures data from your Amazon Redshift cluster into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Redshift batch connector](./redshift-batch.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/chargebee.md
+++ b/docs/reference/Connectors/capture-connectors/chargebee.md
@@ -4,7 +4,7 @@ This connector captures data from Chargebee into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Chargebee connector](./chargebee-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/facebook-marketing.md
+++ b/docs/reference/Connectors/capture-connectors/facebook-marketing.md
@@ -3,7 +3,7 @@
 
 This connector captures data from the Facebook Marketing API into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Facebook Ads connector](./facebook-marketing-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/google-analytics.md
+++ b/docs/reference/Connectors/capture-connectors/google-analytics.md
@@ -3,7 +3,7 @@
 
 This connector previously captured data from a view in Google Universal Analytics.
 
-:::danger
+:::deprecated
 
 This connector and Universal Analytics are now **deprecated** along with the Google Analytics Universal Analytics API - ([see Google announcement](https://support.google.com/analytics/answer/11583528?hl=en)).
 

--- a/docs/reference/Connectors/capture-connectors/greenhouse.md
+++ b/docs/reference/Connectors/capture-connectors/greenhouse.md
@@ -5,7 +5,7 @@ This connector captures data from Greenhouse into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [Greenhouse connector](./greenhouse-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/intercom.md
+++ b/docs/reference/Connectors/capture-connectors/intercom.md
@@ -5,7 +5,7 @@ This connector captures data from Intercom into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Intercom connector](./intercom-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/iterable.md
+++ b/docs/reference/Connectors/capture-connectors/iterable.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Iterable into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Iterable connector](./iterable-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/jira-legacy.md
+++ b/docs/reference/Connectors/capture-connectors/jira-legacy.md
@@ -3,7 +3,7 @@
 
 This connector captures data from [Jira's REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/) into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. It is recommended that you use the new native [Jira connector](./jira-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/jira.md
+++ b/docs/reference/Connectors/capture-connectors/jira.md
@@ -3,7 +3,7 @@
 
 This connector captures data from Jira into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. See the new [Jira connector](./jira-native.md) for the latest integration.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/klaviyo.md
+++ b/docs/reference/Connectors/capture-connectors/klaviyo.md
@@ -5,7 +5,7 @@ This connector captures data from Klaviyo into Estuary collections.
 
 This connector is based on an open-source connector from a third party, with modifications for performance in the Estuary system.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Klaviyo connector](./klaviyo-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/stripe.md
+++ b/docs/reference/Connectors/capture-connectors/stripe.md
@@ -2,7 +2,7 @@
 
 This connector captures data from Stripe into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. See the [Stripe Real-time](./stripe-realtime.md) connector for the latest Stripe integration.
 :::
 

--- a/docs/reference/Connectors/materialization-connectors/Rockset.md
+++ b/docs/reference/Connectors/materialization-connectors/Rockset.md
@@ -3,7 +3,7 @@
 
 This connector materializes [delta updates](/concepts/materialization/#delta-updates) of your Estuary collections into Rockset collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using one of our other [materialization connectors](/reference/Connectors/materialization-connectors).
 :::
 


### PR DESCRIPTION
## Summary
Swaps the "this connector is deprecated" `:::warning`/`:::danger` blocks on 16 deprecated connector pages to a custom `:::deprecated` admonition (renders the same as `:::warning`, just its own type).

Requires estuary/docs#11, which registers the `deprecated` admonition type. Without that PR merged first (or alongside), these pages would render with a raw/unstyled fallback.

Context: Kapa's search widget was surfacing these deprecated pages as generic filler results for unrelated queries (near-duplicate boilerplate clusters tightly in embedding space). Karl Jones proposed excluding pages via a CSS class once we had one to target — [Slack thread](https://estuaryworkspace.slack.com/archives/C08G1A3LPMM/p1784205687491909). This is that class (`theme-admonition-deprecated`, applied automatically by the paired docs-repo change).

## Test plan
- [x] Verified all 16 files have exactly one `:::warning`/`:::danger` block each (the deprecation notice), confirmed no unrelated warnings were touched
- [x] Verified locally: aggregated into a docs-repo build with the paired admonition-type change, HubSpot page renders correctly with the DEPRECATED admonition
- [ ] Merge alongside/after estuary/docs#11