### PR TITLE
source-braintree-native: retry 422 responses indicating timeouts

### DIFF
--- a/source-braintree-native/CHANGELOG.md
+++ b/source-braintree-native/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-29
+
+### Fixed
+- Transient Braintree search timeouts (`HTTP 422` responses with a `timeout` reason) are now retried instead of failing the capture.
+
 ## 2026-07-27
 
 ### Added

--- a/source-braintree-native/source_braintree_native/api/common.py
+++ b/source-braintree-native/source_braintree_native/api/common.py
@@ -69,11 +69,22 @@ async def request_with_search_timeout_retries(
 async def process_completed_fetches(
     fetch_coroutines: list[Awaitable[list[dict[str, Any]]]],
 ) -> AsyncGenerator[dict[str, Any], None]:
-    """Helper to process fetching multiple pages of resources and yield individual resources."""
-    for coro in asyncio.as_completed(fetch_coroutines):
-        result = await coro
-        for resource in result:
-            yield resource
+    """Helper to process fetching multiple pages of resources and yield individual resources.
+
+    If one fetch raises or the consumer stops iterating early, the remaining in-flight
+    fetches are cancelled so they don't outlive this generator and emit "Session is closed"
+    warnings when they touch the torn-down HTTP session.
+    """
+    tasks = [asyncio.ensure_future(coro) for coro in fetch_coroutines]
+    try:
+        for task in asyncio.as_completed(tasks):
+            result = await task
+            for resource in result:
+                yield resource
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def braintree_xml_to_dict(xml_data):

--- a/source-braintree-native/source_braintree_native/api/common.py
+++ b/source-braintree-native/source_braintree_native/api/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from braintree import (
     BraintreeGateway,
     AddOnGateway,
@@ -6,9 +7,12 @@ from braintree import (
     )
 from braintree.attribute_getter import AttributeGetter
 from datetime import datetime, timedelta, UTC
-from typing import Awaitable, Any, AsyncGenerator
+from logging import Logger
+from typing import Awaitable, Any, AsyncGenerator, Callable
 import xmltodict
 import re
+
+from estuary_cdk.http import HTTPError
 
 CONVENIENCE_OBJECTS = [
     'gateway'
@@ -25,6 +29,41 @@ SEARCH_LIMIT = 10_000
 TRANSACTION_SEARCH_LIMIT = 50_000
 
 SEARCH_PAGE_SIZE = 50
+
+# Braintree returns an HTTP 422 with a "timeout" reason when a search query times out
+# server-side (e.g. <unprocessable-entity><reason>timeout</reason></unprocessable-entity>).
+# This is transient and safe to retry, but the CDK treats all 4xx responses as
+# non-retryable and only consults `should_retry` for 5xx, so these timeouts crash the
+# binding task. We retry them here with exponential backoff before giving up and letting
+# the error propagate (which restarts the task from its last cursor/page).
+SEARCH_TIMEOUT_REASON = "<reason>timeout</reason>"
+SEARCH_TIMEOUT_MAX_ATTEMPTS = 5
+
+
+def _is_transient_search_timeout(err: HTTPError) -> bool:
+    return err.code == 422 and SEARCH_TIMEOUT_REASON in err.message
+
+
+async def request_with_search_timeout_retries(
+    log: Logger,
+    request_fn: Callable[[], Awaitable[bytes]],
+) -> bytes:
+    """Issue a Braintree search request, retrying transient server-side search timeouts."""
+    for attempt in range(1, SEARCH_TIMEOUT_MAX_ATTEMPTS + 1):
+        try:
+            return await request_fn()
+        except HTTPError as err:
+            if not _is_transient_search_timeout(err) or attempt == SEARCH_TIMEOUT_MAX_ATTEMPTS:
+                raise
+
+            delay = 2 ** attempt + random.uniform(0, 1)
+            log.warning(
+                "Braintree search timed out (HTTP 422); retrying.",
+                {"attempt": attempt, "delay": delay},
+            )
+            await asyncio.sleep(delay)
+
+    assert False, "unreachable: the loop above always returns a response or raises."
 
 
 async def process_completed_fetches(

--- a/source-braintree-native/source_braintree_native/api/disputes.py
+++ b/source-braintree-native/source_braintree_native/api/disputes.py
@@ -7,7 +7,14 @@ from typing import AsyncGenerator, Awaitable, Any
 import braintree
 from estuary_cdk.http import HTTPSession
 
-from .common import HEADERS, SEARCH_PAGE_SIZE, braintree_object_to_dict, braintree_xml_to_dict, process_completed_fetches
+from .common import (
+    HEADERS,
+    SEARCH_PAGE_SIZE,
+    braintree_object_to_dict,
+    braintree_xml_to_dict,
+    process_completed_fetches,
+    request_with_search_timeout_retries,
+)
 from ..models import IncrementalResource, DisputeSearchField, DisputesSearchResponse
 
 async def _fetch_dispute_page(
@@ -36,7 +43,10 @@ async def _fetch_dispute_page(
     async with semaphore:
         response = DisputesSearchResponse.model_validate(
             braintree_xml_to_dict(
-                await http.request(log, url, "POST", params, body, headers=HEADERS)
+                await request_with_search_timeout_retries(
+                    log,
+                    lambda: http.request(log, url, "POST", params, body, headers=HEADERS),
+                )
             )
         )
 
@@ -73,7 +83,10 @@ async def _determine_total_pages(
 
     response = DisputesSearchResponse.model_validate(
         braintree_xml_to_dict(
-            await http.request(log, url, "POST", params, body, headers=HEADERS)
+            await request_with_search_timeout_retries(
+                log,
+                lambda: http.request(log, url, "POST", params, body, headers=HEADERS),
+            )
         )
     )
 

--- a/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
+++ b/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
@@ -15,6 +15,7 @@ from .common import (
     braintree_object_to_dict,
     braintree_xml_to_dict,
     process_completed_fetches,
+    request_with_search_timeout_retries,
     search_limit_error_message,
     bisect_window,
 )
@@ -60,7 +61,10 @@ async def fetch_searchable_resource_ids_by_field_between(
 
     response = IdSearchResponse.model_validate(
         braintree_xml_to_dict(
-            await http.request(log, url, "POST", json=body, headers=HEADERS)
+            await request_with_search_timeout_retries(
+                log,
+                lambda: http.request(log, url, "POST", json=body, headers=HEADERS),
+            )
         )
     )
 
@@ -122,7 +126,10 @@ async def _fetch_resource_page(
     async with semaphore:
         response = response_model.model_validate(
             braintree_xml_to_dict(
-                await http.request(log, url, "POST", json=body, headers=HEADERS, should_retry=_should_retry)
+                await request_with_search_timeout_retries(
+                    log,
+                    lambda: http.request(log, url, "POST", json=body, headers=HEADERS, should_retry=_should_retry),
+                )
             )
         )
 

--- a/source-braintree-native/source_braintree_native/api/transactions.py
+++ b/source-braintree-native/source_braintree_native/api/transactions.py
@@ -13,6 +13,7 @@ from .common import (
     TRANSACTION_SEARCH_LIMIT,
     braintree_xml_to_dict,
     bisect_window,
+    request_with_search_timeout_retries,
 )
 from ..models import (
     IncrementalResource,
@@ -250,7 +251,10 @@ async def _fetch_transaction_ids_disbursed_between(
 
     response = IdSearchResponse.model_validate(
         braintree_xml_to_dict(
-            await http.request(log, url, "POST", json=body, headers=HEADERS)
+            await request_with_search_timeout_retries(
+                log,
+                lambda: http.request(log, url, "POST", json=body, headers=HEADERS),
+            )
         )
     )
 
@@ -329,7 +333,10 @@ async def _fetch_transaction_ids_disputed_between(
 
     response = IdSearchResponse.model_validate(
         braintree_xml_to_dict(
-            await http.request(log, url, "POST", json=body, headers=HEADERS)
+            await request_with_search_timeout_retries(
+                log,
+                lambda: http.request(log, url, "POST", json=body, headers=HEADERS),
+            )
         )
     )
 


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Closes #4892 

We've observed the `disputes` & other streams crash on large captures when Braintree responds with a 422 status code with a body containing `<reason>timeout</reason>`. The `estuary-cdk` HTTP layer treats all 4xx as non-retryable, so these fail the task when retrying the request may succeed.

This PR's scope includes:
1. Retry transient 422 search timeouts across all search requests, with exponential backoff, matching only 422s whose body carries `<reason>timeout</reason>` and re-raising everything else. Exhausted retries still propagate, restarting the task from its last cursor.
2. Cancel outstanding fetches on error in `process_completed_fetches`, so sibling tasks don't outlive the generator and emit `Session is closed` warnings.

**Notes for reviewers:**

Until we have a better understanding of what's causing the 422s on Braintree's side (the number of concurrent queries? the sheer number of requests?), I'd rather not adjust the connector's concurrency yet.

The 422 retry behavior is _probably_ better suited to be handled at the CDK HTTP client layer, but the `should_retry` hook that we'd use for that only applies to 5xx responses. I'd rather not make a CDK-wide changes to the `should_retry` behavior on a Friday afternoon, so I stuck with the less ideal but still workable connector specific implementation.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
