### PR TITLE
source-braintree-native: configurable concurrency per binding

### DIFF
--- a/docs/reference/Connectors/capture-connectors/braintree.md
+++ b/docs/reference/Connectors/capture-connectors/braintree.md
@@ -62,6 +62,17 @@ See [connectors](../../../concepts/connectors.md#using-connectors) to learn more
 | **`/name`** | Data resource | Name of the data resource. | string | Required |
 | `/interval` | Interval | Interval between data syncs | string | PT5M |
 | `/schedule` | Backfill schedule | The schedule for automatically backfilling this binding. Accepts a cron expression. For example, a schedule of `0 20 * * 5` means the binding will initiate a new backfill at 20:00 UTC every Friday. If left empty, the binding will not automatically backfill. | string | |
+| `/concurrency` | Concurrency | Maximum number of concurrent requests used to fetch this stream. Only affects streams fetched via concurrent pagination or batching. Lower this if Braintree reports elevated errors or throttles requests. | integer | Varies by stream |
+
+:::note
+The default `concurrency` differs per stream, and is set when the binding is discovered:
+
+* **20** for the Credit Card Verifications, Customers, Subscriptions, and Transactions incremental streams.
+* **5** for the Disputes incremental stream. Each Disputes request re-runs the full search on Braintree's side, so these requests are more expensive than those of other streams.
+* **1** for the full refresh streams, which don't fetch pages concurrently.
+
+Bindings that don't specify `concurrency` use 20.
+:::
 
 ### Sample
 
@@ -84,45 +95,50 @@ captures:
       - resource:
           name: add_ons
           interval: PT5M
+          concurrency: 1
         target: ${PREFIX}/add_ons
       - resource:
           name: credit_card_verifications
           interval: PT5M
           schedule: "0 20 * * 5"
+          concurrency: 20
         target: ${PREFIX}/credit_card_verifications
       - resource:
           name: customers
           interval: PT5M
           schedule: "0 20 * * 5"
+          concurrency: 20
         target: ${PREFIX}/customers
       - resource:
           name: discounts
           interval: PT5M
+          concurrency: 1
         target: ${PREFIX}/discounts
       - resource:
           name: disputes
           interval: PT5M
+          concurrency: 5
         target: ${PREFIX}/disputes
       - resource:
           name: merchant_accounts
           interval: PT5M
-        target: ${PREFIX}/merchant_accounts
-      - resource:
-          name: merchant_accounts
-          interval: PT5M
+          concurrency: 1
         target: ${PREFIX}/merchant_accounts
       - resource:
           name: plans
           interval: PT5M
+          concurrency: 1
         target: ${PREFIX}/plans
       - resource:
           name: subscriptions
           interval: PT5M
           schedule: "0 20 * * 5"
+          concurrency: 20
         target: ${PREFIX}/subscriptions
       - resource:
           name: transactions
           interval: PT5M
+          concurrency: 20
         target: ${PREFIX}/transactions
       {...}
 ```

--- a/scripts/obfuscation/config_allowlist.txt
+++ b/scripts/obfuscation/config_allowlist.txt
@@ -112,6 +112,7 @@ snapshot_retention_days
 orphan_file_retention_days
 
 # --- batching / performance / limits (numeric knobs) ---
+concurrency
 backfill_chunk_size
 incremental_chunk_size
 incremental_scn_range

--- a/source-braintree-native/CHANGELOG.md
+++ b/source-braintree-native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-07-27
+
+### Added
+- A per-binding `Concurrency` setting that controls the maximum number of concurrent requests used to fetch a stream. Lower it if Braintree reports elevated errors or throttles requests. New bindings default to 5 for `disputes` and 20 for other search-based streams.

--- a/source-braintree-native/source_braintree_native/__init__.py
+++ b/source-braintree-native/source_braintree_native/__init__.py
@@ -17,34 +17,34 @@ from .resources import all_resources, validate_credentials
 from .models import (
     ConnectorState,
     EndpointConfig,
-    ResourceConfigWithSchedule,
+    ResourceConfig,
 )
 
 
 class Connector(
-    BaseCaptureConnector[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
+    BaseCaptureConnector[EndpointConfig, ResourceConfig, ConnectorState],
 ):
     def request_class(self):
-        return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]
+        return Request[EndpointConfig, ResourceConfig, ConnectorState]
 
     async def spec(self, _: request.Spec, logger: Logger) -> ConnectorSpec:
         return ConnectorSpec(
             configSchema=EndpointConfig.model_json_schema(),
             documentationUrl="https://go.estuary.dev/source-braintree-native",
-            resourceConfigSchema=ResourceConfigWithSchedule.model_json_schema(),
-            resourcePathPointers=ResourceConfigWithSchedule.PATH_POINTERS,
+            resourceConfigSchema=ResourceConfig.model_json_schema(),
+            resourcePathPointers=ResourceConfig.PATH_POINTERS,
         )
 
     async def discover(
         self, log: Logger, discover: request.Discover[EndpointConfig]
-    ) -> response.Discovered[ResourceConfigWithSchedule]:
+    ) -> response.Discovered[ResourceConfig]:
         resources = await all_resources(log, self, discover.config)
         return common.discovered(resources)
 
     async def validate(
         self,
         log: Logger,
-        validate: request.Validate[EndpointConfig, ResourceConfigWithSchedule],
+        validate: request.Validate[EndpointConfig, ResourceConfig],
     ) -> response.Validated:
         await validate_credentials(log, self, validate.config)
         resources = await all_resources(log, self, validate.config)
@@ -54,7 +54,7 @@ class Connector(
     async def open(
         self,
         log: Logger,
-        open: request.Open[EndpointConfig, ResourceConfigWithSchedule, ConnectorState],
+        open: request.Open[EndpointConfig, ResourceConfig, ConnectorState],
     ) -> tuple[response.Opened, Callable[[Task], Awaitable[None]]]:
         resources = await all_resources(log, self, open.capture.config)
         resolved = common.resolve_bindings(open.capture.bindings, resources)

--- a/source-braintree-native/source_braintree_native/api/__init__.py
+++ b/source-braintree-native/source_braintree_native/api/__init__.py
@@ -64,6 +64,7 @@ async def fetch_transactions(
     base_url: str,
     braintree_gateway: BraintreeGateway,
     window_size: int,
+    concurrency: int,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
@@ -103,6 +104,7 @@ async def fetch_transactions(
             start=lookback_start,
             end=end,
             gateway=braintree_gateway,
+            concurrency=concurrency,
             log=log,
         ):
             yield doc
@@ -113,6 +115,7 @@ async def fetch_transactions(
             start=lookback_start,
             end=end,
             gateway=braintree_gateway,
+            concurrency=concurrency,
             log=log,
         ):
             yield doc
@@ -123,6 +126,7 @@ async def fetch_transactions(
         start=log_cursor,
         end=end,
         gateway=braintree_gateway,
+        concurrency=concurrency,
         log=log,
     ):
         yield doc
@@ -135,6 +139,7 @@ async def backfill_transactions(
     base_url: str,
     braintree_gateway: BraintreeGateway,
     window_size: int,
+    concurrency: int,
     start_date: datetime,
     log: Logger,
     page: PageCursor | None,
@@ -173,6 +178,7 @@ async def backfill_transactions(
         start,
         end,
         braintree_gateway,
+        concurrency,
         log,
     ):
         # Yield the document if it has been updated before the cutoff (i.e. the incremental task won't capture it).
@@ -190,6 +196,7 @@ async def fetch_incremental_resources(
     braintree_gateway: BraintreeGateway,
     braintree_class: IncrementalResourceBraintreeClass,
     window_size: int,
+    concurrency: int,
     log: Logger,
     log_cursor: LogCursor
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
@@ -220,6 +227,7 @@ async def fetch_incremental_resources(
         end,
         braintree_gateway,
         braintree_class,
+        concurrency,
         log,
     ):
         if doc.created_at > log_cursor:
@@ -242,6 +250,7 @@ async def backfill_incremental_resources(
     braintree_gateway: BraintreeGateway,
     braintree_class: IncrementalResourceBraintreeClass,
     window_size: int,
+    concurrency: int,
     start_date: datetime,
     log: Logger,
     page: PageCursor | None,
@@ -282,6 +291,7 @@ async def backfill_incremental_resources(
         end,
         braintree_gateway,
         braintree_class,
+        concurrency,
         log,
     ):
         if doc.created_at < cutoff:
@@ -294,6 +304,7 @@ async def fetch_disputes(
         http: HTTPSession,
         base_url: str,
         window_size: int,
+        concurrency: int,
         log: Logger,
         log_cursor: LogCursor,
 ) -> AsyncGenerator[IncrementalResource | LogCursor, None]:
@@ -313,6 +324,7 @@ async def fetch_disputes(
         DisputeSearchField.EFFECTIVE_DATE,
         log_cursor,
         end,
+        concurrency,
         log,
     ):
         if cache.should_yield("disputes", doc.id, doc.updated_at):
@@ -325,6 +337,7 @@ async def backfill_disputes(
     http: HTTPSession,
     base_url: str,
     window_size: int,
+    concurrency: int,
     start_date: datetime,
     log: Logger,
     page: PageCursor | None,
@@ -350,6 +363,7 @@ async def backfill_disputes(
         DisputeSearchField.EFFECTIVE_DATE,
         start,
         end,
+        concurrency,
         log,
     ):
         if cache.should_yield("disputes", doc.id, doc.updated_at):

--- a/source-braintree-native/source_braintree_native/api/common.py
+++ b/source-braintree-native/source_braintree_native/api/common.py
@@ -25,7 +25,6 @@ SEARCH_LIMIT = 10_000
 TRANSACTION_SEARCH_LIMIT = 50_000
 
 SEARCH_PAGE_SIZE = 50
-SEMAPHORE_LIMIT = 20
 
 
 async def process_completed_fetches(

--- a/source-braintree-native/source_braintree_native/api/disputes.py
+++ b/source-braintree-native/source_braintree_native/api/disputes.py
@@ -7,7 +7,7 @@ from typing import AsyncGenerator, Awaitable, Any
 import braintree
 from estuary_cdk.http import HTTPSession
 
-from .common import HEADERS, SEARCH_PAGE_SIZE, SEMAPHORE_LIMIT, braintree_object_to_dict, braintree_xml_to_dict, process_completed_fetches
+from .common import HEADERS, SEARCH_PAGE_SIZE, braintree_object_to_dict, braintree_xml_to_dict, process_completed_fetches
 from ..models import IncrementalResource, DisputeSearchField, DisputesSearchResponse
 
 async def _fetch_dispute_page(
@@ -92,11 +92,12 @@ async def fetch_disputes_between(
     search_field: DisputeSearchField,
     start: datetime,
     end: datetime,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     total_pages = await _determine_total_pages(
         http,
-        base_url, 
+        base_url,
         search_field,
         start,
         end,
@@ -106,7 +107,7 @@ async def fetch_disputes_between(
     if total_pages == 0:
         return
 
-    semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
+    semaphore = asyncio.Semaphore(concurrency)
 
     async for dispute in process_completed_fetches(
         [_fetch_dispute_page(http, base_url, search_field, start, end, page, semaphore, log)

--- a/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
+++ b/source-braintree-native/source_braintree_native/api/searchable_incremental_resource.py
@@ -11,7 +11,6 @@ from estuary_cdk.http import HTTPError, HTTPSession
 from .common import (
     HEADERS,
     SEARCH_PAGE_SIZE,
-    SEMAPHORE_LIMIT,
     SEARCH_LIMIT,
     braintree_object_to_dict,
     braintree_xml_to_dict,
@@ -186,9 +185,10 @@ async def fetch_by_ids(
     ids: list[str],
     gateway: BraintreeGateway,
     braintree_class: IncrementalResourceBraintreeClass,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
-    semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
+    semaphore = asyncio.Semaphore(concurrency)
 
     async for resource in process_completed_fetches(
         [_fetch_resource_batch(http, base_url, path, response_model, list(chunk), semaphore, log)
@@ -210,6 +210,7 @@ async def fetch_searchable_resources_created_between(
     end: datetime,
     gateway: BraintreeGateway,
     braintree_class: IncrementalResourceBraintreeClass,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     ids = await fetch_searchable_resource_ids_by_field_between(
@@ -234,6 +235,7 @@ async def fetch_searchable_resources_created_between(
         ids,
         gateway,
         braintree_class,
+        concurrency,
         log,
     ):
         yield doc

--- a/source-braintree-native/source_braintree_native/api/transactions.py
+++ b/source-braintree-native/source_braintree_native/api/transactions.py
@@ -104,6 +104,7 @@ async def fetch_transactions_updated_between(
     start: datetime,
     end: datetime,
     gateway: BraintreeGateway,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     ids = await _fetch_unique_updated_transaction_ids(
@@ -122,6 +123,7 @@ async def fetch_transactions_updated_between(
         ids,
         gateway,
         braintree.Transaction,
+        concurrency,
         log,
     ):
         yield doc
@@ -133,6 +135,7 @@ async def fetch_transactions_created_between(
     start: datetime,
     end: datetime,
     gateway: BraintreeGateway,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     ids = await fetch_searchable_resource_ids_by_field_between(
@@ -155,6 +158,7 @@ async def fetch_transactions_created_between(
         ids,
         gateway,
         braintree.Transaction,
+        concurrency,
         log,
     ):
         yield doc
@@ -259,6 +263,7 @@ async def fetch_transactions_disbursed_between(
     start: datetime,
     end: datetime,
     gateway: BraintreeGateway,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     start_date = start.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -289,6 +294,7 @@ async def fetch_transactions_disbursed_between(
             ids,
             gateway,
             braintree.Transaction,
+            concurrency,
             log,
         ):
             yield doc
@@ -336,6 +342,7 @@ async def fetch_transactions_disputed_between(
     start: datetime,
     end: datetime,
     gateway: BraintreeGateway,
+    concurrency: int,
     log: Logger,
 ) -> AsyncGenerator[IncrementalResource, None]:
     start_date = start.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -366,6 +373,7 @@ async def fetch_transactions_disputed_between(
             ids,
             gateway,
             braintree.Transaction,
+            concurrency,
             log,
         ):
             yield doc

--- a/source-braintree-native/source_braintree_native/models.py
+++ b/source-braintree-native/source_braintree_native/models.py
@@ -71,6 +71,25 @@ class EndpointConfig(BaseModel):
         json_schema_extra={"advanced": True},
     )
 
+# Default maximum number of concurrent requests used to fetch a stream. Disputes default
+# lower than other streams: each disputes advanced_search re-runs the full search server-side
+# (there is no ids endpoint to page over cheaply), and Braintree has flagged a high volume of
+# these long-running requests as harmful to endpoint availability. Full-refresh snapshots don't
+# fetch pages concurrently, so they use 1.
+DEFAULT_CONCURRENCY = 20
+DEFAULT_DISPUTES_CONCURRENCY = 5
+DEFAULT_SNAPSHOT_CONCURRENCY = 1
+
+
+class ResourceConfig(ResourceConfigWithSchedule):
+    concurrency: Annotated[int, Field(
+        title="Concurrency",
+        description="Maximum number of concurrent requests used to fetch this stream. Only affects streams fetched via concurrent pagination or batching. Lower this if Braintree reports elevated errors or throttles requests.",
+        default=DEFAULT_CONCURRENCY,
+        gt=0,
+    )]
+
+
 ConnectorState = GenericConnectorState[ResourceState]
 
 

--- a/source-braintree-native/source_braintree_native/resources.py
+++ b/source-braintree-native/source_braintree_native/resources.py
@@ -11,8 +11,11 @@ from estuary_cdk.http import HTTPMixin, TokenSource
 
 
 from .models import (
+    DEFAULT_CONCURRENCY,
+    DEFAULT_DISPUTES_CONCURRENCY,
+    DEFAULT_SNAPSHOT_CONCURRENCY,
     EndpointConfig,
-    ResourceConfigWithSchedule,
+    ResourceConfig,
     ResourceState,
     FullRefreshResource,
     IncrementalResource,
@@ -113,7 +116,7 @@ def non_paginated_full_refresh_resources(
             response_model: type[NonPaginatedSnapshotResponse],
             gateway: BraintreeGateway,
             braintree_class: NonPaginatedSnapshotBraintreeClass,
-            binding: CaptureBinding[ResourceConfigWithSchedule],
+            binding: CaptureBinding[ResourceConfig],
             binding_index: int,
             state: ResourceState,
             task: Task,
@@ -143,8 +146,8 @@ def non_paginated_full_refresh_resources(
             model=FullRefreshResource,
             open=functools.partial(open, path, response_model, _create_gateway(config), braintree_class),
             initial_state=ResourceState(),
-            initial_config=ResourceConfigWithSchedule(
-                name=name, interval=timedelta(minutes=5)
+            initial_config=ResourceConfig(
+                name=name, interval=timedelta(minutes=5), concurrency=DEFAULT_SNAPSHOT_CONCURRENCY
             ),
             schema_inference=True,
         )
@@ -159,7 +162,7 @@ def paginated_full_refresh_resources(
     def open(
             snapshot_fn: SnapshotFn,
             gateway: BraintreeGateway,
-            binding: CaptureBinding[ResourceConfigWithSchedule],
+            binding: CaptureBinding[ResourceConfig],
             binding_index: int,
             state: ResourceState,
             task: Task,
@@ -186,8 +189,8 @@ def paginated_full_refresh_resources(
             model=FullRefreshResource,
             open=functools.partial(open, snapshot_fn, _create_gateway(config)),
             initial_state=ResourceState(),
-            initial_config=ResourceConfigWithSchedule(
-                name=name, interval=timedelta(minutes=5)
+            initial_config=ResourceConfig(
+                name=name, interval=timedelta(minutes=5), concurrency=DEFAULT_SNAPSHOT_CONCURRENCY
             ),
             schema_inference=True,
         )
@@ -205,12 +208,13 @@ def incremental_resources(
             gateway: BraintreeGateway,
             braintree_class: IncrementalResourceBraintreeClass,
             window_size: int,
-            binding: CaptureBinding[ResourceConfigWithSchedule],
+            binding: CaptureBinding[ResourceConfig],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings,
     ):
+        concurrency = binding.resourceConfig.concurrency
         common.open_binding(
             binding,
             binding_index,
@@ -225,6 +229,7 @@ def incremental_resources(
                 gateway,
                 braintree_class,
                 window_size,
+                concurrency,
             ),
             fetch_page=functools.partial(
                 backfill_incremental_resources,
@@ -235,6 +240,7 @@ def incremental_resources(
                 gateway,
                 braintree_class,
                 window_size,
+                concurrency,
                 config.start_date,
             )
         )
@@ -251,8 +257,9 @@ def incremental_resources(
                 inc=ResourceState.Incremental(cursor=cutoff),
                 backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
             ),
-            initial_config=ResourceConfigWithSchedule(
+            initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5), schedule="0 20 * * 5",
+                concurrency=DEFAULT_CONCURRENCY,
             ),
             schema_inference=True,
         )
@@ -267,12 +274,13 @@ def transactions(
     def open(
             gateway: BraintreeGateway,
             window_size: int,
-            binding: CaptureBinding[ResourceConfigWithSchedule],
+            binding: CaptureBinding[ResourceConfig],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings,
     ):
+        concurrency = binding.resourceConfig.concurrency
         common.open_binding(
             binding,
             binding_index,
@@ -284,6 +292,7 @@ def transactions(
                 base_url,
                 gateway,
                 window_size,
+                concurrency,
             ),
             fetch_page=functools.partial(
                 backfill_transactions,
@@ -291,6 +300,7 @@ def transactions(
                 base_url,
                 gateway,
                 window_size,
+                concurrency,
                 config.start_date,
             )
         )
@@ -306,8 +316,8 @@ def transactions(
             inc=ResourceState.Incremental(cursor=cutoff),
             backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
         ),
-        initial_config=ResourceConfigWithSchedule(
-            name='transactions', interval=timedelta(minutes=5)
+        initial_config=ResourceConfig(
+            name='transactions', interval=timedelta(minutes=5), concurrency=DEFAULT_CONCURRENCY
         ),
         schema_inference=True,
     )
@@ -318,12 +328,13 @@ def disputes(
 
     def open(
             window_size: int,
-            binding: CaptureBinding[ResourceConfigWithSchedule],
+            binding: CaptureBinding[ResourceConfig],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings,
     ):
+        concurrency = binding.resourceConfig.concurrency
         common.open_binding(
             binding,
             binding_index,
@@ -334,12 +345,14 @@ def disputes(
                 http,
                 base_url,
                 window_size,
+                concurrency,
             ),
             fetch_page=functools.partial(
                 backfill_disputes,
                 http,
                 base_url,
                 window_size,
+                concurrency,
                 config.start_date,
             )
         )
@@ -355,8 +368,8 @@ def disputes(
             inc=ResourceState.Incremental(cursor=cutoff),
             backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff)
         ),
-        initial_config=ResourceConfigWithSchedule(
-            name='disputes', interval=timedelta(minutes=5)
+        initial_config=ResourceConfig(
+            name='disputes', interval=timedelta(minutes=5), concurrency=DEFAULT_DISPUTES_CONCURRENCY
         ),
         schema_inference=True,
     )

--- a/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -73,14 +73,15 @@
         "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
+      "accepted_payment_instrument_logos": [],
       "accepted_payment_methods": [
         "AMERICAN_EXPRESS",
         "DISCOVER",
         "JCB",
+        "LOCAL_PAYMENT",
         "MASTERCARD",
-        "VISA",
         "PAYPAL_ACCOUNT",
-        "LOCAL_PAYMENT"
+        "VISA"
       ],
       "bank_account": "",
       "business_details": {
@@ -89,6 +90,7 @@
       "currency_iso_code": "USD",
       "default": true,
       "funding_details": {},
+      "has_active_processor_connections": true,
       "id": "redacted",
       "individual_details": {
         "address_details": {}
@@ -96,6 +98,7 @@
       "paypal_account": "",
       "status": "active",
       "sub_merchant_account": false,
+      "supports_public_descriptors": false,
       "three_d_secure": {
         "v1": {
           "card_types": [],
@@ -112,7 +115,8 @@
           "enabled": true
         }
       },
-      "type": "MERCHANT_ACCOUNT"
+      "type": "MERCHANT_ACCOUNT",
+      "unique_identifier": "d79qgm3"
     }
   ],
   [

--- a/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -3,7 +3,8 @@
     "recommendedName": "add_ons",
     "resourceConfig": {
       "name": "add_ons",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 1
     },
     "documentSchema": {
       "$defs": {
@@ -74,7 +75,8 @@
     "resourceConfig": {
       "name": "credit_card_verifications",
       "interval": "PT5M",
-      "schedule": "0 20 * * 5"
+      "schedule": "0 20 * * 5",
+      "concurrency": 20
     },
     "documentSchema": {
       "$defs": {
@@ -164,7 +166,8 @@
     "resourceConfig": {
       "name": "customers",
       "interval": "PT5M",
-      "schedule": "0 20 * * 5"
+      "schedule": "0 20 * * 5",
+      "concurrency": 20
     },
     "documentSchema": {
       "$defs": {
@@ -253,7 +256,8 @@
     "recommendedName": "discounts",
     "resourceConfig": {
       "name": "discounts",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 1
     },
     "documentSchema": {
       "$defs": {
@@ -323,7 +327,8 @@
     "recommendedName": "disputes",
     "resourceConfig": {
       "name": "disputes",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 5
     },
     "documentSchema": {
       "$defs": {
@@ -412,7 +417,8 @@
     "recommendedName": "merchant_accounts",
     "resourceConfig": {
       "name": "merchant_accounts",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 1
     },
     "documentSchema": {
       "$defs": {
@@ -482,7 +488,8 @@
     "recommendedName": "plans",
     "resourceConfig": {
       "name": "plans",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 1
     },
     "documentSchema": {
       "$defs": {
@@ -553,7 +560,8 @@
     "resourceConfig": {
       "name": "subscriptions",
       "interval": "PT5M",
-      "schedule": "0 20 * * 5"
+      "schedule": "0 20 * * 5",
+      "concurrency": 20
     },
     "documentSchema": {
       "$defs": {
@@ -642,7 +650,8 @@
     "recommendedName": "transactions",
     "resourceConfig": {
       "name": "transactions",
-      "interval": "PT5M"
+      "interval": "PT5M",
+      "concurrency": 20
     },
     "documentSchema": {
       "$defs": {

--- a/source-braintree-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-braintree-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -123,12 +123,19 @@
           "pattern": "^((?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?)(?:,(?:[0-5]?\\d(?:-[0-5]?\\d)?|\\*(?:/[0-5]?\\d)?))*)\\s+((?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?)(?:,(?:[01]?\\d|2[0-3]|(?:[01]?\\d|2[0-3])-(?:[01]?\\d|2[0-3])|\\*(?:/[01]?\\d|/2[0-3])?))*)\\s+((?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?)(?:,(?:0?[1-9]|[12]\\d|3[01]|(?:0?[1-9]|[12]\\d|3[01])-(?:0?[1-9]|[12]\\d|3[01])|\\*(?:/[0-9]|/1[0-9]|/2[0-9]|/3[01])?))*)\\s+((?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?)(?:,(?:[1-9]|1[0-2]|(?:[1-9]|1[0-2])-(?:[1-9]|1[0-2])|\\*(?:/[1-9]|/1[0-2])?))*)\\s+((?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?)(?:,(?:[0-6]|(?:[0-6])-(?:[0-6])|\\*(?:/[0-6])?))*)$|^$",
           "title": "Schedule",
           "type": "string"
+        },
+        "concurrency": {
+          "default": 20,
+          "description": "Maximum number of concurrent requests used to fetch this stream. Only affects streams fetched via concurrent pagination or batching. Lower this if Braintree reports elevated errors or throttles requests.",
+          "exclusiveMinimum": 0,
+          "title": "Concurrency",
+          "type": "integer"
         }
       },
       "required": [
         "name"
       ],
-      "title": "ResourceConfigWithSchedule",
+      "title": "ResourceConfig",
       "type": "object"
     },
     "documentationUrl": "https://go.estuary.dev/source-braintree-native",


### PR DESCRIPTION
**Regression?**

No.

**Description:**

The connector fanned out search page/batch fetches at a fixed concurrency of 20 with no way to tune it. We observed that for a high-volume merchant, this drove a large number of concurrent, long-running (>50s) `disputes/advanced_search` requests. `disputes` must offset-paginate the full search on every page since there's no ids endpoint, and the window can't go below 24h, so these searches are costly on Braintree's side. Braintree's SRE flagged the resulting volume of long-running requests as harmful to endpoint availability.

This PR addresses this by exposing fetch concurrency as a per-binding resource config field so we can dial back the expensive streams without slowing the cheaper ones. It defaults to 5 for `disputes`, 20 for the other search-based streams, and 1 for full-refresh snapshots since they don't fetch concurrently. The field is optional with a default so existing bindings keep working and stay at their current concurrency until re-discovered or set explicitly.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
