### PR TITLE
source-sage-intacct: handle CURRENCY and PERCENT datatypes

### DIFF
--- a/source-sage-intacct/CHANGELOG.md
+++ b/source-sage-intacct/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-07-22
+
+### Fixed
+- Populated `CURRENCY` and `PERCENT` fields no longer fail the capture with an
+  "Unhandled datatype" error. Their values are now captured as number-formatted
+  strings, the same as `DECIMAL` fields.

--- a/source-sage-intacct/source_sage_intacct/sage.py
+++ b/source-sage-intacct/source_sage_intacct/sage.py
@@ -34,11 +34,11 @@ DATATYPE_MAP: dict[str, Any] = {
     "TIMESTAMP": AwareDatetime,
     "ENUM": str,
     "DECIMAL": str,
-    # TODO(whb): Update the remaining types once we see some values and know
-    # what they look like. `str` is just a placeholder, and may or may not be
-    # appropriate.
     "CURRENCY": str,
     "PERCENT": str,
+    # TODO(bair): Update SEQUENCE once we see some values and know what they
+    # look like. `str` is just a placeholder, and may or may not be
+    # appropriate.
     "SEQUENCE": str,
 }
 
@@ -115,9 +115,9 @@ class SageRecord(BaseModel):
                     assert isinstance(val, str)
                     if val == "":
                         continue
-                case "DECIMAL":
+                case "DECIMAL" | "CURRENCY" | "PERCENT":
                     val = str(val)
-                case "CURRENCY" | "SEQUENCE" | "PERCENT":
+                case "SEQUENCE":
                     # TODO(whb): Update this once we see some values and know
                     # what they look like.
                     raise ValueError(
@@ -156,12 +156,12 @@ class SageRecord(BaseModel):
                         "type": "string",
                         "format": "date-time",
                     }
-                case "DECIMAL":
+                case "DECIMAL" | "CURRENCY" | "PERCENT":
                     field_schema = {
                         "type": "string",
                         "format": "number",
                     }
-                case "CURRENCY" | "SEQUENCE" | "PERCENT":
+                case "SEQUENCE":
                     # TODO(whb): Update this to an appropriate type once we see
                     # some values and know what they look like.
                     continue


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Populated `CURRENCY`-typed fields (e.g. `ITEM.BASIC = "6.50"`) crashed captures with "Unhandled datatype CURRENCY" since `_normalize_values` raised for `CURRENCY`/`SEQUENCE`/`PERCENT` as TODO placeholders. Sage's JSON returnformat delivers these values as numeric strings, so treat `CURRENCY` and `PERCENT` exactly like `DECIMAL`: pass values through as strings and emit `{"type": "string", "format": "number"}` in the sourced schema. `SEQUENCE` still raises until we've seen a real value.

Fixes #4873

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
