### PR TITLE
source-iterate: allow extra fields on API response models

### DIFF
--- a/source-iterate/CHANGELOG.md
+++ b/source-iterate/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-07-24
+
+### Fixed
+- Captures no longer fail when Iterate adds new fields (such as `project`) to survey and survey-response API responses.

--- a/source-iterate/source_iterate/models.py
+++ b/source-iterate/source_iterate/models.py
@@ -29,18 +29,18 @@ class FullRefreshResource(BaseDocument, extra="allow"):
     pass
 
 
-class SurveysResponse(BaseModel, extra="forbid"):
+class SurveysResponse(BaseModel, extra="ignore"):
     results: list[FullRefreshResource]
 
 
-class SurveyResponsesResponse(BaseModel, extra="allow"):
-    class Results(BaseModel, extra="forbid"):
+class SurveyResponsesResponse(BaseModel, extra="ignore"):
+    class Results(BaseModel, extra="allow"):
         count: int
         list: list[FullRefreshResource]
 
     results: Results
 
-    class Links(BaseModel, extra="forbid"):
+    class Links(BaseModel, extra="ignore"):
         next: str
 
     # links is not present on the last page of results.


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've observed captures failing because Iterate added a `project` field to the response when fetching survey responses. Based on the [API docs](https://iteratehq.com/api-docs#get-responses), the `project` should already be present in the documents we emit, so it's safe to just ignore `project` in the response wrapper. I'm opting to ignore all other, non-essential fields in response wrappers as well to avoid similar task failures in the future.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
