### PR TITLE
source-mailchimp-native: raise ValidationError for malformed API keys

### DIFF
--- a/source-mailchimp-native/source_mailchimp_native/api/shared.py
+++ b/source-mailchimp-native/source_mailchimp_native/api/shared.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from logging import Logger
 
 from estuary_cdk.capture.common import LogCursor, PageCursor
+from estuary_cdk.flow import ValidationError
 from estuary_cdk.http import HTTPSession
 from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 from pydantic import BaseModel
@@ -46,11 +47,11 @@ async def resolve_base_url(
     if isinstance(credentials, ApiKey):
         _, sep, dc = credentials.password.rpartition("-")
         if not sep or not dc:
-            raise ValueError(
-                (
+            raise ValidationError(
+                [
                     "Mailchimp API key is missing its data center suffix "
                     "(expected a key ending in e.g. -us21)."
-                )
+                ]
             )
         return API.format(dc=dc)
 

--- a/source-mailchimp-native/source_mailchimp_native/resources.py
+++ b/source-mailchimp-native/source_mailchimp_native/resources.py
@@ -70,8 +70,6 @@ async def validate_credentials(log: Logger, http: HTTPMixin, config: EndpointCon
     try:
         base_url = await resolve_base_url(log, http, config.credentials)
         _ = await http.request(log, f"{base_url}/ping")
-    except ValueError as err:
-        raise ValidationError([str(err)])
     except HTTPError as err:
         if err.code == 401:
             msg = (


### PR DESCRIPTION
Fixes finding I3 from the PR #4895 review.

`resolve_base_url` raised a bare `ValueError` when an API key was missing its data-center suffix (e.g. `-us21`). `validate_credentials` translated it into a `ValidationError`, but `discover` and `open` call `resolve_base_url` directly — a user who pasted a key without its suffix got a raw Python traceback from those paths instead of the actionable message.

Per the house rule ("raise `ValidationError` for config problems" at the point of detection), `resolve_base_url` now raises `ValidationError` directly, and the redundant `except ValueError` translation in `validate_credentials` is dropped. `ValidationError` is caught and pretty-printed without a traceback by the CDK on every entry path.

## Verification

- Unit: `resolve_base_url` with a suffix-less key raises `ValidationError` with the message; a well-formed key still resolves `https://us21.api.mailchimp.com/3.0` without HTTP.
- End-to-end: `flowctl raw discover` with a malformed key now prints `Error: Mailchimp API key is missing its data center suffix (expected a key ending in e.g. -us21).` and no traceback.
- Snapshot suite: spec/discover/capture pass unchanged (capture showed a pre-existing, change-independent flake — missing `segment_members` emission / arrival-order sensitivity — consistent with the test-coverage review findings).

Base branch is `nlazo/source-mailchimp-native` so this folds into #4895.