### PR TITLE
source-mailchimp-native: cap the campaigns window at the last elapsed second

### DIFF
--- a/source-mailchimp-native/bruno/Campaigns/before boundary probe.yml
+++ b/source-mailchimp-native/bruno/Campaigns/before boundary probe.yml
@@ -1,0 +1,87 @@
+info:
+  name: before boundary probe
+  type: http
+  seq: 5
+
+http:
+  method: GET
+  url: "{{base_url}}/campaigns?count=10&before_create_time=2026-06-10T18:28:42Z&sort_field=create_time&sort_dir=ASC&fields=campaigns.id,campaigns.create_time,total_items"
+  params:
+    - name: count
+      value: "10"
+      type: query
+    - name: before_create_time
+      value: 2026-06-10T18:28:42Z
+      type: query
+    - name: sort_field
+      value: create_time
+      type: query
+    - name: sort_dir
+      value: ASC
+      type: query
+    - name: fields
+      value: campaigns.id,campaigns.create_time,total_items
+      type: query
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+examples:
+  - name: 200 - narrowed 5 to 1, before is INCLUSIVE of the exact timestamp
+    request:
+      url: "{{base_url}}/campaigns?count=10&before_create_time=2026-06-10T18:28:42Z&sort_field=create_time&sort_dir=ASC&fields=campaigns.id,campaigns.create_time,total_items"
+      method: GET
+    response:
+      status: 200
+      statusText: OK
+      headers:
+        - name: content-type
+          value: application/json
+      body:
+        type: json
+        data: |-
+          {
+            "campaigns": [
+              { "id": "61cc0c44a6", "create_time": "2026-06-10T18:28:42+00:00" }
+            ],
+            "total_items": 1
+          }
+
+docs: |-
+  **REFERENCE:** [List campaigns](https://mailchimp.com/developer/marketing/api/campaigns/list-campaigns/)
+
+  **WHY:** boundary-semantics probe, mirror of `Members / before boundary probe`
+  for the campaigns family: the threshold equals campaign `61cc0c44a6`'s
+  `create_time` EXACTLY (2026-06-10T18:28:42, the account's oldest — see
+  `Campaigns / since_create_time`). That campaign returned means
+  `before_create_time` is INCLUSIVE of the exact timestamp; excluded means
+  exclusive. Every other campaign is later, so it must be absent either way —
+  its absence doubles as proof the filter is applied, not ignored. Two things
+  depend on this:
+
+  - `fetch_campaigns` caps its window at `before_create_time = horizon` (the
+    last fully-elapsed second) so the cursor can never land inside an
+    in-progress second and suppress a same-second campaign. That only holds if
+    the filter is applied server-side at all.
+  - The seam between `backfill_campaigns` and the first incremental poll:
+    inclusive means the backfill's `before_create_time = cutoff − 1s` covers the
+    `cutoff − 1s` second the incremental cursor seeds at.
+
+  The docs don't state the semantics either way.
+
+  **VERIFIED (2026-07-29):** `before_create_time` is applied server-side and is
+  INCLUSIVE of the exact timestamp. The account holds 5 campaigns at probe time
+  (`61cc0c44a6` 06-10 18:28:42, `524c905696` 06-10 18:40:54, `cff6ca453b` 06-11,
+  `5dfc22e163` 07-08, `3f69f3a595` 07-13 — re-run `Campaigns / since_create_time`
+  for the current set); the threshold narrowed **5 → 1**, returning exactly the
+  campaign whose `create_time` equals it. So the filter is honored rather than
+  ignored, and the horizon second `fetch_campaigns` queries is included in the
+  window rather than deferred. Matches `before_last_changed` on members and
+  segments (`Members / before boundary probe`), and asymmetric with `since_*`,
+  which is exclusive there — `/campaigns` has no exact-boundary `since_*` probe,
+  which is why `fetch_campaigns` still suppresses at-or-before-cursor docs
+  client-side.

--- a/source-mailchimp-native/source_mailchimp_native/api/shared.py
+++ b/source-mailchimp-native/source_mailchimp_native/api/shared.py
@@ -321,7 +321,39 @@ async def fetch_campaigns(
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[Campaign | LogCursor, None]:
+    """Incrementally fetch campaigns created after the cursor, up to the last
+    fully-elapsed second.
+
+    `create_time` is the only time filter `/campaigns` exposes, so a campaign is
+    seen once, at creation; later mutations (status transitions, report stats)
+    are recovered by the daily scheduled backfill.
+
+                      cursor  cursor + 1s  horizon = last elapsed second
+    ─────────────────────┼─────────┼──────────┼────▶ time (1s ticks)
+                         │         │          │
+    since_create_time ───(═════════╪══════════╪═══▶
+    before_create_time ══╪═════════╪══════════]
+    emitted ─────────────┼─────────[══════════]
+                         │         │          └─ the present second is still
+                         │         │             in progress; its campaigns
+                         │         │             wait for the next poll
+                         │         └─ first emitted second
+                         └─ at-or-before-cursor docs are dropped client-side
+
+    `before_create_time` is inclusive, so the horizon second is emitted by this
+    poll rather than the next (`Campaigns / before boundary probe`).
+    `since_create_time` has no exact-boundary probe on `/campaigns`, which is
+    why the client-side drop at the cursor stays: it makes that inclusivity
+    irrelevant.
+    """
     assert isinstance(log_cursor, datetime)
+
+    # The last fully-elapsed second. Capping here keeps the cursor out of a
+    # half-elapsed second, which would permanently suppress a campaign created
+    # later in that same second — the drop below would skip it on every poll.
+    horizon = datetime.now(tz=UTC).replace(microsecond=0) - timedelta(seconds=1)
+    if horizon <= log_cursor:
+        return
 
     last_seen = log_cursor
     offset = 0
@@ -329,13 +361,15 @@ async def fetch_campaigns(
 
     while True:
         count = 0
+        params = _campaign_params(offset, log_cursor)
+        params["before_create_time"] = horizon.isoformat()
         page = fetch_collection_page(
             http,
             base_url,
             Campaign.PATH,
             Campaign.ITEMS_KEY,
             Campaign,
-            _campaign_params(offset, log_cursor),
+            params,
             log,
         )
 


### PR DESCRIPTION
Fixes review finding **C2** on #4895 (`FETCH-COMPLETE-TICKS`, data-loss-class). Stacked on `nlazo/source-mailchimp-native`.

## The bug

`fetch_campaigns` was the only incremental stream without a complete-tick horizon — its two siblings (`fetch_list_children`, `fetch_email_activity`) both floor to the last fully-elapsed second and early-return. It queried `since_create_time = cursor` with no upper bound, so:

1. Two campaigns are created in the same second *S*.
2. A poll lands between them, sees the first, and advances the cursor to *S* (`create_time` is second-resolution — e.g. `2026-06-10T18:28:42+00:00`).
3. The second campaign is then dropped on every subsequent poll by the at-or-before-cursor filter.

Only the daily scheduled backfill recovers it — and per C1 that backfill has its own skip hazard, so the two findings compound.

## The fix

Add the horizon plus its early return, and pass it as `before_create_time`, mirroring `fetch_list_children`. The cursor can then never land inside an in-progress second.

## Evidence

The fix leans on `before_create_time` actually being honored on `/campaigns` — a filter can be accepted yet ignored, which is exactly what `Campaigns / since_create_time` was written to rule out for the lower bound. So I probed it:

| | result |
|---|---|
| baseline (`since_create_time=2026-06-01`) | 5 campaigns |
| `before_create_time=2026-06-10T18:28:42Z` (== oldest campaign's `create_time`) | **1** campaign — the one on the threshold |

So the filter is applied server-side (5 → 1, not ignored) and is **inclusive** of the exact timestamp, matching `before_last_changed` on members and segments. The horizon second is therefore emitted by the poll that queries it rather than deferred.

The probe request itself was drafted on the sibling I1 branch (`fix-i1-campaigns-seam`) and was marked `**PENDING:** not yet run`. Since my fix depends on its answer, it ships here with the live result recorded. **Expect a trivial add/add conflict on that one file if the I1 branch lands separately — keep this version, it carries the `VERIFIED` block.**

`since_create_time`'s inclusivity still has no exact-boundary probe on `/campaigns`, so the client-side at-or-before-cursor drop stays; that's what makes the lower bound's semantics irrelevant. Noted as such in the docstring.

## Checks

- `pytest tests/` — 3 passed (capture / discover / spec), no snapshot drift.
- `ruff check` + `ruff format --check` clean; `basedpyright` error count unchanged from baseline (pre-existing, from the untyped CDK).
- Sibling sweep: all three incremental streams now compute a horizon. The remaining `fetch_*` are helpers (`fetch_collection_page`, `fetch_parent_ids`) and the `snapshot_*` streams carry no cursor, so C2 was the only site.

No `CHANGELOG.md` entry: the connector is unreleased, so the existing "Initial release" entry covers it — there's no shipped behavior for a user to read a fix against.