### PR TITLE
source-smartsheet: general implementation improvements

### DIFF
--- a/docs/reference/Connectors/capture-connectors/smartsheet.md
+++ b/docs/reference/Connectors/capture-connectors/smartsheet.md
@@ -1,0 +1,113 @@
+# Smartsheet
+
+This connector captures data from [Smartsheet](https://www.smartsheet.com/) sheets and reports into Estuary Flow collections.
+It authenticates with a Smartsheet [API access token](https://smartsheet.redoc.ly/#section/API-Basics/Authentication) and reads data through the [Smartsheet API 2.0](https://smartsheet.redoc.ly/).
+
+## Supported data resources
+
+The connector discovers every sheet and report available to your account and exposes them through four streams:
+
+| Stream        | Description                                                                  | Replication           |
+| ------------- | ---------------------------------------------------------------------------- | --------------------- |
+| `sheets`      | Catalog metadata for each sheet.                                             | Incremental           |
+| `sheet_rows`  | Individual rows from every sheet, each stamped with its parent `sheet_id`.   | Incremental           |
+| `reports`     | Catalog metadata for each report.                                            | Full-refresh snapshot |
+| `report_rows` | Individual rows from every report, each stamped with its parent `report_id`. | Full-refresh snapshot |
+
+The connector chooses a replication mode per stream based on what the Smartsheet API can support:
+
+- **Incrementally**, for `sheets` and `sheet_rows`. The connector uses the sheet list's `modifiedSince` filter and each sheet's `rowsModifiedSince` filter as cursors, capturing only new and changed records on each sync after the initial backfill.
+
+:::warning
+Because a row's `rowsModifiedSince` timestamp only advances when a cell is written, blank or never-populated rows are invisible to the incremental cursor. To close this gap, `sheet_rows` also runs a **daily full re-backfill** of every sheet (at midnight UTC) so those rows are reconciled at least once per day.
+:::
+
+- **As a full-refresh snapshot**, for `reports` and `report_rows`. The reports API's `modifiedSince` filter reflects when a report's _definition_ changed (a rename, a column change), not when the underlying sheet data it renders changed, and there is no row-level cursor. Because reports can't be read incrementally, the connector re-captures them on each polling interval.
+
+## Prerequisites
+
+- A Smartsheet account with access to the sheets and reports you want to capture.
+
+- A Smartsheet **API access token**. See [Authentication](#authentication) below to generate one. The token inherits the permissions of the user who created it, so that user must have access to every sheet and report you intend to capture.
+
+- The [Smartsheet region](#configuration) your account is hosted in (US, EU, Gov, or Australia).
+
+## Authentication
+
+The connector authenticates using a Smartsheet API access token, which acts as a bearer token on every request.
+
+To generate a token:
+
+1. Sign in to Smartsheet as the user whose access the connector should use. The connector will have the same access to sheets and reports as this user.
+2. Go to **Account > Apps & Integrations > API Access**.
+3. Click **Generate new access token** and give it a name.
+4. Copy the generated token immediately — Smartsheet only displays it once.
+
+You'll use this value as the `access_token` when configuring the connector.
+
+## Configuration
+
+You configure connectors either in the Estuary web app, or by directly editing the Data Flow specification file.
+See [connectors](../../../concepts/connectors.md#using-connectors) to learn more about using connectors. The values and specification sample below provide configuration details specific to the Smartsheet source connector.
+
+### Properties
+
+#### Endpoint
+
+| Property                        | Title            | Description                                                                                                                                        | Type   | Required/Default |
+| ------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
+| **`/credentials`**              | Authentication   | Smartsheet API access token credentials.                                                                                                           | object | Required         |
+| **`/credentials/access_token`** | API Access Token | Smartsheet API Access Token, generated under Account > Apps & Integrations > API Access.                                                           | string | Required         |
+| `/region`                       | Region           | The Smartsheet data center your account is hosted in. Determines the API base URL used to reach your account. One of `us`, `eu`, `gov`, or `au`.   | string | `us`             |
+| `/start_date`                   | Start Date       | UTC date and time from which to start replicating data. Data generated before this date is not replicated. Defaults to 30 days before the present. | string | 30 days ago      |
+
+The `region` selects which Smartsheet data center base URL the connector uses:
+
+| Region | Base URL                            |
+| ------ | ----------------------------------- |
+| `us`   | `https://api.smartsheet.com/2.0`    |
+| `eu`   | `https://api.smartsheet.eu/2.0`     |
+| `gov`  | `https://api.smartsheetgov.com/2.0` |
+| `au`   | `https://api.smartsheet.au/2.0`     |
+
+#### Bindings
+
+| Property    | Title    | Description                                                                            | Type   | Required/Default                |
+| ----------- | -------- | -------------------------------------------------------------------------------------- | ------ | ------------------------------- |
+| **`/name`** | Name     | Name of the resource to capture (`sheets`, `sheet_rows`, `reports`, or `report_rows`). | string | Required                        |
+| `/interval` | Interval | Interval between data syncs for this resource.                                         | string | PT10M (sheets), PT30M (reports) |
+| `/schedule` | Schedule | Cron schedule for the periodic full re-backfill (`sheet_rows` only).                   | string | `0 0 * * *`                     |
+
+### Sample
+
+```yaml
+captures:
+  ${PREFIX}/${CAPTURE_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-smartsheet:v1
+        config:
+          credentials:
+            credentials_title: API Access Token
+            access_token: <secret>
+          region: us
+          start_date: "2024-01-01T00:00:00Z"
+    bindings:
+      - resource:
+          name: sheets
+          interval: PT10M
+        target: ${PREFIX}/sheets
+      - resource:
+          name: sheet_rows
+          interval: PT10M
+          schedule: "0 0 * * *"
+        target: ${PREFIX}/sheet_rows
+      - resource:
+          name: reports
+          interval: PT30M
+        target: ${PREFIX}/reports
+      - resource:
+          name: report_rows
+          interval: PT30M
+        target: ${PREFIX}/report_rows
+```

--- a/source-smartsheet/CHANGELOG.md
+++ b/source-smartsheet/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-07-22
+
+### Added
+- Initial release of the Smartsheet capture connector.

--- a/source-smartsheet/acmeCo/reports.schema.yaml
+++ b/source-smartsheet/acmeCo/reports.schema.yaml
@@ -18,7 +18,15 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: 'One document per report: catalog/metadata only, never row data'
+description: |-
+  One document per report, mirroring a `GET /reports` list item verbatim:
+  id/name/accessLevel/permalink/isSummaryReport (the passthrough fields ride
+  on `BaseDocument`'s `extra="allow"`). Catalog/metadata only, never row data.
+
+  Unlike `Sheet`, this is *not* refetched from the detail endpoint, so the
+  richer detail-only fields (effectiveAttachmentOptions, totalRowCount,
+  timestamps) are absent by design. The `report_rows` walk also enumerates
+  report ids from this same list, so there's no separate list-summary type.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
@@ -26,14 +34,6 @@ properties:
   id:
     title: Id
     type: integer
-  effectiveAttachmentOptions:
-    anyOf:
-    - items:
-        type: string
-      type: array
-    - type: 'null'
-    default: null
-    title: Effectiveattachmentoptions
 required:
 - id
 title: Report

--- a/source-smartsheet/source_smartsheet/api.py
+++ b/source-smartsheet/source_smartsheet/api.py
@@ -1,7 +1,6 @@
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from logging import Logger
-from typing import Any
 
 from estuary_cdk.capture.common import LogCursor, PageCursor
 from estuary_cdk.http import HTTPSession
@@ -11,27 +10,15 @@ from pydantic import BaseModel, JsonValue
 from .models import (
     DetailPageMeta,
     ListPageMeta,
-    RawRow,
     Report,
     ReportIdValidationContext,
     ReportRow,
-    ReportSummary,
+    RowValidationContext,
     Sheet,
     SheetIdValidationContext,
     SheetRow,
     SheetSummary,
 )
-
-REGION_BASE_URLS = {
-    "us": "https://api.smartsheet.com/2.0",
-    "eu": "https://api.smartsheet.eu/2.0",
-    "gov": "https://api.smartsheetgov.com/2.0",
-    "au": "https://api.smartsheet.au/2.0",
-}
-
-
-def base_url(region: str) -> str:
-    return REGION_BASE_URLS[region]
 
 
 def _format_rfc3339(dt: datetime) -> str:
@@ -52,9 +39,8 @@ LIST_PAGE_SIZE = 100
 
 async def _stream_list_page[ItemT: BaseModel](
     http: HTTPSession,
-    region: str,
     log: Logger,
-    path: str,
+    url: str,
     item_cls: type[ItemT],
     page: int,
     modified_since: datetime | None = None,
@@ -66,17 +52,14 @@ async def _stream_list_page[ItemT: BaseModel](
     if modified_since is not None:
         params["modifiedSince"] = _format_rfc3339(modified_since)
 
-    _, body = await http.request_stream(
-        log, f"{base_url(region)}/{path}", params=params
-    )
+    _, body = await http.request_stream(log, url, params=params)
     return IncrementalJsonProcessor(body(), "data.item", item_cls, ListPageMeta)
 
 
 async def _iter_list_items[ItemT: BaseModel](
     http: HTTPSession,
-    region: str,
     log: Logger,
-    path: str,
+    url: str,
     item_cls: type[ItemT],
     modified_since: datetime | None = None,
 ) -> AsyncGenerator[ItemT, None]:
@@ -84,7 +67,7 @@ async def _iter_list_items[ItemT: BaseModel](
 
     while True:
         processor = await _stream_list_page(
-            http, region, log, path, item_cls, page, modified_since
+            http, log, url, item_cls, page, modified_since
         )
         async for item in processor:
             yield item
@@ -94,45 +77,36 @@ async def _iter_list_items[ItemT: BaseModel](
         # echoes what was actually served, even for a page past the last one.
         if meta.pageNumber >= meta.totalPages:
             return
+
         page += 1
 
 
 async def list_all_sheet_ids(http: HTTPSession, region: str, log: Logger) -> list[int]:
     return [
         summary.id
-        async for summary in _iter_list_items(http, region, log, "sheets", SheetSummary)
+        async for summary in _iter_list_items(
+            http, log, SheetSummary.build_url(region), SheetSummary
+        )
     ]
 
 
 # =============================================================================
 # Detail endpoints — `GET /sheets/{id}` and `GET /reports/{id}` share one
-# envelope shape and one positional-pagination contract, so a single
-# parametrized stream/iterate pair serves both. Rows under `rows[]` are
-# streamed incrementally; the entity's metadata envelope arrives as the
-# processor's remainder (`DetailPageMeta`). Each pair backs its whole
-# cluster: `sheets`/`reports` make one cheap pageSize=1 call and keep only
-# the remainder, `sheet_rows`/`report_rows` walk the full row pagination.
+# envelope shape and one positional-pagination contract
 # =============================================================================
 
-# The docs' "Limitations" guide caps detail reads at 10,000 rows/request;
-# live-confirmed not to 4xx one past it on both endpoints (the `pageSize
-# 10001 over-limit probe` requests). Whether a silent clamp exists below the
-# cap is unobservable on the seeded data (the probes' entities hold fewer
-# rows than a page)
 DETAIL_PAGE_SIZE = 10_000
 
 
 async def _stream_detail_page[RowT: BaseModel](
     http: HTTPSession,
-    region: str,
     log: Logger,
-    path: str,
-    entity_id: int,
+    url: str,
     row_cls: type[RowT],
     page: int,
     page_size: int,
     rows_modified_since: datetime | None = None,
-    validation_context: object | None = None,
+    validation_context: RowValidationContext | None = None,
 ) -> IncrementalJsonProcessor[RowT, DetailPageMeta]:
     # `rows_modified_since` is only ever passed for sheets: `GET /reports/{id}`
     # has no equivalent row filter.
@@ -140,9 +114,7 @@ async def _stream_detail_page[RowT: BaseModel](
     if rows_modified_since is not None:
         params["rowsModifiedSince"] = _format_rfc3339(rows_modified_since)
 
-    _, body = await http.request_stream(
-        log, f"{base_url(region)}/{path}/{entity_id}", params=params
-    )
+    _, body = await http.request_stream(log, url, params=params)
     return IncrementalJsonProcessor(
         body(), "rows.item", row_cls, DetailPageMeta, validation_context
     )
@@ -150,53 +122,50 @@ async def _stream_detail_page[RowT: BaseModel](
 
 async def _iter_detail_rows[RowT: BaseModel](
     http: HTTPSession,
-    region: str,
     log: Logger,
-    path: str,
-    entity_id: int,
+    url: str,
     row_cls: type[RowT],
     page_size: int,
     rows_modified_since: datetime | None = None,
-    validation_context: object | None = None,
+    validation_context: RowValidationContext | None = None,
 ) -> AsyncGenerator[RowT, None]:
-    """Paginate a detail endpoint by row position, walking until every row
-    has been served.
-
-    Unlike the list endpoints, the detail endpoints silently CLAMP to the
+    """Unlike the list endpoints, the detail endpoints silently *clamp* to the
     last valid page instead of erroring or returning empty once `page` goes
     past the entity's real page count, and carry no `pageNumber`/`totalPages`
-    field to detect the clamp. The loop bound is therefore computed
-    client-side from the remainder's `totalRowCount` after each page drains.
+    field to detect the clamp. The loop bound is therefore computed client-side
+    from the remainder's `totalRowCount` after each page drains.
 
     An empty page ends the walk ONLY when no `rows_modified_since` filter is
     set: pagination is applied before the filter, so a filtered page can
-    legitimately be empty mid-walk while later pages still hold matching
-    rows. `totalRowCount` is always the entity's real, unfiltered total, so
-    it's a correct loop bound whether or not a filter is set.
-    """
+    legitimately be empty mid-walk while later pages still hold matching rows.
+    `totalRowCount` is always the entity's real, unfiltered total, so it's a
+    correct loop bound whether or not a filter is set."""
+
     page = 1
+
     while True:
         processor = await _stream_detail_page(
             http,
-            region,
             log,
-            path,
-            entity_id,
+            url,
             row_cls,
             page,
             page_size,
             rows_modified_since,
             validation_context,
         )
+
         empty = True
         async for row in processor:
             empty = False
             yield row
+
         meta = processor.get_remainder()
         if rows_modified_since is None and empty:
             return
         if page * page_size >= meta.totalRowCount:
             return
+
         page += 1
 
 
@@ -205,9 +174,7 @@ async def _iter_detail_rows[RowT: BaseModel](
 # =============================================================================
 
 # The sheet list's `modifiedSince` index lags content edits — observed in
-# (5s, 65s] on a single live measurement (`bruno/Seeding/D2 - Recheck List
-# Sheets modifiedSince after edit`), so treat that bound as indicative and
-# trail by a comfortably larger window.
+# 5s-65s on a live measurement.
 LIST_INDEX_LAG_ALLOWANCE = timedelta(minutes=5)
 
 
@@ -218,10 +185,12 @@ async def _fetch_sheet_metadata(
     # envelope — the one embedded row is drained and discarded; only the
     # remainder is kept.
     processor = await _stream_detail_page(
-        http, region, log, "sheets", sheet_id, RawRow, page=1, page_size=1
+        http, log, SheetRow.build_url(region, sheet_id), SheetRow, page=1, page_size=1
     )
+
     async for _ in processor:
         pass
+
     return Sheet.from_detail(processor.get_remainder())
 
 
@@ -238,35 +207,18 @@ async def fetch_sheets(
                    │       │             │             └ poll_start
     modifiedSince ─┼───────[═════════════╪═════════════╪════▶
     emitted ───────┼───────[═════════════╪═════════════]
-                   │       │             └─ next cursor = min(max modifiedAt
-                   │       │                emitted, horizon): the list
-                   │       │                index publishes edits late
-                   │       │                (LIST_INDEX_LAG_ALLOWANCE), so
-                   │       │                the cursor never enters the
-                   │       │                window it may not cover yet;
-                   │       │                docs in (horizon, poll_start]
-                   │       │                re-emit next poll — duplicate
-                   │       │                upserts, never skips
-                   │       └─ queried bound: floor(cursor) + 1s.
-                   │          `modifiedSince` is >=-inclusive at exact
-                   │          equality (`bruno/Sheets/List Sheets
-                   │          (modifiedSince equality probe)`), so the
-                   │          request alone yields exactly the ticks after
-                   │          the cursor — no client-side skip; NOT the
-                   │          same semantics as `rowsModifiedSince`
-                   └─ excluding the cursor's own second is safe: see below
-
-    Docs stamped at or before the cursor's second were already emitted by
-    the poll that set it: the cursor never exceeds horizon, so anything in
-    that second — even an index-lagged edit — had published by
-    second + allowance <= that poll's poll_start, and was seen then.
+                   │       │             └─ next cursor = min(max emitted, horizon)
+                   │       └─ queried bound: floor(cursor) + 1s
+                   └─ cursor's own second already emitted last poll (safe to skip)
     """
     assert isinstance(log_cursor, datetime)
+
     poll_start = datetime.now(tz=UTC)
     since = log_cursor.replace(microsecond=0) + timedelta(seconds=1)
     max_modified = log_cursor
+
     async for summary in _iter_list_items(
-        http, region, log, "sheets", SheetSummary, modified_since=since
+        http, log, SheetSummary.build_url(region), SheetSummary, modified_since=since
     ):
         yield await _fetch_sheet_metadata(http, region, summary.id, log)
         max_modified = max(max_modified, summary.modifiedAt)
@@ -281,7 +233,7 @@ async def backfill_sheets(
     region: str,
     start_date: datetime,
     log: Logger,
-    page: PageCursor,
+    _page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[Sheet | PageCursor, None]:
     """Backfill sheet metadata from the unfiltered list walk.
@@ -290,36 +242,22 @@ async def backfill_sheets(
     ──────────────┼──────────────────┼──────────┼───▶ time (1s ticks)
                   │                  │          │
     emitted ──────[══════════════════]          │
-                  │                  │          └─ first incremental tick:
-                  │                  │             fetch_sheets' cursor
-                  │                  │             seeds at cutoff − 1s
-                  │                  └─ last backfilled second (client-side
-                  │                     `>= cutoff` skip — the bare list
-                  │                     has no server-side time filter)
-                  └─ configured replication start; older sheets skipped
+                  │                  │          └─ first incremental tick
+                  │                  └─ last backfilled second
+                  └─ configured replication start
 
-    Resume is positional (`page` number): a sheet deleted mid-backfill
-    renumbers everything after it, so one innocent sheet is skipped on
-    resume — the API offers no value-ordered pagination to key a watermark
-    on. Tolerated per House rule 9's carve-out: the walk is short (100
-    sheets/page, usually one in-memory run), and a skipped sheet's
-    metadata self-heals on its next edit via the incremental task.
+    The API offers only positional pagination.
     """
     assert isinstance(cutoff, datetime)
-    page_num = 1 if page is None else page
-    assert isinstance(page_num, int)
 
-    processor = await _stream_list_page(
-        http, region, log, "sheets", SheetSummary, page_num
-    )
-    async for summary in processor:
+    async for summary in _iter_list_items(
+        http, log, SheetSummary.build_url(region), SheetSummary
+    ):
         if summary.modifiedAt >= cutoff:
-            continue  # already covered by incremental once it starts
+            continue  # already covered by incremental
         if summary.modifiedAt < start_date:
             continue  # before the configured replication window
         yield await _fetch_sheet_metadata(http, region, summary.id, log)
-    if page_num < processor.get_remainder().totalPages:
-        yield page_num + 1
 
 
 # =============================================================================
@@ -334,66 +272,49 @@ async def fetch_sheet_rows(
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[SheetRow | LogCursor, None]:
-    """Incremental row fetch, windowed by `rowsModifiedSince`.
+    """Incremental sheet row fetch.
 
                   cursor  cursor+1s     horizon = last elapsed second
     ───────────────────┼───────┼─────────────────┼────▶ time (1s ticks)
                        │       │                 │
     rowsModifiedSince ─(═══════╪═════════════════╪════▶
     emitted ───────────┼───────[═════════════════]
-                       │       │                 └─ the present second may
-                       │       │                    still take edits; rows
-                       │       │                    stamped past horizon
-                       │       │                    are skipped and served
-                       │       │                    by the next poll — the
-                       │       │                    one remaining
-                       │       │                    client-side skip (no
-                       │       │                    upper-bound param
-                       │       │                    exists)
+                       │       │                 └─ present second may still
+                       │       │                    take edits
                        │       └─ first emitted second
-                       └─ queried bound: the cursor itself.
-                          `rowsModifiedSince` is strict `>` at exact
-                          equality (`bruno/Sheets/Get Sheet
-                          (rowsModifiedSince equality probe)`), so the
-                          request alone yields exactly the ticks after the
-                          cursor; NOT the same semantics as the list's
-                          `modifiedSince`
+                       └─ queried bound: the cursor itself (strict `>` at
+                          equality)
 
-    The detail endpoint publishes edits immediately (no list-index lag —
-    `bruno/Seeding/D2`), and an elapsed second is final because rows stamp
-    their own "now", so the cursor advances straight to the newest emitted
-    `modifiedAt` with no lag allowance and no re-emission.
+    The detail endpoint publishes edits immediately (no list-index lag).
 
-    Two blind spots:
-
-    - Blank/never-cell-written rows are invisible to the filter forever
-      (`bruno/Sheets/Get Sheet (rowsModifiedSince narrows, blank-row gap)`);
-      only a periodic full re-backfill per sheet closes this, which the
-      `sheet_rows` resource schedules daily.
-    - Row deletions leave zero trace in the API — no tombstone, no marker,
-      `totalRowCount` silently decrements (`bruno/Seeding/E3`) — so neither
-      this fetcher nor a backfill can observe them.
+    One blind spot: blank/never-cell-written rows are invisible to the filter
+    forever. Only a periodic full re-backfill per sheet closes this, which the
+    `sheet_rows` resource schedules daily.
     """
     assert isinstance(log_cursor, datetime)
+
     horizon = datetime.now(tz=UTC).replace(microsecond=0) - timedelta(seconds=1)
     if horizon <= log_cursor:
         return
-    max_modified = log_cursor
+
     ctx = SheetIdValidationContext(sheet_id=sheet_id)
+    max_modified = log_cursor
+
     async for row in _iter_detail_rows(
         http,
-        region,
         log,
-        "sheets",
-        sheet_id,
-        RawRow,
+        SheetRow.build_url(region, sheet_id),
+        SheetRow,
         DETAIL_PAGE_SIZE,
         rows_modified_since=log_cursor,
+        validation_context=ctx,
     ):
         if row.modifiedAt > horizon:
             continue
-        yield SheetRow.model_validate(row.model_dump(mode="json"), context=ctx)
+        yield row
+
         max_modified = max(max_modified, row.modifiedAt)
+
     if max_modified > log_cursor:
         yield max_modified
 
@@ -404,7 +325,7 @@ async def backfill_sheet_rows(
     start_date: datetime,
     sheet_id: int,
     log: Logger,
-    page: PageCursor,
+    _page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[SheetRow | PageCursor, None]:
     """Backfill rows from the unfiltered detail-page walk.
@@ -413,107 +334,59 @@ async def backfill_sheet_rows(
     ──────────────┼──────────────────┼──────────┼───▶ time (1s ticks)
                   │                  │          │
     emitted ──────[══════════════════]          │
-                  │                  │          └─ first incremental tick:
-                  │                  │             fetch_sheet_rows' cursor
-                  │                  │             seeds at cutoff − 1s
-                  │                  └─ last backfilled second (client-side
-                  │                     `>= cutoff` skip — the unfiltered
-                  │                     detail walk has no time bound;
-                  │                     pages are bounded by totalRowCount,
-                  │                     see `_iter_detail_rows`)
-                  └─ configured replication start; older rows skipped
+                  │                  │          └─ first incremental tick
+                  │                  └─ last backfilled second
+                  └─ configured replication start
 
-    Resume is positional (`page` number): a row deleted mid-backfill
-    renumbers everything after it, so one innocent row is skipped on
-    resume — the API offers no value-ordered pagination to key a watermark
-    on. Tolerated per House rule 9's carve-out: the daily scheduled
-    re-backfill bounds the exposure to 24h (deletions themselves are
-    already invisible outside that same re-read, see fetch_sheet_rows).
     """
     assert isinstance(cutoff, datetime)
-    page_num = 1 if page is None else page
-    assert isinstance(page_num, int)
 
-    processor = await _stream_detail_page(
-        http, region, log, "sheets", sheet_id, RawRow, page_num, DETAIL_PAGE_SIZE
-    )
     ctx = SheetIdValidationContext(sheet_id=sheet_id)
-    async for row in processor:
+
+    async for row in _iter_detail_rows(
+        http,
+        log,
+        SheetRow.build_url(region, sheet_id),
+        SheetRow,
+        DETAIL_PAGE_SIZE,
+        validation_context=ctx,
+    ):
         if row.modifiedAt >= cutoff:
             continue
         if row.modifiedAt < start_date:
             continue  # before the configured replication window
-        yield SheetRow.model_validate(row.model_dump(mode="json"), context=ctx)
-    if page_num * DETAIL_PAGE_SIZE < processor.get_remainder().totalRowCount:
-        yield page_num + 1
+
+        yield row
 
 
 # =============================================================================
 # Reports cluster: `reports` (catalog metadata) and `report_rows` (row data)
-#
-# Both streams are Snapshot replication and share the per-report detail
-# stream/pagination primitive above. This is a simplified variant of the
-# child-entities "snapshot-child" shortcut (source-ashby's
-# `snapshot_child_entity`, source-ashby/source_ashby/api.py:110-131):
-# Smartsheet's single `GET /reports/{id}` call returns both the parent
-# metadata and the first page of child rows in the same response, so there's
-# no separate parent-detail call to make.
-# =============================================================================
-
-
-async def _list_report_ids(http: HTTPSession, region: str, log: Logger) -> list[int]:
-    # Drain the parent (report) list into bare ids before iterating into
-    # per-report detail calls, per child-entities' drain-parents-first
-    # guidance -- report list objects carry no filter field we trust (see
-    # Classification), so there's nothing else worth holding onto.
-    return [
-        summary.id
-        async for summary in _iter_list_items(
-            http, region, log, "reports", ReportSummary
-        )
-    ]
-
-
-# =============================================================================
-# `reports` stream (metadata)
 # =============================================================================
 
 
 async def snapshot_reports(
     http: HTTPSession, region: str, log: Logger
 ) -> AsyncGenerator[Report, None]:
-    for report_id in await _list_report_ids(http, region, log):
-        # pageSize=1 is the cheapest call that still returns the full
-        # metadata envelope -- the one embedded row is drained and discarded,
-        # only the remainder is kept. `report_rows` independently re-fetches
-        # page 1 at the real page size; sharing the fetch across these two
-        # independent snapshot bindings isn't a pattern used elsewhere in
-        # this codebase and isn't worth the complexity at expected report
-        # counts.
-        processor = await _stream_detail_page(
-            http, region, log, "reports", report_id, ReportRow, page=1, page_size=1
-        )
-        async for _ in processor:
-            pass
-        yield Report.from_detail(processor.get_remainder())
-
-
-# =============================================================================
-# `report_rows` stream (row data)
-# =============================================================================
+    async for report in _iter_list_items(http, log, Report.build_url(region), Report):
+        yield report
 
 
 async def snapshot_report_rows(
     http: HTTPSession, region: str, log: Logger
 ) -> AsyncGenerator[ReportRow, None]:
-    for report_id in await _list_report_ids(http, region, log):
+    report_ids = [
+        report.id
+        async for report in _iter_list_items(
+            http, log, Report.build_url(region), Report
+        )
+    ]
+
+    for report_id in report_ids:
         ctx = ReportIdValidationContext(report_id=report_id)
         async for row in _iter_detail_rows(
             http,
-            region,
             log,
-            "reports",
-            report_id,
+            ReportRow.build_url(region, report_id),
             ReportRow,
             DETAIL_PAGE_SIZE,
             validation_context=ctx,

--- a/source-smartsheet/source_smartsheet/models.py
+++ b/source-smartsheet/source_smartsheet/models.py
@@ -1,13 +1,10 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal, override
 
-from estuary_cdk.capture.common import (
-    ResourceState,
-)
-from estuary_cdk.capture.common import (
-    ConnectorState as GenericConnectorState,
-)
+from estuary_cdk.capture.common import ConnectorState as GenericConnectorState
+from estuary_cdk.capture.common import ResourceState
 from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.flow import AccessToken
 from pydantic import (
@@ -15,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    JsonValue,
     ValidationInfo,
     field_validator,
     model_validator,
@@ -57,6 +55,19 @@ class EndpointConfig(BaseModel):
 
 ConnectorState = GenericConnectorState[ResourceState]
 
+# Keys mirror EndpointConfig.region's Literal values.
+REGION_BASE_URLS = {
+    "us": "https://api.smartsheet.com/2.0",
+    "eu": "https://api.smartsheet.eu/2.0",
+    "gov": "https://api.smartsheetgov.com/2.0",
+    "au": "https://api.smartsheet.au/2.0",
+}
+
+
+def base_url(region: str) -> str:
+    return REGION_BASE_URLS[region]
+
+
 # =============================================================================
 # Shared API envelopes -- the sheets and reports endpoint families return one
 # list-page and one detail-page shape.
@@ -81,27 +92,40 @@ class DetailPageMeta(BaseModel, extra="allow"):
     """Remainder of a `GET /sheets/{id}` / `GET /reports/{id}` detail page
     once the `rows[]` items have been streamed out: the entity's full
     metadata envelope, plus `totalRowCount` -- the row walks' client-side
-    pagination bound. `Sheet.from_detail` / `Report.from_detail` dump this
-    wholesale into the metadata streams' output."""
+    pagination bound. `Sheet.from_detail` dumps this wholesale into the sheets
+    metadata stream's output."""
 
     totalRowCount: int
 
 
-class SortedAttachmentOptionsMixin(BaseDocument):
-    """Shared by `Sheet` and `Report`: Smartsheet returns
-    `effectiveAttachmentOptions` in non-deterministic order across
-    otherwise-identical requests, so it's sorted for stable, comparable output.
+class RowValidationContext(ABC):
+    __slots__: tuple[str, ...] = ()
 
-    Validator-only (`check_fields=False`): subclasses declare the field
-    themselves, keeping it after `id` in field -- and thus output -- order.
+    @abstractmethod
+    def inject(self, meta: dict[str, JsonValue]) -> None:
+        """Write this context's parent id into a row's `_meta` mapping."""
+        ...
+
+
+class RowScopedMixin(BaseDocument):
+    """Base for detail-row documents scoped to a parent entity (a sheet or a
+    report). Applies whatever `RowValidationContext` is supplied at validation
+    time; concrete subclasses declare the specific `_meta` id field the context
+    writes into.
     """
 
-    @field_validator("effectiveAttachmentOptions", check_fields=False)
+    @model_validator(mode="before")
     @classmethod
-    def _sort_effective_attachment_options(
-        cls, v: list[str] | None
-    ) -> list[str] | None:
-        return sorted(v) if v is not None else v
+    def _inject_id_from_context(
+        cls, data: JsonValue, info: ValidationInfo
+    ) -> JsonValue:
+        if not isinstance(data, dict):
+            return data
+        if isinstance(info.context, RowValidationContext):
+            meta = data.get("_meta") or {}
+            info.context.inject(meta)
+            data["_meta"] = meta
+        return data
 
 
 # =============================================================================
@@ -109,22 +133,31 @@ class SortedAttachmentOptionsMixin(BaseDocument):
 # =============================================================================
 
 
-class RawRow(BaseModel, extra="allow"):
-    modifiedAt: AwareDatetime
-
-
 class SheetSummary(BaseModel, extra="allow"):
     id: int
     modifiedAt: AwareDatetime
 
+    @staticmethod
+    def build_url(region: str) -> str:
+        return f"{base_url(region)}/sheets"
 
-class Sheet(SortedAttachmentOptionsMixin, BaseDocument):
+
+class Sheet(BaseDocument):
     """One document per sheet: catalog/metadata only, never row data."""
 
     resource_name: ClassVar[str] = "sheets"
 
     id: int
     effectiveAttachmentOptions: list[str] | None = None
+
+    @field_validator("effectiveAttachmentOptions")
+    @classmethod
+    def _sort_effective_attachment_options(
+        cls, v: list[str] | None
+    ) -> list[str] | None:
+        # Option ordering is non-deterministic and can cause snapshot tests to
+        # fail. Sort for stable, comparable output.
+        return sorted(v) if v is not None else v
 
     @classmethod
     def from_detail(cls, meta: DetailPageMeta) -> "Sheet":
@@ -134,15 +167,16 @@ class Sheet(SortedAttachmentOptionsMixin, BaseDocument):
 
 
 @dataclass(frozen=True, slots=True)
-class SheetIdValidationContext:
+class SheetIdValidationContext(RowValidationContext):
     sheet_id: int
 
+    @override
+    def inject(self, meta: dict[str, JsonValue]) -> None:
+        meta["sheet_id"] = self.sheet_id
 
-class SheetScopedMixin(BaseDocument):
-    """Mixin for documents scoped to a Smartsheet sheet.
 
-    Extends _meta with sheet_id and injects it from validation context.
-    """
+class SheetScopedMixin(RowScopedMixin):
+    """Documents scoped to a Smartsheet sheet."""
 
     class Meta(BaseDocument.Meta):
         model_config = ConfigDict(validate_assignment=True)
@@ -157,22 +191,16 @@ class SheetScopedMixin(BaseDocument):
         description="Document metadata",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _inject_sheet_id_from_context(cls, data: Any, info: ValidationInfo) -> Any:
-        if not isinstance(data, dict):
-            return data
-        if info.context and isinstance(info.context, SheetIdValidationContext):
-            meta = data.get("_meta") or {}
-            meta["sheet_id"] = info.context.sheet_id
-            data["_meta"] = meta
-        return data
-
 
 class SheetRow(SheetScopedMixin, BaseDocument):
     resource_name: ClassVar[str] = "sheet_rows"
 
     id: int
+    modifiedAt: AwareDatetime
+
+    @staticmethod
+    def build_url(region: str, sheet_id: int) -> str:
+        return f"{base_url(region)}/sheets/{sheet_id}"
 
 
 # =============================================================================
@@ -186,38 +214,30 @@ class SheetRow(SheetScopedMixin, BaseDocument):
 # =============================================================================
 
 
-class ReportSummary(BaseModel, extra="allow"):
-    """One `GET /reports` list-page item. Only `id` is needed -- report
-    metadata is refetched from the detail endpoint (cheaply, `pageSize=1`),
-    not trusted from the list summary."""
-
-    id: int
-
-
-class Report(SortedAttachmentOptionsMixin, BaseDocument):
-    """One document per report: catalog/metadata only, never row data"""
+class Report(BaseDocument):
+    """One document per report, mirroring a `GET /reports` list item."""
 
     resource_name: ClassVar[str] = "reports"
 
     id: int
-    effectiveAttachmentOptions: list[str] | None = None
 
-    @classmethod
-    def from_detail(cls, meta: DetailPageMeta) -> "Report":
-        # The remainder still carries the streamed-out `rows` key (as an
-        # empty array); `columns[]` is report-definition detail that doesn't
-        # belong on the metadata document -- drop both.
-        return cls(**meta.model_dump(exclude={"columns", "rows"}))
+    @staticmethod
+    def build_url(region: str) -> str:
+        return f"{base_url(region)}/reports"
 
 
 @dataclass(frozen=True, slots=True)
-class ReportIdValidationContext:
-    """Validation context carrying the report_id for ReportRow construction."""
-
+class ReportIdValidationContext(RowValidationContext):
     report_id: int
 
+    @override
+    def inject(self, meta: dict[str, JsonValue]) -> None:
+        meta["report_id"] = self.report_id
 
-class ReportScopedMixin(BaseDocument):
+
+class ReportScopedMixin(RowScopedMixin):
+    """Documents scoped to a Smartsheet report."""
+
     class Meta(BaseDocument.Meta):
         model_config = ConfigDict(validate_assignment=True)
         report_id: int = Field(
@@ -231,19 +251,12 @@ class ReportScopedMixin(BaseDocument):
         description="Document metadata",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _inject_report_id_from_context(cls, data: Any, info: ValidationInfo) -> Any:
-        if not isinstance(data, dict):
-            return data
-        if info.context and isinstance(info.context, ReportIdValidationContext):
-            meta = data.get("_meta") or {}
-            meta["report_id"] = info.context.report_id
-            data["_meta"] = meta
-        return data
-
 
 class ReportRow(ReportScopedMixin, BaseDocument):
     resource_name: ClassVar[str] = "report_rows"
 
     id: int
+
+    @staticmethod
+    def build_url(region: str, report_id: int) -> str:
+        return f"{base_url(region)}/reports/{report_id}"

--- a/source-smartsheet/source_smartsheet/resources.py
+++ b/source-smartsheet/source_smartsheet/resources.py
@@ -18,14 +18,13 @@ from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
 from .api import (
     backfill_sheet_rows,
     backfill_sheets,
-    base_url,
     fetch_sheet_rows,
     fetch_sheets,
     list_all_sheet_ids,
     snapshot_report_rows,
     snapshot_reports,
 )
-from .models import EndpointConfig, Report, ReportRow, Sheet, SheetRow
+from .models import EndpointConfig, Report, ReportRow, Sheet, SheetRow, base_url
 
 # Daily reconciliation schedule for `sheet_rows` — its `rowsModifiedSince`
 # cursor has confirmed gaps (blank/never-cell-written rows are invisible to

--- a/source-smartsheet/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-smartsheet/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -114,25 +114,10 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "accessLevel": "OWNER",
-      "cellImageUploadEnabled": true,
-      "createdAt": "2026-07-21T13:54:39Z",
-      "effectiveAttachmentOptions": [
-        "BOX_COM",
-        "DROPBOX",
-        "EGNYTE",
-        "EVERNOTE",
-        "FILE",
-        "GOOGLE_DRIVE",
-        "LINK",
-        "ONEDRIVE"
-      ],
-      "ganttEnabled": false,
       "id": 3852843205396356,
       "isSummaryReport": false,
-      "modifiedAt": "2026-07-21T13:54:39Z",
       "name": "Estuary Connector Test Report",
-      "permalink": "https://app.smartsheet.eu/reports/xqcjPxpg4pMJgvQJfQr94v9whM9HcFH3RHccr2w1",
-      "totalRowCount": 3
+      "permalink": "https://app.smartsheet.eu/reports/xqcjPxpg4pMJgvQJfQr94v9whM9HcFH3RHccr2w1"
     }
   ],
   [

--- a/source-smartsheet/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-smartsheet/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -140,10 +140,16 @@
         "id": {
           "title": "Id",
           "type": "integer"
+        },
+        "modifiedAt": {
+          "format": "date-time",
+          "title": "Modifiedat",
+          "type": "string"
         }
       },
       "required": [
-        "id"
+        "id",
+        "modifiedAt"
       ],
       "title": "SheetRow",
       "type": "object",
@@ -210,7 +216,7 @@
         }
       },
       "additionalProperties": true,
-      "description": "One document per report: catalog/metadata only, never row data",
+      "description": "One document per report, mirroring a `GET /reports` list item.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
@@ -219,21 +225,6 @@
         "id": {
           "title": "Id",
           "type": "integer"
-        },
-        "effectiveAttachmentOptions": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Effectiveattachmentoptions"
         }
       },
       "required": [


### PR DESCRIPTION
**Regression?**

(Is this pull-request fixing a regression introduced by an earlier pull-request? If so please link the earlier pull-request, otherwise remove this section)

**Description:**

Fixes several details related to https://github.com/estuary/connectors/pull/4804:

- Add source documentation
- Snapshot accurate report documents, do not concatenate detailed metadata from individual "get report" API calls
- Truncate verbose documentation
- Implement `build_url` helper methods to simplify function signatures
- Remove unnecessary backfill checkpoint churn based on unstable page cursors
- Inline or remove vestigial helper artifacts (e.g. `_list_report_ids` and `SortedAttachmentOptionsMixin`)
- Remove `RawRow` model and eagerly validate data using final models during timestamp filtering — minor performance benefits do not justify the added code complexity

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

Reviewed using `flowctl preview`. Snapshots changed as expected

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
