### PR TITLE
source-mailchimp-native: floor the campaigns backfill/incremental seam to whole seconds

### DIFF
--- a/source-mailchimp-native/bruno/Campaigns/before boundary probe.yml
+++ b/source-mailchimp-native/bruno/Campaigns/before boundary probe.yml
@@ -1,0 +1,76 @@
+info:
+  name: before boundary probe
+  type: http
+  seq: 5
+
+http:
+  method: GET
+  url: "{{base_url}}/campaigns?count=10&before_create_time=2026-06-10T18:28:42Z&sort_field=create_time&sort_dir=ASC&fields=campaigns.id,campaigns.create_time,total_items"
+  params:
+    - name: count
+      value: "10"
+      type: query
+    - name: before_create_time
+      value: 2026-06-10T18:28:42Z
+      type: query
+    - name: sort_field
+      value: create_time
+      type: query
+    - name: sort_dir
+      value: ASC
+      type: query
+    - name: fields
+      value: campaigns.id,campaigns.create_time,total_items
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+examples:
+  - name: 200 - threshold campaign returned, before is INCLUSIVE
+    request:
+      url: "{{base_url}}/campaigns?count=10&before_create_time=2026-06-10T18:28:42Z&sort_field=create_time&sort_dir=ASC&fields=campaigns.id,campaigns.create_time,total_items"
+      method: GET
+    response:
+      status: 200
+      statusText: OK
+      headers:
+        - name: content-type
+          value: application/json
+      body:
+        type: json
+        data: |-
+          {
+            "campaigns": [
+              {
+                "id": "61cc0c44a6",
+                "create_time": "2026-06-10T18:28:42+00:00"
+              }
+            ],
+            "total_items": 1
+          }
+
+docs: |-
+  **REFERENCE:** [List campaigns](https://mailchimp.com/developer/marketing/api/campaigns/list-campaigns/)
+
+  **WHY:** boundary-semantics probe, mirror of `Members / before boundary probe`
+  for the campaigns family: the threshold equals campaign `61cc0c44a6`'s
+  `create_time` EXACTLY (2026-06-10T18:28:42, the account's oldest — see
+  `Campaigns / since_create_time`). That campaign returned means
+  `before_create_time` is INCLUSIVE of the exact timestamp; excluded means
+  exclusive. Every other campaign is later, so it must be absent either way —
+  its absence doubles as proof the filter is applied, not ignored. The seam
+  between `backfill_campaigns` and the first incremental poll depends on this:
+  inclusive means the backfill's `before_create_time = cutoff − 1s` covers the
+  `cutoff − 1s` second the incremental cursor seeds at. The docs don't state
+  the semantics either way.
+
+  **VERIFIED (2026-07-29):** `before_create_time` is INCLUSIVE of the exact
+  timestamp — `61cc0c44a6` (== threshold) returned, `total_items: 1`, both
+  later campaigns excluded. Same asymmetry as the members/segments family:
+  `before_*` inclusive, `since_*` exclusive (exclusivity pinned there, only
+  narrowing pinned here — `Campaigns / since_create_time`).

--- a/source-mailchimp-native/source_mailchimp_native/api/shared.py
+++ b/source-mailchimp-native/source_mailchimp_native/api/shared.py
@@ -367,14 +367,37 @@ async def backfill_campaigns(
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[Campaign | PageCursor, None]:
+    """Backfill campaigns over the frozen `(start_date, cutoff − 1s]` window,
+    checkpointing a plain int offset per full page.
+
+                        start_date            cutoff − 1s cutoff
+    ────────────────────────┼─────────────────────┼───────┼──▶ time (1s ticks)
+                            │                     │       │
+    since_create_time ──────(═════════════════════╪═══════╪══▶
+    before_create_time ═════╪═════════════════════]       │
+    window ─────────────────(═════════════════════]       │
+                            │                     │       └─ covered by the
+                            │                     │          FIRST incremental
+                            │                     │          poll: its cursor
+                            │                     │          seeds at cutoff − 1s
+                            │                     └─ last backfilled second
+                            └─ start-of-window precision is not load-bearing;
+                               campaigns' since_* boundary inclusivity is
+                               unverified (only narrowing is pinned)
+
+    `before_create_time` is inclusive of the exact timestamp
+    (`Campaigns / before boundary probe`), matching the members/segments
+    family, so `cutoff − 1s` covers exactly the seconds the incremental
+    rail skips.
+    """
     assert page is None or isinstance(page, int)
     assert isinstance(cutoff, datetime)
 
     offset = page or 0
-    # ASC sort under a frozen [start_date, cutoff) query keeps offsets stable
-    # across restarts: new campaigns fall outside before_create_time.
+    # New campaigns fall outside before_create_time, so inserts never shift
+    # offsets across restarts.
     params = _campaign_params(offset, start_date)
-    params["before_create_time"] = cutoff.isoformat()
+    params["before_create_time"] = (cutoff - timedelta(seconds=1)).isoformat()
 
     count = 0
     page_gen = fetch_collection_page(

--- a/source-mailchimp-native/source_mailchimp_native/resources.py
+++ b/source-mailchimp-native/source_mailchimp_native/resources.py
@@ -135,7 +135,7 @@ def campaigns(
     http: HTTPMixin, base_url: str, config: EndpointConfig
 ) -> MailchimpResource:
     """Return Resource for incremental + backfill campaigns capture."""
-    cutoff = datetime.now(tz=UTC)
+    cutoff = datetime.now(tz=UTC).replace(microsecond=0)
 
     def open(
         binding: CaptureBinding[ResourceConfigWithSchedule],
@@ -161,7 +161,10 @@ def campaigns(
         model=Campaign,
         open=open,
         initial_state=ResourceState(
-            inc=ResourceState.Incremental(cursor=cutoff),
+            # cutoff − 1s: the first incremental poll then emits from
+            # `cutoff` onward, exactly one second after backfill's last
+            # covered second (`cutoff − 1s`) — no gap, no overlap.
+            inc=ResourceState.Incremental(cursor=cutoff - timedelta(seconds=1)),
             backfill=ResourceState.Backfill(cutoff=cutoff, next_page=None),
         ),
         initial_config=ResourceConfigWithSchedule(


### PR DESCRIPTION
Stacks onto #4895 — fixes review finding **I1** (`FETCH-SEAM-PRECISION`).

## Problem

`campaigns()` computed `cutoff = datetime.now(tz=UTC)` with microseconds retained, then used it verbatim for both rails: the incremental cursor seeded at `cutoff` and the backfill got `before_create_time = cutoff`. With `create_time` at second resolution, a campaign created later within the cutoff second (e.g. cutoff `12:00:05.400`, campaign at `12:00:05.700` → `create_time = 12:00:05`) is suppressed by the incremental filter (`12:00:05 <= 12:00:05.400`) and only raced-for by the backfill. Both sibling streams (`email_activity`, list children) already floor and apply the `− 1s` convention; campaigns did neither.

## Fix

- Floor `cutoff` to a whole second; seed the incremental cursor at `cutoff − 1s`; end the backfill window at `cutoff − 1s` (inclusive) — the first incremental poll's first emitted second is then exactly `cutoff`: no gap, no overlap.
- The seam's gaplessness depends on `before_create_time`'s inclusivity, which was never probed for campaigns (only members/segments were pinned). Added `Campaigns / before boundary probe` and ran it live: **INCLUSIVE** of the exact timestamp (threshold campaign `61cc0c44a6` returned, later campaigns excluded — filter demonstrably applied).
- Added the `DOC-RAIL-TIMELINE` docstring to `backfill_campaigns` (previously undocumented) and corrected the inline offset-stability comment's wrong bracket notation.

Deliberately **not** touched: `fetch_campaigns` (missing horizon — review finding C2, handled separately) and the offset-resume mechanism (C1, handled separately).

## Verification

- Bruno probe run live (saved example + dated VERIFIED marker in the collection).
- `pytest tests/` — 3/3 snapshot tests pass, no snapshot changes (the fix alters state seeding, not emitted documents).
- ruff clean; basedpyright reports only pre-existing env-artifact errors (unresolved imports), none on changed lines.