### PR TITLE
materialize-clickhouse: wait for the acknowledgement before staging load keys

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## 2026-07-29
 
 ### Fixed
+- Fixed a restart loop with the error `Table <database>.flow_temp_load_… does
+  not exist` (code 60) on materializations with many bindings. The load phase
+  began staging keys before the internal staging tables had finished being
+  established, which happens concurrently, so a large materialization could
+  reference a table that did not exist yet. Materializations using the
+  `allow_existing_tables_for_new_bindings` or `retain_existing_data_on_backfill`
+  feature flags were the most exposed, because those flags load every binding
+  rather than skipping bindings known to be empty.
 - Fixed a permanent restart loop with the error `refusing to load <table>: load
   table contains N keys but M were inserted` on ClickHouse Cloud. Truncating a
   replicated table — which on Cloud is every table, since `MergeTree` is

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -498,6 +498,12 @@ const (
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) (err error) {
 	var ctx = it.Context()
 
+	// Staging keys writes to the persistent load tables, which Acknowledge
+	// establishes via ensureTempTables. RunTransactions runs Acknowledge and
+	// Load in concurrent goroutines, so those tables are only guaranteed to
+	// exist once the acknowledgement has completed.
+	it.WaitForAcknowledged()
+
 	// activeBindings tracks the number of keys inserted into each binding's
 	// load table this round, for verification against an authoritative count
 	// before the join.


### PR DESCRIPTION
**Regression?**

Latent, not bisected to a PR: staging tables are created in `Acknowledge`, `Load` writes to them, and `RunTransactions` runs the two phases concurrently.

**Description:**

`transactor.Load` staged keys without first calling `it.WaitForAcknowledged()`, so staging raced staging-table creation:

```
transactor.Load: preparing load batch for <table>: code: 60,
message: Table <db>.flow_temp_load_0_<table> does not exist
```

One-line fix: wait before staging anything. `materialize-dynamodb`, `-bigtable`, `-elasticsearch`, `-mongodb` and `-google-sheets` already do this.

Exposure scales with binding count, and `allow_existing_tables_for_new_bindings` / `retain_existing_data_on_backfill` widen it — both set `DisableLoadOptimization`, so every binding is loaded. Observed as a crash-loop at ~214 bindings.

**Workflow steps:**

No user-facing change.

**Documentation links affected:**

None.

**Notes for reviewers:**

- `code: 60` is treated as transient and retried ~13s, so small materializations finish `ensureTempTables` inside that budget and survive the race silently. Hundreds of bindings don't.
- `Load` no longer overlaps `Acknowledge`, which here does the partition moves. Throughput-preserving alternative: create only the *load* tables at session setup. Happy to switch.
- No automated test — it needs either test-only API in `go/materialize` or ~100 lines of `Request_Open` scaffolding. A throwaway version reproduced the error above verbatim.

**Checklist:**

- [x] `CHANGELOG.md` updated; no documentation change warranted.
