### PR TITLE
source-salesforce-native: paginate backfills by `Id` instead of date windows

### DIFF
--- a/source-salesforce-native/CHANGELOG.md
+++ b/source-salesforce-native/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 2026-07-22
+
+### Changed
+- Backfills of incremental streams now paginate by the object's `Id` field instead of
+  date windows over the cursor field. Backfill performance no longer depends on how
+  records are distributed over time, and the `advanced.window_size` setting no longer
+  needs tuning for large objects (it still applies to backfills already in progress
+  and to incremental catch-up sweeps).
+- Backfills that were already in progress before this change continue from their
+  saved position using the previous date window strategy; no re-backfill is needed.

--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -14,8 +14,8 @@ from .bulk_job_manager import (
     NOT_SUPPORTED_BY_BULK_API,
     MAX_BULK_QUERY_SET_SIZE,
 )
-from .rest_query_manager import RestQueryManager
-from .shared import dt_to_str, str_to_dt, now, should_retry, VERSION
+from .rest_query_manager import MAX_REST_RESPONSE_SIZE, RestQueryManager, chunk_fields
+from .shared import build_query, dt_to_str, str_to_dt, now, should_retry, VERSION
 from .models import (
     MIN_INCREMENTAL_WINDOW_SIZE,
     FieldDetails,
@@ -26,7 +26,8 @@ from .models import (
     create_salesforce_model,
 )
 
-REST_CHECKPOINT_INTERVAL = 2_000
+# Checkpoint intervals match the transports' page sizes; records arrive at most a page at a time.
+REST_CHECKPOINT_INTERVAL = MAX_REST_RESPONSE_SIZE
 BULK_CHECKPOINT_INTERVAL = MAX_BULK_QUERY_SET_SIZE
 
 # We have reason to believe the Salesforce API is eventually consistent to some degree. Fivetran
@@ -109,7 +110,7 @@ async def snapshot_resources(
 
     async for record in bulk_job_manager.execute(
         name,
-        fields,
+        build_query(name, list(fields.keys())),
         model_cls,
     ):
         yield record
@@ -204,23 +205,32 @@ async def backfill_incremental_resources(
             return
 
     async def _execute(
-        manager: BulkJobManager | RestQueryManager, 
+        gen: AsyncGenerator[SalesforceRecord, None],
         checkpoint_interval: int
     ) -> AsyncGenerator[SalesforceRecord | str, None]:
-        gen = manager.execute(
-            name,
-            fields,
-            model_cls,
-            cursor_field,
-            start,
-            end,
-        )
-
         async for record_or_dt in _execution_wrapper(gen, cursor_field, start, end, max_window_size, checkpoint_interval):
             if isinstance(record_or_dt, datetime):
                 yield dt_to_str(record_or_dt)
             else:
                 yield record_or_dt
+
+    def _execute_bulk() -> AsyncGenerator[SalesforceRecord | str, None]:
+        gen = bulk_job_manager.execute(
+            name,
+            build_query(name, list(fields.keys()), cursor_field, start, end),
+            model_cls,
+        )
+
+        return _execute(gen, BULK_CHECKPOINT_INTERVAL)
+
+    def _execute_rest() -> AsyncGenerator[SalesforceRecord | str, None]:
+        queries = [
+            build_query(name, chunk, cursor_field, start, end)
+            for chunk in chunk_fields(fields, cursor_field)
+        ]
+        gen = rest_query_manager.execute(name, queries, model_cls, cursor_field, end)
+
+        return _execute(gen, REST_CHECKPOINT_INTERVAL)
 
     log.debug("Executing backfill.", {
         "start": start,
@@ -229,7 +239,7 @@ async def backfill_incremental_resources(
     })
 
     try:
-        gen = _execute(bulk_job_manager, BULK_CHECKPOINT_INTERVAL) if is_supported_by_bulk_api else _execute(rest_query_manager, REST_CHECKPOINT_INTERVAL)
+        gen = _execute_bulk() if is_supported_by_bulk_api else _execute_rest()
         async for doc_or_str in gen:
             yield doc_or_str
     except BulkJobError as err:
@@ -244,7 +254,7 @@ async def backfill_incremental_resources(
                 should_fallback_to_rest_api = True
 
         if should_fallback_to_rest_api:
-            async for doc_or_str in _execute(rest_query_manager, REST_CHECKPOINT_INTERVAL):
+            async for doc_or_str in _execute_rest():
                 yield doc_or_str
         else:
             raise
@@ -287,14 +297,11 @@ async def fetch_incremental_resources(
         "is_support_by_bulk_api": is_supported_by_bulk_api,
     })
 
-    gen = rest_query_manager.execute(
-        name,
-        fields,
-        model_cls,
-        cursor_field,
-        log_cursor,
-        end,
-    )
+    queries = [
+        build_query(name, chunk, cursor_field, log_cursor, end)
+        for chunk in chunk_fields(fields, cursor_field)
+    ]
+    gen = rest_query_manager.execute(name, queries, model_cls, cursor_field, end)
 
     async for record_or_dt in _execution_wrapper(gen, cursor_field, log_cursor, end, window_size, REST_CHECKPOINT_INTERVAL):
         yield record_or_dt

--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -154,6 +154,20 @@ async def _execution_wrapper(
         yield end
 
 
+def _should_fallback_to_rest_api(err: BulkJobError, name: str, log: Logger) -> bool:
+    # If this object can't be queried via the Bulk API, fallback to using the REST API.
+    should_fallback = False
+    if err.errors:
+        if CANNOT_FETCH_COMPOUND_DATA in err.errors or NOT_SUPPORTED_BY_BULK_API in err.errors:
+            log.info(f"{name} cannot be queried via the Bulk API. Attempting to use the REST API instead.", {"errors": err.errors})
+            should_fallback = True
+        elif DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED in err.errors or DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED in err.errors:
+            log.info(f"{err.message}. Attempting to use the REST API instead.", {"errors": err.errors})
+            should_fallback = True
+
+    return should_fallback
+
+
 async def backfill_incremental_resources(
     http: HTTPSession,
     is_supported_by_bulk_api: bool,
@@ -243,17 +257,7 @@ async def backfill_incremental_resources(
         async for doc_or_str in gen:
             yield doc_or_str
     except BulkJobError as err:
-        # If this object can't be queried via the Bulk API, fallback to using the REST API.
-        should_fallback_to_rest_api = False
-        if err.errors:
-            if CANNOT_FETCH_COMPOUND_DATA in err.errors or NOT_SUPPORTED_BY_BULK_API in err.errors:
-                log.info(f"{name} cannot be queried via the Bulk API. Attempting to use the REST API instead.", {"errors": err.errors})
-                should_fallback_to_rest_api = True
-            elif DAILY_MAX_BULK_API_QUERY_VOLUME_EXCEEDED in err.errors or DAILY_MAX_BULK_API_QUERY_LIMIT_EXCEEDED in err.errors:
-                log.info(f"{err.message}. Attempting to use the REST API instead.", {"errors": err.errors})
-                should_fallback_to_rest_api = True
-
-        if should_fallback_to_rest_api:
+        if _should_fallback_to_rest_api(err, name, log):
             async for doc_or_str in _execute_rest():
                 yield doc_or_str
         else:

--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -15,11 +15,12 @@ from .bulk_job_manager import (
     MAX_BULK_QUERY_SET_SIZE,
 )
 from .rest_query_manager import MAX_REST_RESPONSE_SIZE, RestQueryManager, chunk_fields
-from .shared import build_query, dt_to_str, str_to_dt, now, should_retry, VERSION
+from .shared import build_date_window_query, build_id_page_query, build_snapshot_query, dt_to_str, is_salesforce_id, str_to_dt, now, should_retry, VERSION
 from .models import (
     MIN_INCREMENTAL_WINDOW_SIZE,
     FieldDetails,
     FieldDetailsDict,
+    QueryResponse,
     SalesforceRecord,
     CursorFields,
     SObject,
@@ -29,6 +30,10 @@ from .models import (
 # Checkpoint intervals match the transports' page sizes; records arrive at most a page at a time.
 REST_CHECKPOINT_INTERVAL = MAX_REST_RESPONSE_SIZE
 BULK_CHECKPOINT_INTERVAL = MAX_BULK_QUERY_SET_SIZE
+
+# Page sizes for Id-based keyset pagination during backfills.
+BULK_ID_PAGE_LIMIT = 500_000
+REST_ID_PAGE_LIMIT = MAX_REST_RESPONSE_SIZE
 
 # We have reason to believe the Salesforce API is eventually consistent to some degree. Fivetran
 # re-fetches all records in the 5 minutes before their cursor value to combat eventual consistency.
@@ -110,14 +115,14 @@ async def snapshot_resources(
 
     async for record in bulk_job_manager.execute(
         name,
-        build_query(name, list(fields.keys())),
+        build_snapshot_query(name, list(fields.keys())),
         model_cls,
     ):
         yield record
 
 
-# _execution_wrapper centralizes the cursor management logic for incremental resources.
-async def _execution_wrapper(
+# _datetime_execution_wrapper centralizes the datetime cursor management logic for incremental resources.
+async def _datetime_execution_wrapper(
     record_generator: AsyncGenerator[SalesforceRecord, None],
     cursor_field: CursorFields,
     start: datetime,
@@ -154,6 +159,67 @@ async def _execution_wrapper(
         yield end
 
 
+# _id_execution_wrapper interleaves Id page cursors into a strictly Id-ordered record stream.
+# A trailing cursor is emitted only if the page was full: a short page means no records remain.
+async def _id_execution_wrapper(
+    record_generator: AsyncGenerator[SalesforceRecord, None],
+    checkpoint_interval: int,
+    limit: int,
+) -> AsyncGenerator[SalesforceRecord | str, None]:
+    last_id: str | None = None
+    count = 0
+    count_since_checkpoint = 0
+
+    async for record in record_generator:
+        if last_id is not None and count_since_checkpoint >= checkpoint_interval:
+            yield last_id
+            count_since_checkpoint = 0
+
+        yield record
+        last_id = record.Id
+        count += 1
+        count_since_checkpoint += 1
+
+    if count >= limit and last_id is not None:
+        yield last_id
+
+
+# _fetch_id_page_boundary locates the Id of the next page's last record so every field-chunk
+# query can share an identical closed Id range and merge deterministically. A None boundary
+# means fewer than a full page remains, which stays true since updates only ever move records'
+# cursor fields past the cutoff and out of the window.
+async def _fetch_id_page_boundary(
+    http: HTTPSession,
+    instance_url: str,
+    name: str,
+    cursor_field: CursorFields,
+    start: datetime,
+    end: datetime,
+    last_id: str | None,
+    log: Logger,
+) -> str | None:
+    query = build_id_page_query(
+        name,
+        ["Id"],
+        cursor_field,
+        start,
+        end,
+        last_id=last_id,
+        limit=1,
+        offset=REST_ID_PAGE_LIMIT - 1,
+    )
+    url = f"{instance_url}/services/data/v{VERSION}/queryAll"
+
+    response = QueryResponse.model_validate_json(
+        await http.request(log, url, params={"q": query}, should_retry=should_retry)
+    )
+
+    if not response.records:
+        return None
+
+    return response.records[0]["Id"]
+
+
 def _should_fallback_to_rest_api(err: BulkJobError, name: str, log: Logger) -> bool:
     # If this object can't be queried via the Bulk API, fallback to using the REST API.
     should_fallback = False
@@ -186,22 +252,6 @@ async def backfill_incremental_resources(
 ) -> AsyncGenerator[SalesforceRecord | PageCursor, None]:
     assert isinstance(cutoff, datetime)
 
-    if page is None:
-        start = start_date
-    else:
-        assert isinstance(page, str)
-        start = str_to_dt(page)
-
-    if start >= cutoff:
-        log.debug("Page cursor is after cutoff, indicating backfill is complete.", {
-            "start": start,
-            "cutoff": cutoff,
-        })
-        return
-
-    max_window_size = min(window_size, cutoff - start)
-    end = min(cutoff, start + max_window_size)
-
     cursor_field = _determine_cursor_field(fields)
 
     # On connector-initiated backfills, only fetch formula fields and rely on the top level
@@ -218,11 +268,142 @@ async def backfill_incremental_resources(
         if not has_fields_to_refresh:
             return
 
+    if page is not None:
+        assert isinstance(page, str)
+
+    # Backfills that started before Id-based pagination existed persisted a datetime page cursor
+    # and are driven to completion with the original date window strategy.
+    # TODO(bair): Remove the backwards-compatible date window logic once we're sure all on-going
+    # backfills have completed.
+    if isinstance(page, str) and not is_salesforce_id(page):
+        gen = _backfill_with_date_windows(
+            is_supported_by_bulk_api,
+            bulk_job_manager,
+            rest_query_manager,
+            name,
+            fields,
+            model_cls,
+            cursor_field,
+            window_size,
+            log,
+            str_to_dt(page),
+            cutoff,
+        )
+    else:
+        gen = _backfill_with_id_pages(
+            http,
+            is_supported_by_bulk_api,
+            bulk_job_manager,
+            rest_query_manager,
+            instance_url,
+            name,
+            fields,
+            model_cls,
+            cursor_field,
+            start_date,
+            log,
+            page,
+            cutoff,
+        )
+
+    async for record_or_cursor in gen:
+        yield record_or_cursor
+
+
+async def _backfill_with_id_pages(
+    http: HTTPSession,
+    is_supported_by_bulk_api: bool,
+    bulk_job_manager: BulkJobManager,
+    rest_query_manager: RestQueryManager,
+    instance_url: str,
+    name: str,
+    fields: FieldDetailsDict,
+    model_cls: type[SalesforceRecord],
+    cursor_field: CursorFields,
+    start_date: datetime,
+    log: Logger,
+    last_id: str | None,
+    cutoff: datetime,
+) -> AsyncGenerator[SalesforceRecord | str, None]:
+    if start_date >= cutoff:
+        log.debug("Start date is at or after cutoff, indicating there is no date range to backfill.", {
+            "start_date": start_date,
+            "cutoff": cutoff,
+        })
+        return
+
+    async def _execute_bulk() -> AsyncGenerator[SalesforceRecord | str, None]:
+        gen = bulk_job_manager.execute(
+            name,
+            build_id_page_query(name, list(fields.keys()), cursor_field, start_date, cutoff, last_id=last_id, limit=BULK_ID_PAGE_LIMIT),
+            model_cls,
+        )
+
+        async for record_or_id in _id_execution_wrapper(gen, BULK_CHECKPOINT_INTERVAL, BULK_ID_PAGE_LIMIT):
+            yield record_or_id
+
+    # The boundary Id is yielded as the page cursor after the page's records; no boundary means
+    # this is the final page, and ending without a trailing cursor completes the backfill.
+    async def _execute_rest() -> AsyncGenerator[SalesforceRecord | str, None]:
+        boundary_id = await _fetch_id_page_boundary(http, instance_url, name, cursor_field, start_date, cutoff, last_id, log)
+
+        queries = [
+            build_id_page_query(name, chunk, cursor_field, start_date, cutoff, last_id=last_id, max_id=boundary_id)
+            for chunk in chunk_fields(fields, cursor_field)
+        ]
+
+        async for record in rest_query_manager.execute(name, queries, model_cls, cursor_field, cutoff):
+            yield record
+
+        if boundary_id is not None:
+            yield boundary_id
+
+    log.debug("Executing backfill page.", {
+        "last_id": last_id,
+        "cutoff": cutoff,
+        "is_supported_by_bulk_api": is_supported_by_bulk_api,
+    })
+
+    try:
+        gen = _execute_bulk() if is_supported_by_bulk_api else _execute_rest()
+        async for record_or_id in gen:
+            yield record_or_id
+    except BulkJobError as err:
+        if _should_fallback_to_rest_api(err, name, log):
+            async for record_or_id in _execute_rest():
+                yield record_or_id
+        else:
+            raise
+
+
+async def _backfill_with_date_windows(
+    is_supported_by_bulk_api: bool,
+    bulk_job_manager: BulkJobManager,
+    rest_query_manager: RestQueryManager,
+    name: str,
+    fields: FieldDetailsDict,
+    model_cls: type[SalesforceRecord],
+    cursor_field: CursorFields,
+    window_size: timedelta,
+    log: Logger,
+    start: datetime,
+    cutoff: datetime,
+) -> AsyncGenerator[SalesforceRecord | str, None]:
+    if start >= cutoff:
+        log.debug("Page cursor is after cutoff, indicating backfill is complete.", {
+            "start": start,
+            "cutoff": cutoff,
+        })
+        return
+
+    max_window_size = min(window_size, cutoff - start)
+    end = min(cutoff, start + max_window_size)
+
     async def _execute(
         gen: AsyncGenerator[SalesforceRecord, None],
         checkpoint_interval: int
     ) -> AsyncGenerator[SalesforceRecord | str, None]:
-        async for record_or_dt in _execution_wrapper(gen, cursor_field, start, end, max_window_size, checkpoint_interval):
+        async for record_or_dt in _datetime_execution_wrapper(gen, cursor_field, start, end, max_window_size, checkpoint_interval):
             if isinstance(record_or_dt, datetime):
                 yield dt_to_str(record_or_dt)
             else:
@@ -231,7 +412,7 @@ async def backfill_incremental_resources(
     def _execute_bulk() -> AsyncGenerator[SalesforceRecord | str, None]:
         gen = bulk_job_manager.execute(
             name,
-            build_query(name, list(fields.keys()), cursor_field, start, end),
+            build_date_window_query(name, list(fields.keys()), cursor_field, start, end),
             model_cls,
         )
 
@@ -239,7 +420,7 @@ async def backfill_incremental_resources(
 
     def _execute_rest() -> AsyncGenerator[SalesforceRecord | str, None]:
         queries = [
-            build_query(name, chunk, cursor_field, start, end)
+            build_date_window_query(name, chunk, cursor_field, start, end)
             for chunk in chunk_fields(fields, cursor_field)
         ]
         gen = rest_query_manager.execute(name, queries, model_cls, cursor_field, end)
@@ -302,12 +483,12 @@ async def fetch_incremental_resources(
     })
 
     queries = [
-        build_query(name, chunk, cursor_field, log_cursor, end)
+        build_date_window_query(name, chunk, cursor_field, log_cursor, end)
         for chunk in chunk_fields(fields, cursor_field)
     ]
     gen = rest_query_manager.execute(name, queries, model_cls, cursor_field, end)
 
-    async for record_or_dt in _execution_wrapper(gen, cursor_field, log_cursor, end, window_size, REST_CHECKPOINT_INTERVAL):
+    async for record_or_dt in _datetime_execution_wrapper(gen, cursor_field, log_cursor, end, window_size, REST_CHECKPOINT_INTERVAL):
         yield record_or_dt
 
     log.debug("Finished fetching incremental changes.", {

--- a/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
+++ b/source-salesforce-native/source_salesforce_native/bulk_job_manager.py
@@ -1,15 +1,12 @@
 import asyncio
-from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator
 
 from estuary_cdk.http import HTTPSession, HTTPError
 from estuary_cdk.incremental_csv_processor import CSVConfig, IncrementalCSVProcessor
-from .shared import build_query, should_retry, VERSION
+from .shared import should_retry, VERSION
 from .models import (
     BulkJobError,
-    FieldDetailsDict,
-    CursorFields,
     BulkJobStates,
     BulkJobSubmitResponse,
     BulkJobCheckStatusResponse,
@@ -49,14 +46,9 @@ class BulkJobManager:
 
     async def _submit(
             self,
-            object_name: str, 
-            field_names: list[str],
-            cursor_field: CursorFields | None = None,
-            start: datetime | None = None,
-            end: datetime | None = None,
+            object_name: str,
+            query: str,
         ) -> str:
-        query = build_query(object_name, field_names, cursor_field, start, end)
-
         body = {
             "operation": "queryAll",
             "query" : query,
@@ -65,8 +57,6 @@ class BulkJobManager:
         try:
             self.log.debug("Submitting bulk job.", {
                 "object_name": object_name,
-                "start": start,
-                "end": end,
                 "query": query,
             })
 
@@ -92,8 +82,6 @@ class BulkJobManager:
         self.log.debug("Submitted bulk job.", {
             "job_id": response.id,
             "object_name": object_name,
-            "start": start,
-            "end": end,
             "query": query,
         })
 
@@ -166,16 +154,14 @@ class BulkJobManager:
             params['locator'] = next_page
 
 
+    # execute runs a caller-provided SOQL query as a bulk query job and streams its results.
     async def execute(
         self,
-        object_name: str, 
-        fields: FieldDetailsDict,
+        object_name: str,
+        query: str,
         model_cls: type[SalesforceRecord],
-        cursor_field: CursorFields | None = None,
-        start: datetime | None = None,
-        end: datetime | None = None,
     ) -> AsyncGenerator[SalesforceRecord, None]:
-        job_id = await self._submit(object_name, list(fields.keys()), cursor_field, start, end)
+        job_id = await self._submit(object_name, query)
 
         delay = INITIAL_SLEEP
         attempt = 1
@@ -188,8 +174,7 @@ class BulkJobManager:
                         self.log.debug("Bulk job returned no results.", {
                             "job_id": job_id,
                             "object_name": object_name,
-                            "start": start,
-                            "end": end,
+                            "query": query,
                         })
                         return
                     break
@@ -198,7 +183,7 @@ class BulkJobManager:
                         self.log.info(f"Sleeping for {delay} seconds after attempt #{attempt} of waiting for job completion.", {
                             "job_details": job_details,
                         })
-                    await asyncio.sleep(delay)  
+                    await asyncio.sleep(delay)
                     delay = min(delay * 2, MAX_SLEEP)
                     attempt += 1
                 case BulkJobStates.ABORTED | BulkJobStates.FAILED:
@@ -219,8 +204,7 @@ class BulkJobManager:
             "job_id": job_id,
             "job_details": job_details,
             "object_name": object_name,
-            "start": start,
-            "end": end,
+            "query": query,
         })
 
         async for result in self._fetch_results(job_id, model_cls):
@@ -234,7 +218,6 @@ class BulkJobManager:
         self.log.debug("Finished fetching results for bulk job.", {
             "job_id": job_id,
             "object_name": object_name,
-            "start": start,
-            "end": end,
+            "query": query,
             "count": received,
         })

--- a/source-salesforce-native/source_salesforce_native/rest_query_manager.py
+++ b/source-salesforce-native/source_salesforce_native/rest_query_manager.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import Any, AsyncGenerator, TypedDict
 
 from estuary_cdk.http import HTTPSession
-from .shared import build_query, should_retry, str_to_dt, VERSION
+from .shared import should_retry, str_to_dt, VERSION
 from .models import (
     CursorFields,
     FieldDetailsDict,
@@ -19,6 +19,9 @@ from .models import (
 # https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_api.htm#:~:text=In%20each%20REST%20call%2C%20the%20maximum%20length%20for%20the%20combined%20URI%20and%20headers%20is%2016%2C384%20bytes.
 MAX_URI_LENGTH = 16_384
 MAX_FIELDS_LENGTH = MAX_URI_LENGTH - 2_500
+
+# Salesforce returns at most this many records in a single REST API query response.
+MAX_REST_RESPONSE_SIZE = 2_000
 
 REST_VALIDATION_CONTEXT = ValidationContext(SalesforceDataSource.REST_API)
 
@@ -92,62 +95,62 @@ class RecordAndChunksCompleted(TypedDict):
     chunks_completed_count: int
 
 
+# chunk_fields splits an object's fields into chunks that fit within Salesforce's URI length
+# limits. Callers build one query per chunk with an identical WHERE clause, and RestQueryManager
+# merges the per-chunk results back into complete records.
+def chunk_fields(fields: FieldDetailsDict, cursor_field: CursorFields) -> list[list[str]]:
+    # The Id and cursor field are required later to merge together documents across
+    # chunks and detect if a document was updated between querys.
+    mandatory_fields: list[str] = ['Id', cursor_field]
+    mandatory_fields_length = sum([len(field) for field in mandatory_fields])
+
+    field_names = [f for f in list(fields.keys()) if f not in mandatory_fields]
+    chunks: list[list[str]] = []
+
+    chunk_fields_length = mandatory_fields_length
+    chunk: list[str] = [*mandatory_fields]
+    for field in field_names:
+        if chunk_fields_length + len(field) > MAX_FIELDS_LENGTH:
+            chunks.append(chunk)
+
+            chunk = [field, *mandatory_fields]
+            chunk_fields_length = len(field) + mandatory_fields_length
+        else:
+            chunk.append(field)
+            chunk_fields_length += len(field)
+
+    if len(chunk) > len(mandatory_fields):
+        chunks.append(chunk)
+
+    return chunks
+
+
 class RestQueryManager:
     def __init__(self, http: HTTPSession, log: Logger, instance_url: str):
         self.http = http
         self.log = log
         self.base_url = f"{instance_url}/services/data/v{VERSION}/queryAll"
 
-    def _chunk_fields(self, fields: FieldDetailsDict, cursor_field: CursorFields) -> list[list[str]]:
-        # The Id and cursor field are required later to merge together documents across
-        # chunks and detect if a document was updated between querys.
-        mandatory_fields: list[str] = ['Id', cursor_field]
-        mandatory_fields_length = sum([len(field) for field in mandatory_fields])
-
-        field_names = [f for f in list(fields.keys()) if f not in mandatory_fields]
-        chunks: list[list[str]] = []
-
-        chunk_fields_length = mandatory_fields_length
-        chunk: list[str] = [*mandatory_fields]
-        for field in field_names:
-            if chunk_fields_length + len(field) > MAX_FIELDS_LENGTH:
-                chunks.append(chunk)
-
-                chunk = [field, *mandatory_fields]
-                chunk_fields_length = len(field) + mandatory_fields_length
-            else:
-                chunk.append(field)
-                chunk_fields_length += len(field)
-
-        if len(chunk) > len(mandatory_fields):
-            chunks.append(chunk)
-
-        return chunks
-
-
+    # execute runs one caller-provided SOQL query per chunk_fields chunk and merges their results
+    # into complete records. The queries must share an identical WHERE clause; cursor_field and
+    # end are only used to suppress records that were updated past `end` while the queries ran.
     async def execute(
         self,
         object_name: str,
-        fields: FieldDetailsDict,
+        queries_soql: list[str],
         model_cls: type[SalesforceRecord],
         cursor_field: CursorFields,
-        start: datetime,
         end: datetime,
     ) -> AsyncGenerator[SalesforceRecord, None]:
-        # All fields are chunked across separate queries to avoid Salesforce's URI length limits. Results from
-        # each query are merged together before yielding the complete record.
-        field_chunks = self._chunk_fields(fields, cursor_field)
-
         queries: list[Query] = []
-        for chunk in field_chunks:
-            q = Query(self.http, self.log, self.base_url, build_query(object_name, chunk, cursor_field, start, end))
+        for soql in queries_soql:
+            q = Query(self.http, self.log, self.base_url, soql)
             queries.append(q)
 
         records: dict[str, RecordAndChunksCompleted] = {}
 
         self.log.debug("Executing REST API queries.", {
             "object_name": object_name,
-            "start": start,
             "end": end,
             "len(queries)": len(queries),
         })
@@ -191,7 +194,7 @@ class RestQueryManager:
                 record = records[id]["record"]
 
                 # Do not emit a record if we haven't fetched all of its fields yet.
-                if chunk_completed_count < len(field_chunks):
+                if chunk_completed_count < len(queries):
                     continue
 
                 # If the record was updated after our end date, we ignore it since we should capture it on a future sweep.
@@ -209,10 +212,9 @@ class RestQueryManager:
                 # These are ignored since they should be captured on a future incremental sweep.
                 if len(records) > 0:
                     self.log.debug(f"There were {len(records)} records that were not yielded when all queries completed. These updated records will be picked up on the next incremental sweep.")
-                
+
                 self.log.debug("Finished executing REST API queries.", {
                     "object_name": object_name,
-                    "start": start,
                     "end": end,
                     "len(queries)": len(queries),
                 })

--- a/source-salesforce-native/source_salesforce_native/shared.py
+++ b/source-salesforce-native/source_salesforce_native/shared.py
@@ -1,9 +1,13 @@
+import re
 from datetime import datetime, UTC
 
 from estuary_cdk.http import Headers
 
 VERSION = "62.0"
 DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+# Salesforce record Ids are 15 case-sensitive or 18 case-safe alphanumeric characters.
+SALESFORCE_ID_REGEX = re.compile(r"^[a-zA-Z0-9]{15}(?:[a-zA-Z0-9]{3})?$")
 
 # Salesforce recommends retrying transient 500 errors with exponential backoff,
 # but limiting retry attempts to avoid burning API credits indefinitely.
@@ -29,23 +33,58 @@ def now() -> datetime:
     return str_to_dt(dt_to_str(datetime.now(tz=UTC)))
 
 
-def build_query(
+def is_salesforce_id(value: str) -> bool:
+    return bool(SALESFORCE_ID_REGEX.fullmatch(value))
+
+
+def build_snapshot_query(object_name: str, fields: list[str]) -> str:
+    return f"SELECT {','.join(fields)} FROM {object_name}"
+
+
+def build_date_window_query(
         object_name: str,
         fields: list[str],
-        cursor_field: str | None = None,
-        start: datetime | None = None,
-        end: datetime | None = None,
+        cursor_field: str,
+        start: datetime,
+        end: datetime,
     ) -> str:
     query = f"SELECT {','.join(fields)} FROM {object_name}"
+    query += f" WHERE {cursor_field} > {dt_to_str(start)} AND {cursor_field} <= {dt_to_str(end)}"
+    query += f" ORDER BY {cursor_field} ASC"
 
-    if cursor_field and (start or end):
-        query += f" WHERE"
-        if start:
-            query += f" {cursor_field} > {dt_to_str(start)}"
-        if start and end:
-            query += " AND"
-        if end:
-            query += f" {cursor_field} <= {dt_to_str(end)}"
-        query += f" ORDER BY {cursor_field} ASC"
+    return query
+
+
+# build_id_page_query builds a keyset pagination query over the object's primary key: a bounded,
+# indexed range scan regardless of how records are distributed over the cursor field.
+def build_id_page_query(
+        object_name: str,
+        fields: list[str],
+        cursor_field: str,
+        start: datetime,
+        end: datetime,
+        last_id: str | None = None,
+        max_id: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> str:
+    for id_bound in (last_id, max_id):
+        if id_bound is not None and not is_salesforce_id(id_bound):
+            raise ValueError(f"{id_bound} is not a valid Salesforce record Id.")
+
+    query = f"SELECT {','.join(fields)} FROM {object_name}"
+    query += f" WHERE {cursor_field} > {dt_to_str(start)} AND {cursor_field} <= {dt_to_str(end)}"
+
+    if last_id:
+        query += f" AND Id > '{last_id}'"
+    if max_id:
+        query += f" AND Id <= '{max_id}'"
+
+    query += " ORDER BY Id ASC"
+
+    if limit is not None:
+        query += f" LIMIT {limit}"
+    if offset is not None:
+        query += f" OFFSET {offset}"
 
     return query

--- a/source-salesforce-native/tests/test_id_backfill.py
+++ b/source-salesforce-native/tests/test_id_backfill.py
@@ -1,0 +1,376 @@
+import json
+import logging
+from datetime import datetime, timedelta, UTC
+
+import pytest
+
+from source_salesforce_native.api import (
+    BULK_ID_PAGE_LIMIT,
+    REST_ID_PAGE_LIMIT,
+    _id_execution_wrapper,
+    backfill_incremental_resources,
+)
+from source_salesforce_native.models import (
+    CursorFields,
+    FieldDetailsDict,
+    SalesforceDataSource,
+    SalesforceRecord,
+    ValidationContext,
+    create_salesforce_model,
+)
+from source_salesforce_native.rest_query_manager import RestQueryManager
+from source_salesforce_native.shared import build_id_page_query, dt_to_str, is_salesforce_id
+
+_LOG = logging.getLogger(__name__)
+
+START_DATE = datetime(1999, 2, 3, tzinfo=UTC)
+CUTOFF = datetime(2026, 7, 1, tzinfo=UTC)
+WINDOW_SIZE = timedelta(days=18250)
+MODSTAMP = "2026-06-01T00:00:00.000Z"
+INSTANCE_URL = "https://instance.example.com"
+
+FIELDS = FieldDetailsDict.model_validate({
+    "Id": {"soapType": "tns:ID", "calculated": False, "custom": False},
+    "SystemModstamp": {"soapType": "xsd:dateTime", "calculated": False, "custom": False},
+    "Name": {"soapType": "xsd:string", "calculated": False, "custom": False},
+})
+
+MODEL = create_salesforce_model("Account", FIELDS)
+REST_CONTEXT = ValidationContext(SalesforceDataSource.REST_API)
+
+
+def _id(n: int) -> str:
+    return f"001{n:012d}AAA"
+
+
+def _record(n: int) -> SalesforceRecord:
+    return MODEL.model_validate(
+        {"Id": _id(n), "SystemModstamp": MODSTAMP, "Name": f"record {n}"},
+        context=REST_CONTEXT,
+    )
+
+
+async def _collect(gen) -> list:
+    return [item async for item in gen]
+
+
+def test_is_salesforce_id():
+    assert is_salesforce_id("001000000000001")
+    assert is_salesforce_id("001000000000001AAA")
+    assert is_salesforce_id("a0B4x00000FaKeI")
+    # Legacy datetime page cursors are never classified as Ids.
+    assert not is_salesforce_id(dt_to_str(CUTOFF))
+    assert not is_salesforce_id("")
+    assert not is_salesforce_id("001-00000000001")
+    assert not is_salesforce_id("0010000000000012")
+    assert not is_salesforce_id("001000000000001AAAX")
+
+
+def test_build_id_page_query():
+    fields = ["Id", "SystemModstamp", "Name"]
+
+    assert build_id_page_query("Account", fields, CursorFields.SYSTEM_MODSTAMP, START_DATE, CUTOFF, limit=2000) == (
+        "SELECT Id,SystemModstamp,Name FROM Account"
+        " WHERE SystemModstamp > 1999-02-03T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        " ORDER BY Id ASC LIMIT 2000"
+    )
+
+    assert build_id_page_query("Account", fields, CursorFields.SYSTEM_MODSTAMP, START_DATE, CUTOFF, last_id=_id(5), limit=2000) == (
+        "SELECT Id,SystemModstamp,Name FROM Account"
+        " WHERE SystemModstamp > 1999-02-03T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        f" AND Id > '{_id(5)}'"
+        " ORDER BY Id ASC LIMIT 2000"
+    )
+
+    assert build_id_page_query("Account", fields, CursorFields.SYSTEM_MODSTAMP, START_DATE, CUTOFF, last_id=_id(5), max_id=_id(9)) == (
+        "SELECT Id,SystemModstamp,Name FROM Account"
+        " WHERE SystemModstamp > 1999-02-03T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        f" AND Id > '{_id(5)}' AND Id <= '{_id(9)}'"
+        " ORDER BY Id ASC"
+    )
+
+    assert build_id_page_query("Account", ["Id"], CursorFields.SYSTEM_MODSTAMP, START_DATE, CUTOFF, limit=1, offset=1999) == (
+        "SELECT Id FROM Account"
+        " WHERE SystemModstamp > 1999-02-03T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        " ORDER BY Id ASC LIMIT 1 OFFSET 1999"
+    )
+
+    with pytest.raises(ValueError):
+        build_id_page_query("Account", fields, CursorFields.SYSTEM_MODSTAMP, START_DATE, CUTOFF, last_id="Robert'); DROP")
+
+
+async def _record_stream(records: list[SalesforceRecord]):
+    for record in records:
+        yield record
+
+
+@pytest.mark.asyncio
+async def test_id_execution_wrapper_full_page():
+    records = [_record(n) for n in range(1, 6)]
+
+    items = await _collect(_id_execution_wrapper(_record_stream(records), checkpoint_interval=2, limit=5))
+
+    assert [i if isinstance(i, str) else i.Id for i in items] == [
+        _id(1), _id(2), _id(2), _id(3), _id(4), _id(4), _id(5), _id(5),
+    ]
+    # A full page ends with a trailing cursor so the CDK invokes the next page.
+    assert isinstance(items[-1], str)
+
+
+@pytest.mark.asyncio
+async def test_id_execution_wrapper_short_page():
+    records = [_record(n) for n in range(1, 6)]
+
+    items = await _collect(_id_execution_wrapper(_record_stream(records), checkpoint_interval=2, limit=10))
+
+    # Intra-page checkpoints are still emitted, but a short page must end on a document
+    # so the CDK considers the backfill complete.
+    assert [i for i in items if isinstance(i, str)] == [_id(2), _id(4)]
+    assert isinstance(items[-1], SalesforceRecord)
+
+
+@pytest.mark.asyncio
+async def test_id_execution_wrapper_never_ends_on_interval_checkpoint():
+    records = [_record(n) for n in range(1, 5)]
+
+    items = await _collect(_id_execution_wrapper(_record_stream(records), checkpoint_interval=2, limit=10))
+
+    # 4 records with interval 2: the stream ends exactly on a checkpoint boundary, but the
+    # wrapper must not end a short page with a cursor.
+    assert isinstance(items[-1], SalesforceRecord)
+
+
+@pytest.mark.asyncio
+async def test_id_execution_wrapper_empty():
+    items = await _collect(_id_execution_wrapper(_record_stream([]), checkpoint_interval=2, limit=10))
+    assert items == []
+
+
+class FakeBulkManager:
+    def __init__(self, records: list[SalesforceRecord]):
+        self.records = records
+        self.queries: list[str] = []
+
+    async def execute(self, name, query, model_cls):
+        self.queries.append(query)
+        for record in self.records:
+            yield record
+
+
+class FakeHTTP:
+    def __init__(self, responses: list[str]):
+        self.responses = list(responses)
+        self.requests: list[tuple[str, dict | None]] = []
+
+    async def request(self, log, url, method="GET", params=None, json=None, should_retry=None):
+        self.requests.append((url, params))
+        return self.responses.pop(0)
+
+
+def _query_response(records: list[dict], done: bool = True, next_records_url: str | None = None) -> str:
+    return json.dumps({
+        "totalSize": len(records),
+        "done": done,
+        "records": records,
+        "nextRecordsUrl": next_records_url,
+    })
+
+
+def _rest_record(n: int, modstamp: str = MODSTAMP, **extra) -> dict:
+    return {
+        "attributes": {"type": "Account"},
+        "Id": _id(n),
+        "SystemModstamp": modstamp,
+        "Name": f"record {n}",
+        **extra,
+    }
+
+
+def _backfill(http, is_supported_by_bulk_api, bulk_manager, rest_manager, page):
+    return backfill_incremental_resources(
+        http,
+        is_supported_by_bulk_api,
+        bulk_manager,
+        rest_manager,
+        INSTANCE_URL,
+        "Account",
+        FIELDS,
+        MODEL,
+        WINDOW_SIZE,
+        START_DATE,
+        _LOG,
+        page,
+        CUTOFF,
+        False,  # is_connector_initiated
+    )
+
+
+def _bulk_backfill(bulk_manager: FakeBulkManager, page):
+    return _backfill(None, True, bulk_manager, None, page)
+
+
+@pytest.mark.asyncio
+async def test_backfill_new_backfills_use_id_pagination():
+    manager = FakeBulkManager([_record(1), _record(2)])
+
+    items = await _collect(_bulk_backfill(manager, page=None))
+
+    assert manager.queries == [
+        "SELECT Id,SystemModstamp,Name FROM Account"
+        " WHERE SystemModstamp > 1999-02-03T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        f" ORDER BY Id ASC LIMIT {BULK_ID_PAGE_LIMIT}"
+    ]
+    # A short page ends on a document, completing the backfill.
+    assert [i.Id for i in items] == [_id(1), _id(2)]
+
+
+@pytest.mark.asyncio
+async def test_backfill_id_page_cursor_resumes_id_pagination():
+    manager = FakeBulkManager([_record(2)])
+
+    await _collect(_bulk_backfill(manager, page=_id(1)))
+
+    assert len(manager.queries) == 1
+    assert f"AND Id > '{_id(1)}'" in manager.queries[0]
+    assert "ORDER BY Id ASC" in manager.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_datetime_page_cursor_uses_date_windows():
+    manager = FakeBulkManager([_record(1), _record(2)])
+    page = dt_to_str(datetime(2026, 1, 1, tzinfo=UTC))
+
+    items = await _collect(_bulk_backfill(manager, page=page))
+
+    assert manager.queries == [
+        "SELECT Id,SystemModstamp,Name FROM Account"
+        " WHERE SystemModstamp > 2026-01-01T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
+        " ORDER BY SystemModstamp ASC"
+    ]
+    # The legacy strategy checkpoints datetime cursors.
+    assert items[-1] == MODSTAMP
+
+
+@pytest.mark.asyncio
+async def test_backfill_rest_full_page_yields_boundary():
+    http = FakeHTTP([
+        # Boundary probe locates the Id of the last record in the page.
+        _query_response([{"attributes": {"type": "Account"}, "Id": _id(2)}]),
+        _query_response([_rest_record(1), _rest_record(2)]),
+    ])
+    rest_manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    items = await _collect(_backfill(http, False, None, rest_manager, page=None))
+
+    assert [i if isinstance(i, str) else i.Id for i in items] == [_id(1), _id(2), _id(2)]
+    assert isinstance(items[-1], str)
+
+    _, probe_params = http.requests[0]
+    assert probe_params is not None and f"LIMIT 1 OFFSET {REST_ID_PAGE_LIMIT - 1}" in probe_params["q"]
+
+    _, data_params = http.requests[1]
+    assert data_params is not None
+    assert f"Id <= '{_id(2)}'" in data_params["q"]
+    assert "LIMIT" not in data_params["q"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_rest_final_page_has_no_boundary():
+    http = FakeHTTP([
+        # An empty probe means fewer than a full page of records remain.
+        _query_response([]),
+        _query_response([_rest_record(1)]),
+    ])
+    rest_manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    items = await _collect(_backfill(http, False, None, rest_manager, page=None))
+
+    # The final page ends on a document, completing the backfill.
+    assert [i.Id for i in items] == [_id(1)]
+
+    _, data_params = http.requests[1]
+    assert data_params is not None
+    assert "Id <=" not in data_params["q"]
+    assert "LIMIT" not in data_params["q"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_rest_empty_page():
+    http = FakeHTTP([
+        _query_response([]),
+        _query_response([]),
+    ])
+    rest_manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    items = await _collect(_backfill(http, False, None, rest_manager, page=None))
+
+    assert items == []
+
+
+CHUNKED_FIELDS = FieldDetailsDict.model_validate({
+    "Id": {"soapType": "tns:ID", "calculated": False, "custom": False},
+    "SystemModstamp": {"soapType": "xsd:dateTime", "calculated": False, "custom": False},
+    "Name": {"soapType": "xsd:string", "calculated": False, "custom": False},
+    "Website": {"soapType": "xsd:string", "calculated": False, "custom": False},
+})
+
+CHUNKED_MODEL = create_salesforce_model("Account", CHUNKED_FIELDS)
+
+CHUNK_QUERIES = [
+    "SELECT Id,SystemModstamp,Name FROM Account ORDER BY Id ASC",
+    "SELECT Id,SystemModstamp,Website FROM Account ORDER BY Id ASC",
+]
+
+
+@pytest.mark.asyncio
+async def test_rest_execute_merges_chunked_queries():
+    http = FakeHTTP([
+        _query_response([_rest_record(1), _rest_record(2)]),
+        _query_response([
+            {"attributes": {"type": "Account"}, "Id": _id(1), "SystemModstamp": MODSTAMP, "Website": "https://one.example.com"},
+            {"attributes": {"type": "Account"}, "Id": _id(2), "SystemModstamp": MODSTAMP, "Website": "https://two.example.com"},
+        ]),
+    ])
+    manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    records = await _collect(
+        manager.execute("Account", CHUNK_QUERIES, CHUNKED_MODEL, CursorFields.SYSTEM_MODSTAMP, CUTOFF)
+    )
+
+    assert len(records) == 2
+    assert records[0].Name == "record 1"
+    assert records[0].Website == "https://one.example.com"
+
+
+@pytest.mark.asyncio
+async def test_rest_execute_drops_records_missing_chunks():
+    http = FakeHTTP([
+        _query_response([_rest_record(1), _rest_record(2)]),
+        # The second query only returns the first record, as if the second record was
+        # updated past the cutoff between the queries.
+        _query_response([
+            {"attributes": {"type": "Account"}, "Id": _id(1), "SystemModstamp": MODSTAMP, "Website": "https://one.example.com"},
+        ]),
+    ])
+    manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    records = await _collect(
+        manager.execute("Account", CHUNK_QUERIES, CHUNKED_MODEL, CursorFields.SYSTEM_MODSTAMP, CUTOFF)
+    )
+
+    assert [r.Id for r in records] == [_id(1)]
+
+
+@pytest.mark.asyncio
+async def test_rest_execute_suppresses_records_updated_past_end():
+    updated_past_cutoff = "2026-08-01T00:00:00.000Z"
+    http = FakeHTTP([
+        _query_response([_rest_record(1, modstamp=updated_past_cutoff)]),
+    ])
+    manager = RestQueryManager(http, _LOG, INSTANCE_URL)
+
+    records = await _collect(
+        manager.execute("Account", [CHUNK_QUERIES[0]], MODEL, CursorFields.SYSTEM_MODSTAMP, CUTOFF)
+    )
+
+    assert records == []


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Backfills in `source-salesforce-native` have been querying records in chunks of date windows. For organizations with large amounts of data & uneven distributions of data among date windows, it has been tedious finding the best `advanced.window_size` setting for all bindings' backfills to complete in a reasonable amount of time.

Instead of continuing to use date windows, this PR updates the connector to use objects' `Id` field as a page cursor in queries like `SELECT Id, Field1, Field2 FROM Object WHERE Id > :lastId ORDER BY Id LIMIT N`. This eliminates the need to chunk backfill ranges up by date windows completely and instead paginate through the records we care about by the always present `Id` field. This should both make it easier for backfills to complete without requiring tinkering with capture tasks' specs _and_ potentially help bulk jobs complete faster since `Id` _should_ be indexed on Salesforce's side.

Per-API strategy is now:
  - Bulk API backfills run one query job per 500,000-record page, checkpointing an `Id` cursor every 25,000 records within a job.
  - REST API backfills (objects with compound fields, or when falling back from the Bulk API) fetch 2,000-record pages. Each page's boundary `Id` is located upfront with a cheap probe query so the field-chunked queries share an identical closed `Id` range and merge deterministically.

See individual commits for more details.

**Workflow steps:**

All new backfills (including scheduled formula field refreshes) will use `Id` as a page cursor and use the new `Id` centric queries. Ongoing backfills will continue using date window queries until they complete.

**Notes for reviewers:**

Tested with `flowctl preview` and dropping the backfill limit low enough to require multiple bulk jobs to fetch all records. Confirmed all records are captured by the backfill as anticipated.

Note: We may need to add another advanced config option to allow users to change the `BULK_ID_PAGE_LIMIT` if the 500,000 default does not work well for their use case. But I'd like to see how well the connector performs with the 500,000 limit before introducing another setting in the endpoint config.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
