### PR TITLE
source-zuora: use AQuA API & paginate backfills by `Id`

### DIFF
--- a/docs/reference/Connectors/capture-connectors/zuora.md
+++ b/docs/reference/Connectors/capture-connectors/zuora.md
@@ -1,7 +1,7 @@
 # Zuora
 
 This connector captures data from [Zuora](https://www.zuora.com/) objects into Estuary Flow collections.
-It authenticates with Zuora's [OAuth 2.0](https://developer.zuora.com/api-references/api/overview/#section/Authentication) client credentials flow and reads data through Zuora's [Data Query / Export API](https://developer.zuora.com/api-references/api/operation/POST_DataQuery/).
+It authenticates with Zuora's [OAuth 2.0](https://developer.zuora.com/api-references/api/overview/#section/Authentication) client credentials flow and reads data through Zuora's [AQuA API](https://docs.zuora.com/en/zuora-platform/data/aggregate-query-api-aqua/aqua-api-introduction).
 
 ## Supported data resources
 

--- a/source-zuora/CHANGELOG.md
+++ b/source-zuora/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-21
+
+### Changed
+- Exports now run through Zuora's AQuA API (`POST /v1/batch-query/`, stateless
+  mode) instead of the legacy `/v1/object/export` API. Some tenants
+  feature-gate fields (e.g. `Account.DefaultPaymentMethodId`) out of the legacy
+  export engine even though the describe API marks them exportable, failing
+  captures with "There is no field named X"; AQuA accepts those fields. Export
+  ZOQL queries, cursor state, and bindings are unchanged. Datetime output is
+  pinned to UTC via `dateTimeUtc`, and segmented result files (tenants with
+  AQuA file segmentation enabled) are supported.
+
 ## 2026-07-17
 
 ### Added

--- a/source-zuora/CHANGELOG.md
+++ b/source-zuora/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-22
+
+### Changed
+- Backfills now paginate by `Id` (`WHERE Id > :last ORDER BY Id LIMIT 250000`) instead of walking 30-day cursor-field windows. An oversized page halves its `LIMIT` and retries.
+
 ## 2026-07-21
 
 ### Changed

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -23,6 +23,12 @@ from .shared import VERSION_HEADERS
 # unboundedly large and checkpoints stay reasonably frequent.
 MAX_EXPORT_WINDOW = timedelta(days=30)
 
+# Records per Id-ordered backfill page. Zuora's export file cap is 2047 MB,
+# so this budgets ~8.5 KB per CSV row before a page overflows and
+# _fetch_page_by_id halves its LIMIT; per-page job overhead is small (~10s
+# measured), so a conservative page size costs little.
+BACKFILL_PAGE_SIZE = 250_000
+
 # Hold the leading edge this far behind real time. Zuora's export index is
 # eventually consistent, so a record can become visible with an UpdatedDate a
 # little in the past. Staying this far back gives such records time to appear
@@ -68,6 +74,33 @@ def build_query(
     if conditions:
         query = f"{query} WHERE {' AND '.join(conditions)} ORDER BY {cursor_field}"
     return query
+
+
+def build_id_page_query(
+    object_name: str,
+    fields: list[str],
+    cursor_field: str,
+    *,
+    start: datetime,
+    cutoff: datetime,
+    after_id: str | None,
+    limit: int,
+) -> str:
+    """Build an Export ZOQL query for one Id-ordered backfill page: rows in the
+    half-open cursor_field range [start, cutoff) with Id strictly above
+    after_id (None for the first page), ordered by Id so `Id >` resume is
+    dupe-free, capped at limit rows.
+    """
+    conditions = [
+        f"{cursor_field} >= '{_format_dt_to_utc(start)}'",
+        f"{cursor_field} < '{_format_dt_to_utc(cutoff)}'",
+    ]
+    if after_id is not None:
+        conditions.append(f"Id > '{after_id}'")
+    return (
+        f"SELECT {', '.join(fields)} FROM {object_name} "
+        f"WHERE {' AND '.join(conditions)} ORDER BY Id LIMIT {limit}"
+    )
 
 
 async def discover_object_names(
@@ -157,9 +190,9 @@ class _WindowEnd:
     """Terminal item _export_window yields once, after all documents and
     intermediate checkpoints: the largest cursor value seen in the window (None
     if it was empty) and the effective end of the window actually covered (the
-    original window_end, or a smaller value if bisection shrank it). Each caller
-    turns this into its own final cursor, so the incremental and backfill
-    end-of-window advance rules stay distinct while sharing one export engine.
+    original window_end, or a smaller value if bisection shrank it).
+    fetch_changes turns this into its final cursor, choosing between the
+    advance rules for data-bearing, empty-full, and leading-edge windows.
     """
     max_cursor: datetime | None
     covered_end: datetime
@@ -298,37 +331,68 @@ async def fetch_page(
     cutoff: LogCursor,
 ) -> AsyncGenerator[ZuoraDocument | str, None]:
     assert isinstance(cutoff, datetime)
-
-    if page is None:
-        window_start = start_date
-    else:
+    if page is not None:
         assert isinstance(page, str)
-        window_start = datetime.fromisoformat(page)
 
-    if window_start >= cutoff:
-        return
+    resume_id: str | None = page
+    limit = BACKFILL_PAGE_SIZE
+    docs_since_checkpoint = 0
 
-    window_end = min(window_start + MAX_EXPORT_WINDOW, cutoff)
+    while True:
+        query = build_id_page_query(
+            object_name,
+            fields,
+            model.CURSOR_FIELD,
+            start=start_date,
+            cutoff=cutoff,
+            after_id=resume_id,
+            limit=limit,
+        )
+        count = 0
+        try:
+            async for row in manager.export_rows(query):
+                doc = model.model_validate(row)
+                if resume_id is not None and doc.Id <= resume_id:
+                    # `Id >` resume is only correct if ORDER BY Id is a stable
+                    # total order. Fail loudly if a tenant violates that.
+                    raise RuntimeError(
+                        f"{object_name}: Id ordering violation: "
+                        f"{doc.Id!r} after {resume_id!r}"
+                    )
+                if docs_since_checkpoint >= CHECKPOINT_INTERVAL and resume_id is not None:
+                    yield resume_id
+                    docs_since_checkpoint = 0
+                yield doc
+                resume_id = doc.Id
+                count += 1
+                docs_since_checkpoint += 1
+            break
+        except ExportTooLargeError as err:
+            # The size overflow surfaces before any row of the attempt streams,
+            # so normally the whole page retries; if rows did stream, resume_id
+            # has advanced past them and the retry continues where they ended.
+            limit //= 2
+            if limit < 1:
+                raise ExportTooLargeError(
+                    f"{object_name}: a single-record export page still exceeds "
+                    f"Zuora's size limit and cannot be narrowed further"
+                ) from err
+            log.debug(
+                "export exceeded size limit, halving backfill page",
+                {"object": object_name, "limit": limit, "resume_id": resume_id},
+            )
 
-    async for item in _export_window(
-        object_name, fields, model, manager, window_start, window_end, log
-    ):
-        if isinstance(item, _WindowEnd):
-            # A non-final window ends on a PageCursor to resume from; the final
-            # window (covered_end == cutoff) ends on documents so backfill
-            # completes without emitting a further page.
-            if item.covered_end < cutoff:
-                log.debug(
-                    "backfill window complete, resuming from next page cursor",
-                    {"object": object_name, "next_page": item.covered_end.isoformat()},
-                )
-                yield item.covered_end.isoformat()
-            else:
-                log.debug("backfill reached cutoff", {"object": object_name})
-        elif isinstance(item, datetime):
-            yield item.isoformat()  # PageCursors are isoformat strings
-        else:
-            yield item
+    log.debug(
+        "backfill page complete",
+        {
+            "object": object_name,
+            "docs": count,
+            "last_id": resume_id,
+            "full_page": count == limit,
+        },
+    )
+    if count == limit and resume_id is not None:
+        yield resume_id
 
 
 async def fetch_snapshot(

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -18,7 +18,9 @@ from .models import (
 )
 from .shared import VERSION_HEADERS
 
-# Maximum date range for a single REST export job, enforced by Zuora.
+# Maximum date range for a single export job. Zuora's legacy export API
+# enforced 30 days; the same cap is kept under AQuA so no single job grows
+# unboundedly large and checkpoints stay reasonably frequent.
 MAX_EXPORT_WINDOW = timedelta(days=30)
 
 # Hold the leading edge this far behind real time. Zuora's export index is
@@ -105,7 +107,8 @@ async def fetch_object_fields(
         await http.request(log, url, headers=VERSION_HEADERS)
     )
     # Field availability in exports is tenant-dependent and describe has been
-    # seen disagreeing with what POST /v1/object/export actually accepts, so
+    # seen disagreeing with what the export engine actually accepts (the reason
+    # this connector uses AQuA over the legacy /v1/object/export API), so
     # record exactly how each field was classified and why.
     log.debug(
         "described object",

--- a/source-zuora/source_zuora/export_manager.py
+++ b/source-zuora/source_zuora/export_manager.py
@@ -5,8 +5,22 @@ from typing import AsyncGenerator
 from estuary_cdk.http import HTTPError, HTTPSession
 from estuary_cdk.incremental_csv_processor import IncrementalCSVProcessor
 
-from .models import ExportStatus, ExportStatusResponse, ExportSubmitResponse
+from .models import AquaJobResponse, AquaJobStatus
 from .shared import VERSION_HEADERS
+
+# AQuA request schema version. With partner/project omitted the job runs in
+# stateless mode regardless, so this only selects the response semantics.
+AQUA_VERSION = "1.2"
+
+# Informational job/query name shown in Zuora's UI and result file names.
+AQUA_JOB_NAME = "estuary-capture-connector"
+
+TERMINAL_FAILURE_STATUSES = (
+    AquaJobStatus.ERROR,
+    AquaJobStatus.ABORTED,
+    AquaJobStatus.CANCELLED,
+    AquaJobStatus.FAILED,
+)
 
 # An oversized export file (over 2047 MB) fails download with a 403 whose XML
 # body carries this marker, e.g. <security:max-object-size>2047MB</...>. A 403
@@ -31,9 +45,10 @@ MAX_RETRIES = 3
 RETRY_BACKOFF_BASE_SECONDS = 30
 RETRY_BACKOFF_FACTOR = 2
 
-# Cap on concurrent export jobs. Zuora limits concurrent exports per tenant to
-# around 5, so one semaphore shared across a task's bindings keeps us under it.
-MAX_CONCURRENT_EXPORTS = 4
+# Cap on concurrent export jobs. Zuora allows up to 50 concurrent stateless
+# AQuA jobs per tenant; staying far below that leaves room for the tenant's
+# other AQuA integrations and keeps our polling load modest.
+MAX_CONCURRENT_EXPORTS = 10
 
 
 class ExportError(Exception):
@@ -52,7 +67,7 @@ class ExportError(Exception):
         message: str,
         *,
         job_id: str | None = None,
-        status: ExportStatus | None = None,
+        status: AquaJobStatus | None = None,
     ):
         super().__init__(message)
         self.job_id = job_id
@@ -68,14 +83,17 @@ class ExportTooLargeError(Exception):
 
 
 class ExportManager:
-    """Runs Zuora REST Export API jobs.
+    """Runs Zuora AQuA (Aggregate Query API) export jobs in stateless mode.
 
-    Each export is an async job: submit a ZOQL query, poll until it reaches a
-    terminal status, then stream the resulting CSV. Callers build their own
-    queries (see api.build_query), so the manager stays query-agnostic.
+    Each export is an async job: submit an Export ZOQL query, poll until it
+    reaches a terminal status, then stream the resulting CSV file(s). Callers
+    build their own queries (see api.build_query), so the manager stays
+    query-agnostic. AQuA is used over the legacy /v1/object/export API because
+    some tenants feature-gate fields out of the legacy engine that AQuA (and
+    describe's export context) still consider exportable.
 
     One manager is shared across all of a task's bindings, so its semaphore
-    bounds total concurrent export jobs (Zuora allows ~5 per tenant).
+    bounds total concurrent export jobs.
     """
 
     def __init__(self, http: HTTPSession, log: Logger, base_url: str):
@@ -85,12 +103,15 @@ class ExportManager:
         self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_EXPORTS)
 
     async def export_rows(self, query: str) -> AsyncGenerator[dict, None]:
-        file_id = await self._run_job(query)
-        async for row in self._fetch_results(file_id):
-            yield row
+        # Each segment file is a self-contained CSV with its own header row, so
+        # streaming them back-to-back through per-file processors is seamless.
+        for file_id in await self._run_job(query):
+            async for row in self._fetch_results(file_id):
+                yield row
 
-    async def _run_job(self, query: str) -> str:
-        """Submit an export job, poll until complete, and return the file ID.
+    async def _run_job(self, query: str) -> list[str]:
+        """Submit an export job, poll until complete, and return its file IDs
+        (multiple when the tenant has AQuA file segmentation enabled).
 
         Holds the semaphore for the full duration so at most
         MAX_CONCURRENT_EXPORTS jobs run concurrently, staying within Zuora's
@@ -120,68 +141,90 @@ class ExportManager:
                 )
                 await asyncio.sleep(wait)
         # The final attempt always returns or re-raises above, so the loop never
-        # exits normally. This assert satisfies the type checker's -> str path.
+        # exits normally. This assert satisfies the type checker's return path.
         assert False, "unreachable"
 
     async def _submit(self, query: str) -> str:
-        url = f"{self.base_url}/v1/object/export"
-        payload = {"Format": "csv", "Query": query}
-        # Logged before the request so a submit-time rejection (e.g. a 400 for a
-        # field describe claimed was exportable) sits next to the query that
-        # caused it in the task logs.
+        url = f"{self.base_url}/v1/batch-query/"
+        # partner/project are deliberately omitted: that runs the job in
+        # stateless mode, and cursor windows in the query's WHERE clause carry
+        # our incremental state instead.
+        payload = {
+            "format": "csv",
+            "version": AQUA_VERSION,
+            "name": AQUA_JOB_NAME,
+            # dateTimeUtc keeps datetime output in
+            # UTC rather than the tenant's local timezone, which cursor parsing
+            # (AwareDatetime) depends on. 
+            "dateTimeUtc": "true",
+            # useQueryLabels makes CSV headers echo the
+            # query's field names (e.g. "AccountNumber"). Without it they are
+            # "Object: Field Label" display labels that match nothing in describe.
+            "useQueryLabels": "true",
+            "queries": [
+                {"name": AQUA_JOB_NAME, "query": query, "type": "zoqlexport"}
+            ],
+        }
+        # Logged before the request so a submit-time rejection (e.g. for a field
+        # describe claimed was exportable) sits next to the query that caused it
+        # in the task logs.
         self.log.debug("submitting export job", {"query": query})
         submit_bytes = await self.http.request(
             self.log, url, method="POST", json=payload, headers=VERSION_HEADERS
         )
-        submit = ExportSubmitResponse.model_validate_json(submit_bytes)
-        if not submit.Success or submit.Id is None:
-            reason = "; ".join(
-                f"{e.Code}: {e.Message}" for e in submit.Errors
-            ) or "no error detail"
+        submit = AquaJobResponse.model_validate_json(submit_bytes)
+        if submit.message or submit.id is None:
             raise ExportError(
-                f"Export job submission failed for query {query!r}: {reason}"
+                f"Export job submission failed for query {query!r}: "
+                f"{submit.message or 'no error detail'}",
+                status=submit.status,
             )
-        self.log.debug("created export job", {"job_id": submit.Id})
-        return submit.Id
+        self.log.debug("created export job", {"job_id": submit.id})
+        return submit.id
 
-    async def _check_job(self, job_id: str) -> ExportStatusResponse:
-        url = f"{self.base_url}/v1/object/export/{job_id}"
-        return ExportStatusResponse.model_validate_json(
+    async def _check_job(self, job_id: str) -> AquaJobResponse:
+        url = f"{self.base_url}/v1/batch-query/jobs/{job_id}"
+        return AquaJobResponse.model_validate_json(
             await self.http.request(self.log, url, headers=VERSION_HEADERS)
         )
 
-    async def _poll_until_complete(self, job_id: str) -> str:
-        """Poll a submitted job until it completes, returning its file ID."""
-        last_status: ExportStatus | None = None
+    async def _poll_until_complete(self, job_id: str) -> list[str]:
+        """Poll a submitted job until it completes, returning its file IDs."""
+        last_status: AquaJobStatus | None = None
         for attempt in range(MAX_POLL_ATTEMPTS):
             job = await self._check_job(job_id)
+            batch = job.batches[0] if job.batches else None
             # Logged only on transitions (not every poll) so a long-running job
             # stays visible in the logs without flooding them.
-            if job.Status is not last_status:
-                last_status = job.Status
+            if job.status is not last_status:
+                last_status = job.status
                 self.log.debug(
                     "export job status",
                     {
                         "job_id": job_id,
-                        "status": job.Status,
-                        "file_id": job.FileId,
+                        "status": job.status,
+                        "record_count": batch.recordCount if batch else None,
                         "elapsed_s": attempt * POLL_INTERVAL,
                     },
                 )
-            if job.Status is ExportStatus.COMPLETED:
-                if job.FileId is None:
+            if job.status is AquaJobStatus.COMPLETED:
+                file_ids = (
+                    batch.segments or ([batch.fileId] if batch.fileId else [])
+                ) if batch else []
+                if not file_ids:
                     raise ExportError(
-                        f"Export job {job_id} completed without a FileId",
+                        f"Export job {job_id} completed without any file IDs",
                         job_id=job_id,
-                        status=job.Status,
+                        status=job.status,
                     )
-                return job.FileId
-            if job.Status in (ExportStatus.CANCELED, ExportStatus.FAILED):
+                return file_ids
+            if job.status in TERMINAL_FAILURE_STATUSES:
+                detail = (batch.message if batch else None) or job.message
                 raise ExportError(
-                    f"Export job {job_id} {job.Status}: "
-                    f"{job.StatusReason or 'no reason given'}",
+                    f"Export job {job_id} {job.status}: "
+                    f"{detail or 'no reason given'}",
                     job_id=job_id,
-                    status=job.Status,
+                    status=job.status,
                 )
             await asyncio.sleep(POLL_INTERVAL)
         raise ExportError(

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -83,34 +83,43 @@ class TransactionDateDocument(ZuoraDocument):
         return self.TransactionDate
 
 
-class ExportStatus(StrEnum):
-    # https://developer.zuora.com/v1-api-reference/older-api/operation/Object_POSTExport/
-    PENDING = "Pending"
-    PROCESSING = "Processing"
-    COMPLETED = "Completed"
-    CANCELED = "Canceled"
-    FAILED = "Failed"
+class AquaJobStatus(StrEnum):
+    # https://developer.zuora.com/v1-api-reference/api/operation/GET_BatchQueryJob/
+    SUBMITTED = "submitted"
+    PENDING = "pending"
+    EXECUTING = "executing"
+    COMPLETED = "completed"
+    ERROR = "error"
+    ABORTED = "aborted"
+    CANCELLED = "cancelled"
+    # failed is undocumented, but it seems like it's a possible status since
+    # the legacy Export API had it.
+    FAILED = "failed"
 
 
-class ExportSubmitError(BaseModel, extra="allow"):
-    """One error entry within a POST /v1/object/export response's Errors list.
+class AquaBatch(BaseModel, extra="allow"):
+    """One entry in an AQuA job's batches list, corresponding to one submitted
+    query. When the tenant has AQuA file segmentation enabled, a large result
+    arrives as multiple files listed in segments instead of a single fileId.
     """
-    Code: str | None = None
-    Message: str | None = None
+    status: str | None = None
+    fileId: str | None = None
+    segments: list[str] | None = None
+    recordCount: int | None = None
+    message: str | None = None
 
 
-class ExportSubmitResponse(BaseModel, extra="allow"):
-    """Response from POST /v1/object/export."""
-    Success: bool = False
-    Id: str | None = None
-    Errors: list[ExportSubmitError] = Field(default_factory=list)
+class AquaJobResponse(BaseModel, extra="allow"):
+    """Response from POST /v1/batch-query/ and GET /v1/batch-query/jobs/{id}.
 
-
-class ExportStatusResponse(BaseModel, extra="allow"):
-    """Response from GET /v1/object/export/{id}."""
-    Status: ExportStatus
-    FileId: str | None = None
-    StatusReason: str | None = None
+    A submission rejected at validation time reports the problem in the
+    top-level message field rather than an HTTP error status, so status and id
+    are optional to keep such responses parseable.
+    """
+    id: str | None = None
+    status: AquaJobStatus | None = None
+    message: str | None = None
+    batches: list[AquaBatch] = Field(default_factory=list)
 
 
 class DescribeField(BaseModel, extra="allow"):

--- a/source-zuora/tests/test_capture.py
+++ b/source-zuora/tests/test_capture.py
@@ -1,9 +1,11 @@
 """Unit tests for the capture logic in source_zuora.api.
 
 These exercise cursor advancement, intermediate checkpointing, the LAG settle
-delay, the window-shrinking bisect on too-large exports, and query construction —
-none of which the spec/discover snapshot tests touch. A FakeManager stands in for
-ExportManager so tests run without a live Zuora tenant.
+delay, Id-paged backfills (including LIMIT-halving on too-large exports), the
+incremental engine's window-shrinking bisect on too-large exports, and query
+construction — none of which the spec/discover snapshot tests touch. A
+FakeManager stands in for ExportManager so tests run without a live Zuora
+tenant.
 """
 
 import logging
@@ -36,9 +38,11 @@ def _parse(s: str) -> datetime:
 
 class FakeManager:
     """Mimics ExportManager.export_rows: parses the query's cursor window (keyed
-    on cursor_field, default UpdatedDate), yields matching records sorted
-    ascending (as ORDER BY <cursor_field> would), and optionally raises
-    ExportTooLargeError for windows wider than too_large_over.
+    on cursor_field, default UpdatedDate), an optional `Id > 'x'` bound, and an
+    optional `LIMIT n`; yields matching records sorted as the query's ORDER BY
+    would. Raises ExportTooLargeError for date windows wider than
+    too_large_over, or when the rows an Id page would export exceed
+    too_large_over_rows (simulating the file size cap).
     """
 
     def __init__(
@@ -47,6 +51,7 @@ class FakeManager:
         too_large_over: timedelta | None = None,
         emit_millis: bool = False,
         cursor_field: str = "UpdatedDate",
+        too_large_over_rows: int | None = None,
     ):
         self.records = sorted(records or [], key=lambda r: r[1])
         self.too_large_over = too_large_over
@@ -57,6 +62,7 @@ class FakeManager:
         # second-aligned checkpoint logic has to handle.
         self.emit_millis = emit_millis
         self.cursor_field = cursor_field
+        self.too_large_over_rows = too_large_over_rows
         self.queries: list[str] = []
 
     async def export_rows(self, query: str):
@@ -65,6 +71,10 @@ class FakeManager:
         hi = re.search(rf"{self.cursor_field} < '([^']+)'", query)
         start = _parse(lo.group(1)) if lo else None
         end = _parse(hi.group(1)) if hi else None
+        id_after_m = re.search(r"Id > '([^']+)'", query)
+        id_after = id_after_m.group(1) if id_after_m else None
+        limit_m = re.search(r"LIMIT (\d+)", query)
+        limit = int(limit_m.group(1)) if limit_m else None
 
         if (
             self.too_large_over is not None
@@ -74,10 +84,25 @@ class FakeManager:
         ):
             raise ExportTooLargeError("too large")
 
+        matching = [
+            (rid, dt)
+            for rid, dt in self.records
+            if (start is None or dt >= start)
+            and (end is None or dt < end)
+            and (id_after is None or rid > id_after)
+        ]
+        if "ORDER BY Id" in query:
+            matching.sort(key=lambda r: r[0])
+        # The rows this export's file would hold, for the file-size-cap analog.
+        would_export = min(limit, len(matching)) if limit is not None else len(matching)
+        if self.too_large_over_rows is not None and would_export > self.too_large_over_rows:
+            raise ExportTooLargeError("too large")
+        if limit is not None:
+            matching = matching[:limit]
+
         out_fmt = "%Y-%m-%dT%H:%M:%S.%fZ" if self.emit_millis else _FMT
-        for rid, dt in self.records:
-            if (start is None or dt >= start) and (end is None or dt < end):
-                yield {"Id": rid, self.cursor_field: dt.astimezone(UTC).strftime(out_fmt)}
+        for rid, dt in matching:
+            yield {"Id": rid, self.cursor_field: dt.astimezone(UTC).strftime(out_fmt)}
 
 
 async def _collect(agen) -> list:
@@ -134,6 +159,38 @@ def test_build_query_normalizes_non_utc_bounds_to_utc():
         "Account", ["Id"], after=datetime(2020, 1, 1, tzinfo=plus_ten)
     )
     assert "UpdatedDate >= '2019-12-31T14:00:00Z'" in q
+
+
+def test_build_id_page_query_first_page_has_no_id_bound():
+    q = api.build_id_page_query(
+        "Account",
+        ["Id", "UpdatedDate"],
+        "UpdatedDate",
+        start=datetime(2020, 1, 1, tzinfo=UTC),
+        cutoff=datetime(2020, 2, 1, tzinfo=UTC),
+        after_id=None,
+        limit=250000,
+    )
+    assert q == (
+        "SELECT Id, UpdatedDate FROM Account "
+        "WHERE UpdatedDate >= '2020-01-01T00:00:00Z' "
+        "AND UpdatedDate < '2020-02-01T00:00:00Z' "
+        "ORDER BY Id LIMIT 250000"
+    )
+
+
+def test_build_id_page_query_resume_adds_strict_id_bound():
+    q = api.build_id_page_query(
+        "PaymentTransactionLog",
+        ["Id"],
+        "TransactionDate",
+        start=datetime(2020, 1, 1, tzinfo=UTC),
+        cutoff=datetime(2020, 2, 1, tzinfo=UTC),
+        after_id="aa02",
+        limit=100,
+    )
+    assert "TransactionDate >= '2020-01-01T00:00:00Z'" in q
+    assert "AND Id > 'aa02' ORDER BY Id LIMIT 100" in q
 
 
 # --- fetch_changes -------------------------------------------------------------
@@ -277,120 +334,138 @@ async def _run_page(manager, start_date, page, cutoff, model=UpdatedDateDocument
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_none_starts_at_start_date():
+async def test_fetch_page_fresh_backfill_queries_by_id_within_cursor_bounds():
     start = datetime(2020, 1, 1, tzinfo=UTC)
     cutoff = start + timedelta(days=5)
-    manager = FakeManager([("1", start + timedelta(days=1))])
-    await _run_page(manager, start, None, cutoff)
-    assert f"UpdatedDate >= '{_fmt(start)}'" in manager.queries[0]
+    manager = FakeManager([("aa01", start + timedelta(days=1))])
+    out = await _run_page(manager, start, None, cutoff)
+    (query,) = manager.queries
+    assert f"UpdatedDate >= '{_fmt(start)}'" in query
+    assert f"UpdatedDate < '{_fmt(cutoff)}'" in query
+    assert f"ORDER BY Id LIMIT {api.BACKFILL_PAGE_SIZE}" in query
+    assert "Id > " not in query  # fresh backfill has no Id lower bound
+    assert [d.Id for d in _docs(out)] == ["aa01"]
+    assert isinstance(out[-1], ZuoraDocument)  # short page -> backfill complete
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_resumes_from_page_cursor():
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    resume = datetime(2020, 1, 10, tzinfo=UTC)
-    cutoff = datetime(2020, 3, 1, tzinfo=UTC)
-    manager = FakeManager([])
-    await _run_page(manager, start, resume.isoformat(), cutoff)
-    assert f"UpdatedDate >= '{_fmt(resume)}'" in manager.queries[0]
-
-
-@pytest.mark.asyncio
-async def test_fetch_page_non_final_window_ends_with_page_cursor():
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=100)  # window_end = start+30d < cutoff
-    out = await _run_page(FakeManager([("1", start + timedelta(days=1))]), start, None, cutoff)
-    assert out[-1] == (start + api.MAX_EXPORT_WINDOW).isoformat()
-
-
-@pytest.mark.asyncio
-async def test_fetch_page_final_window_ends_on_documents():
-    # window reaches cutoff -> ends on docs (no PageCursor) so backfill completes
+async def test_fetch_page_full_page_ends_with_id_cursor(monkeypatch):
+    monkeypatch.setattr(api, "BACKFILL_PAGE_SIZE", 2)
     start = datetime(2020, 1, 1, tzinfo=UTC)
     cutoff = start + timedelta(days=5)
-    out = await _run_page(FakeManager([("1", start + timedelta(days=1))]), start, None, cutoff)
+    records = [(f"aa0{i}", start + timedelta(hours=i)) for i in range(1, 4)]
+    out = await _run_page(FakeManager(records), start, None, cutoff)
+    assert [d.Id for d in _docs(out)] == ["aa01", "aa02"]
+    assert out[-1] == "aa02"  # full page -> trailing Id PageCursor to resume from
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_resumes_from_id_cursor():
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    cutoff = start + timedelta(days=5)
+    records = [(f"aa0{i}", start + timedelta(hours=i)) for i in range(1, 4)]
+    manager = FakeManager(records)
+    out = await _run_page(manager, start, "aa01", cutoff)
+    assert "Id > 'aa01'" in manager.queries[0]
+    assert [d.Id for d in _docs(out)] == ["aa02", "aa03"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_id_engine_emits_intermediate_id_checkpoints(monkeypatch):
+    monkeypatch.setattr(api, "CHECKPOINT_INTERVAL", 2)
+    monkeypatch.setattr(api, "BACKFILL_PAGE_SIZE", 10)
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    cutoff = start + timedelta(days=5)
+    records = [(f"aa0{i}", start + timedelta(hours=i)) for i in range(1, 6)]
+    out = await _run_page(FakeManager(records), start, None, cutoff)
+    # A checkpoint lands before the doc that crosses the interval, naming the
+    # last durable Id, so the stream still ends on documents.
+    assert _cursors(out) == ["aa02", "aa04"]
     assert isinstance(out[-1], ZuoraDocument)
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_empty_final_window_completes():
-    # Reaches cutoff with no rows -> no docs, no PageCursor -> backfill complete.
+async def test_fetch_page_id_engine_halves_limit_when_too_large(monkeypatch):
+    monkeypatch.setattr(api, "BACKFILL_PAGE_SIZE", 8)
     start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=5)  # window_end == cutoff
+    cutoff = start + timedelta(days=5)
+    records = [(f"aa0{i}", start + timedelta(hours=i)) for i in range(1, 6)]
+    manager = FakeManager(records, too_large_over_rows=3)
+    out = await _run_page(manager, start, None, cutoff)
+    # 8-row page too large, 4-row page too large, 2-row page fits.
+    assert [q.rsplit("LIMIT ", 1)[1] for q in manager.queries] == ["8", "4", "2"]
+    assert [d.Id for d in _docs(out)] == ["aa01", "aa02"]
+    assert out[-1] == "aa02"  # the shrunken page is full -> continue from its end
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_id_engine_single_record_too_large_raises(monkeypatch):
+    # Even one record per page exceeds the cap -> fail loudly, naming the object.
+    monkeypatch.setattr(api, "BACKFILL_PAGE_SIZE", 4)
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    cutoff = start + timedelta(days=5)
+    manager = FakeManager([("aa01", start + timedelta(hours=1))], too_large_over_rows=0)
+    with pytest.raises(ExportTooLargeError) as exc:
+        await _run_page(manager, start, None, cutoff)
+    assert "Account" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_id_engine_ordering_violation_raises():
+    # `Id >` resume is only dupe-free if ORDER BY Id is a stable total order;
+    # out-of-order rows must kill the backfill rather than risk skipped records.
+    class UnorderedManager:
+        async def export_rows(self, query):
+            yield {"Id": "aa02", "UpdatedDate": "2020-01-02T00:00:00Z"}
+            yield {"Id": "aa01", "UpdatedDate": "2020-01-01T00:00:00Z"}
+
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    with pytest.raises(RuntimeError, match="ordering violation"):
+        await _run_page(UnorderedManager(), start, None, start + timedelta(days=5))
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_empty_backfill_completes():
+    # No rows in [start_date, cutoff) -> no docs, no PageCursor -> complete.
+    start = datetime(2020, 1, 1, tzinfo=UTC)
+    cutoff = start + timedelta(days=5)
     out = await _run_page(FakeManager([]), start, None, cutoff)
     assert out == []
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_window_start_at_cutoff_returns_nothing():
+async def test_fetch_page_start_date_at_cutoff_returns_nothing():
     start = datetime(2020, 1, 1, tzinfo=UTC)
-    out = await _run_page(FakeManager([]), start, None, start)  # cutoff == start
+    records = [("aa01", start - timedelta(days=1))]
+    out = await _run_page(FakeManager(records), start, None, start)  # cutoff == start
     assert out == []
 
 
-@pytest.mark.asyncio
-async def test_fetch_page_intermediate_cursors_are_isoformat_strings(monkeypatch):
-    monkeypatch.setattr(api, "CHECKPOINT_INTERVAL", 2)
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=5)
-    records = [(str(i), start + timedelta(seconds=s)) for i, s in enumerate([0, 0, 10, 20])]
-    out = await _run_page(FakeManager(records), start, None, cutoff)
-    intermediate = [x for x in out if isinstance(x, str)]
-    assert intermediate  # at least one intermediate PageCursor
-    for c in intermediate:
-        datetime.fromisoformat(c)  # parses as an ISO string
+# --- bisect on ExportTooLargeError (incremental engine) -------------------------
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_intermediate_cursor_is_second_aligned_on_ms_data(monkeypatch):
-    # Sub-second values in second 1 then a jump to second 4. The intermediate
-    # PageCursor floors floor(1.800)+1s = second 2, second-aligned so it resumes
-    # the whole-second filter exactly and re-reads nothing committed.
-    monkeypatch.setattr(api, "CHECKPOINT_INTERVAL", 2)
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=5)
-    records = [
-        ("a", start + timedelta(seconds=1, milliseconds=200)),
-        ("b", start + timedelta(seconds=1, milliseconds=800)),
-        ("c", start + timedelta(seconds=4, milliseconds=100)),
-    ]
-    out = await _run_page(FakeManager(records, emit_millis=True), start, None, cutoff)
-
-    intermediate = [datetime.fromisoformat(x) for x in out if isinstance(x, str)]
-    assert intermediate
-    assert all(c.microsecond == 0 for c in intermediate)
-    assert start + timedelta(seconds=2) in intermediate
-
-
-# --- bisect on ExportTooLargeError --------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_fetch_page_shrinks_to_first_fitting_window_and_returns_early():
-    # 30d window 403s; data at day 2. Shrinks 30->15->7.5d (fits), processes ONLY
-    # that window, returns a continue-cursor well before the full 30d.
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=100)
-    manager = FakeManager([("1", start + timedelta(days=2))], too_large_over=timedelta(days=8))
-    out = await _run_page(manager, start, None, cutoff)
-
-    assert [d.Id for d in _docs(out)] == ["1"]
-    eff_end = datetime.fromisoformat(out[-1])
-    assert eff_end < start + api.MAX_EXPORT_WINDOW  # returned early
-    assert len(manager.queries) == 3  # 30d(403) + 15d(403) + 7.5d(ok)
-
-
-@pytest.mark.asyncio
-async def test_fetch_page_empty_after_shrink_still_advances():
-    # data at day 20 but the fitting sub-window [start, ~7.5d) is empty; must still
-    # advance so the next call reaches the data.
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(days=100)
-    manager = FakeManager([("1", start + timedelta(days=20))], too_large_over=timedelta(days=8))
-    out = await _run_page(manager, start, None, cutoff)
+async def test_fetch_changes_empty_after_shrink_still_advances():
+    # The 30d window 403s and bisects to ~7.5d, which holds no data (it lives at
+    # day 20); the cursor must still advance so a later sweep reaches the data.
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(days=60)
+    manager = FakeManager(
+        [("1", base + timedelta(days=20))], too_large_over=timedelta(days=8)
+    )
+    out = await _run_changes(manager, base)
     assert not _docs(out)
-    eff_end = datetime.fromisoformat(out[-1])
-    assert start < eff_end < start + timedelta(days=15)
+    assert base < _cursors(out)[-1] < base + timedelta(days=15)
+
+
+@pytest.mark.asyncio
+async def test_fetch_changes_too_large_single_second_raises():
+    # An unsplittable one-second window that stays too large must fail loudly,
+    # naming the object rather than an opaque Zuora file id.
+    cursor = datetime.now(UTC).replace(microsecond=0) - api.LAG - timedelta(seconds=1)
+    manager = FakeManager([], too_large_over=timedelta(0))
+    with pytest.raises(ExportTooLargeError) as exc:
+        await _run_changes(manager, cursor)
+    assert "Account" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -402,20 +477,6 @@ async def test_fetch_changes_bisects_too_large_window():
     out = await _run_changes(manager, base)
     assert [d.Id for d in _docs(out)] == ["1"]
     assert _cursors(out)[-1] > base
-
-
-@pytest.mark.asyncio
-async def test_export_too_large_single_second_raises():
-    # An unsplittable one-second window that stays too large must fail loudly,
-    # naming the object and window rather than an opaque Zuora file id.
-    start = datetime(2020, 1, 1, tzinfo=UTC)
-    cutoff = start + timedelta(seconds=1)
-    manager = FakeManager([], too_large_over=timedelta(0))  # everything is "too large"
-    with pytest.raises(ExportTooLargeError) as exc:
-        await _run_page(manager, start, None, cutoff)
-    message = str(exc.value)
-    assert "Account" in message
-    assert "2020-01-01T00:00:00Z" in message
 
 
 # --- fetch_snapshot ------------------------------------------------------------

--- a/source-zuora/tests/test_export_manager.py
+++ b/source-zuora/tests/test_export_manager.py
@@ -1,6 +1,7 @@
-"""Unit tests for ExportManager: submit/poll/download lifecycle, status handling
-(including the `Canceled` one-l spelling), the 403 -> ExportTooLargeError
-detection, CSV prefix stripping, and the retry-only-on-ExportError policy.
+"""Unit tests for ExportManager: AQuA submit/poll/download lifecycle, status
+handling (documented statuses plus tap-zuora's observed "failed"), file
+segmentation, the 403 -> ExportTooLargeError detection, CSV prefix stripping,
+and the retry-only-on-ExportError policy.
 
 A FakeHTTP stands in for the CDK HTTPSession, routing by URL.
 """
@@ -13,6 +14,7 @@ from estuary_cdk.http import HTTPError
 
 from source_zuora import export_manager as em
 from source_zuora.export_manager import ExportError, ExportManager, ExportTooLargeError
+from source_zuora.models import AquaJobStatus
 from source_zuora.shared import ZUORA_API_VERSION
 
 _LOG = logging.getLogger(__name__)
@@ -27,23 +29,27 @@ def _no_sleep(monkeypatch):
 
 
 class FakeHTTP:
-    def __init__(self, *, submit=None, polls=None, download=None):
-        # Each of submit/download may be bytes or an Exception (raised).
-        # polls is a list of bytes/Exception; the last entry repeats.
+    def __init__(self, *, submit=None, polls=None, downloads=None):
+        # Each of submit/downloads entries may be bytes or an Exception (raised).
+        # polls is a list of bytes/Exception; the last entry repeats. downloads
+        # is keyed by file id.
         self.submit_response = submit
         self.poll_responses = list(polls or [])
-        self.download = download
+        self.downloads = downloads or {}
         self.submit_calls = 0
+        self.submit_payloads: list = []
         self.poll_calls = 0
         self.request_headers: list = []
         self.stream_headers = None
+        self.downloaded_file_ids: list = []
 
     async def request(self, log, url, method=None, json=None, headers=None):
         self.request_headers.append(headers)
-        if url.endswith("/v1/object/export") and method == "POST":
+        if url.endswith("/v1/batch-query/") and method == "POST":
             self.submit_calls += 1
+            self.submit_payloads.append(json)
             return _resolve(self.submit_response)
-        if "/v1/object/export/" in url:
+        if "/v1/batch-query/jobs/" in url:
             i = min(self.poll_calls, len(self.poll_responses) - 1)
             self.poll_calls += 1
             return _resolve(self.poll_responses[i])
@@ -51,8 +57,10 @@ class FakeHTTP:
 
     async def request_stream(self, log, url, headers=None):
         assert "/v1/files/" in url, url
+        file_id = url.rsplit("/", 1)[-1]
+        self.downloaded_file_ids.append(file_id)
         self.stream_headers = headers
-        data = _resolve(self.download)
+        data = _resolve(self.downloads[file_id])
 
         async def body():
             yield data
@@ -70,23 +78,48 @@ def _mgr(http) -> ExportManager:
     return ExportManager(http, _LOG, _BASE)
 
 
+_SUBMIT_OK = b'{"id": "job1", "status": "submitted"}'
+
+
 # --- _submit -------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_submit_returns_job_id_on_success():
-    mgr = _mgr(FakeHTTP(submit=b'{"Success": true, "Id": "job1"}'))
+    mgr = _mgr(FakeHTTP(submit=_SUBMIT_OK))
     assert await mgr._submit("SELECT Id FROM Account") == "job1"
 
 
 @pytest.mark.asyncio
-async def test_submit_failure_raises_export_error_with_detail():
+async def test_submit_validation_failure_raises_export_error_with_detail():
+    # AQuA reports a rejected submission via a top-level message, not an HTTP
+    # error status.
     http = FakeHTTP(
-        submit=b'{"Success": false, "Errors": [{"Code": "C", "Message": "There is no field named X."}]}'
+        submit=b'{"message": "There is a syntax error in one of the queries in the AQuA input", "status": "error"}'
     )
     with pytest.raises(ExportError) as exc:
         await _mgr(http)._submit("SELECT X FROM Account")
-    assert "There is no field named X." in str(exc.value)
+    assert "syntax error" in str(exc.value)
+    assert exc.value.status is AquaJobStatus.ERROR
+
+
+@pytest.mark.asyncio
+async def test_submit_sends_stateless_zoqlexport_payload():
+    http = FakeHTTP(submit=_SUBMIT_OK)
+    await _mgr(http)._submit("SELECT Id FROM Account")
+    (payload,) = http.submit_payloads
+    assert payload["format"] == "csv"
+    assert payload["version"] == em.AQUA_VERSION
+    assert payload["dateTimeUtc"] == "true"
+    # Without useQueryLabels, CSV headers are "Object: Field Label" display
+    # labels and no row key matches the models' field names.
+    assert payload["useQueryLabels"] == "true"
+    # partner/project must be absent: their presence would flip the job into
+    # stateful mode and change the query's incremental semantics.
+    assert "partner" not in payload and "project" not in payload
+    (query,) = payload["queries"]
+    assert query["query"] == "SELECT Id FROM Account"
+    assert query["type"] == "zoqlexport"
 
 
 # --- _poll_until_complete ------------------------------------------------------
@@ -94,31 +127,44 @@ async def test_submit_failure_raises_export_error_with_detail():
 
 @pytest.mark.asyncio
 async def test_poll_completed_returns_file_id():
-    http = FakeHTTP(polls=[b'{"Status": "Completed", "FileId": "file1"}'])
-    assert await _mgr(http)._poll_until_complete("job1") == "file1"
+    http = FakeHTTP(
+        polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}']
+    )
+    assert await _mgr(http)._poll_until_complete("job1") == ["file1"]
 
 
 @pytest.mark.asyncio
-async def test_poll_canceled_raises_export_error():
-    # Guards the "Canceled" (one-l) spelling fix: "Cancelled" would ValidationError.
-    http = FakeHTTP(polls=[b'{"Status": "Canceled", "StatusReason": "aborted"}'])
+async def test_poll_completed_prefers_segments_over_file_id():
+    # Tenants with AQuA file segmentation enabled return the result as multiple
+    # files; all of them must be surfaced or rows are silently lost.
+    http = FakeHTTP(
+        polls=[
+            b'{"id": "job1", "status": "completed",'
+            b' "batches": [{"fileId": "f0", "segments": ["s1", "s2"]}]}'
+        ]
+    )
+    assert await _mgr(http)._poll_until_complete("job1") == ["s1", "s2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["error", "aborted", "cancelled", "failed"])
+async def test_poll_terminal_failure_raises_export_error(status):
+    http = FakeHTTP(
+        polls=[
+            f'{{"id": "job1", "status": "{status}",'
+            f' "batches": [{{"message": "boom"}}]}}'.encode()
+        ]
+    )
     with pytest.raises(ExportError) as exc:
         await _mgr(http)._poll_until_complete("job1")
-    assert exc.value.status is em.ExportStatus.CANCELED
+    assert exc.value.status is AquaJobStatus(status)
     assert exc.value.job_id == "job1"
+    assert "boom" in str(exc.value)
 
 
 @pytest.mark.asyncio
-async def test_poll_failed_raises_export_error():
-    http = FakeHTTP(polls=[b'{"Status": "Failed", "StatusReason": "boom"}'])
-    with pytest.raises(ExportError) as exc:
-        await _mgr(http)._poll_until_complete("job1")
-    assert exc.value.status is em.ExportStatus.FAILED
-
-
-@pytest.mark.asyncio
-async def test_poll_completed_without_file_id_raises():
-    http = FakeHTTP(polls=[b'{"Status": "Completed"}'])
+async def test_poll_completed_without_file_ids_raises():
+    http = FakeHTTP(polls=[b'{"id": "job1", "status": "completed", "batches": [{}]}'])
     with pytest.raises(ExportError):
         await _mgr(http)._poll_until_complete("job1")
 
@@ -126,16 +172,19 @@ async def test_poll_completed_without_file_id_raises():
 @pytest.mark.asyncio
 async def test_poll_pending_then_completed_loops():
     http = FakeHTTP(
-        polls=[b'{"Status": "Pending"}', b'{"Status": "Completed", "FileId": "f"}']
+        polls=[
+            b'{"id": "job1", "status": "pending"}',
+            b'{"id": "job1", "status": "completed", "batches": [{"fileId": "f"}]}',
+        ]
     )
-    assert await _mgr(http)._poll_until_complete("job1") == "f"
+    assert await _mgr(http)._poll_until_complete("job1") == ["f"]
     assert http.poll_calls == 2
 
 
 @pytest.mark.asyncio
 async def test_poll_times_out(monkeypatch):
     monkeypatch.setattr(em, "MAX_POLL_ATTEMPTS", 3)
-    http = FakeHTTP(polls=[b'{"Status": "Processing"}'])
+    http = FakeHTTP(polls=[b'{"id": "job1", "status": "executing"}'])
     with pytest.raises(ExportError) as exc:
         await _mgr(http)._poll_until_complete("job1")
     assert "timed out" in str(exc.value)
@@ -147,7 +196,7 @@ async def test_poll_times_out(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_fetch_results_strips_object_prefix():
-    http = FakeHTTP(download=b"Account.Id,Account.Name\n1,Acme\n")
+    http = FakeHTTP(downloads={"file1": b"Account.Id,Account.Name\n1,Acme\n"})
     rows = [r async for r in _mgr(http)._fetch_results("file1")]
     assert rows == [{"Id": "1", "Name": "Acme"}]
 
@@ -164,7 +213,7 @@ _TOO_LARGE_403 = HTTPError(
 
 @pytest.mark.asyncio
 async def test_fetch_results_403_with_marker_raises_too_large():
-    http = FakeHTTP(download=_TOO_LARGE_403)
+    http = FakeHTTP(downloads={"file1": _TOO_LARGE_403})
     with pytest.raises(ExportTooLargeError):
         [r async for r in _mgr(http)._fetch_results("file1")]
 
@@ -175,11 +224,13 @@ async def test_fetch_results_403_without_marker_propagates():
     # lacks the "Enable DataSource Exports Reporting" permission — must propagate
     # as HTTPError, not be misdiagnosed as a too-large export.
     http = FakeHTTP(
-        download=HTTPError(
-            "Encountered HTTP error status 403 which cannot be retried.\nResponse:\n"
-            "You do not have permission to perform this action.",
-            403,
-        )
+        downloads={
+            "file1": HTTPError(
+                "Encountered HTTP error status 403 which cannot be retried.\nResponse:\n"
+                "You do not have permission to perform this action.",
+                403,
+            )
+        }
     )
     with pytest.raises(HTTPError) as exc:
         [r async for r in _mgr(http)._fetch_results("file1")]
@@ -188,7 +239,7 @@ async def test_fetch_results_403_without_marker_propagates():
 
 @pytest.mark.asyncio
 async def test_fetch_results_other_http_error_propagates():
-    http = FakeHTTP(download=HTTPError("server error", 500))
+    http = FakeHTTP(downloads={"file1": HTTPError("server error", 500)})
     with pytest.raises(HTTPError):
         [r async for r in _mgr(http)._fetch_results("file1")]
 
@@ -199,20 +250,39 @@ async def test_fetch_results_other_http_error_propagates():
 @pytest.mark.asyncio
 async def test_export_rows_submit_poll_stream():
     http = FakeHTTP(
-        submit=b'{"Success": true, "Id": "job1"}',
-        polls=[b'{"Status": "Completed", "FileId": "file1"}'],
-        download=b"Account.Id\n7\n",
+        submit=_SUBMIT_OK,
+        polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
+        downloads={"file1": b"Account.Id\n7\n"},
     )
     rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
     assert rows == [{"Id": "7"}]
 
 
 @pytest.mark.asyncio
+async def test_export_rows_concatenates_segments_in_order():
+    # Each segment is a self-contained CSV with its own header row.
+    http = FakeHTTP(
+        submit=_SUBMIT_OK,
+        polls=[
+            b'{"id": "job1", "status": "completed",'
+            b' "batches": [{"segments": ["s1", "s2"]}]}'
+        ],
+        downloads={
+            "s1": b"Account.Id\n1\n2\n",
+            "s2": b"Account.Id\n3\n",
+        },
+    )
+    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
+    assert rows == [{"Id": "1"}, {"Id": "2"}, {"Id": "3"}]
+    assert http.downloaded_file_ids == ["s1", "s2"]
+
+
+@pytest.mark.asyncio
 async def test_export_rows_pins_api_version_header():
     http = FakeHTTP(
-        submit=b'{"Success": true, "Id": "job1"}',
-        polls=[b'{"Status": "Completed", "FileId": "file1"}'],
-        download=b"Account.Id\n7\n",
+        submit=_SUBMIT_OK,
+        polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
+        downloads={"file1": b"Account.Id\n7\n"},
     )
     _ = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
     # submit + poll (request) and download (request_stream) all carry the pin
@@ -228,10 +298,10 @@ async def test_export_rows_pins_api_version_header():
 
 @pytest.mark.asyncio
 async def test_run_job_retries_export_error_then_raises():
-    # Job keeps Failing -> ExportError -> retried MAX_RETRIES times.
+    # Job keeps aborting -> ExportError -> retried MAX_RETRIES times.
     http = FakeHTTP(
-        submit=b'{"Success": true, "Id": "job1"}',
-        polls=[b'{"Status": "Failed"}'],
+        submit=_SUBMIT_OK,
+        polls=[b'{"id": "job1", "status": "aborted"}'],
     )
     with pytest.raises(ExportError):
         await _mgr(http)._run_job("SELECT Id FROM Account")


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Shortly after releasing `source-zuora`, we observed that the [`/v1/object/export`](https://developer.zuora.com/v1-api-reference/older-api/exports/object_postexport) endpoint didn't support fields that the `/v1/describe` endpoint says are exportable. There are likely many other incompatibilities & quirks with the legacy `/v1/object/export` endpoint & Export API, and I'd like to completely move the connector off of it & onto an actually support API.

This PR's scope includes:
- Using the [AQuA API](https://docs.zuora.com/en/zuora-platform/data/aggregate-query-api-aqua/aqua-api-introduction) for exporting data instead of the legacy `/v1/object/export` endpoint. The query structure and general export manager control flow remained the same; I mostly had to update models to reflect AQuA API response shapes & the spots the connector referenced fields on those model instances.
- Paginating backfills by `Id` rather than using date window chunks to improve backfill speed. This was inspired by the same improvement for `source-salesforce-native` in https://github.com/estuary/connectors/pull/4875. 
  - Note: Unlike with `source-salesforce-native`, we don't need to support the date window chunk backfill path after this PR is merged since there are no capture tasks that have successfully made any backfill progress. 

**Notes for reviewers:**

This is untested against the actual Zuora API, but the AQuA API docs are more thorough than the previous `/v1/object/export` docs, so I'm cautiously optimistic that this docs-only based development will work at least reasonably well & actually be able to capture some data.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
