### PR TITLE
source-ashby: derive stream scopes before building resources

### DIFF
--- a/source-ashby/CHANGELOG.md
+++ b/source-ashby/CHANGELOG.md
@@ -6,3 +6,7 @@
 - The `archive_reasons`, `interview_stages`, `job_postings`, and `sources` collections are
   now discovered with a minimal write schema instead of declaring a required `id` string.
   Documents are still captured as Ashby returns them, and existing captures are unaffected.
+
+### Fixed
+- Captures no longer fail on startup with an `AssertionError` while checking which streams
+  the configured API key is permitted to read.

--- a/source-ashby/source_ashby/resources.py
+++ b/source-ashby/source_ashby/resources.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from logging import Logger
 
 from estuary_cdk.capture.common import (
-    BaseDocument,
     Resource,
     ResourceConfig,
     ResourceState,
@@ -32,32 +31,35 @@ from .models import (
 
 AshbyResource = Resource[AshbyEntity, ResourceConfig, ResourceState]
 
+_ALL_DECLARED_SCOPES = {
+    stream_cls.required_scope
+    for stream_cls in (*INCREMENTAL_STREAMS, *SNAPSHOT_STREAMS)
+}
 
-async def filter_resources_by_scopes(
+
+async def _fetch_available_scopes(
     log: Logger,
     http: HTTPMixin,
     config: EndpointConfig,
-    resources: list[AshbyResource],
-) -> list[AshbyResource]:
+) -> set[str]:
     # This escape hatch value allows us to run discoveries
-    # without having a valid set of credentials
+    # without having a valid set of credentials.
     if config.credentials.access_token == "ESTUARY_TEST_ACCESS_TOKEN":
-        return resources
+        return _ALL_DECLARED_SCOPES
 
-    available_scopes = await fetch_api_key_scopes(http, log)
+    return await fetch_api_key_scopes(http, log)
 
-    filtered: list[AshbyResource] = []
-    for resource in resources:
-        model = resource.model
-        assert isinstance(model, type) and issubclass(model, AshbyEntity)
-        required_scope = model.required_scope
 
-        if required_scope in available_scopes:
-            filtered.append(resource)
-        else:
-            log.info(f"Skipping {resource.name}: missing scope '{required_scope}'")
+def _has_required_scope(
+    log: Logger,
+    entity_cls: type[AshbyEntity],
+    available_scopes: set[str],
+) -> bool:
+    if entity_cls.required_scope in available_scopes:
+        return True
 
-    return filtered
+    log.info(f"Skipping {entity_cls.name}: missing scope '{entity_cls.required_scope}'")
+    return False
 
 
 async def validate_credentials(
@@ -165,12 +167,17 @@ async def all_resources(
             ),
         )
 
+    available_scopes = await _fetch_available_scopes(log, http, config)
+
     resources: list[AshbyResource] = [
         _create_incremental_resource(stream_cls, http)
         for stream_cls in INCREMENTAL_STREAMS
+        if _has_required_scope(log, stream_cls, available_scopes)
     ]
     resources.extend(
-        _create_snapshot_resource(stream_cls, http) for stream_cls in SNAPSHOT_STREAMS
+        _create_snapshot_resource(stream_cls, http)
+        for stream_cls in SNAPSHOT_STREAMS
+        if _has_required_scope(log, stream_cls, available_scopes)
     )
 
-    return await filter_resources_by_scopes(log, http, config, resources)
+    return resources


### PR DESCRIPTION


**Regression?**

Yes, https://github.com/estuary/connectors/pull/4898.

**Description:**

After merging https://github.com/estuary/connectors/pull/4898, we observed captures were failing at startup with an `AssertionError`:
```
Traceback (most recent call last):
  File "/opt/estuary-cdk/estuary_cdk/capture/base_capture_connector.py", line 148, in handle
    opened, capture = await self.open(log, open)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-ashby/source_ashby/__init__.py", line 67, in open
    resources = await all_resources(log, self, open.capture.config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-ashby/source_ashby/resources.py", line 176, in all_resources
    return await filter_resources_by_scopes(log, http, config, resources)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/source-ashby/source_ashby/resources.py", line 52, in filter_resources_by_scopes
    assert isinstance(model, type) and issubclass(model, AshbyEntity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Scope filtering recovered each stream's `required_scope` from the constructed `Resource`'s `model`, which stopped being an `AshbyEntity` subclass once snapshot bindings began relying on the CDK's default `BaseDocument` model.

This PR fixes this by filtering the entity classes by scope before resources are built, where `required_scope` is still readable off the class.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
