### PR TITLE
source-mailchimp-native: remove dead EmailActivityEvent.get_cursor (review S1)

### DIFF
--- a/source-mailchimp-native/source_mailchimp_native/models.py
+++ b/source-mailchimp-native/source_mailchimp_native/models.py
@@ -585,6 +585,3 @@ class EmailActivityEvent(RawEmailActivityEvent, MailchimpChildEntity):
         alias="_meta", description="Document metadata"
     )
     # fmt: on
-
-    def get_cursor(self) -> AwareDatetime:
-        return self.timestamp


### PR DESCRIPTION
Stacked on #4895 — addresses suggestion S1 from the comprehensive PR review.

`EmailActivityEvent.get_cursor` was never called: the only `get_cursor()` call sites are in `fetch_list_children` (`api/shared.py:456-457`), whose type bound is `MailchimpIncrementalChildEntity` — a hierarchy `EmailActivityEvent` deliberately doesn't join (no `before`-style upper-bound param on the email-activity endpoint, per its class docstring). `fetch_email_activity` reads `event.timestamp` directly.

Keeping the method mimicked the incremental-child contract without being bound by it, inviting the false belief that the generic fetchers can consume this type.

No behavior change; no schema/snapshot impact (method, not a field).