### PR TITLE
source-ashby: rely on CDK defaults for SnapshotResource model and tombstone

### DIFF
--- a/source-ashby/CHANGELOG.md
+++ b/source-ashby/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-07-27
+
+### Changed
+- The `archive_reasons`, `interview_stages`, `job_postings`, and `sources` collections are
+  now discovered with a minimal write schema instead of declaring a required `id` string.
+  Documents are still captured as Ashby returns them, and existing captures are unaffected.

--- a/source-ashby/source_ashby/resources.py
+++ b/source-ashby/source_ashby/resources.py
@@ -138,12 +138,10 @@ def _create_snapshot_resource(
             state,
             task,
             fetch_snapshot=functools.partial(snapshot_fn, entity_cls, http),
-            tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
         )
 
     return SnapshotResource(
         name=entity_cls.name,
-        model=entity_cls,
         open=open,
         initial_config=ResourceConfig(
             name=entity_cls.name,

--- a/source-ashby/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-ashby/tests/snapshots/snapshots__discover__stdout.json
@@ -190,16 +190,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "ArchiveReasons",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -883,16 +876,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "InterviewStages",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -1114,16 +1100,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "JobPostings",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -1653,16 +1632,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Sources",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've observed `source-ashby` captures failing when a tombstone is written to collections for snapshot bindings. The failures are due to additional required fields specified in the collection's write schema (which is determined by the `model` provided during `Resource`/`SnapshotResource` instantiation) that are not in the emitted tombstones.

This PR fixes this by using the CDK defaults for `SnapshotResource`s- `BaseDocument` for the model as well as for the tombstone. This makes the write schema align with the fields specified in deletion tombstones & address the errors we observed.

Discover snapshot changes are expected due to the removal of additional fields from snapshot bindings' schemas.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
