### PR TITLE
source-hubspot-native: request all form types in `forms`

### DIFF
--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2026-07-29
+### Fixed
+- The `forms` binding now captures `captured`, `flow`, and `blog_comment` forms in
+  addition to the already captured `hubspot` forms.
+- The `form_submissions` binding now captures submissions for `captured` and `flow`
+  form in addition to submissions already captured for `hubspot` forms. Submissions
+  for `blog_comment` forms are not captured because HubSpot responds with a 400 error
+  when requesting submissions for those forms.

--- a/source-hubspot-native/acmeCo/forms.schema.yaml
+++ b/source-hubspot-native/acmeCo/forms.schema.yaml
@@ -25,6 +25,9 @@ properties:
   id:
     title: Id
     type: string
+  formType:
+    title: Formtype
+    type: string
   createdAt:
     anyOf:
     - format: date-time
@@ -39,6 +42,7 @@ properties:
     title: Updatedat
 required:
 - id
+- formType
 - createdAt
 - updatedAt
 title: Form

--- a/source-hubspot-native/source_hubspot_native/api/form_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/form_submissions.py
@@ -20,6 +20,12 @@ from .shared import (
 )
 
 
+
+# HubSpot refuses to export submissions for blog_comment forms, responding 400
+# FORM_TYPE_NOT_ALLOWED.
+FORM_TYPES_WITHOUT_SUBMISSIONS = frozenset({"blog_comment"})
+
+
 async def _fetch_form_submissions_since(
     http: HTTPSession,
     log: Logger,
@@ -66,6 +72,9 @@ async def fetch_form_submissions(
     form_ids: list[str] = []
 
     async for form in fetch_forms(http, log):
+        if form.formType in FORM_TYPES_WITHOUT_SUBMISSIONS:
+            continue
+
         form_ids.append(form.id)
 
     latest_submitted_at = log_cursor

--- a/source-hubspot-native/source_hubspot_native/api/forms.py
+++ b/source-hubspot-native/source_hubspot_native/api/forms.py
@@ -23,6 +23,9 @@ async def fetch_forms(
 
     input: dict[str, Any] = {
         "limit": 500,
+        # HubSpot defaults to formTypes=hubspot, so we have
+        # to explicitly ask for all formTypes.
+        "formTypes": "all",
     }
 
     while True:

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -231,6 +231,7 @@ class Owner(BaseDocument, extra="allow"):
 
 class Form(BaseDocument, extra="allow"):
     id: str
+    formType: str
     createdAt: AwareDatetime | None
     updatedAt: AwareDatetime | None
 

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -643,7 +643,11 @@ def forms(http: HTTPSession) -> Resource:
             task,
             fetch_snapshot=functools.partial(fetch_forms, http),
             tombstone=Form(
-                _meta=Form.Meta(op="d"), id="", createdAt=None, updatedAt=None
+                _meta=Form.Meta(op="d"),
+                id="",
+                formType="",
+                createdAt=None,
+                updatedAt=None,
             ),
         )
 

--- a/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__capture__stdout.json
@@ -76,22 +76,6 @@
         "hs_csm_sentiment": null,
         "hs_current_customer": null,
         "hs_customer_success_ticket_sentiment": null,
-        "hs_date_entered_customer": "redacted",
-        "hs_date_entered_evangelist": "redacted",
-        "hs_date_entered_lead": "redacted",
-        "hs_date_entered_marketingqualifiedlead": "redacted",
-        "hs_date_entered_opportunity": "redacted",
-        "hs_date_entered_other": "redacted",
-        "hs_date_entered_salesqualifiedlead": "redacted",
-        "hs_date_entered_subscriber": "redacted",
-        "hs_date_exited_customer": "redacted",
-        "hs_date_exited_evangelist": "redacted",
-        "hs_date_exited_lead": "redacted",
-        "hs_date_exited_marketingqualifiedlead": "redacted",
-        "hs_date_exited_opportunity": "redacted",
-        "hs_date_exited_other": "redacted",
-        "hs_date_exited_salesqualifiedlead": "redacted",
-        "hs_date_exited_subscriber": "redacted",
         "hs_domain_status": null,
         "hs_employee_range": null,
         "hs_excluded_from_cross_account_data_mirroring": null,
@@ -189,14 +173,6 @@
         "hs_target_account_recommendation_state": null,
         "hs_task_label": "HubSpot",
         "hs_tax_id": null,
-        "hs_time_in_customer": "redacted",
-        "hs_time_in_evangelist": "redacted",
-        "hs_time_in_lead": "redacted",
-        "hs_time_in_marketingqualifiedlead": "redacted",
-        "hs_time_in_opportunity": "redacted",
-        "hs_time_in_other": "redacted",
-        "hs_time_in_salesqualifiedlead": "redacted",
-        "hs_time_in_subscriber": "redacted",
         "hs_total_deal_value": null,
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": null,
@@ -391,7 +367,6 @@
             "value": "sample-contact"
           }
         ],
-        "hs_date_entered_lead": "redacted",
         "hs_lastmodifieddate": "redacted",
         "hs_logo_url": [
           {
@@ -508,7 +483,6 @@
             "value": "HubSpot"
           }
         ],
-        "hs_time_in_lead": "redacted",
         "hs_v2_date_entered_current_stage": [
           {
             "sourceId": "RecalculateCalculatedPropertiesHelper",
@@ -700,6 +674,7 @@
         "hs_email_customer_quarantined_reason": null,
         "hs_email_delivered": null,
         "hs_email_domain": "hubspot.com",
+        "hs_email_engagement_likelihood_category": null,
         "hs_email_first_click_date": null,
         "hs_email_first_open_date": null,
         "hs_email_first_reply_date": null,
@@ -1540,6 +1515,7 @@
         "hs_email_customer_quarantined_reason": null,
         "hs_email_delivered": null,
         "hs_email_domain": "hubspot.com",
+        "hs_email_engagement_likelihood_category": null,
         "hs_email_first_click_date": null,
         "hs_email_first_open_date": null,
         "hs_email_first_reply_date": null,
@@ -2376,6 +2352,7 @@
         "hs_email_customer_quarantined_reason": null,
         "hs_email_delivered": null,
         "hs_email_domain": "test.com",
+        "hs_email_engagement_likelihood_category": null,
         "hs_email_first_click_date": null,
         "hs_email_first_open_date": null,
         "hs_email_first_reply_date": null,
@@ -3298,7 +3275,7 @@
         "hs_unique_creation_key": null,
         "hs_updated_by_user_id": "73074756",
         "hs_user_ids_of_all_notification_followers": null,
-        "hs_user_ids_of_all_notification_recipients": null,
+        "hs_user_ids_of_all_notification_recipients": "73074756",
         "hs_user_ids_of_all_notification_unfollowers": null,
         "hs_user_ids_of_all_owners": "73074756",
         "hs_v2_cumulative_time_in_appointmentscheduled": null,
@@ -3739,6 +3716,14 @@
             "sourceType": "CRM_UI",
             "timestamp": "2025-04-03T12:59:10.726000Z",
             "updatedByUserId": 73074756,
+            "value": "73074756"
+          }
+        ],
+        "hs_user_ids_of_all_notification_recipients": [
+          {
+            "sourceId": "com.hubspot.crm.notifications.data.property.NotificationRecipientsUpdater",
+            "sourceType": "CALCULATED",
+            "timestamp": "2026-07-16T20:55:20.476000Z",
             "value": "73074756"
           }
         ],

--- a/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__discover__stdout.json
@@ -2134,6 +2134,10 @@
           "title": "Id",
           "type": "string"
         },
+        "formType": {
+          "title": "Formtype",
+          "type": "string"
+        },
         "createdAt": {
           "anyOf": [
             {
@@ -2161,6 +2165,7 @@
       },
       "required": [
         "id",
+        "formType",
         "createdAt",
         "updatedAt"
       ],


### PR DESCRIPTION
**Regression?**

No.

**Description:**

HubSpot's [`/marketing/v3/forms` endpoint](https://developers.hubspot.com/docs/api-reference/legacy/marketing/forms/get-forms#parameter-form-types) defaults to only returning `hubspot` type of forms. We have to explicitly use the `formTypes=all` query parameter to receive all form types from HubSpot.

HubSpot returns a 400 error when requesting submissions for forms with the `blog_comment` type, so `form_submissions` skips requesting submissions for those.

Discover snapshot changes are expected due to the addition of the `formType` field on the `Form` model. Ideally, we'd move these snapshot streams over to use `SnapshotResource` soon so fields required by the connector to do its job aren't tied to the JSON schema for emitted documents, but I wanted to keep the diff small for this PR & we can do that refactor in a follow up PR later.

I also updated the capture snapshot with various API-side field renames / removals / additions in order to get that snapshot test to pass.

**Notes for reviewers:**

Tested with a HubSpot account with all of the different `formType`s present. Confirmed all forms are now captured & submissions for forms that support submissions are captured.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
