### PR TITLE
source-sage-intacct: handle CURRENCY and PERCENT datatypes

### DIFF
--- a/source-sage-intacct/CHANGELOG.md
+++ b/source-sage-intacct/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2026-07-22
+
+### Fixed
+- Captures no longer fail on populated `CURRENCY` and `PERCENT` fields. These
+  values are now emitted as numeric strings (like `DECIMAL`) instead of raising
+  `Unhandled datatype ... for ...`, and their fields are included in the
+  captured document schema.

--- a/source-sage-intacct/source_sage_intacct/sage.py
+++ b/source-sage-intacct/source_sage_intacct/sage.py
@@ -34,9 +34,9 @@ DATATYPE_MAP: dict[str, Any] = {
     "TIMESTAMP": AwareDatetime,
     "ENUM": str,
     "DECIMAL": str,
-    # TODO(whb): Update the remaining types once we see some values and know
-    # what they look like. `str` is just a placeholder, and may or may not be
-    # appropriate.
+    # CURRENCY and PERCENT are numeric values serialized as strings, handled
+    # like DECIMAL. SEQUENCE's shape is still unconfirmed; `str` is a
+    # placeholder and it is not yet normalized or emitted in schemas.
     "CURRENCY": str,
     "PERCENT": str,
     "SEQUENCE": str,
@@ -115,9 +115,9 @@ class SageRecord(BaseModel):
                     assert isinstance(val, str)
                     if val == "":
                         continue
-                case "DECIMAL":
+                case "DECIMAL" | "CURRENCY" | "PERCENT":
                     val = str(val)
-                case "CURRENCY" | "SEQUENCE" | "PERCENT":
+                case "SEQUENCE":
                     # TODO(whb): Update this once we see some values and know
                     # what they look like.
                     raise ValueError(
@@ -156,12 +156,12 @@ class SageRecord(BaseModel):
                         "type": "string",
                         "format": "date-time",
                     }
-                case "DECIMAL":
+                case "DECIMAL" | "CURRENCY" | "PERCENT":
                     field_schema = {
                         "type": "string",
                         "format": "number",
                     }
-                case "CURRENCY" | "SEQUENCE" | "PERCENT":
+                case "SEQUENCE":
                     # TODO(whb): Update this to an appropriate type once we see
                     # some values and know what they look like.
                     continue

--- a/source-sage-intacct/tests/test_datatypes.py
+++ b/source-sage-intacct/tests/test_datatypes.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+from typing import Optional
+
+import pytest
+from pydantic import create_model
+
+from source_sage_intacct.sage import DATATYPE_MAP, SageRecord
+
+
+def build_model(fields: list[tuple[str, str]]) -> type[SageRecord]:
+    """Build a SageRecord subclass the same way `Sage._build_model` does, so we
+    can exercise value normalization and schema generation for specific
+    datatypes without talking to the Sage Intacct API."""
+    base_fields = set(SageRecord.model_fields.keys())
+    field_defs = {
+        name: (Optional[DATATYPE_MAP[datatype]], None)
+        for name, datatype in fields
+        if name not in base_fields
+    }
+    model = create_model("TestObject", __base__=SageRecord, **field_defs)
+    model.tz_dt = datetime.now(UTC)
+    model.field_names = [name for name, _ in fields]
+    model.field_datatypes = [datatype for _, datatype in fields]
+    return model
+
+
+def test_currency_value_normalizes_to_string():
+    # Regression for estuary/connectors#4873: a populated CURRENCY field (e.g.
+    # ITEM.BASIC = "6.50") previously raised
+    # `Unhandled datatype CURRENCY for BASIC: 6.50` during runTransactions.
+    model = build_model([("RECORDNO", "INTEGER"), ("BASIC", "CURRENCY")])
+
+    record = model.model_validate({"RECORDNO": 1, "BASIC": "6.50"})
+
+    assert record.model_dump()["BASIC"] == "6.50"
+
+
+def test_percent_value_normalizes_to_string():
+    model = build_model([("RECORDNO", "INTEGER"), ("RATE", "PERCENT")])
+
+    record = model.model_validate({"RECORDNO": 1, "RATE": "12.5"})
+
+    assert record.model_dump()["RATE"] == "12.5"
+
+
+def test_sequence_still_raises_pending_confirmed_shape():
+    # SEQUENCE is intentionally left unhandled until a real value is observed;
+    # keep the explicit failure so we don't silently emit an unverified shape.
+    model = build_model([("RECORDNO", "INTEGER"), ("SEQ", "SEQUENCE")])
+
+    with pytest.raises(ValueError, match="Unhandled datatype SEQUENCE"):
+        model.model_validate({"RECORDNO": 1, "SEQ": "7"})
+
+
+def test_sourced_schema_emits_currency_and_percent_as_number_strings():
+    model = build_model(
+        [
+            ("RECORDNO", "INTEGER"),
+            ("BASIC", "CURRENCY"),
+            ("RATE", "PERCENT"),
+            ("SEQ", "SEQUENCE"),
+        ]
+    )
+
+    schema = model.sourced_schema()
+
+    assert schema["properties"]["BASIC"] == {"type": "string", "format": "number"}
+    assert schema["properties"]["RATE"] == {"type": "string", "format": "number"}
+    assert "BASIC" in schema["required"]
+    assert "RATE" in schema["required"]
+    # SEQUENCE shape is unconfirmed, so it is still dropped from the schema.
+    assert "SEQ" not in schema["properties"]
+    assert "SEQ" not in schema["required"]


### PR DESCRIPTION
**Regression?**

Not a regression from a specific PR — `CURRENCY`/`SEQUENCE`/`PERCENT` were left as `# TODO(whb)` placeholders that raise. This surfaced now that a production object (`ITEM.BASIC`) has a populated `CURRENCY` value.

**Description:**

Fixes #4873. The Sage Intacct connector fails during `runTransactions` when it encounters a populated `CURRENCY`-typed field:

```
Value error, Unhandled datatype CURRENCY for BASIC: 6.50
```

`SageRecord._normalize_values` explicitly raised for `CURRENCY | SEQUENCE | PERCENT`, and `sourced_schema()` dropped those fields.

`CURRENCY` and `PERCENT` are numeric values serialized as strings, so this handles them exactly like `DECIMAL`:

- `_normalize_values`: `val = str(val)` instead of raising.
- `sourced_schema()`: emit `{"type": "string", "format": "number"}` instead of `continue`.

`SEQUENCE` is intentionally left raising, per the issue's guidance to confirm its real value shape before emitting an unverified type. It's split out into its own `case` so it fails loudly rather than silently.

**Workflow steps:**

No config change. Captures that include an object with a populated `CURRENCY` or `PERCENT` field now succeed, and those fields appear in the captured document schema as numeric strings.

**Documentation links affected:**

None. Behavior is described in the connector's `CHANGELOG.md` (added here).

**Notes for reviewers:**

- `DATATYPE_MAP` already mapped all three types to `str`; only the normalization/schema branches raised, so the field type is unchanged.
- Added `source-sage-intacct/tests/test_datatypes.py` covering: `CURRENCY`/`PERCENT` normalize to strings, `sourced_schema()` emits `{"type":"string","format":"number"}` for them, and `SEQUENCE` still raises (guarding the deferred scope).
- `pytest source-sage-intacct` → 28 passed.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated. Added `source-sage-intacct/CHANGELOG.md`.
