### PR TITLE
materialize: commit pending staged transactions before Apply runs schema updates

### DIFF
--- a/filesink/filesink.go
+++ b/filesink/filesink.go
@@ -432,8 +432,20 @@ func (t *transactor[T]) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 // Acknowledge completes all staged uploads and removes them from the
 // checkpoint, so that the checkpoint contains only the list of file counts.
-func (t *transactor[T]) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor[T]) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
+	}
+
+	var processed bool
 	for _, b := range t.bindings {
+		if _, ok := drainKeys[b.stateKey]; !ok {
+			// This state key's pending work was not requested to be processed,
+			// so it remains staged in the persisted state.
+			continue
+		}
+
 		uploads, ok := t.state.Uploads[b.stateKey]
 		if !ok {
 			continue
@@ -446,9 +458,13 @@ func (t *transactor[T]) Acknowledge(ctx context.Context, statePatches []json.Raw
 			log.WithField("key", upload.FileKey()).Info("completed file upload")
 		}
 
+		delete(t.state.Uploads, b.stateKey)
+		processed = true
 	}
 
-	t.state.Uploads = make(map[string][]T)
+	if !processed {
+		return nil, nil
+	}
 
 	checkpointJSON, err := json.Marshal(t.state)
 	if err != nil {

--- a/filesink/filesink.go
+++ b/filesink/filesink.go
@@ -433,14 +433,11 @@ func (t *transactor[T]) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 // Acknowledge completes all staged uploads and removes them from the
 // checkpoint, so that the checkpoint contains only the list of file counts.
 func (t *transactor[T]) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 
 	var processed bool
 	for _, b := range t.bindings {
-		if _, ok := drainKeys[b.stateKey]; !ok {
+		if !shouldProcess(b.stateKey) {
 			// This state key's pending work was not requested to be processed,
 			// so it remains staged in the persisted state.
 			continue

--- a/go/materialize/logging.go
+++ b/go/materialize/logging.go
@@ -375,7 +375,11 @@ type BindingEvents struct {
 	activeStores map[string]time.Time
 }
 
-func newBindingEvents() *BindingEvents {
+// NewBindingEvents returns a BindingEvents that discards all events until it
+// is activated by a transactions stream. Contexts without interactive logging,
+// like an Apply RPC draining staged work through Acknowledge, can pass it to a
+// Transactor as-is.
+func NewBindingEvents() *BindingEvents {
 	return &BindingEvents{activeStores: make(map[string]time.Time)}
 }
 

--- a/go/materialize/logging_test.go
+++ b/go/materialize/logging_test.go
@@ -13,7 +13,7 @@ func TestExtendedLoggerWaitingForDocsRace(t *testing.T) {
 	// sequence ~100 times or so will reliably produce a panic unless sufficient
 	// synchronization is provided in the extended logger event handler.
 	for idx := 0; idx < 100; idx++ {
-		be := newBindingEvents()
+		be := NewBindingEvents()
 		logger := newExtendedLogger(loggerAtLevel{lvl: log.InfoLevel}, be)
 		handler := logger.handler()
 
@@ -77,7 +77,7 @@ func TestLoads(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			be := newBindingEvents()
+			be := NewBindingEvents()
 			logger := newExtendedLogger(loggerAtLevel{lvl: log.InfoLevel}, be)
 			handler := logger.handler()
 			tt.do(handler)

--- a/go/materialize/transactor.go
+++ b/go/materialize/transactor.go
@@ -70,12 +70,15 @@ type Transactor interface {
 	// applies it; a task that isn't sharded is its own primary, so connectors
 	// without multi-shard support simply ignore it.
 	//
-	// `stateKeys` are the binding state keys whose pending staged work must be
-	// processed. Entries staged under other state keys must be left untouched,
-	// remaining pending in the persisted state. During transaction sessions the
-	// runtime passes the state keys of all active bindings; the Apply RPC
-	// instead invokes Acknowledge with only the state keys of bindings about to
-	// receive schema updates, committing their staged work before any DDL runs.
+	// `stateKeys` restricts which binding state keys' pending staged work is
+	// processed. A nil stateKeys processes every state key, including ones a
+	// connector cannot enumerate from the active bindings alone (e.g. entries
+	// staged by since-removed bindings, subject to the connector's own
+	// handling of them); transaction sessions pass nil. A non-nil stateKeys
+	// processes exactly those keys, leaving entries under other state keys
+	// untouched and pending in the persisted state: the Apply RPC invokes
+	// Acknowledge with only the state keys of bindings about to receive
+	// schema updates, committing their staged work before any DDL runs.
 	//
 	// It returns an optional ConnectorState update which will be applied in a best-effort fashion
 	// upon its successful completion. When Acknowledge processed no pending
@@ -90,6 +93,25 @@ type Transactor interface {
 
 	// Destroy the Transactor, releasing any held resources.
 	Destroy()
+}
+
+// StateKeyFilter returns a predicate reporting whether pending work staged
+// under a state key must be processed by Acknowledge, per its stateKeys
+// contract: a nil stateKeys processes everything, and a non-nil stateKeys
+// processes exactly those keys.
+func StateKeyFilter(stateKeys []string) func(string) bool {
+	if stateKeys == nil {
+		return func(string) bool { return true }
+	}
+
+	set := make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		set[sk] = struct{}{}
+	}
+	return func(sk string) bool {
+		_, ok := set[sk]
+		return ok
+	}
 }
 
 // SplitStatePatches decodes a state_patches_json payload into its individual
@@ -198,14 +220,6 @@ func RunTransactions(
 		}
 	}
 
-	// Within a transactions session, Acknowledge always processes the pending
-	// work of every active binding. The Apply RPC separately invokes
-	// Acknowledge with a narrowed set of state keys.
-	var allStateKeys = make([]string, 0, len(open.Materialization.Bindings))
-	for _, b := range open.Materialization.Bindings {
-		allStateKeys = append(allStateKeys, b.StateKey)
-	}
-
 	var txResponse pm.Response
 	var rxRequest = pm.Request{Open: open}
 	txResponse, err = writeOpened(stream, opened)
@@ -250,7 +264,7 @@ func RunTransactions(
 			return nil
 		}
 
-		if ackState, err := transactor.Acknowledge(ctx, statePatches, allStateKeys); err != nil {
+		if ackState, err := transactor.Acknowledge(ctx, statePatches, nil); err != nil {
 			return err
 		} else if err := writeAcknowledged(stream, ackState, &txResponse); err != nil {
 			return err

--- a/go/materialize/transactor.go
+++ b/go/materialize/transactor.go
@@ -70,13 +70,23 @@ type Transactor interface {
 	// applies it; a task that isn't sharded is its own primary, so connectors
 	// without multi-shard support simply ignore it.
 	//
+	// `stateKeys` are the binding state keys whose pending staged work must be
+	// processed. Entries staged under other state keys must be left untouched,
+	// remaining pending in the persisted state. During transaction sessions the
+	// runtime passes the state keys of all active bindings; the Apply RPC
+	// instead invokes Acknowledge with only the state keys of bindings about to
+	// receive schema updates, committing their staged work before any DDL runs.
+	//
 	// It returns an optional ConnectorState update which will be applied in a best-effort fashion
-	// upon its successful completion.
+	// upon its successful completion. When Acknowledge processed no pending
+	// work at all, it must return a nil ConnectorState rather than a no-op
+	// update, since the Apply RPC uses a non-nil update as its signal to
+	// persist state and re-run.
 	//
 	// Acknowledge may perform long-running, idempotent operations such as merging staged
 	// updates into a base table. Upon its successful return, response.Acknowledged is sent to
 	// the runtime, allowing the next pipelined transaction to begin to close.
-	Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error)
+	Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error)
 
 	// Destroy the Transactor, releasing any held resources.
 	Destroy()
@@ -152,7 +162,7 @@ func RunTransactions(
 	open *pm.Request_Open,
 	lvl log.Level,
 ) (_err error) {
-	be := newBindingEvents()
+	be := NewBindingEvents()
 
 	openStart := time.Now()
 	log.Info("requesting materialization Open")
@@ -186,6 +196,14 @@ func RunTransactions(
 		if err := transactor.UnmarshalState(open.StateJson); err != nil {
 			return fmt.Errorf("transactor.UnmarshalState: %w", err)
 		}
+	}
+
+	// Within a transactions session, Acknowledge always processes the pending
+	// work of every active binding. The Apply RPC separately invokes
+	// Acknowledge with a narrowed set of state keys.
+	var allStateKeys = make([]string, 0, len(open.Materialization.Bindings))
+	for _, b := range open.Materialization.Bindings {
+		allStateKeys = append(allStateKeys, b.StateKey)
 	}
 
 	var txResponse pm.Response
@@ -232,7 +250,7 @@ func RunTransactions(
 			return nil
 		}
 
-		if ackState, err := transactor.Acknowledge(ctx, statePatches); err != nil {
+		if ackState, err := transactor.Acknowledge(ctx, statePatches, allStateKeys); err != nil {
 			return err
 		} else if err := writeAcknowledged(stream, ackState, &txResponse); err != nil {
 			return err

--- a/go/materialize/transactor_test.go
+++ b/go/materialize/transactor_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStateKeyFilter(t *testing.T) {
+	// nil processes everything, including keys that can't be enumerated from
+	// the active bindings.
+	all := StateKeyFilter(nil)
+	require.True(t, all("a_table.v1"))
+	require.True(t, all("removed_table.v1"))
+
+	// A non-nil list processes exactly those keys; an empty list processes
+	// nothing.
+	some := StateKeyFilter([]string{"a_table.v1"})
+	require.True(t, some("a_table.v1"))
+	require.False(t, some("b_table.v1"))
+	require.False(t, StateKeyFilter([]string{})("a_table.v1"))
+}
+
 func TestSplitStatePatches(t *testing.T) {
 	// Fixtures mirror the wire format produced by the runtime's patch
 	// encoder: a JSON array whose elements are each followed by a tab.

--- a/materialize-azure-fabric-warehouse/transactor.go
+++ b/materialize-azure-fabric-warehouse/transactor.go
@@ -103,7 +103,7 @@ func newTransactor(
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (t *transactor) RecoverCheckpoint(_ context.Context, _ pf.MaterializationSpec, _ pf.RangeSpec) (m.RuntimeCheckpoint, error) {
 	return t.fence.Checkpoint, nil

--- a/materialize-bigquery/CHANGELOG.md
+++ b/materialize-bigquery/CHANGELOG.md
@@ -1,5 +1,20 @@
 # materialize-bigquery
 
+## 2026-07-23
+
+### Changed
+- Schema changes now first commit any transaction that was staged but not yet
+  fully applied to the tables they affect, instead of leaving it to be applied
+  afterwards. This prevents failures where staged data built against the
+  previous table schema could no longer be applied after a column was added,
+  made nullable, or had its type migrated.
+
+### Fixed
+- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
+  a binding no longer risks losing the rows of a transaction that was committed
+  but not yet fully applied to the destination: the pending transaction is now
+  applied before the backfill takes effect.
+
 ## 2026-07-18
 
 ### Fixed

--- a/materialize-bigquery/bigquery_test.go
+++ b/materialize-bigquery/bigquery_test.go
@@ -1,10 +1,21 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/estuary/connectors/go/blob"
+	testutil "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegration(t *testing.T) {
@@ -33,6 +44,47 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("apply", func(t *testing.T) {
 		sql.RunApplyTest(t, newBigQueryDriver(), "testdata/apply.flow.yaml", makeResourceFn)
+	})
+
+	t.Run("apply-drain", func(t *testing.T) {
+		testutil.RunTestAllTasks(t, "testdata/apply.flow.yaml", func(t *testing.T, bundled []byte, taskName string, cfg config) {
+			ctx := context.Background()
+			tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+			res := makeResourceFn(tableName, false).WithDefaults(cfg)
+
+			seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+				// A staged transaction is a query persisted in the connector
+				// state, keyed by the binding's state key, along with the GCS
+				// files it consumes as an external table and the job prefix
+				// making its execution idempotent. The staged file must exist
+				// since Acknowledge deletes it after the query succeeds.
+				credOption, err := cfg.CredentialsClientOption()
+				require.NoError(t, err)
+				bucket, err := blob.NewGCSBucket(ctx, cfg.Bucket, credOption)
+				require.NoError(t, err)
+
+				fileKey := path.Join(cfg.effectiveBucketPath(), fmt.Sprintf("applydrain-%s.json", uuid.NewString()))
+				require.NoError(t, bucket.Upload(ctx, fileKey, strings.NewReader("")))
+
+				query := sql.DrainSeedInsertQuery(t, newBigQueryDriver(), cfg, appliedSpec, "JSON '{}'")
+				state, err := json.Marshal(map[string]any{
+					appliedSpec.Bindings[0].StateKey: map[string]any{
+						"Query":         query,
+						"SourceURIs":    []string{bucket.URI(fileKey)},
+						"JobPrefix":     uuid.NewString(),
+						"TempTableName": "flow_temp_table_0",
+					},
+				})
+				require.NoError(t, err)
+				return state
+			}
+
+			verifyDrained := func(t *testing.T, _ *pf.MaterializationSpec, _ []string, rows [][]any) {
+				require.Len(t, rows, 1, "the staged transaction's row must have been committed")
+			}
+
+			sql.RunApplyDrainTest(t, newBigQueryDriver(), cfg, res, seedPending, verifyDrained)
+		})
 	})
 
 	t.Run("migrate", func(t *testing.T) {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -413,14 +413,21 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}, nil
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	group, groupCtx := errgroup.WithContext(ctx)
 	// You can run up to 1,000 concurrent multi-statement queries, so we use a
 	// generous concurrency limit here, while not leaving it completely
 	// unlimited just to maintain some sense of decorum.
 	group.SetLimit(100)
 
-	for sk, item := range t.cp {
+	var drained []string
+	for _, sk := range stateKeys {
+		item, ok := t.cp[sk]
+		if !ok {
+			// No pending work is staged for this state key.
+			continue
+		}
+
 		var b *binding
 		for _, binding := range t.bindings {
 			if binding.target.StateKey == sk {
@@ -434,6 +441,7 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 			continue
 		}
 
+		drained = append(drained, sk)
 		group.Go(func() error {
 			t.be.StartedResourceCommit(b.target.Path)
 			if err := t.client.queryIdempotent(groupCtx, b.storeSchema, item.Query, item.JobPrefix, item.SourceURIs, item.TempTableName); err != nil {
@@ -462,10 +470,14 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		return nil, err
 	}
 
+	if len(drained) == 0 {
+		return nil, nil
+	}
+
 	var checkpointClear = make(checkpoint)
-	for _, b := range t.bindings {
-		checkpointClear[b.target.StateKey] = nil
-		delete(t.cp, b.target.StateKey)
+	for _, sk := range drained {
+		checkpointClear[sk] = nil
+		delete(t.cp, sk)
 	}
 	var checkpointJSON, err = json.Marshal(checkpointClear)
 	if err != nil {

--- a/materialize-bigquery/transactor.go
+++ b/materialize-bigquery/transactor.go
@@ -420,11 +420,13 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	// unlimited just to maintain some sense of decorum.
 	group.SetLimit(100)
 
+	shouldProcess := m.StateKeyFilter(stateKeys)
+
 	var drained []string
-	for _, sk := range stateKeys {
-		item, ok := t.cp[sk]
-		if !ok {
-			// No pending work is staged for this state key.
+	for sk, item := range t.cp {
+		if !shouldProcess(sk) {
+			// This state key's pending work was not requested to be
+			// processed, so it remains staged in the persisted state.
 			continue
 		}
 

--- a/materialize-bigquery/transactor_test.go
+++ b/materialize-bigquery/transactor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -8,6 +9,28 @@ import (
 	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAcknowledgeSubsetLeavesOtherKeysPending(t *testing.T) {
+	tr := &transactor{
+		cp: checkpoint{
+			"a_table.v1": {Query: "MERGE INTO a", JobPrefix: "jp"},
+			"b_table.v1": {Query: "MERGE INTO b", JobPrefix: "jp"},
+		},
+		bindings: []*binding{
+			{target: sql.Table{StateKey: "a_table.v1"}},
+			{target: sql.Table{StateKey: "b_table.v1"}},
+		},
+	}
+
+	// No staged entry's state key is requested: nothing may execute (the nil
+	// client would panic if a query ran) and no state update is returned, so
+	// the entries remain pending in the persisted state.
+	state, err := tr.Acknowledge(context.Background(), nil, []string{"c_table.v1"})
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.NotNil(t, tr.cp["a_table.v1"])
+	require.NotNil(t, tr.cp["b_table.v1"])
+}
 
 func TestSchemaForColsStripsPolicyTags(t *testing.T) {
 	makeCol := func(field string) *sql.Column {

--- a/materialize-bigtable/transactor.go
+++ b/materialize-bigtable/transactor.go
@@ -65,7 +65,7 @@ func (t *transactor) UnmarshalState(raw json.RawMessage) error {
 	return nil
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	return nil, nil
 }
 

--- a/materialize-boilerplate/materializer.go
+++ b/materialize-boilerplate/materializer.go
@@ -435,11 +435,6 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 	}
 	defer materializer.Close(ctx)
 
-	// TODO(whb): Some point soon we will have the last committed checkpoint
-	// available here in the Apply message, and should start calling Unmarshal
-	// State + Acknowledge somewhere around here to commit any previously staged
-	// transaction before applying the next spec's updates.
-
 	mCfg := materializer.Config()
 
 	paths := make([][]string, 0, len(req.Materialization.Bindings))
@@ -521,6 +516,14 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 		return nil, err
 	}
 
+	// destructiveBindings are bindings whose existing resource is really being
+	// truncated or dropped & re-created by this Apply. drainBindings are
+	// bindings which retain their materialized data while their binding
+	// changes: any transaction previously staged for them must be committed
+	// before this Apply's actions run (see the drain below).
+	destructiveBindings := make(map[int]bool)
+	drainBindings := make(map[int]bool)
+
 	for _, bindingIdx := range common.newBindings {
 		if mapped, err := buildMappedBinding(endpointCfg, materializer, *req.Materialization, bindingIdx); err != nil {
 			return nil, err
@@ -590,12 +593,19 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 
 		if !mCfg.NoTruncateResources && !parsedFlags["always_drop_tables_on_backfill"] && doTruncate {
 			if parsedFlags["retain_existing_data_on_backfill"] {
-				// Only run TruncateTable if retain_existing_data_on_backfill is disabled
+				// Only run TruncateTable if retain_existing_data_on_backfill is disabled.
+				// Since the resource retains its data, a previously staged
+				// transaction remains applicable and must be committed: the
+				// backfill rotates the binding's state key, so pending work
+				// staged under the pre-backfill key would otherwise be
+				// orphaned, losing its staged-but-unacknowledged rows.
+				drainBindings[bindingIdx] = true
 			} else if desc, action, err := materializer.TruncateResource(ctx, thisBinding.ResourcePath); err != nil {
 				return nil, fmt.Errorf("getting TruncateResource action: %w", err)
 			} else {
 				truncationActionDescriptions = append(truncationActionDescriptions, desc)
 				truncationActions = append(truncationActions, action)
+				destructiveBindings[bindingIdx] = true
 			}
 
 			// A resource may be truncated, but require other updates as well.
@@ -615,6 +625,7 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 			} else if createDesc, createAction, err := materializer.CreateResource(ctx, *mapped); err != nil {
 				return nil, fmt.Errorf("getting CreateResource action to replace resource: %w", err)
 			} else {
+				destructiveBindings[bindingIdx] = true
 				descs := make([]string, 2)
 				if deleteAction != nil {
 					descs = append(descs, deleteDesc)
@@ -712,6 +723,54 @@ func RunApply[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT Ma
 			return nil, err
 		} else {
 			addResourceAction(desc, action)
+			if (action != nil || update.NewlyDeltaUpdates) && !destructiveBindings[bindingIdx] {
+				// The binding's resource is being updated in-place, so any
+				// transaction previously staged against it must be committed
+				// before the update runs.
+				drainBindings[bindingIdx] = true
+			}
+		}
+	}
+
+	// Post-commit apply connectors persist staged transactions in their
+	// connector state and only commit them during Acknowledge. Work pending
+	// for a binding of drainBindings was staged against the last-applied
+	// specification's resource, so it must be committed before that resource
+	// is altered. This is done by invoking the connector's own Acknowledge
+	// restricted to the affected state keys, and returning its state update in
+	// the Applied response WITHOUT running any of the computed actions: the
+	// runtime durably persists the update and invokes Apply again, and only
+	// that next invocation - finding no remaining pending work - performs the
+	// actions. Running them in the same invocation as the drain would risk a
+	// crash after the staged DML commits but before the state update persists,
+	// re-running staged queries against an altered schema on the next attempt.
+	//
+	// Bindings of destructiveBindings are deliberately not drained: their
+	// backfill rotates the binding's state key, so the pending entries become
+	// inert, the truncated or re-created resource is re-materialized in full
+	// anyway, and a user backfilling to recover from wedged pending work is
+	// not blocked by a failing drain.
+	if len(req.StateJson) > 0 && len(drainBindings) > 0 {
+		var commitKeys []string
+		for bindingIdx := range drainBindings {
+			// Pending work was staged under the last-applied binding's state
+			// key, which differs from the current binding's key when the
+			// backfill counter is changing.
+			if lastBinding := FindLastBinding(req.Materialization.Bindings[bindingIdx].ResourcePath, req.LastMaterialization); lastBinding != nil {
+				commitKeys = append(commitKeys, lastBinding.StateKey)
+			}
+		}
+		slices.Sort(commitKeys)
+
+		if len(commitKeys) > 0 {
+			if patch, err := drainPendingState(ctx, materializer, req, endpointCfg, is, commitKeys); err != nil {
+				return nil, fmt.Errorf("committing pending transaction before applying schema updates: %w", err)
+			} else if patch != nil {
+				return &pm.Response_Applied{
+					ActionDescription: fmt.Sprintf("committed previously staged transaction for state keys: %s", strings.Join(commitKeys, ", ")),
+					State:             patch,
+				}, nil
+			}
 		}
 	}
 

--- a/materialize-boilerplate/materializer_test.go
+++ b/materialize-boilerplate/materializer_test.go
@@ -233,6 +233,137 @@ func TestRunApplyRetainExistingDataOnBackfill(t *testing.T) {
 	}
 }
 
+func TestRunApplyDrainsPendingState(t *testing.T) {
+	ctx := context.Background()
+
+	pendingState := json.RawMessage(`{"key_value":{"query":"MERGE INTO ..."}}`)
+	clearingPatch := &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"key_value":null}`), MergePatch: true}
+
+	for _, tt := range []struct {
+		name         string
+		newSpec      *pf.MaterializationSpec
+		stateJson    json.RawMessage
+		ackPatch     *pf.ConnectorState
+		featureFlags string
+		wantAckKeys  []string
+		wantState    *pf.ConnectorState
+		wantExecuted int
+	}{
+		{
+			name:         "pending state is drained before in-place updates",
+			newSpec:      loadMaterializerSpec(t, "updated.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     clearingPatch,
+			wantAckKeys:  []string{"key_value"},
+			wantState:    clearingPatch,
+			wantExecuted: 0, // the drain returns early: no actions may run
+		},
+		{
+			name:         "no pending work proceeds to actions in the same invocation",
+			newSpec:      loadMaterializerSpec(t, "updated.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     nil,
+			wantAckKeys:  []string{"key_value"},
+			wantState:    nil,
+			wantExecuted: 1,
+		},
+		{
+			name:         "a state update changing nothing proceeds to actions",
+			newSpec:      loadMaterializerSpec(t, "updated.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"unrelated":null}`), MergePatch: true},
+			wantAckKeys:  []string{"key_value"},
+			wantState:    nil,
+			wantExecuted: 1,
+		},
+		{
+			name:         "no state means no drain",
+			newSpec:      loadMaterializerSpec(t, "updated.flow.proto"),
+			stateJson:    nil,
+			ackPatch:     clearingPatch,
+			wantAckKeys:  nil,
+			wantState:    nil,
+			wantExecuted: 1,
+		},
+		{
+			name:         "truncated backfill discards pending state without draining",
+			newSpec:      loadMaterializerSpec(t, "truncate.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     clearingPatch,
+			wantAckKeys:  nil,
+			wantState:    nil,
+			wantExecuted: 2, // truncation + update
+		},
+		{
+			name:         "re-created backfill discards pending state without draining",
+			newSpec:      loadMaterializerSpec(t, "incompatible-changes.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     clearingPatch,
+			wantAckKeys:  nil,
+			wantState:    nil,
+			wantExecuted: 2, // delete + create
+		},
+		{
+			name:         "data-retaining backfill drains the pre-backfill state key",
+			newSpec:      loadMaterializerSpec(t, "backfill-nullable.flow.proto"),
+			stateJson:    pendingState,
+			ackPatch:     clearingPatch,
+			featureFlags: "retain_existing_data_on_backfill",
+			wantAckKeys:  []string{"key_value"}, // NOT key_value.v1: pending work was staged under the pre-backfill key
+			wantState:    clearingPatch,
+			wantExecuted: 0,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSpec := loadMaterializerSpec(t, "base.flow.proto")
+
+			req := &pm.Request_Apply{
+				Materialization:     tt.newSpec,
+				Version:             "thisone",
+				LastMaterialization: originalSpec,
+				LastVersion:         "oldone",
+				StateJson:           tt.stateJson,
+			}
+
+			if tt.featureFlags != "" {
+				var config testEndpointConfiger
+				require.NoError(t, json.Unmarshal(req.Materialization.ConfigJson, &config))
+				config.Config = map[string]any{
+					"advanced": map[string]any{"feature_flags": tt.featureFlags},
+				}
+				modifiedConfigJson, err := json.Marshal(config)
+				require.NoError(t, err)
+				req.Materialization.ConfigJson = modifiedConfigJson
+			}
+
+			is := testInfoSchemaFromSpec(t, originalSpec, func(in string) string { return in })
+			rec := &drainRecorder{ackPatch: tt.ackPatch}
+
+			applied, err := RunApply(ctx, req, makeDrainTestMaterializerFn(rec, is))
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wantAckKeys, rec.ackKeys)
+			require.Equal(t, tt.wantState, applied.State)
+			require.Equal(t, tt.wantExecuted, rec.executedActions)
+
+			if tt.wantAckKeys != nil {
+				// The transactor must have been built from the last-applied
+				// specification and given the prior state, then destroyed.
+				require.Same(t, originalSpec, rec.openedSpec)
+				require.Equal(t, "oldone", rec.openedVersion)
+				require.Equal(t, tt.stateJson, rec.unmarshaled)
+				require.True(t, rec.destroyed)
+			} else {
+				require.Nil(t, rec.openedSpec) // no transactor was built
+			}
+
+			if tt.wantState != nil {
+				require.Contains(t, applied.ActionDescription, "key_value")
+			}
+		})
+	}
+}
+
 type testCalls struct {
 	createResource   [][]string
 	updateResource   [][]string
@@ -433,10 +564,90 @@ func (t *testTransactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	panic("unimplemented")
 }
 
-func (t *testTransactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *testTransactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	panic("unimplemented")
 }
 
 func (t *testTransactor) Destroy() {
 	panic("unimplemented")
+}
+
+// drainRecorder records the interactions of RunApply's pending-state drain:
+// which actions were actually executed, how the transactor was built, and the
+// state keys its Acknowledge was restricted to.
+type drainRecorder struct {
+	executedActions int
+	openedSpec      *pf.MaterializationSpec
+	openedVersion   string
+	unmarshaled     json.RawMessage
+	ackKeys         []string
+	ackPatch        *pf.ConnectorState // returned by Acknowledge
+	destroyed       bool
+}
+
+type drainTestMaterializer struct {
+	testMaterializer
+	rec *drainRecorder
+}
+
+func makeDrainTestMaterializerFn(rec *drainRecorder, is *InfoSchema) NewMaterializerFn[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper] {
+	return func(
+		ctx context.Context,
+		materializationName string,
+		endpointConfig testEndpointConfiger,
+		featureFlags map[string]bool,
+	) (Materializer[testEndpointConfiger, testFieldConfiger, testResourcer, testMappedTyper], error) {
+		return &drainTestMaterializer{
+			testMaterializer: testMaterializer{calls: &testCalls{}, is: is},
+			rec:              rec,
+		}, nil
+	}
+}
+
+func (d *drainTestMaterializer) countingAction() ActionApplyFn {
+	return func(context.Context) error {
+		d.rec.executedActions++
+		return nil
+	}
+}
+
+func (d *drainTestMaterializer) CreateResource(ctx context.Context, binding MappedBinding[testEndpointConfiger, testResourcer, testMappedTyper]) (string, ActionApplyFn, error) {
+	return "", d.countingAction(), nil
+}
+
+func (d *drainTestMaterializer) DeleteResource(ctx context.Context, path []string) (string, ActionApplyFn, error) {
+	return "", d.countingAction(), nil
+}
+
+func (d *drainTestMaterializer) UpdateResource(ctx context.Context, path []string, existing ExistingResource, update BindingUpdate[testEndpointConfiger, testResourcer, testMappedTyper]) (string, ActionApplyFn, error) {
+	return "", d.countingAction(), nil
+}
+
+func (d *drainTestMaterializer) TruncateResource(ctx context.Context, path []string) (string, ActionApplyFn, error) {
+	return "", d.countingAction(), nil
+}
+
+func (d *drainTestMaterializer) NewTransactor(ctx context.Context, req pm.Request_Open, is InfoSchema, bindings []MappedBinding[testEndpointConfiger, testResourcer, testMappedTyper], be *m.BindingEvents) (m.Transactor, error) {
+	d.rec.openedSpec = req.Materialization
+	d.rec.openedVersion = req.Version
+	return &drainTestTransactor{rec: d.rec}, nil
+}
+
+type drainTestTransactor struct {
+	testTransactor
+	rec *drainRecorder
+}
+
+func (t *drainTestTransactor) UnmarshalState(state json.RawMessage) error {
+	t.rec.unmarshaled = state
+	return nil
+}
+
+func (t *drainTestTransactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
+	t.rec.ackKeys = append([]string(nil), stateKeys...)
+	return t.rec.ackPatch, nil
+}
+
+func (t *drainTestTransactor) Destroy() {
+	t.rec.destroyed = true
 }

--- a/materialize-boilerplate/pending_state.go
+++ b/materialize-boilerplate/pending_state.go
@@ -1,0 +1,125 @@
+package boilerplate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+
+	m "github.com/estuary/connectors/go/materialize"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+)
+
+// drainPendingState commits the transaction previously staged for the given
+// state keys, if any, by invoking the connector's own Transactor.Acknowledge
+// restricted to those keys. It returns the connector state update clearing
+// the committed entries, or nil when there was no pending work to commit.
+//
+// The transactor is built against the last-applied specification: pending
+// work was staged under its bindings and state keys, and the current
+// (pre-Apply) resources still match it.
+func drainPendingState[EC EndpointConfiger, FC FieldConfiger, RC Resourcer[RC, EC], MT MappedTyper](
+	ctx context.Context,
+	materializer Materializer[EC, FC, RC, MT],
+	req *pm.Request_Apply,
+	endpointCfg EC,
+	is *InfoSchema,
+	stateKeys []string,
+) (*pf.ConnectorState, error) {
+	lastSpec := req.LastMaterialization
+
+	mapped := make([]MappedBinding[EC, RC, MT], 0, len(lastSpec.Bindings))
+	for idx := range lastSpec.Bindings {
+		if mb, err := buildMappedBinding(endpointCfg, materializer, *lastSpec, idx); err != nil {
+			return nil, fmt.Errorf("building mapped binding %d of the last-applied specification: %w", idx, err)
+		} else {
+			mapped = append(mapped, *mb)
+		}
+	}
+
+	// The Apply RPC runs on shard zero before any transactions session opens,
+	// so the transactor stands in for the task's entire key range.
+	open := pm.Request_Open{
+		Materialization: lastSpec,
+		Version:         req.LastVersion,
+		Range: &pf.RangeSpec{
+			KeyEnd:    math.MaxUint32,
+			RClockEnd: math.MaxUint32,
+		},
+		StateJson: req.StateJson,
+	}
+
+	transactor, err := materializer.NewTransactor(ctx, open, *is, mapped, m.NewBindingEvents())
+	if err != nil {
+		return nil, fmt.Errorf("building transactor: %w", err)
+	}
+	defer transactor.Destroy()
+
+	if err := transactor.UnmarshalState(req.StateJson); err != nil {
+		return nil, fmt.Errorf("unmarshalling state: %w", err)
+	}
+
+	patch, err := transactor.Acknowledge(ctx, nil, stateKeys)
+	if err != nil {
+		return nil, fmt.Errorf("acknowledging pending transaction: %w", err)
+	} else if patch == nil || stateUnchanged(req.StateJson, patch) {
+		return nil, nil
+	}
+
+	return patch, nil
+}
+
+// stateUnchanged reports whether applying the connector state update to the
+// prior state produces no change. It protects the runtime's bounded Apply
+// loop: a non-nil state update in the Applied response causes the runtime to
+// persist it and invoke Apply again, so an update that changes nothing must
+// never be returned, lest the loop's iteration budget be exhausted by
+// connectors which return an unconditional clearing update.
+func stateUnchanged(prior json.RawMessage, update *pf.ConnectorState) bool {
+	var before any
+	if err := json.Unmarshal(prior, &before); err != nil {
+		return false
+	}
+
+	var after any
+	if update.MergePatch {
+		var patch any
+		if err := json.Unmarshal(update.UpdatedJson, &patch); err != nil {
+			return false
+		}
+		after = applyMergePatch(before, patch)
+	} else if err := json.Unmarshal(update.UpdatedJson, &after); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(before, after)
+}
+
+// applyMergePatch applies an RFC 7396 JSON merge patch to target, returning
+// the patched value without modifying target.
+func applyMergePatch(target, patch any) any {
+	patchObj, ok := patch.(map[string]any)
+	if !ok {
+		return patch
+	}
+
+	targetObj, ok := target.(map[string]any)
+	if !ok {
+		targetObj = nil // a non-object target is replaced by the patched object
+	}
+
+	out := make(map[string]any, len(targetObj)+len(patchObj))
+	for k, v := range targetObj {
+		out[k] = v
+	}
+	for k, v := range patchObj {
+		if v == nil {
+			delete(out, k)
+		} else {
+			out[k] = applyMergePatch(out[k], v)
+		}
+	}
+	return out
+}

--- a/materialize-boilerplate/pending_state.go
+++ b/materialize-boilerplate/pending_state.go
@@ -89,7 +89,7 @@ func stateUnchanged(prior json.RawMessage, update *pf.ConnectorState) bool {
 		if err := json.Unmarshal(update.UpdatedJson, &patch); err != nil {
 			return false
 		}
-		after = applyMergePatch(before, patch)
+		after = ApplyMergePatch(before, patch)
 	} else if err := json.Unmarshal(update.UpdatedJson, &after); err != nil {
 		return false
 	}
@@ -97,9 +97,9 @@ func stateUnchanged(prior json.RawMessage, update *pf.ConnectorState) bool {
 	return reflect.DeepEqual(before, after)
 }
 
-// applyMergePatch applies an RFC 7396 JSON merge patch to target, returning
+// ApplyMergePatch applies an RFC 7396 JSON merge patch to target, returning
 // the patched value without modifying target.
-func applyMergePatch(target, patch any) any {
+func ApplyMergePatch(target, patch any) any {
 	patchObj, ok := patch.(map[string]any)
 	if !ok {
 		return patch
@@ -118,7 +118,7 @@ func applyMergePatch(target, patch any) any {
 		if v == nil {
 			delete(out, k)
 		} else {
-			out[k] = applyMergePatch(out[k], v)
+			out[k] = ApplyMergePatch(out[k], v)
 		}
 	}
 	return out

--- a/materialize-boilerplate/pending_state_test.go
+++ b/materialize-boilerplate/pending_state_test.go
@@ -1,0 +1,54 @@
+package boilerplate
+
+import (
+	"encoding/json"
+	"testing"
+
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateUnchanged(t *testing.T) {
+	prior := json.RawMessage(`{"a":{"q":"Q1"},"b":{"q":"Q2"}}`)
+
+	for _, tt := range []struct {
+		name   string
+		update *pf.ConnectorState
+		want   bool
+	}{
+		{
+			name:   "merge patch removing an entry changes state",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"a":null}`), MergePatch: true},
+			want:   false,
+		},
+		{
+			name:   "merge patch removing an absent entry is unchanged",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"c":null}`), MergePatch: true},
+			want:   true,
+		},
+		{
+			name:   "empty merge patch is unchanged",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{}`), MergePatch: true},
+			want:   true,
+		},
+		{
+			name:   "nested merge patch removing an entry changes state",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"a":{"q":null}}`), MergePatch: true},
+			want:   false,
+		},
+		{
+			name:   "full replacement with identical document is unchanged",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"b":{"q":"Q2"},"a":{"q":"Q1"}}`)},
+			want:   true,
+		},
+		{
+			name:   "full replacement with a subset changes state",
+			update: &pf.ConnectorState{UpdatedJson: json.RawMessage(`{"b":{"q":"Q2"}}`)},
+			want:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, stateUnchanged(prior, tt.update))
+		})
+	}
+}

--- a/materialize-boilerplate/testutil/test_support_drain.go
+++ b/materialize-boilerplate/testutil/test_support_drain.go
@@ -107,35 +107,8 @@ func reduceConnectorState(t *testing.T, prior json.RawMessage, update *pf.Connec
 	var before, patch any
 	require.NoError(t, json.Unmarshal(prior, &before))
 	require.NoError(t, json.Unmarshal(update.UpdatedJson, &patch))
-	reduced, err := json.Marshal(applyMergePatch(before, patch))
+	reduced, err := json.Marshal(boilerplate.ApplyMergePatch(before, patch))
 	require.NoError(t, err)
 
 	return reduced
-}
-
-// applyMergePatch applies an RFC 7396 JSON merge patch to target, returning
-// the patched value without modifying target.
-func applyMergePatch(target, patch any) any {
-	patchObj, ok := patch.(map[string]any)
-	if !ok {
-		return patch
-	}
-
-	targetObj, ok := target.(map[string]any)
-	if !ok {
-		targetObj = nil
-	}
-
-	out := make(map[string]any, len(targetObj)+len(patchObj))
-	for k, v := range targetObj {
-		out[k] = v
-	}
-	for k, v := range patchObj {
-		if v == nil {
-			delete(out, k)
-		} else {
-			out[k] = applyMergePatch(out[k], v)
-		}
-	}
-	return out
 }

--- a/materialize-boilerplate/testutil/test_support_drain.go
+++ b/materialize-boilerplate/testutil/test_support_drain.go
@@ -1,0 +1,141 @@
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+)
+
+// RunApplyDrainTest verifies the two-iteration Apply drain of a post-commit
+// apply connector, which stages transactions in its connector state and only
+// commits them during Acknowledge:
+//
+//  1. A base specification is applied, creating the resource.
+//  2. seedPending stages destination-side pending work for the resource, as a
+//     committed-but-unacknowledged transaction would, and returns the
+//     connector state document describing it.
+//  3. An Apply adding a column to the resource is invoked carrying that state.
+//     It must commit the pending work and return a clearing state update
+//     WITHOUT altering the resource.
+//  4. The same Apply is re-invoked with the reduced state, as the runtime's
+//     apply loop does. It must perform the schema update and return no
+//     further state update, and a subsequent re-invocation (as after a crash)
+//     must converge as a no-op.
+func RunApplyDrainTest[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger, RC boilerplate.Resourcer[RC, EC], MT boilerplate.MappedTyper](
+	t *testing.T,
+	driver boilerplate.Connector,
+	newMaterializer boilerplate.NewMaterializerFn[EC, FC, RC, MT],
+	cfg EC,
+	res RC,
+	seedPending func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage,
+	verifyDrained func(t *testing.T, appliedSpec *pf.MaterializationSpec, colNames []string, rows [][]any),
+) {
+	ctx := context.Background()
+	configJson, resourceConfigJson := rawJson(t, cfg), rawJson(t, res)
+
+	materializer, err := newMaterializer(ctx, "apply-drain-test", cfg, boilerplate.ParseFlags(cfg))
+	require.NoError(t, err)
+
+	resourcePath, _, err := res.Parameters()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, fn, err := materializer.DeleteResource(ctx, resourcePath); err == nil && fn != nil {
+			_ = fn(ctx)
+		}
+	})
+
+	initial := loadSpec(t, "base.flow.proto")
+	updated := loadSpec(t, "add-single-optional.flow.proto")
+
+	validateRes, err := driver.Validate(ctx, validateReq(initial, nil, configJson, resourceConfigJson))
+	require.NoError(t, err)
+	_, err = driver.Apply(ctx, applyReq(initial, nil, configJson, resourceConfigJson, validateRes, true))
+	require.NoError(t, err)
+
+	baseSchema := dumpSchema(t, ctx, materializer, res)
+	stateJson := seedPending(t, initial)
+
+	validateRes, err = driver.Validate(ctx, validateReq(updated, initial, configJson, resourceConfigJson))
+	require.NoError(t, err)
+	req := applyReq(updated, initial, configJson, resourceConfigJson, validateRes, true)
+	req.LastVersion = "priorVersion"
+	req.StateJson = stateJson
+
+	// First iteration: the affected binding's pending work is committed and a
+	// clearing state update returned, with the resource left unaltered.
+	firstApplied, err := driver.Apply(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, firstApplied.State, "first Apply must return a state update draining the pending transaction")
+	require.NotEmpty(t, firstApplied.ActionDescription, "a state-updating Applied must carry a non-empty action description")
+	require.Equal(t, baseSchema, dumpSchema(t, ctx, materializer, res), "first Apply must not alter the resource")
+	colNames, rows, err := materializer.SnapshotTestResource(ctx, resourcePath)
+	require.NoError(t, err)
+	verifyDrained(t, initial, colNames, rows)
+
+	// The runtime durably persists the update and re-invokes Apply with the
+	// reduced state.
+	req.StateJson = reduceConnectorState(t, stateJson, firstApplied.State)
+
+	// Second iteration: nothing remains pending, so the schema update is
+	// performed with no further state update, ending the runtime's loop.
+	secondApplied, err := driver.Apply(ctx, req)
+	require.NoError(t, err)
+	require.Nil(t, secondApplied.State, "second Apply must not return a state update")
+	require.NotEmpty(t, secondApplied.ActionDescription)
+	require.NotEqual(t, baseSchema, dumpSchema(t, ctx, materializer, res), "second Apply must alter the resource")
+
+	// Apply must be idempotent: last_materialization is only bumped once the
+	// loop converges, so a crash-and-retry re-runs the same request.
+	thirdApplied, err := driver.Apply(ctx, req)
+	require.NoError(t, err)
+	require.Nil(t, thirdApplied.State)
+}
+
+// reduceConnectorState applies a connector state update to a prior state
+// document exactly as the runtime does between Apply iterations.
+func reduceConnectorState(t *testing.T, prior json.RawMessage, update *pf.ConnectorState) json.RawMessage {
+	t.Helper()
+
+	if !update.MergePatch {
+		return update.UpdatedJson
+	}
+
+	var before, patch any
+	require.NoError(t, json.Unmarshal(prior, &before))
+	require.NoError(t, json.Unmarshal(update.UpdatedJson, &patch))
+	reduced, err := json.Marshal(applyMergePatch(before, patch))
+	require.NoError(t, err)
+
+	return reduced
+}
+
+// applyMergePatch applies an RFC 7396 JSON merge patch to target, returning
+// the patched value without modifying target.
+func applyMergePatch(target, patch any) any {
+	patchObj, ok := patch.(map[string]any)
+	if !ok {
+		return patch
+	}
+
+	targetObj, ok := target.(map[string]any)
+	if !ok {
+		targetObj = nil
+	}
+
+	out := make(map[string]any, len(targetObj)+len(patchObj))
+	for k, v := range targetObj {
+		out[k] = v
+	}
+	for k, v := range patchObj {
+		if v == nil {
+			delete(out, k)
+		} else {
+			out[k] = applyMergePatch(out[k], v)
+		}
+	}
+	return out
+}

--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-07-23
+
+### Changed
+- Schema changes now first commit any transaction that was staged but not yet
+  fully applied to the tables they affect, instead of leaving it to be applied
+  afterwards. This prevents failures where staged data built against the
+  previous table schema could no longer be applied after a column was added,
+  made nullable, or had its type migrated.
+
+### Fixed
+- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
+  a binding no longer risks losing the rows of a transaction that was committed
+  but not yet fully applied to the destination: the pending transaction is now
+  applied before the backfill takes effect.
+
 ## 2026-07-22
 
 ### Changed

--- a/materialize-clickhouse/config_test.go
+++ b/materialize-clickhouse/config_test.go
@@ -74,10 +74,9 @@ func TestResolvedAddress(t *testing.T) {
 
 func TestAcknowledge(t *testing.T) {
 	var tr transactor
-	state, err := tr.Acknowledge(t.Context(), nil)
+	state, err := tr.Acknowledge(t.Context(), nil, nil)
 	require.NoError(t, err)
-	require.JSONEq(t, `{}`, string(state.UpdatedJson))
-	require.True(t, state.MergePatch)
+	require.Nil(t, state)
 }
 
 func TestSpecification(t *testing.T) {

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -753,7 +753,13 @@ func (t *transactor) bindingForStateKey(stateKey string) (*binding, bool) {
 	return nil, false
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
+	}
+	var drained []string
+
 	if !t.ensured {
 		// First Acknowledge of the session: recover pending commits and
 		// ensure every binding's persistent temp tables. This always runs
@@ -761,6 +767,16 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		// of the next transaction's store phase).
 		for _, b := range t.bindings {
 			if si, pending := t.state[b.target.StateKey]; pending {
+				if _, ok := drainKeys[b.target.StateKey]; !ok {
+					// This binding's pending work was not requested, so its
+					// staged rows must stay put. ensureTempTables would
+					// discard them, so it is skipped as well; a session
+					// always requests every active binding's state key, so
+					// this only happens in the Apply RPC's narrowed drain,
+					// where no Store follows.
+					continue
+				}
+				drained = append(drained, b.target.StateKey)
 				// A store table whose partition key differs from the target's
 				// predates a partition-changing backfill: the backfill dropped
 				// and re-created the target, so the staged rows belong to a
@@ -807,6 +823,9 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		t.ensured = true
 	} else {
 		for stateKey, si := range t.state {
+			if _, ok := drainKeys[stateKey]; !ok {
+				continue
+			}
 			// Skip target tables which do not have a binding anymore since
 			// these tables might be deleted already. Note that the persistent
 			// stage table of a removed binding with pending state is stranded
@@ -819,6 +838,7 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 			if err := t.moveStorePartitionsToTarget(ctx, b, si, false); err != nil {
 				return nil, fmt.Errorf("moving stage to target %s: %w", b.target.Identifier, err)
 			}
+			drained = append(drained, stateKey)
 		}
 	}
 	t.recovery = false
@@ -831,10 +851,14 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	// that have been committed in this transaction. The reason is that it may be the case that a binding
 	// which has been disabled right after a failed attempt to run its queries, must be able to recover by enabling
 	// the binding and running the queries that are pending for its last transaction.
-	var stateClear = make(connectorState, len(t.bindings))
-	for _, b := range t.bindings {
-		stateClear[b.target.StateKey] = nil
-		delete(t.state, b.target.StateKey)
+	if len(drained) == 0 {
+		return nil, nil
+	}
+
+	var stateClear = make(connectorState, len(drained))
+	for _, sk := range drained {
+		stateClear[sk] = nil
+		delete(t.state, sk)
 	}
 
 	checkpointJSON, err := json.Marshal(stateClear)

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -754,10 +754,7 @@ func (t *transactor) bindingForStateKey(stateKey string) (*binding, bool) {
 }
 
 func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 	var drained []string
 
 	if !t.ensured {
@@ -767,13 +764,13 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		// of the next transaction's store phase).
 		for _, b := range t.bindings {
 			if si, pending := t.state[b.target.StateKey]; pending {
-				if _, ok := drainKeys[b.target.StateKey]; !ok {
+				if !shouldProcess(b.target.StateKey) {
 					// This binding's pending work was not requested, so its
 					// staged rows must stay put. ensureTempTables would
 					// discard them, so it is skipped as well; a session
-					// always requests every active binding's state key, so
-					// this only happens in the Apply RPC's narrowed drain,
-					// where no Store follows.
+					// always processes every state key, so this only happens
+					// in the Apply RPC's narrowed drain, where no Store
+					// follows.
 					continue
 				}
 				drained = append(drained, b.target.StateKey)
@@ -823,7 +820,7 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		t.ensured = true
 	} else {
 		for stateKey, si := range t.state {
-			if _, ok := drainKeys[stateKey]; !ok {
+			if !shouldProcess(stateKey) {
 				continue
 			}
 			// Skip target tables which do not have a binding anymore since

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -1387,7 +1387,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_full")))
 		require.Empty(t, tr.state)
@@ -1404,7 +1404,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 3}
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_partial")))
 	})
@@ -1422,7 +1422,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.Empty(t, tr.state)
 
@@ -1441,7 +1441,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		// No pending state for the binding: the staged row was never
 		// committed and must be discarded, not moved.
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_leftovers")))
@@ -1452,7 +1452,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		_ = tr.store.conn.Exec(ctx, b.store.dropTableSQL)
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
 	})
@@ -1467,7 +1467,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 			fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", stageName, tr.dialect.Identifier("value"))))
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 
 		// The stage table must once again match the target (and so accept
@@ -1502,7 +1502,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 
 		// The next transaction must stage and commit cleanly. On the unfixed
@@ -1532,7 +1532,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.True(t, tr.recovery)
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_upgrade")))
 	})

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -1387,7 +1387,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_full")))
 		require.Empty(t, tr.state)
@@ -1404,7 +1404,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 3}
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_partial")))
 	})
@@ -1422,7 +1422,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.Empty(t, tr.state)
 
@@ -1441,7 +1441,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		// No pending state for the binding: the staged row was never
 		// committed and must be discarded, not moved.
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_leftovers")))
@@ -1452,7 +1452,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		_ = tr.store.conn.Exec(ctx, b.store.dropTableSQL)
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
 	})
@@ -1467,7 +1467,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 			fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", stageName, tr.dialect.Identifier("value"))))
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 
 		// The stage table must once again match the target (and so accept
@@ -1502,7 +1502,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 
 		// The next transaction must stage and commit cleanly. On the unfixed
@@ -1532,7 +1532,7 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.True(t, tr.recovery)
 
 		tr.ensured = false
-		_, err := tr.Acknowledge(ctx, nil)
+		_, err := tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_upgrade")))
 	})
@@ -1561,5 +1561,46 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.NoError(t, batch.Send())
 		require.NoError(t, tr.store.conn.QueryRow(ctx, b.load.countKeysSQL).Scan(&counted))
 		require.EqualValues(t, 1, counted)
+	})
+
+	t.Run("subset drain leaves other bindings' staged rows pending", func(t *testing.T) {
+		// The Apply RPC invokes Acknowledge with only the state keys of
+		// bindings receiving schema updates: pending rows of every other
+		// binding must remain staged, and their state entries retained.
+		tr, b1 := newTestTransactor(t, ctx, "test_subset_a")
+		b1.target.StateKey = "test_subset_a.v1"
+
+		table2 := buildTestTable(t, tr.dialect, "test_subset_b")
+		table2.StateKey = "test_subset_b.v1"
+		createSQL, err := sql.RenderTableTemplate(table2, tr.templates.createTargetTable)
+		require.NoError(t, err)
+		require.NoError(t, tr.store.conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tr.dialect.Identifier("test_subset_b"))))
+		require.NoError(t, tr.store.conn.Exec(ctx, createSQL))
+		require.NoError(t, tr.addBinding(ctx, table2))
+		b2 := tr.bindings[1]
+
+		require.NoError(t, tr.ensureTempTables(ctx, b1))
+		require.NoError(t, tr.ensureTempTables(ctx, b2))
+		stageTestRows(t, ctx, tr, b1, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
+		stageTestRows(t, ctx, tr, b2, []any{"k2", "v2", "c", testTime, `{"id":"k2"}`})
+
+		tr.ensured = false
+		tr.recovery = true
+		tr.state[b1.target.StateKey] = &stateItem{StoredRows: 1}
+		tr.state[b2.target.StateKey] = &stateItem{StoredRows: 1}
+
+		state, err := tr.Acknowledge(ctx, nil, []string{b1.target.StateKey})
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.JSONEq(t, fmt.Sprintf(`{%q: null}`, b1.target.StateKey), string(state.UpdatedJson))
+		require.True(t, state.MergePatch)
+
+		// b1's staged row was moved to its target; b2's remains staged with
+		// its state entry intact.
+		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_subset_a")))
+		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier("test_subset_b")))
+		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b2.target, 0))))
+		require.Nil(t, tr.state[b1.target.StateKey])
+		require.NotNil(t, tr.state[b2.target.StateKey])
 	})
 }

--- a/materialize-clickhouse/driver_test.go
+++ b/materialize-clickhouse/driver_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	sql "github.com/estuary/connectors/materialize-sql"
 	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +30,56 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("apply", func(t *testing.T) {
 		sql.RunApplyTest(t, newClickHouseDriver().sqlDriver, "testdata/apply.flow.yaml", makeResourceFn)
+	})
+
+	t.Run("apply-drain", func(t *testing.T) {
+		var ctx = t.Context()
+		var cfg = testConfig()
+		var dialect = clickHouseDialect(cfg.Database)
+
+		tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+		res := makeResourceFn(tableName, false).WithDefaults(cfg)
+
+		conn, err := clickhouse.Open(cfg.newClickhouseOptions())
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		target := dialect.Identifier(tableName)
+		stage := dialect.Identifier(fmt.Sprintf("flow_temp_store_0_%s", tableName))
+		t.Cleanup(func() { _ = conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+stage) })
+
+		count := func(t *testing.T, ident string) uint64 {
+			t.Helper()
+			var c uint64
+			require.NoError(t, conn.QueryRow(ctx, "SELECT count(*) FROM "+ident).Scan(&c))
+			return c
+		}
+
+		seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+			// Stage a row of a committed-but-unacknowledged transaction: the
+			// store stage table is a structural copy of the target, holding
+			// rows whose MOVE PARTITION into the target only happens at
+			// Acknowledge.
+			require.NoError(t, conn.Exec(ctx, fmt.Sprintf("CREATE TABLE %s AS %s", stage, target)))
+			require.NoError(t, conn.Exec(ctx, fmt.Sprintf(
+				"INSERT INTO %s (%s, %s, %s, %s, %s, %s) VALUES ('k1', now(), true, 1, 'req', '{}')",
+				stage,
+				dialect.Identifier("key"),
+				dialect.Identifier("flow_published_at"),
+				dialect.Identifier("requiredBoolean"),
+				dialect.Identifier("requiredInteger"),
+				dialect.Identifier("requiredString"),
+				dialect.Identifier("flow_document"),
+			)))
+			return json.RawMessage(fmt.Sprintf(`{%q: {"StoredRows": 1}}`, appliedSpec.Bindings[0].StateKey))
+		}
+
+		verifyDrained := func(t *testing.T, appliedSpec *pf.MaterializationSpec, colNames []string, rows [][]any) {
+			require.Len(t, rows, 1, "the staged row must have been moved to the target")
+			require.EqualValues(t, 0, count(t, stage), "the stage table must have been drained")
+		}
+
+		sql.RunApplyDrainTest(t, newClickHouseDriver().sqlDriver, cfg, res, seedPending, verifyDrained)
 	})
 
 	t.Run("migrate", func(t *testing.T) {

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -443,7 +443,7 @@ func TestRecoveryAfterPartitionChangingBackfill(t *testing.T) {
 	tr.ensured = false
 	tr.recovery = true
 	tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-	_, err = tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
+	_, err = tr.Acknowledge(ctx, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, tr.state)
 

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -443,7 +443,7 @@ func TestRecoveryAfterPartitionChangingBackfill(t *testing.T) {
 	tr.ensured = false
 	tr.recovery = true
 	tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
-	_, err = tr.Acknowledge(ctx, nil)
+	_, err = tr.Acknowledge(ctx, nil, []string{b.target.StateKey})
 	require.NoError(t, err)
 	require.Empty(t, tr.state)
 

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -665,9 +665,14 @@ func (d *transactor) startCommitState() (*pf.ConnectorState, error) {
 }
 
 // Acknowledge merges data from temporary table to main table
-func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	if err := d.mergePeerStatePatches(statePatches); err != nil {
 		return nil, err
+	}
+
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
 	}
 
 	if d.scaleOut && !d.primary {
@@ -676,7 +681,9 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		// state patches. Drop them from local bookkeeping, mirroring the
 		// clearing the primary emits.
 		for _, b := range d.bindings {
-			delete(d.cp, b.target.StateKey)
+			if _, ok := drainKeys[b.target.StateKey]; ok {
+				delete(d.cp, b.target.StateKey)
+			}
 		}
 		d.cpRecovery = false
 		return nil, nil
@@ -690,14 +697,16 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	}
 	defer db.Close()
 
-	return d.acknowledgeApply(ctx, db)
+	return d.acknowledgeApply(ctx, db, drainKeys)
 }
 
-// acknowledgeApply executes all pending checkpoint entries — this shard's
-// own, and (as the primary) those of peer shards and of prior sessions — and
-// builds the state update which clears the executed entries.
-func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB) (*pf.ConnectorState, error) {
-	if _, err := d.applyCheckpoint(ctx, db, d.cp); err != nil {
+// acknowledgeApply executes the pending checkpoint entries of the requested
+// state keys — this shard's own, and (as the primary) those of peer shards
+// and of prior sessions — and builds the state update which clears the
+// executed entries. It returns a nil state when no entry was executed.
+func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, drainKeys map[string]struct{}) (*pf.ConnectorState, error) {
+	executedOwn, err := d.applyCheckpoint(ctx, db, d.cp, drainKeys)
+	if err != nil {
 		return nil, err
 	}
 
@@ -708,15 +717,21 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB) (*pf.C
 	sort.Strings(peerRangeKeys)
 
 	var executedPeers = make(map[string][]string)
+	var executedPeersCount int
 	for _, rk := range peerRangeKeys {
-		executed, err := d.applyCheckpoint(ctx, db, d.peerShardsCheckpoints[rk])
+		executed, err := d.applyCheckpoint(ctx, db, d.peerShardsCheckpoints[rk], drainKeys)
 		if err != nil {
 			return nil, err
 		}
 		executedPeers[rk] = executed
+		executedPeersCount += len(executed)
 	}
 
 	d.cpRecovery = false
+
+	if len(executedOwn)+executedPeersCount == 0 {
+		return nil, nil
+	}
 
 	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
 	// so that a restart of the connector does not need to run the same queries again
@@ -729,16 +744,18 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB) (*pf.C
 	var clear = make(map[string]interface{})
 
 	if d.scaleOut {
-		var ownClear = make(map[string]interface{})
-		for _, b := range d.bindings {
-			ownClear[b.target.StateKey] = nil
-			delete(d.cp, b.target.StateKey)
+		if len(executedOwn) > 0 {
+			var ownClear = make(map[string]interface{})
+			for _, sk := range executedOwn {
+				ownClear[sk] = nil
+				delete(d.cp, sk)
+			}
+			clear[d.rangeKey] = ownClear
 		}
-		clear[d.rangeKey] = ownClear
 	} else {
-		for _, b := range d.bindings {
-			clear[b.target.StateKey] = nil
-			delete(d.cp, b.target.StateKey)
+		for _, sk := range executedOwn {
+			clear[sk] = nil
+			delete(d.cp, sk)
 		}
 	}
 
@@ -760,7 +777,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB) (*pf.C
 		}
 	}
 
-	var checkpointJSON, err = json.Marshal(clear)
+	checkpointJSON, err := json.Marshal(clear)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint clearing json: %w", err)
 	}
@@ -769,12 +786,18 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB) (*pf.C
 }
 
 // applyCheckpoint executes the staged queries of every entry in cp whose
-// stateKey still has an active binding, deleting the staged files afterwards.
-// It returns the stateKeys which were executed.
+// stateKey is in drainKeys and still has an active binding, deleting the
+// staged files afterwards. It returns the stateKeys which were executed.
 // TODO: run these queries concurrently for improved performance
-func (d *transactor) applyCheckpoint(ctx context.Context, db *stdsql.DB, cp checkpoint) ([]string, error) {
+func (d *transactor) applyCheckpoint(ctx context.Context, db *stdsql.DB, cp checkpoint, drainKeys map[string]struct{}) ([]string, error) {
 	var executed []string
 	for stateKey, item := range cp {
+		// entries staged under other state keys are left untouched, remaining
+		// pending in the persisted state
+		if _, ok := drainKeys[stateKey]; !ok {
+			continue
+		}
+
 		path := d.pathForStateKey(stateKey)
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -670,10 +670,7 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		return nil, err
 	}
 
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 
 	if d.scaleOut && !d.primary {
 		// Non-primary shards only stage files: their committed entries are
@@ -681,7 +678,7 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		// state patches. Drop them from local bookkeeping, mirroring the
 		// clearing the primary emits.
 		for _, b := range d.bindings {
-			if _, ok := drainKeys[b.target.StateKey]; ok {
+			if shouldProcess(b.target.StateKey) {
 				delete(d.cp, b.target.StateKey)
 			}
 		}
@@ -697,15 +694,15 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	}
 	defer db.Close()
 
-	return d.acknowledgeApply(ctx, db, drainKeys)
+	return d.acknowledgeApply(ctx, db, shouldProcess)
 }
 
 // acknowledgeApply executes the pending checkpoint entries of the requested
 // state keys — this shard's own, and (as the primary) those of peer shards
 // and of prior sessions — and builds the state update which clears the
 // executed entries. It returns a nil state when no entry was executed.
-func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, drainKeys map[string]struct{}) (*pf.ConnectorState, error) {
-	executedOwn, err := d.applyCheckpoint(ctx, db, d.cp, drainKeys)
+func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, shouldProcess func(string) bool) (*pf.ConnectorState, error) {
+	executedOwn, err := d.applyCheckpoint(ctx, db, d.cp, shouldProcess)
 	if err != nil {
 		return nil, err
 	}
@@ -719,7 +716,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, drainK
 	var executedPeers = make(map[string][]string)
 	var executedPeersCount int
 	for _, rk := range peerRangeKeys {
-		executed, err := d.applyCheckpoint(ctx, db, d.peerShardsCheckpoints[rk], drainKeys)
+		executed, err := d.applyCheckpoint(ctx, db, d.peerShardsCheckpoints[rk], shouldProcess)
 		if err != nil {
 			return nil, err
 		}
@@ -786,15 +783,15 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, drainK
 }
 
 // applyCheckpoint executes the staged queries of every entry in cp whose
-// stateKey is in drainKeys and still has an active binding, deleting the
-// staged files afterwards. It returns the stateKeys which were executed.
+// stateKey passes shouldProcess and still has an active binding, deleting
+// the staged files afterwards. It returns the stateKeys which were executed.
 // TODO: run these queries concurrently for improved performance
-func (d *transactor) applyCheckpoint(ctx context.Context, db *stdsql.DB, cp checkpoint, drainKeys map[string]struct{}) ([]string, error) {
+func (d *transactor) applyCheckpoint(ctx context.Context, db *stdsql.DB, cp checkpoint, shouldProcess func(string) bool) ([]string, error) {
 	var executed []string
 	for stateKey, item := range cp {
 		// entries staged under other state keys are left untouched, remaining
 		// pending in the persisted state
-		if _, ok := drainKeys[stateKey]; !ok {
+		if !shouldProcess(stateKey) {
 			continue
 		}
 

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -42,6 +42,14 @@ func item(query string, toDelete ...string) *checkpointItem {
 	return &checkpointItem{Queries: []string{query}, ToDelete: toDelete}
 }
 
+func keys(stateKeys ...string) map[string]struct{} {
+	var out = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		out[sk] = struct{}{}
+	}
+	return out
+}
+
 // recordingDriver is a database/sql driver whose connections record every
 // executed statement (or fail with a configured error), so Acknowledge tests
 // run against a real *sql.DB without a Databricks connection.
@@ -207,11 +215,11 @@ func TestAcknowledge(t *testing.T) {
 		var d = testTransactor(false, fullRangeKey, "a_table.v1", "b_table.v1")
 		d.cp["a_table.v1"] = item("Q1")
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1", "b_table.v1"))
 		require.NoError(t, err)
 		require.Equal(t, []string{"Q1"}, recording.executed)
 		require.True(t, state.MergePatch)
-		require.Equal(t, `{"a_table.v1":null,"b_table.v1":null}`, string(state.UpdatedJson))
+		require.Equal(t, `{"a_table.v1":null}`, string(state.UpdatedJson))
 		require.Empty(t, d.cp)
 	})
 
@@ -221,7 +229,7 @@ func TestAcknowledge(t *testing.T) {
 		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{"a_table.v1": item("PEER")}
 		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("LEGACY")}
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
 		require.NoError(t, err)
 		require.Equal(t, []string{"OWN", "LEGACY", "PEER"}, recording.executed)
 		require.True(t, state.MergePatch)
@@ -241,14 +249,55 @@ func TestAcknowledge(t *testing.T) {
 			"removed_table.v1": item("REMOVED"),
 		}
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
 		require.NoError(t, err)
 		require.Equal(t, []string{"PEER"}, recording.executed)
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
 			"80000000-ffffffff": {"a_table.v1": null}
 		}`, string(state.UpdatedJson))
 		require.NotNil(t, d.peerShardsCheckpoints[upperRangeKey]["removed_table.v1"])
+	})
+
+	t.Run("subset drain executes only requested state keys", func(t *testing.T) {
+		var d = testTransactor(false, fullRangeKey, "a_table.v1", "b_table.v1")
+		d.cp["a_table.v1"] = item("QA")
+		d.cp["b_table.v1"] = item("QB")
+
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"QA"}, recording.executed)
+		require.Equal(t, `{"a_table.v1":null}`, string(state.UpdatedJson))
+		require.NotNil(t, d.cp["b_table.v1"]) // untouched, still pending
+	})
+
+	t.Run("subset drain spans all range buckets", func(t *testing.T) {
+		var d = testTransactor(true, lowerRangeKey, "a_table.v1", "b_table.v1")
+		d.cp["a_table.v1"] = item("OWN-A")
+		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
+			"a_table.v1": item("PEER-A"),
+			"b_table.v1": item("PEER-B"),
+		}
+		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("LEGACY-A")}
+
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
+		require.NoError(t, err)
+		require.Equal(t, []string{"OWN-A", "LEGACY-A", "PEER-A"}, recording.executed)
+		require.JSONEq(t, `{
+			"00000000-7fffffff": {"a_table.v1": null},
+			"a_table.v1": null,
+			"80000000-ffffffff": {"a_table.v1": null}
+		}`, string(state.UpdatedJson))
+		require.NotNil(t, d.peerShardsCheckpoints[upperRangeKey]["b_table.v1"])
+	})
+
+	t.Run("nothing to drain returns nil state", func(t *testing.T) {
+		var d = testTransactor(false, fullRangeKey, "a_table.v1", "b_table.v1")
+		d.cp["b_table.v1"] = item("QB")
+
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
+		require.NoError(t, err)
+		require.Nil(t, state)
+		require.NotNil(t, d.cp["b_table.v1"]) // untouched, still pending
 	})
 
 	t.Run("flag on non-primary does no work", func(t *testing.T) {
@@ -258,7 +307,7 @@ func TestAcknowledge(t *testing.T) {
 
 		// Acknowledge itself is callable here since the non-primary path
 		// never opens a database connection.
-		state, err := d.Acknowledge(context.Background(), nil)
+		state, err := d.Acknowledge(context.Background(), nil, []string{"a_table.v1"})
 		require.NoError(t, err)
 		require.Nil(t, state)
 		require.Empty(t, d.cp)
@@ -270,12 +319,12 @@ func TestAcknowledge(t *testing.T) {
 		d.cp["a_table.v1"] = item("Q1")
 		d.cpRecovery = true
 
-		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")))
+		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), keys("a_table.v1"))
 		require.NoError(t, err)
 		require.False(t, d.cpRecovery)
 
 		d.cp["a_table.v1"] = item("Q1")
-		_, err = d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")))
+		_, err = d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), keys("a_table.v1"))
 		require.Error(t, err) // no longer a recovery apply
 	})
 }

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -42,13 +42,13 @@ func item(query string, toDelete ...string) *checkpointItem {
 	return &checkpointItem{Queries: []string{query}, ToDelete: toDelete}
 }
 
-func keys(stateKeys ...string) map[string]struct{} {
-	var out = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		out[sk] = struct{}{}
-	}
-	return out
+// keys builds the non-nil restricted-processing predicate of Acknowledge's
+// stateKeys contract; allKeys is the nil process-everything form.
+func keys(stateKeys ...string) func(string) bool {
+	return m.StateKeyFilter(stateKeys)
 }
+
+var allKeys = m.StateKeyFilter(nil)
 
 // recordingDriver is a database/sql driver whose connections record every
 // executed statement (or fail with a configured error), so Acknowledge tests
@@ -215,7 +215,7 @@ func TestAcknowledge(t *testing.T) {
 		var d = testTransactor(false, fullRangeKey, "a_table.v1", "b_table.v1")
 		d.cp["a_table.v1"] = item("Q1")
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1", "b_table.v1"))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
 		require.Equal(t, []string{"Q1"}, recording.executed)
 		require.True(t, state.MergePatch)
@@ -229,7 +229,7 @@ func TestAcknowledge(t *testing.T) {
 		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{"a_table.v1": item("PEER")}
 		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("LEGACY")}
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
 		require.Equal(t, []string{"OWN", "LEGACY", "PEER"}, recording.executed)
 		require.True(t, state.MergePatch)
@@ -249,7 +249,7 @@ func TestAcknowledge(t *testing.T) {
 			"removed_table.v1": item("REMOVED"),
 		}
 
-		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
 		require.Equal(t, []string{"PEER"}, recording.executed)
 		require.JSONEq(t, `{
@@ -307,7 +307,7 @@ func TestAcknowledge(t *testing.T) {
 
 		// Acknowledge itself is callable here since the non-primary path
 		// never opens a database connection.
-		state, err := d.Acknowledge(context.Background(), nil, []string{"a_table.v1"})
+		state, err := d.Acknowledge(context.Background(), nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, state)
 		require.Empty(t, d.cp)
@@ -319,12 +319,12 @@ func TestAcknowledge(t *testing.T) {
 		d.cp["a_table.v1"] = item("Q1")
 		d.cpRecovery = true
 
-		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), keys("a_table.v1"))
+		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
 		require.NoError(t, err)
 		require.False(t, d.cpRecovery)
 
 		d.cp["a_table.v1"] = item("Q1")
-		_, err = d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), keys("a_table.v1"))
+		_, err = d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
 		require.Error(t, err) // no longer a recovery apply
 	})
 }

--- a/materialize-databricks/driver_test.go
+++ b/materialize-databricks/driver_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
+	testutil "github.com/estuary/connectors/materialize-boilerplate/testutil"
 	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegration(t *testing.T) {
@@ -34,6 +41,32 @@ func TestIntegration(t *testing.T) {
 	})
 	t.Run("apply", func(t *testing.T) {
 		sql.RunApplyTest(t, newDatabricksDriver(), "testdata/apply.flow.yaml", makeResourceFn)
+	})
+	t.Run("apply-drain", func(t *testing.T) {
+		testutil.RunTestAllTasks(t, "testdata/apply.flow.yaml", func(t *testing.T, bundled []byte, taskName string, cfg config) {
+			tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+			res := makeResourceFn(tableName, false).WithDefaults(cfg)
+
+			seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+				// A staged transaction is a set of queries persisted in the
+				// connector state, keyed by the binding's state key.
+				query := sql.DrainSeedInsertQuery(t, newDatabricksDriver(), cfg, appliedSpec, "'{}'")
+				state, err := json.Marshal(map[string]any{
+					appliedSpec.Bindings[0].StateKey: map[string]any{
+						"Queries":  []string{query},
+						"ToDelete": []string{},
+					},
+				})
+				require.NoError(t, err)
+				return state
+			}
+
+			verifyDrained := func(t *testing.T, _ *pf.MaterializationSpec, _ []string, rows [][]any) {
+				require.Len(t, rows, 1, "the staged transaction's row must have been committed")
+			}
+
+			sql.RunApplyDrainTest(t, newDatabricksDriver(), cfg, res, seedPending, verifyDrained)
+		})
 	})
 	t.Run("migrate", func(t *testing.T) {
 		sql.RunMigrationTest(t, newDatabricksDriver(), "testdata/migrate.flow.yaml", makeResourceFn, sanitizers)

--- a/materialize-dynamodb/transactor.go
+++ b/materialize-dynamodb/transactor.go
@@ -98,7 +98,7 @@ func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.Materializat
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	ctx := it.Context()

--- a/materialize-elasticsearch/transactor.go
+++ b/materialize-elasticsearch/transactor.go
@@ -72,7 +72,7 @@ func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.Materializat
 	return nil, nil
 }
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	ctx := it.Context()

--- a/materialize-eventbridge/transactor.go
+++ b/materialize-eventbridge/transactor.go
@@ -79,7 +79,7 @@ type transactor struct {
 var _ m.Transactor = (*transactor)(nil)
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 func (t *transactor) Destroy()                                                    {}
 
 func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.MaterializationSpec, rangeSpec pf.RangeSpec) (m.RuntimeCheckpoint, error) {

--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -23,7 +23,7 @@ type topicBinding struct {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 // PubSub is delta-update only.
 func (t *transactor) Load(it *m.LoadIterator, _ func(int, json.RawMessage) error) error {

--- a/materialize-google-sheets/transactor.go
+++ b/materialize-google-sheets/transactor.go
@@ -69,7 +69,7 @@ func (b transactorBinding) columnCount() int {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	it.WaitForAcknowledged()

--- a/materialize-hubspot/transactor.go
+++ b/materialize-hubspot/transactor.go
@@ -75,7 +75,7 @@ func (t *transactor) UnmarshalState(state json.RawMessage) error {
 	return nil
 }
 
-func (t *transactor) Acknowledge(context.Context, []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(context.Context, []json.RawMessage, []string) (*pf.ConnectorState, error) {
 	return nil, nil
 }
 

--- a/materialize-iceberg/driver_test.go
+++ b/materialize-iceberg/driver_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/estuary/connectors/materialize-iceberg/catalog"
 	"github.com/estuary/connectors/materialize-iceberg/python"
 	boilerplate "github.com/estuary/connectors/materialize-boilerplate/testutil"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/google/uuid"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
@@ -173,6 +174,133 @@ func TestIntegration(t *testing.T) {
 
 	t.Run("apply", func(t *testing.T) {
 		boilerplate.RunApplyTestParallel(t, &Driver{}, newMaterialization, applySpec, makeResourceFn)
+	})
+
+	t.Run("apply-drain", func(t *testing.T) {
+		boilerplate.RunTestAllTasks(t, applySpec, func(t *testing.T, bundled []byte, taskName string, cfg config) {
+			if cfg.Compute.ComputeType != computeTypeSparkStandalone {
+				// Row verification runs eager queries through the local spark
+				// daemon, which the cloud compute variants don't expose.
+				t.Skipf("apply-drain only runs against the local spark stack, not %q", cfg.Compute.ComputeType)
+			}
+
+			ctx := context.Background()
+			tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+			res := makeResourceFn(tableName, false).WithDefaults(cfg)
+
+			// sparkExec runs an eagerly-evaluated statement through the local
+			// spark daemon, returning its error, since this connector has no
+			// direct query access to table data.
+			sparkExec := func(t *testing.T, query string) error {
+				t.Helper()
+				body, err := json.Marshal(struct {
+					Action string           `json:"action"`
+					Input  python.ExecInput `json:"input"`
+				}{Action: "exec", Input: python.ExecInput{Query: query}})
+				require.NoError(t, err)
+
+				resp, err := http.Post("http://localhost:9806/run", "application/json", bytes.NewReader(body))
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				respBody, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.Equalf(t, http.StatusOK, resp.StatusCode, "daemon response: %s", respBody)
+
+				var result struct {
+					Success bool   `json:"success"`
+					Error   string `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(respBody, &result))
+				if !result.Success {
+					return fmt.Errorf("%s", result.Error)
+				}
+				return nil
+			}
+
+			seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+				// A staged transaction is a Spark SQL query persisted in the
+				// connector state along with the staged CSV files it consumes
+				// through a temporary view, keyed by the binding's state key.
+				// The file must exist since recovery prunes missing files and
+				// Acknowledge deletes them after the merge job succeeds.
+				bucket, err := cfg.toBucket(ctx)
+				require.NoError(t, err)
+				fileKey := stagedFileClient{}.NewKey([]string{cfg.Compute.BucketPath, fmt.Sprintf("applydrain-%s", uuid.NewString()), "seed"})
+				fileWriter := stagedFileClient{}.NewWriter(bucket.NewWriter(ctx, fileKey), []string{"key"})
+				require.NoError(t, fileWriter.Write([]any{"k1"}))
+				require.NoError(t, fileWriter.Close())
+
+				b := appliedSpec.Bindings[0]
+				fqnParts := []string{"`estuary`"}
+				for _, part := range b.ResourcePath {
+					fqnParts = append(fqnParts, quoteIdentifier(part))
+				}
+
+				// Literals for the fields of the drain fixture specs; the key
+				// is read from the staged file's temporary view.
+				literals := map[string]string{
+					"key":                  "r.`key`",
+					"flow_published_at":    "current_timestamp()",
+					"_meta/flow_truncated": "false",
+					"optionalBoolean":      "true",
+					"requiredBoolean":      "true",
+					"optionalInteger":      "2",
+					"requiredInteger":      "1",
+					"optionalString":       "'opt'",
+					"requiredString":       "'req'",
+					"optionalObject":       "'{}'",
+					"requiredObject":       "'{}'",
+					"second_root":          "'{}'",
+					"flow_document":        "'{}'",
+				}
+				fields := append(append([]string{}, b.FieldSelection.Keys...), b.FieldSelection.Values...)
+				if b.FieldSelection.Document != "" {
+					fields = append(fields, b.FieldSelection.Document)
+				}
+				var cols, vals []string
+				for _, f := range fields {
+					lit, ok := literals[f]
+					require.True(t, ok, "no seed literal for selected field %q", f)
+					cols = append(cols, quoteIdentifier(f))
+					vals = append(vals, lit)
+				}
+				query := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM merge_view_0 AS r",
+					strings.Join(fqnParts, "."), strings.Join(cols, ", "), strings.Join(vals, ", "))
+
+				state, err := json.Marshal(map[string]*python.MergeBinding{
+					b.StateKey: {
+						Binding: 0,
+						Query:   query,
+						Columns: []python.NestedField{{Name: "key", Type: "string"}},
+						Files:   []string{bucket.URI(fileKey)},
+					},
+				})
+				require.NoError(t, err)
+				return state
+			}
+
+			verifyDrained := func(t *testing.T, appliedSpec *pf.MaterializationSpec, _ []string, _ [][]any) {
+				// SnapshotTestResource is unimplemented for this connector, so
+				// assert on the committed row with an eager CTAS: assert_true
+				// fails the statement unless the target holds exactly the
+				// seeded row.
+				b := appliedSpec.Bindings[0]
+				fqnParts := []string{"`estuary`"}
+				for _, part := range b.ResourcePath {
+					fqnParts = append(fqnParts, quoteIdentifier(part))
+				}
+				fqn := strings.Join(fqnParts, ".")
+				verifyFQN := fmt.Sprintf("`estuary`.%s.%s", quoteIdentifier(b.ResourcePath[0]), quoteIdentifier(tableName+"_verify"))
+
+				require.NoError(t, sparkExec(t, fmt.Sprintf("DROP TABLE IF EXISTS %s", verifyFQN)))
+				require.NoError(t, sparkExec(t,
+					fmt.Sprintf("CREATE TABLE %s AS SELECT CAST(assert_true((SELECT count(*) FROM %s) = 1, 'expected exactly one committed row') AS STRING) AS ok", verifyFQN, fqn)),
+					"the staged transaction's row must have been committed")
+				require.NoError(t, sparkExec(t, fmt.Sprintf("DROP TABLE IF EXISTS %s", verifyFQN)))
+			}
+
+			boilerplate.RunApplyDrainTest(t, &Driver{}, newMaterialization, cfg, res, seedPending, verifyDrained)
+		})
 	})
 
 	t.Run("migrate", func(t *testing.T) {

--- a/materialize-iceberg/driver_unit_test.go
+++ b/materialize-iceberg/driver_unit_test.go
@@ -6,9 +6,31 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	"github.com/estuary/connectors/materialize-iceberg/python"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAcknowledgeSubsetLeavesOtherKeysPending(t *testing.T) {
+	tr := &transactor{
+		cp: map[string]*python.MergeBinding{
+			"a_table.v1": {Binding: 0, Query: "MERGE INTO a"},
+		},
+		bindings: []binding{{Mapped: &boilerplate.MappedBinding[config, resource, mapped]{
+			MaterializationSpec_Binding: pf.MaterializationSpec_Binding{StateKey: "a_table.v1"},
+		}}},
+	}
+
+	// The staged entry's state key is not requested: no merge job may run
+	// (the nil compute runner would panic otherwise) and no state update is
+	// returned, so the entry remains pending in the persisted state.
+	state, err := tr.Acknowledge(context.Background(), nil, []string{"other_table.v1"})
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.NotNil(t, tr.cp["a_table.v1"])
+}
 
 func TestSpec(t *testing.T) {
 	var resp, err = (Driver{}).

--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -226,14 +226,11 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	var mergeInput python.MergeInput
 	var allFileUris []string
 
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 
 	for _, b := range t.bindings {
 		sk := b.Mapped.StateKey
-		if _, ok := drainKeys[sk]; !ok {
+		if !shouldProcess(sk) {
 			// This state key's pending work was not requested to be processed,
 			// so it remains staged in the persisted state.
 			continue

--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -220,14 +220,24 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}, nil
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	outputPrefix := path.Join(t.cfg.Compute.BucketPath, uuid.NewString())
 	checkpointClear := make(map[string]*python.MergeBinding)
 	var mergeInput python.MergeInput
 	var allFileUris []string
 
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
+	}
+
 	for _, b := range t.bindings {
 		sk := b.Mapped.StateKey
+		if _, ok := drainKeys[sk]; !ok {
+			// This state key's pending work was not requested to be processed,
+			// so it remains staged in the persisted state.
+			continue
+		}
 		if pyMergeBinding, ok := t.cp[sk]; ok {
 			delete(t.cp, sk)
 			checkpointClear[sk] = nil

--- a/materialize-mongodb/transactor.go
+++ b/materialize-mongodb/transactor.go
@@ -95,7 +95,7 @@ func (t *transactor) RecoverCheckpoint(ctx context.Context, spec pf.Materializat
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	ctx := it.Context()

--- a/materialize-motherduck/driver.go
+++ b/materialize-motherduck/driver.go
@@ -149,7 +149,7 @@ type binding struct {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	var ctx = it.Context()

--- a/materialize-mysql/driver.go
+++ b/materialize-mysql/driver.go
@@ -436,7 +436,7 @@ func (t *transactor) RecoverCheckpoint(_ context.Context, _ pf.MaterializationSp
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func prepareNewTransactor(
 	templates templates,

--- a/materialize-pinecone/transactor.go
+++ b/materialize-pinecone/transactor.go
@@ -40,7 +40,7 @@ type upsertDoc struct {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	for it.Next() {

--- a/materialize-postgres/driver.go
+++ b/materialize-postgres/driver.go
@@ -499,7 +499,7 @@ func (t *transactor) RecoverCheckpoint(_ context.Context, _ pf.MaterializationSp
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	var ctx = it.Context()

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -507,7 +507,7 @@ func (t *transactor) addBinding(
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	var ctx = it.Context()

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-07-23
+
+### Changed
+- Schema changes now first commit any transaction that was staged but not yet
+  fully applied to the tables they affect, instead of leaving it to be applied
+  afterwards. This prevents failures where staged data built against the
+  previous table schema could no longer be applied after a column was added,
+  made nullable, or had its type migrated.
+
+### Fixed
+- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
+  a binding no longer risks losing the rows of a transaction that was committed
+  but not yet fully applied to the destination: the pending transaction is now
+  applied before the backfill takes effect.
+
 ## 2026-07-20
 
 ### Added

--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -149,6 +149,93 @@ func TestIntegration(t *testing.T) {
 		boilerplate.RunApplyTest(t, &driver{}, newMaterialization, "testdata/apply.flow.yaml", makeResourceFn)
 	})
 
+	t.Run("apply-drain", func(t *testing.T) {
+		ctx := context.Background()
+		tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+		res := makeResourceFn(tableName, true).WithDefaults(cfg)
+
+		seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+			// A staged transaction is a set of parquet data files recorded in
+			// the connector state, appended to the Iceberg table during
+			// Acknowledge under a per-materialization checkpoint fence. The
+			// file must carry the table's field IDs, exactly as the connector
+			// writes them.
+			b := appliedSpec.Bindings[0]
+
+			cat, err := newCatalog(ctx, cfg, NestedLocationStyle)
+			require.NoError(t, err)
+			infos, err := cat.tableInfos(ctx, [][]string{b.ResourcePath})
+			require.NoError(t, err)
+			require.NotEmpty(t, infos[0].location, "the base Apply must have created the table")
+
+			pqSchema, err := parquetSchema(b.FieldSelection.AllFields(), b.Collection, b.FieldSelection.FieldConfigJsonMap, cfg.nanosecondTimestamps())
+			require.NoError(t, err)
+			for i := range pqSchema {
+				id, ok := infos[0].fieldIDs[pqSchema[i].Name]
+				require.True(t, ok, "no field ID for column %q", pqSchema[i].Name)
+				id32 := int32(id)
+				pqSchema[i].FieldId = &id32
+			}
+
+			// Values for the fields of the drain fixture specs.
+			literals := map[string]any{
+				"key":                  "k1",
+				"flow_published_at":    "2024-01-01T00:00:00Z",
+				"_meta/flow_truncated": false,
+				"optionalBoolean":      true,
+				"requiredBoolean":      true,
+				"optionalInteger":      int64(2),
+				"requiredInteger":      int64(1),
+				"optionalString":       "opt",
+				"requiredString":       "req",
+				"optionalObject":       json.RawMessage(`{}`),
+				"requiredObject":       json.RawMessage(`{}`),
+				"second_root":          json.RawMessage(`{}`),
+				"flow_document":        json.RawMessage(`{}`),
+			}
+			var row []any
+			for _, f := range b.FieldSelection.AllFields() {
+				v, ok := literals[f]
+				require.True(t, ok, "no seed value for selected field %q", f)
+				row = append(row, v)
+			}
+
+			s3opts := s3.Options{
+				Region:      cfg.Region,
+				Credentials: credentials.NewStaticCredentialsProvider(cfg.Credentials.AWSAccessKeyID, cfg.Credentials.AWSSecretAccessKey, ""),
+			}
+			if cfg.S3Endpoint != "" {
+				s3opts.BaseEndpoint = aws.String(cfg.S3Endpoint)
+				s3opts.UsePathStyle = true
+			}
+			rt := &regressionTable{
+				cfg:      cfg,
+				cat:      cat,
+				ident:    icebergtable.Identifier(b.ResourcePath),
+				location: infos[0].location,
+				s3client: s3.New(s3opts),
+			}
+			s3Path, _ := rt.uploadParquetRows(t, ctx, pqSchema, row)
+
+			state, err := json.Marshal(map[string]any{
+				"bindingStates": map[string]any{
+					b.StateKey: map[string]any{
+						"fileKeys":          []string{s3Path},
+						"currentCheckpoint": "applydrain-" + uuid.NewString()[:8],
+					},
+				},
+			})
+			require.NoError(t, err)
+			return state
+		}
+
+		verifyDrained := func(t *testing.T, _ *pf.MaterializationSpec, _ []string, rows [][]any) {
+			require.Len(t, rows, 1, "the staged transaction's files must have been appended")
+		}
+
+		boilerplate.RunApplyDrainTest(t, &driver{}, newMaterialization, cfg, res, seedPending, verifyDrained)
+	})
+
 	t.Run("ts-overflow-regression", func(t *testing.T) {
 		runTimestampOverflowRegression(t, cfg)
 	})

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -230,13 +230,26 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	}, nil
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
+	}
+
+	var processed bool
 	for _, b := range t.bindings {
+		if _, ok := drainKeys[b.stateKey]; !ok {
+			// This state key's pending work was not requested to be processed,
+			// so it remains staged in the persisted state.
+			continue
+		}
+
 		bindingState := t.state.BindingStates[b.stateKey]
 
 		if len(bindingState.FileKeys) == 0 {
 			continue // no data for this binding
 		}
+		processed = true
 
 		ll := log.WithFields(log.Fields{
 			"table":              pathToFQN(b.path),
@@ -253,6 +266,10 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		ll.Info("finished appendFiles for table")
 
 		bindingState.FileKeys = nil // reset for next txn
+	}
+
+	if !processed {
+		return nil, nil
 	}
 
 	checkpointJSON, err := json.Marshal(t.state)

--- a/materialize-s3-iceberg/transactor.go
+++ b/materialize-s3-iceberg/transactor.go
@@ -231,14 +231,11 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 }
 
 func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 
 	var processed bool
 	for _, b := range t.bindings {
-		if _, ok := drainKeys[b.stateKey]; !ok {
+		if !shouldProcess(b.stateKey) {
 			// This state key's pending work was not requested to be processed,
 			// so it remains staged in the persisted state.
 			continue

--- a/materialize-slack/main.go
+++ b/materialize-slack/main.go
@@ -308,7 +308,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 func (transactor) Destroy() {
 }
 
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	return nil, nil
 }
 

--- a/materialize-snowflake/CHANGELOG.md
+++ b/materialize-snowflake/CHANGELOG.md
@@ -1,4 +1,19 @@
 # materialize-snowflake
 
+## 2026-07-23
+
+### Changed
+- Schema changes now first commit any transaction that was staged but not yet
+  fully applied to the tables they affect, instead of leaving it to be applied
+  afterwards. This prevents failures where staged data built against the
+  previous table schema could no longer be applied after a column was added,
+  made nullable, or had its type migrated.
+
+### Fixed
+- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
+  a binding no longer risks losing the rows of a transaction that was committed
+  but not yet fully applied to the destination: the pending transaction is now
+  applied before the backfill takes effect.
+
 ## v1, 2022-07-27
 - Beginning of changelog.

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -842,7 +842,7 @@ func (d *transactor) copyHistory(ctx context.Context, tableName string, fileName
 }
 
 // Acknowledge merges data from temporary table to main table
-func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) {
+func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) {
 	defer func() {
 		d.didRecovery = true
 	}()
@@ -851,14 +851,28 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(MaxConcurrentQueries)
 
+	var drainKeys = make(map[string]struct{}, len(stateKeys))
+	for _, sk := range stateKeys {
+		drainKeys[sk] = struct{}{}
+	}
+
+	var drained []string
 	var pipes = make(map[string]*pipeRecord)
 	for stateKey, item := range d.cp {
+		// only process the state keys we've been asked to; other pending work
+		// remains staged in the persisted state
+		if _, ok := drainKeys[stateKey]; !ok {
+			continue
+		}
+
 		path := d.pathForStateKey(stateKey)
 		// we skip queries that belong to tables which do not have a binding anymore
 		// since these tables might be deleted already
 		if len(path) == 0 {
 			continue
 		}
+
+		drained = append(drained, stateKey)
 
 		if len(item.Query) > 0 {
 			item := item
@@ -1115,6 +1129,10 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		}
 	}
 
+	if len(drained) == 0 {
+		return nil, nil
+	}
+
 	// After having applied the checkpoint, we try to clean up the checkpoint in the ack response
 	// so that a restart of the connector does not need to run the same queries again
 	// Note that this is an best-effort "attempt" and there is no guarantee that this checkpoint update
@@ -1124,9 +1142,9 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	// which has been disabled right after a failed attempt to run its queries, must be able to recover by enabling
 	// the binding and running the queries that are pending for its last transaction.
 	var checkpointClear = make(checkpoint)
-	for _, b := range d.bindings {
-		checkpointClear[b.target.StateKey] = nil
-		delete(d.cp, b.target.StateKey)
+	for _, sk := range drained {
+		checkpointClear[sk] = nil
+		delete(d.cp, sk)
 	}
 
 	checkpointJSON, err := json.Marshal(checkpointClear)

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -851,17 +851,14 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(MaxConcurrentQueries)
 
-	var drainKeys = make(map[string]struct{}, len(stateKeys))
-	for _, sk := range stateKeys {
-		drainKeys[sk] = struct{}{}
-	}
+	shouldProcess := m.StateKeyFilter(stateKeys)
 
 	var drained []string
 	var pipes = make(map[string]*pipeRecord)
 	for stateKey, item := range d.cp {
 		// only process the state keys we've been asked to; other pending work
 		// remains staged in the persisted state
-		if _, ok := drainKeys[stateKey]; !ok {
+		if !shouldProcess(stateKey) {
 			continue
 		}
 

--- a/materialize-snowflake/snowflake_test.go
+++ b/materialize-snowflake/snowflake_test.go
@@ -7,8 +7,11 @@ import (
 	"os/exec"
 	"regexp"
 	"testing"
+	"time"
 
 	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/snowflakedb/gosnowflake/v2"
@@ -42,6 +45,37 @@ func TestIntegration(t *testing.T) {
 			Delta:  delta,
 		}
 	}
+
+	t.Run("apply-drain", func(t *testing.T) {
+		cfg := mustGetCfg(t)
+		tableName := fmt.Sprintf("applydrain%s_flow_test_%d", uuid.NewString()[:8], time.Now().Unix())
+		res := makeResourceFn(tableName, false).WithDefaults(cfg)
+
+		seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
+			// A staged transaction is a query persisted in the connector
+			// state, keyed by the binding's state key, along with the staged
+			// directory holding its files. The directory is cleaned up after
+			// the query executes; a directory with no files under the
+			// connector's flow_v1 stage (created by Setup during the base
+			// Apply) stands in for one whose files were already consumed.
+			query := sql.DrainSeedInsertQuery(t, newSnowflakeDriver(), cfg, appliedSpec, "PARSE_JSON('{}')")
+			state, err := json.Marshal(map[string]any{
+				appliedSpec.Bindings[0].StateKey: map[string]any{
+					"Table":     tableName,
+					"Query":     query,
+					"StagedDir": fmt.Sprintf("@flow_v1/applydrain-%s", uuid.NewString()),
+				},
+			})
+			require.NoError(t, err)
+			return state
+		}
+
+		verifyDrained := func(t *testing.T, _ *pf.MaterializationSpec, _ []string, rows [][]any) {
+			require.Len(t, rows, 1, "the staged transaction's row must have been committed")
+		}
+
+		sql.RunApplyDrainTest(t, newSnowflakeDriver(), cfg, res, seedPending, verifyDrained)
+	})
 
 	actionDescSanitizers := []func(string) string{
 		func(s string) string {

--- a/materialize-snowflake/snowflake_unit_test.go
+++ b/materialize-snowflake/snowflake_unit_test.go
@@ -7,9 +7,28 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	sql "github.com/estuary/connectors/materialize-sql"
 	pm "github.com/estuary/flow/go/protocols/materialize"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAcknowledgeSubsetLeavesOtherKeysPending(t *testing.T) {
+	d := &transactor{
+		cp: checkpoint{
+			"a_table.v1": {Table: "a_table", Query: "MERGE INTO a", StagedDir: "dir"},
+		},
+		bindings: []*binding{{target: sql.Table{StateKey: "a_table.v1"}}},
+	}
+
+	// The staged entry's state key is not requested: nothing may execute (the
+	// nil database would panic if a query ran) and no state update is
+	// returned, so the entry remains pending in the persisted state.
+	state, err := d.Acknowledge(context.Background(), nil, []string{"other_table.v1"})
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.NotNil(t, d.cp["a_table.v1"])
+	require.True(t, d.didRecovery)
+}
 
 func TestSpecification(t *testing.T) {
 	var resp, err = newSnowflakeDriver().

--- a/materialize-sns/transactor.go
+++ b/materialize-sns/transactor.go
@@ -35,7 +35,7 @@ type topicBinding struct {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 // SNS is delta-update only.
 func (t *transactor) Load(it *materialize.LoadIterator, _ func(int, json.RawMessage) error) error {

--- a/materialize-spanner/driver.go
+++ b/materialize-spanner/driver.go
@@ -587,7 +587,7 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table, is *boile
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 // timedSpannerApply wraps spanner.Client.Apply with timing instrumentation
 func (t *transactor) timedSpannerApply(ctx context.Context, mutations []*spanner.Mutation, operation string) (time.Time, time.Duration, error) {

--- a/materialize-sql/test_support.go
+++ b/materialize-sql/test_support.go
@@ -55,6 +55,82 @@ func RunApplyTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, 
 	testutil.RunApplyTest(t, driver, driver.newMaterialization, sourcePath, makeResourceFn)
 }
 
+// RunApplyDrainTest verifies the two-iteration Apply drain of a post-commit
+// apply connector. See the testutil function of the same name.
+func RunApplyDrainTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
+	t *testing.T,
+	driver *Driver[EC, RC],
+	cfg EC,
+	res RC,
+	seedPending func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage,
+	verifyDrained func(t *testing.T, appliedSpec *pf.MaterializationSpec, colNames []string, rows [][]any),
+) {
+	testutil.RunApplyDrainTest(t, driver, driver.newMaterialization, cfg, res, seedPending, verifyDrained)
+}
+
+// DrainSeedInsertQuery builds an INSERT statement adding a single row to the
+// applied base specification's resource, covering every selected field. It
+// serves as the staged work of a committed-but-unacknowledged transaction
+// when seeding connector state for RunApplyDrainTest: post-commit apply SQL
+// connectors persist the queries of a staged transaction in their state and
+// execute them during Acknowledge. Identifiers are quoted and fields
+// translated by the connector's own dialect; jsonLiteral is the dialect's
+// expression for a JSON/object value.
+func DrainSeedInsertQuery[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
+	t *testing.T,
+	driver *Driver[EC, RC],
+	cfg EC,
+	appliedSpec *pf.MaterializationSpec,
+	jsonLiteral string,
+) string {
+	t.Helper()
+	ctx := context.Background()
+
+	m, err := driver.newMaterialization(ctx, "apply-drain-seed", cfg, boilerplate.ParseFlags(cfg))
+	require.NoError(t, err)
+	defer m.Close(ctx)
+	s, ok := m.(*sqlMaterialization[EC, RC])
+	require.True(t, ok)
+	dialect := s.endpoint.Dialect
+
+	// Literals for the fields of the testutil drain fixture specs
+	// (validate_apply_test_cases base.flow.proto).
+	literals := map[string]string{
+		"key":                  "'k1'",
+		"flow_published_at":    "CURRENT_TIMESTAMP",
+		"_meta/flow_truncated": "false",
+		"optionalBoolean":      "true",
+		"requiredBoolean":      "true",
+		"optionalInteger":      "2",
+		"requiredInteger":      "1",
+		"optionalString":       "'opt'",
+		"requiredString":       "'req'",
+		"optionalObject":       jsonLiteral,
+		"requiredObject":       jsonLiteral,
+		"second_root":          jsonLiteral,
+		"flow_document":        jsonLiteral,
+	}
+
+	b := appliedSpec.Bindings[0]
+	fields := append(append([]string{}, b.FieldSelection.Keys...), b.FieldSelection.Values...)
+	if b.FieldSelection.Document != "" {
+		fields = append(fields, b.FieldSelection.Document)
+	}
+
+	var cols, vals []string
+	for _, f := range fields {
+		lit, ok := literals[f]
+		require.True(t, ok, "no seed literal for selected field %q", f)
+		cols = append(cols, dialect.Identifier(dialect.ColumnLocator(f)))
+		vals = append(vals, lit)
+	}
+
+	return fmt.Sprintf("INSERT INTO %s (%s) SELECT %s",
+		dialect.Identifier(b.ResourcePath...),
+		strings.Join(cols, ", "),
+		strings.Join(vals, ", "))
+}
+
 func RunMigrationTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
 	t *testing.T,
 	driver *Driver[EC, RC],

--- a/materialize-sqlite/sqlite.go
+++ b/materialize-sqlite/sqlite.go
@@ -303,7 +303,7 @@ func (t *transactor) RecoverCheckpoint(_ context.Context, _ pf.MaterializationSp
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(
 	it *m.LoadIterator,

--- a/materialize-sqlserver/driver.go
+++ b/materialize-sqlserver/driver.go
@@ -503,7 +503,7 @@ func (t *transactor) addBinding(ctx context.Context, target sql.Table, featureFl
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 func (d *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) error {
 	var ctx = it.Context()

--- a/materialize-webhook/driver.go
+++ b/materialize-webhook/driver.go
@@ -185,7 +185,7 @@ type transactor struct {
 }
 
 func (t *transactor) UnmarshalState(state json.RawMessage) error                  { return nil }
-func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage) (*pf.ConnectorState, error) { return nil, nil }
+func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMessage, stateKeys []string) (*pf.ConnectorState, error) { return nil, nil }
 
 // Load should not be called and panics.
 func (d *transactor) Load(it *m.LoadIterator, _ func(int, json.RawMessage) error) error {


### PR DESCRIPTION
## Description

Post-commit apply materializations (databricks, snowflake, bigquery, clickhouse, iceberg, s3-iceberg, filesink-based) stage a transaction's work in their connector state at `StartCommit` and only execute it during `Acknowledge`. An Apply RPC altering a table while such work is pending leaves staged DML — built against the previous table schema — to fail once it finally runs. This was flagged by a long-standing TODO in `RunApply`.

Runtime v2 plumbs connector state through Apply (`Request_Apply.state_json` in, `Response_Applied.state` out), and drives Apply as a loop. This PR uses that loop to commit affected pending work before any DDL:

1. **First Apply — commit pending data, change nothing.** The runtime sends Apply with the last-persisted connector state. The connector sees that a table it is about to alter has a staged-but-unacknowledged transaction in that state, commits just that pending work (by invoking its own `Acknowledge` restricted to the affected state keys), and returns `Applied` with a state update clearing it — performing **no schema changes**.
2. **Runtime persists and re-invokes.** Because `Applied` carried a state update, the runtime durably persists it and calls Apply again with the reduced state.
3. **Second Apply — change the schema.** The connector finds nothing pending for the affected tables, performs the schema changes, and returns `Applied` with no state update. Seeing no update, the runtime exits the loop, records the spec as applied, and starts the transactions session.

**Why a loop instead of one call:** the staged DML was built against the *old* table schema. If a single invocation committed the DML and then altered the table, a crash in between (after the DML commits, before the cleared state persists) would make the runtime retry Apply with the old state — replaying the staged queries against the already-altered table, which is exactly the failure being prevented. The loop makes the ordering durable: the cleared state is persisted before any DDL runs, so a crash at any point retries into a consistent world — either the drain re-runs (idempotently) or the DDL proceeds with nothing pending. An RFC 7396 no-op check guards the runtime's bounded iteration budget.

Supporting changes:

- **`Transactor.Acknowledge(ctx, statePatches, stateKeys)`**: a nil `stateKeys` processes every state key — including entries staged under keys that can't be enumerated from the active bindings, such as those of since-removed bindings, subject to the connector's own handling — and is what transaction sessions pass (behavior unchanged). A non-nil `stateKeys` processes exactly those keys, which is what the Apply drain passes. Acknowledge now returns a nil state update when it processed nothing.
- **Backfills**: bindings whose table is really truncated or dropped & re-created are not drained — the backfill rotates their state key, the pending entries become inert, and a user backfilling to escape wedged pending work is never blocked by a failing drain. Backfills that retain data (`retain_existing_data_on_backfill`) are drained under the pre-backfill state key so staged rows don't orphan.
- Databricks drains a state key across all of its scale-out range buckets (including legacy and peer-shard buckets); clickhouse skips `ensureTempTables` for unrequested pending bindings since it would destroy their staged rows. The v1 runtime never sends state with Apply, so nothing changes there.

## Workflow steps

No configuration changes. Under runtime v2, publishing a schema change to a materialization with a committed-but-unacknowledged transaction now first commits that transaction for the affected tables (visible in the publication's action description as `committed previously staged transaction for state keys: ...`), then applies the schema change on the runtime's follow-up Apply.

## Documentation links

Protocol fields: `Request.Apply.state_json` / `Response.Applied.state` in [materialize.proto](https://github.com/estuary/flow/blob/master/go/protocols/materialize/materialize.proto); the runtime apply loop lives in flow's `crates/runtime-next` (leader `apply_loop`).

## Notes for reviewers

- Every state-persisting connector has a passing end-to-end `TestIntegration/apply-drain` driving the real two-iteration loop against its live destination (databricks/snowflake/bigquery warehouses; clickhouse, iceberg, and s3-iceberg local docker stacks), seeded through each connector's actual staging machinery.
- Full integration suites for databricks (2-shard scale-out), snowflake, bigquery, clickhouse, iceberg, and s3-iceberg pass with byte-identical snapshots. The databricks materialize test requires flowctl >= v0.6.12 (`preview-next` drain session).
- Remote-store-authoritative connectors (postgres, mysql, sqlserver, redshift, motherduck, ...) only receive the mechanical signature change: they never persist connector state, so the drain never engages.


This change is [Reviewable](https://reviewable.io/reviews/estuary/connectors)
