### PR TITLE
source-asana: update `portfolios` stream's schema

### DIFF
--- a/source-asana/CHANGELOG.md
+++ b/source-asana/CHANGELOG.md
@@ -5,4 +5,4 @@
 ### Fixed
 - `portfolios` documents with members or project templates no longer fail collection schema
   validation — `members` and `project_templates` are now correctly declared as arrays.
-
+- `portfolios` `due_on` and `start_on` are now declared as dates rather than date-times.

--- a/source-asana/CHANGELOG.md
+++ b/source-asana/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-07-29
+
+### Fixed
+- `portfolios` documents with members or project templates no longer fail collection schema
+  validation — `members` and `project_templates` are now correctly declared as arrays.
+

--- a/source-asana/source_asana/schemas/portfolios.json
+++ b/source-asana/source_asana/schemas/portfolios.json
@@ -26,11 +26,14 @@
     },
     "due_on": { "type": ["null", "string"], "format": "date-time" },
     "members": {
-      "type": ["null", "object"],
-      "properties": {
-        "gid": { "type": ["null", "string"] },
-        "resource_type": { "type": ["null", "string"] },
-        "name": { "type": ["null", "string"] }
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "gid": { "type": ["null", "string"] },
+          "resource_type": { "type": ["null", "string"] },
+          "name": { "type": ["null", "string"] }
+        }
       }
     },
     "owner": {
@@ -53,11 +56,14 @@
     "permalink_url": { "type": ["null", "string"] },
     "public": { "type": ["null", "boolean"] },
     "project_templates": {
-      "type": ["null", "object"],
-      "properties": {
-        "gid": { "type": ["null", "string"] },
-        "resource_type": { "type": ["null", "string"] },
-        "name": { "type": ["null", "string"] }
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "gid": { "type": ["null", "string"] },
+          "resource_type": { "type": ["null", "string"] },
+          "name": { "type": ["null", "string"] }
+        }
       }
     }
   }

--- a/source-asana/source_asana/schemas/portfolios.json
+++ b/source-asana/source_asana/schemas/portfolios.json
@@ -24,7 +24,7 @@
         "resource_subtype": { "type": ["null", "string"] }
       }
     },
-    "due_on": { "type": ["null", "string"], "format": "date-time" },
+    "due_on": { "type": ["null", "string"], "format": "date" },
     "members": {
       "type": ["null", "array"],
       "items": {
@@ -44,7 +44,7 @@
         "name": { "type": ["null", "string"] }
       }
     },
-    "start_on": { "type": ["null", "string"], "format": "date-time" },
+    "start_on": { "type": ["null", "string"], "format": "date" },
     "workspace": {
       "type": ["null", "object"],
       "properties": {

--- a/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -905,26 +905,32 @@
         "members": {
           "type": [
             "null",
-            "object"
+            "array"
           ],
-          "properties": {
-            "gid": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "resource_type": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "name": {
-              "type": [
-                "null",
-                "string"
-              ]
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "gid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "resource_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           }
         },

--- a/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-asana/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -900,7 +900,7 @@
             "null",
             "string"
           ],
-          "format": "date-time"
+          "format": "date"
         },
         "members": {
           "type": [
@@ -965,7 +965,7 @@
             "null",
             "string"
           ],
-          "format": "date-time"
+          "format": "date"
         },
         "workspace": {
           "type": [
@@ -1008,26 +1008,32 @@
         "project_templates": {
           "type": [
             "null",
-            "object"
+            "array"
           ],
-          "properties": {
-            "gid": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "resource_type": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "name": {
-              "type": [
-                "null",
-                "string"
-              ]
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "gid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "resource_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
             }
           }
         },


### PR DESCRIPTION
**Regression?**

No.

**Description:**

After unblocking a capture with https://github.com/estuary/connectors/pull/4935, it failed again with JSON schema violations indicating that for the `portfolios` stream:
- the `members` and `project_templates` fields are arrays, not objects.
- the `due_on` and `start_on` fields are formatted as dates, not datetimes.

This PR updates the `portfolios` stream's schema so it aligns with the shape of the documents emitted by the connector.

Discovery snapshot changes are expected due to the changes to the `portfolios` stream's schema file.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
