### PR TITLE
materialize-kafka: use projection constraints

### DIFF
--- a/materialize-kafka/src/validate.rs
+++ b/materialize-kafka/src/validate.rs
@@ -3,7 +3,7 @@ use proto_flow::{
     flow::{MaterializationSpec, Projection, SerPolicy},
     materialize::{
         request::Validate,
-        response::validated::{constraint, Binding, Constraint},
+        response::validated::{constraint, Binding, Constraint, ProjectionConstraint},
     },
 };
 use rdkafka::producer::Producer;
@@ -46,17 +46,20 @@ pub async fn do_validate(req: Validate) -> Result<Vec<Binding>> {
             let res: Resource = serde_json::from_slice(&binding.resource_config_json)?;
 
             Ok(Binding {
-                constraints: binding
+                constraints: Default::default(),
+                projection_constraints: binding
                     .collection
                     .as_ref()
                     .expect("binding must have collection spec")
                     .projections
                     .iter()
-                    .map(|p| {
-                        (
-                            p.field.clone(),
-                            constraint_for_projection(p, &res, req.last_materialization.as_ref()),
-                        )
+                    .map(|p| ProjectionConstraint {
+                        field: p.field.clone(),
+                        constraint: Some(constraint_for_projection(
+                            p,
+                            &res,
+                            req.last_materialization.as_ref(),
+                        )),
                     })
                     .collect(),
                 resource_path: vec![res.topic],
@@ -67,7 +70,6 @@ pub async fn do_validate(req: Validate) -> Result<Vec<Binding>> {
                     nested_obj_truncate_after: 1000,
                     array_truncate_after: 1000,
                 }),
-                projection_constraints: Vec::new(),
             })
         })
         .collect::<Result<Vec<Binding>>>()


### PR DESCRIPTION
**Regression?**

Yes, https://github.com/estuary/flow/pull/3104

**Description:**

Support for constraints was removed in favor of projection_constraints, but materialize-kafka was not updated.  This has began causing the test to fail.

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [x] ~~If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.~~ Not user visible.
