### PR TITLE
materialize-hubspot: update signature for Transactor changes

### DIFF
--- a/materialize-hubspot/transactor.go
+++ b/materialize-hubspot/transactor.go
@@ -75,7 +75,7 @@ func (t *transactor) UnmarshalState(state json.RawMessage) error {
 	return nil
 }
 
-func (t *transactor) Acknowledge(ctx context.Context) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(context.Context, []json.RawMessage) (*pf.ConnectorState, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
**Regression?**

No

**Description:**

The Transactor interface was updated on main to support scale-out, but the HubSpot PR was based on an prior revision.

**Workflow steps:**

No

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
