### PR TITLE
materialize-clickhouse: truncate and drop tables with SYNC

### DIFF
--- a/materialize-clickhouse/.snapshots/TestSQLGeneration
+++ b/materialize-clickhouse/.snapshots/TestSQLGeneration
@@ -98,12 +98,12 @@ ORDER BY (theKey);
 
 --- Begin key_value truncateLoadTable ---
 
-TRUNCATE TABLE IF EXISTS flow_temp_load_0_key_value;
+TRUNCATE TABLE IF EXISTS flow_temp_load_0_key_value SYNC;
 --- End key_value truncateLoadTable ---
 
 --- Begin delta_updates truncateLoadTable ---
 
-TRUNCATE TABLE IF EXISTS flow_temp_load_0_delta_updates;
+TRUNCATE TABLE IF EXISTS flow_temp_load_0_delta_updates SYNC;
 --- End delta_updates truncateLoadTable ---
 
 --- Begin key_value countLoadKeys ---
@@ -188,12 +188,12 @@ INSERT INTO flow_temp_load_0_delta_updates (theKey)
 
 --- Begin key_value dropLoadTable ---
 
-DROP TABLE IF EXISTS flow_temp_load_0_key_value;
+DROP TABLE IF EXISTS flow_temp_load_0_key_value SYNC;
 --- End key_value dropLoadTable ---
 
 --- Begin delta_updates dropLoadTable ---
 
-DROP TABLE IF EXISTS flow_temp_load_0_delta_updates;
+DROP TABLE IF EXISTS flow_temp_load_0_delta_updates SYNC;
 --- End delta_updates dropLoadTable ---
 
 --- Begin key_value createStoreTable ---
@@ -210,12 +210,12 @@ AS delta_updates;
 
 --- Begin key_value truncateStoreTable ---
 
-TRUNCATE TABLE IF EXISTS flow_temp_store_0_key_value;
+TRUNCATE TABLE IF EXISTS flow_temp_store_0_key_value SYNC;
 --- End key_value truncateStoreTable ---
 
 --- Begin delta_updates truncateStoreTable ---
 
-TRUNCATE TABLE IF EXISTS flow_temp_store_0_delta_updates;
+TRUNCATE TABLE IF EXISTS flow_temp_store_0_delta_updates SYNC;
 --- End delta_updates truncateStoreTable ---
 
 --- Begin key_value insertStoreTable ---
@@ -258,12 +258,12 @@ TO TABLE delta_updates;
 
 --- Begin key_value dropStoreTable ---
 
-DROP TABLE IF EXISTS flow_temp_store_0_key_value;
+DROP TABLE IF EXISTS flow_temp_store_0_key_value SYNC;
 --- End key_value dropStoreTable ---
 
 --- Begin delta_updates dropStoreTable ---
 
-DROP TABLE IF EXISTS flow_temp_store_0_delta_updates;
+DROP TABLE IF EXISTS flow_temp_store_0_delta_updates SYNC;
 --- End delta_updates dropStoreTable ---
 
 

--- a/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
+++ b/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
@@ -98,12 +98,12 @@ ORDER BY (theKey);
 
 --- Begin `key_value-@你好-``-"especiál` truncateLoadTable ---
 
-TRUNCATE TABLE IF EXISTS `flow_temp_load_0_key_value-@你好-``-"especiál`;
+TRUNCATE TABLE IF EXISTS `flow_temp_load_0_key_value-@你好-``-"especiál` SYNC;
 --- End `key_value-@你好-``-"especiál` truncateLoadTable ---
 
 --- Begin `delta_updates-@你好-``-"especiál` truncateLoadTable ---
 
-TRUNCATE TABLE IF EXISTS `flow_temp_load_0_delta_updates-@你好-``-"especiál`;
+TRUNCATE TABLE IF EXISTS `flow_temp_load_0_delta_updates-@你好-``-"especiál` SYNC;
 --- End `delta_updates-@你好-``-"especiál` truncateLoadTable ---
 
 --- Begin `key_value-@你好-``-"especiál` countLoadKeys ---
@@ -188,12 +188,12 @@ INSERT INTO `flow_temp_load_0_delta_updates-@你好-``-"especiál` (theKey)
 
 --- Begin `key_value-@你好-``-"especiál` dropLoadTable ---
 
-DROP TABLE IF EXISTS `flow_temp_load_0_key_value-@你好-``-"especiál`;
+DROP TABLE IF EXISTS `flow_temp_load_0_key_value-@你好-``-"especiál` SYNC;
 --- End `key_value-@你好-``-"especiál` dropLoadTable ---
 
 --- Begin `delta_updates-@你好-``-"especiál` dropLoadTable ---
 
-DROP TABLE IF EXISTS `flow_temp_load_0_delta_updates-@你好-``-"especiál`;
+DROP TABLE IF EXISTS `flow_temp_load_0_delta_updates-@你好-``-"especiál` SYNC;
 --- End `delta_updates-@你好-``-"especiál` dropLoadTable ---
 
 --- Begin `key_value-@你好-``-"especiál` createStoreTable ---
@@ -210,12 +210,12 @@ AS `delta_updates-@你好-``-"especiál`;
 
 --- Begin `key_value-@你好-``-"especiál` truncateStoreTable ---
 
-TRUNCATE TABLE IF EXISTS `flow_temp_store_0_key_value-@你好-``-"especiál`;
+TRUNCATE TABLE IF EXISTS `flow_temp_store_0_key_value-@你好-``-"especiál` SYNC;
 --- End `key_value-@你好-``-"especiál` truncateStoreTable ---
 
 --- Begin `delta_updates-@你好-``-"especiál` truncateStoreTable ---
 
-TRUNCATE TABLE IF EXISTS `flow_temp_store_0_delta_updates-@你好-``-"especiál`;
+TRUNCATE TABLE IF EXISTS `flow_temp_store_0_delta_updates-@你好-``-"especiál` SYNC;
 --- End `delta_updates-@你好-``-"especiál` truncateStoreTable ---
 
 --- Begin `key_value-@你好-``-"especiál` insertStoreTable ---
@@ -258,12 +258,12 @@ TO TABLE `delta_updates-@你好-``-"especiál`;
 
 --- Begin `key_value-@你好-``-"especiál` dropStoreTable ---
 
-DROP TABLE IF EXISTS `flow_temp_store_0_key_value-@你好-``-"especiál`;
+DROP TABLE IF EXISTS `flow_temp_store_0_key_value-@你好-``-"especiál` SYNC;
 --- End `key_value-@你好-``-"especiál` dropStoreTable ---
 
 --- Begin `delta_updates-@你好-``-"especiál` dropStoreTable ---
 
-DROP TABLE IF EXISTS `flow_temp_store_0_delta_updates-@你好-``-"especiál`;
+DROP TABLE IF EXISTS `flow_temp_store_0_delta_updates-@你好-``-"especiál` SYNC;
 --- End `delta_updates-@你好-``-"especiál` dropStoreTable ---
 
 

--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-29
+
+### Fixed
+- Fixed a permanent restart loop with the error `refusing to load <table>: load
+  table contains N keys but M were inserted` on ClickHouse Cloud. Truncating a
+  replicated table — which on Cloud is every table, since `MergeTree` is
+  transparently `SharedMergeTree` — happens asynchronously unless `SYNC` is
+  requested, so a queued truncate of an internal staging table could execute
+  after the rows of the next transaction had been staged and silently drop them.
+  Truncating a table when backfilling a binding was exposed the same way, which
+  could drop rows materialized just after the backfill was applied.
+
 ## 2026-07-23
 
 ### Changed

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -340,7 +340,10 @@ func (c *client) partitionKeyColumns(ctx context.Context, table string) (map[str
 }
 
 func (c *client) TruncateTable(_ context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
-	var stmt = fmt.Sprintf("TRUNCATE TABLE %s;", c.ep.Dialect.Identifier(path...))
+	// SYNC because a replicated table (every table on ClickHouse Cloud)
+	// otherwise truncates asynchronously, and a queued truncate would drop the
+	// rows the shard materializes once this backfill has been applied.
+	var stmt = fmt.Sprintf("TRUNCATE TABLE %s SYNC;", c.ep.Dialect.Identifier(path...))
 	return stmt, func(ctx context.Context) error {
 		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("executing truncate table: %w", err)

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -540,7 +540,14 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			// drop: the load table's identity must stay stable so that key
 			// inserts and the join query resolve the same table from any
 			// replica of a clustered deployment.
-			_ = t.load.conn.Exec(ctx, b.load.truncateSQL)
+			//
+			// A failure leaves this round's keys in the table, so it is
+			// reported: should the truncate at the start of the next round
+			// fail too, that round's key-count check trips with no indication
+			// of why the table was not empty.
+			if truncErr := t.load.conn.Exec(ctx, b.load.truncateSQL); truncErr != nil && err == nil {
+				err = fmt.Errorf("truncating load table for %s after load: %w", b.target.Identifier, truncErr)
+			}
 		}
 	}()
 

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -495,8 +495,15 @@ ORDER BY (
 );
 {{ end }}
 
+{{/*
+Every truncate and drop of a staging table carries SYNC. Without it ClickHouse
+executes the statement asynchronously on a replicated table -- which on
+ClickHouse Cloud is every table, since MergeTree is transparently
+SharedMergeTree -- so a queued truncate can execute after subsequent INSERTs
+and drop the rows they just staged.
+*/}}
 {{ define "truncateLoadTable" }}
-TRUNCATE TABLE IF EXISTS {{ template "loadTableName" . }};
+TRUNCATE TABLE IF EXISTS {{ template "loadTableName" . }} SYNC;
 {{ end }}
 
 {{ define "countLoadKeys" }}
@@ -580,7 +587,7 @@ SELECT ''::String LIMIT 0
 {{ end }}
 
 {{ define "dropLoadTable" }}
-DROP TABLE IF EXISTS {{ template "loadTableName" . }};
+DROP TABLE IF EXISTS {{ template "loadTableName" . }} SYNC;
 {{ end }}
 
 ---- Store tables
@@ -656,11 +663,11 @@ TO TABLE {{ $.Identifier }};
 {{ end }}
 
 {{ define "truncateStoreTable" }}
-TRUNCATE TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
+TRUNCATE TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }} SYNC;
 {{ end }}
 
 {{ define "dropStoreTable" }}
-DROP TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }};
+DROP TABLE IF EXISTS {{ template "storeTableNameIdentifier" . }} SYNC;
 {{ end }}
 `, template.FuncMap{"PartitionExpr": partitionExpr})
 


### PR DESCRIPTION
**Regression?**

Partly — #4627 made the staging tables persistent, which moved `TRUNCATE` onto the hot path of every transaction and exposed this race.

**Description:**

Fixes #4938. On ClickHouse Cloud every `MergeTree` is transparently `SharedMergeTree`, i.e. replicated, and [truncating a replicated table is asynchronous unless `SYNC` is passed](https://clickhouse.com/docs/sql-reference/statements/truncate). A queued truncate could execute *after* subsequent `INSERT`s and drop the rows just staged, tripping the load-table key-count guard and crash-looping the shard indefinitely.

- `sqlgen.go`: `SYNC` on the load/store staging table truncates and drops.
- `client.go`: `SYNC` on the target-table truncate used when backfilling a binding — same hazard, but against user data rather than staging rows. Beyond the issue's list.
- `driver.go`: the end-of-round load-table truncate no longer discards its error.

**Workflow steps:**

No user-facing change; an affected materialization stops crash-looping once released.

**Documentation links affected:**

None — no config or behavior surface changes, and `TRUNCATE ... SYNC` needs no privilege beyond the `TRUNCATE` already listed.

**Notes for reviewers:**

Not reproducible locally: the test server is a single non-replicated node, so the async path can't be exercised. Full suite green, and `TestIntegration` / `TestTruncateTable` confirm the statements parse and execute on 25.8. Snapshots updated.

Two open questions from the issue I did not settle — both need a real Cloud endpoint:

- `SYNC` waits on the replica serving the statement (`alter_sync` defaults to 1), not all of them. The connection pool spans replicas, so `alter_sync = 2` may be needed to fully close the race.
- Nothing bounds `replication_wait_for_inactive_replica_timeout`, so a sick replica can now stall a transaction where it previously couldn't.

`DeleteTable`'s `DROP` is deliberately left alone: on Atomic databases the name is freed immediately and only data removal is deferred, so a following `CREATE` of the same name isn't racing it.

**Checklist:**

- [x] `CHANGELOG.md` updated; no documentation change warranted (see above).
