### PR TITLE
source-mailchimp-native: never checkpoint a backfill offset

### DIFF
--- a/source-mailchimp-native/source_mailchimp_native/api/shared.py
+++ b/source-mailchimp-native/source_mailchimp_native/api/shared.py
@@ -367,34 +367,24 @@ async def backfill_campaigns(
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[Campaign | PageCursor, None]:
-    """Backfill campaigns over the frozen `[start_date, cutoff)` window,
-    walked in `create_time ASC` order and checkpointing the max `create_time`
-    seen after each full page.
+    """Backfill campaigns over the frozen `[start_date, cutoff)` window in a
+    single invocation, checkpointing nothing.
 
-    Resume is by value, never by stored offset: `create_time` is immutable,
-    but a campaign deleted mid-backfill still renumbers every later position,
-    so a resumed offset would skip an untouched neighbor — lost until the
-    daily scheduled backfill. A resume instead re-anchors `since_create_time`
-    at `watermark − 1s`; re-reading the boundary second costs only duplicates
-    the collection key collapses, and makes the (unprobed) inclusivity of
-    `since_create_time` irrelevant. Page offsets stay local to a single
-    invocation, anchored to that invocation's `since` value.
+    `create_time` is immutable, but a campaign deleted mid-backfill still
+    renumbers every later position, so an offset must never cross a
+    checkpoint: resuming from one would skip an untouched neighbor. Offsets
+    stay local to this invocation and an interrupted backfill restarts its
+    window — a re-read costs only duplicates the collection key collapses,
+    while a skipped row is lost until the daily scheduled backfill.
     """
-    assert page is None or isinstance(page, str)
+    assert page is None
     assert isinstance(cutoff, datetime)
 
-    since = (
-        datetime.fromisoformat(page) - timedelta(seconds=1)
-        if page is not None
-        else start_date
-    )
-
     offset = 0
-    watermark: datetime | None = None
 
     while True:
         count = 0
-        params = _campaign_params(offset, since)
+        params = _campaign_params(offset, start_date)
         params["before_create_time"] = cutoff.isoformat()
 
         page_gen = fetch_collection_page(
@@ -404,16 +394,11 @@ async def backfill_campaigns(
         async for item in page_gen:
             yield item
             count += 1
-            if watermark is None or item.create_time > watermark:
-                watermark = item.create_time
 
         offset += count
         # A full page means there may be more; a short page is the last one.
         if count < MAX_PAGE_SIZE:
             return
-
-        if watermark is not None:
-            yield watermark.isoformat()
 
 
 async def fetch_list_children[T: MailchimpIncrementalChildEntity](
@@ -496,14 +481,14 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
     model: type[T],
     list_id: ParentId,
     extra_request_params: dict[str, str | int],
-    watermark_resume: bool,
     start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[T | PageCursor, None]:
     """Backfill one (list, sweep) subtask of a list-child stream over the
-    frozen `(start_date, cutoff − 1s]` window.
+    frozen `(start_date, cutoff − 1s]` window in a single invocation,
+    checkpointing nothing.
 
               start_date            cutoff − 1s cutoff
     ──────────────┼─────────────────────┼───────┼──▶ time (1s ticks)
@@ -525,30 +510,16 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
     update stamps a cursor past the cutoff, which renumbers every later row,
     so a positional offset must never cross a checkpoint — a resumed offset
     would skip an untouched row that neither this backfill nor the incremental
-    task (seeded at `cutoff − 1s`) ever revisits.
-
-    With `watermark_resume` (list_members — requires a server-side ASC sort on
-    the model's cursor field in `extra_request_params`), each full page
-    checkpoints the max cursor seen; a resume re-anchors `SINCE_PARAM` at
-    `watermark − 1s`, re-reading the boundary second so same-second ties
-    behind a crash are never skipped — duplicates collapse under the
-    collection key. Without it (segments — the endpoint documents no sort, so
-    no order survives a resume gap), nothing is checkpointed and a resumed
-    backfill restarts the window from scratch. Page offsets stay local to a
-    single invocation either way.
+    task (seeded at `cutoff − 1s`) ever revisits. Offsets therefore stay local
+    to this invocation and an interrupted backfill restarts its window: a
+    re-read costs only duplicates the collection key collapses, while a
+    skipped row is lost for good.
     """
-    assert page is None or isinstance(page, str)
+    assert page is None
     assert isinstance(cutoff, datetime)
-
-    since = (
-        datetime.fromisoformat(page) - timedelta(seconds=1)
-        if page is not None
-        else start_date
-    )
 
     path = model.PATH_TEMPLATE.format(list_id=list_id)
     offset = 0
-    watermark: datetime | None = None
 
     while True:
         count = 0
@@ -561,7 +532,7 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
             {
                 "count": MAX_PAGE_SIZE,
                 "offset": offset,
-                model.SINCE_PARAM: since.isoformat(),
+                model.SINCE_PARAM: start_date.isoformat(),
                 model.BEFORE_PARAM: (cutoff - timedelta(seconds=1)).isoformat(),
                 **extra_request_params,
             },
@@ -571,14 +542,8 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
         async for item in page_gen:
             yield item
             count += 1
-            cursor = item.get_cursor()
-            if watermark is None or cursor > watermark:
-                watermark = cursor
 
         offset += count
         # A full page means there may be more; a short page is the last one.
         if count < MAX_PAGE_SIZE:
             return
-
-        if watermark_resume and watermark is not None:
-            yield watermark.isoformat()

--- a/source-mailchimp-native/source_mailchimp_native/api/shared.py
+++ b/source-mailchimp-native/source_mailchimp_native/api/shared.py
@@ -367,27 +367,53 @@ async def backfill_campaigns(
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[Campaign | PageCursor, None]:
-    assert page is None or isinstance(page, int)
+    """Backfill campaigns over the frozen `[start_date, cutoff)` window,
+    walked in `create_time ASC` order and checkpointing the max `create_time`
+    seen after each full page.
+
+    Resume is by value, never by stored offset: `create_time` is immutable,
+    but a campaign deleted mid-backfill still renumbers every later position,
+    so a resumed offset would skip an untouched neighbor — lost until the
+    daily scheduled backfill. A resume instead re-anchors `since_create_time`
+    at `watermark − 1s`; re-reading the boundary second costs only duplicates
+    the collection key collapses, and makes the (unprobed) inclusivity of
+    `since_create_time` irrelevant. Page offsets stay local to a single
+    invocation, anchored to that invocation's `since` value.
+    """
+    assert page is None or isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    offset = page or 0
-    # ASC sort under a frozen [start_date, cutoff) query keeps offsets stable
-    # across restarts: new campaigns fall outside before_create_time.
-    params = _campaign_params(offset, start_date)
-    params["before_create_time"] = cutoff.isoformat()
-
-    count = 0
-    page_gen = fetch_collection_page(
-        http, base_url, Campaign.PATH, Campaign.ITEMS_KEY, Campaign, params, log
+    since = (
+        datetime.fromisoformat(page) - timedelta(seconds=1)
+        if page is not None
+        else start_date
     )
 
-    async for item in page_gen:
-        yield item
-        count += 1
+    offset = 0
+    watermark: datetime | None = None
 
-    # A full page means there may be more; a short page is the last one.
-    if count == MAX_PAGE_SIZE:
-        yield offset + count
+    while True:
+        count = 0
+        params = _campaign_params(offset, since)
+        params["before_create_time"] = cutoff.isoformat()
+
+        page_gen = fetch_collection_page(
+            http, base_url, Campaign.PATH, Campaign.ITEMS_KEY, Campaign, params, log
+        )
+
+        async for item in page_gen:
+            yield item
+            count += 1
+            if watermark is None or item.create_time > watermark:
+                watermark = item.create_time
+
+        offset += count
+        # A full page means there may be more; a short page is the last one.
+        if count < MAX_PAGE_SIZE:
+            return
+
+        if watermark is not None:
+            yield watermark.isoformat()
 
 
 async def fetch_list_children[T: MailchimpIncrementalChildEntity](
@@ -470,15 +496,14 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
     model: type[T],
     list_id: ParentId,
     extra_request_params: dict[str, str | int],
+    watermark_resume: bool,
     start_date: datetime,
     log: Logger,
     page: PageCursor,
     cutoff: LogCursor,
 ) -> AsyncGenerator[T | PageCursor, None]:
     """Backfill one (list, sweep) subtask of a list-child stream over the
-    frozen `(start_date, cutoff − 1s]` window, checkpointing a plain int
-    offset per full page like `backfill_campaigns`. The window is frozen,
-    so nothing new ever enters it.
+    frozen `(start_date, cutoff − 1s]` window.
 
               start_date            cutoff − 1s cutoff
     ──────────────┼─────────────────────┼───────┼──▶ time (1s ticks)
@@ -495,34 +520,65 @@ async def backfill_list_children[T: MailchimpIncrementalChildEntity](
                   └─ docs stamped exactly at start_date are skipped
                      (since_* is exclusive) — start-of-window precision
                      is not load-bearing, unlike the cutoff seam
+
+    Nothing new enters the frozen window, but rows *leave* it mid-walk: an
+    update stamps a cursor past the cutoff, which renumbers every later row,
+    so a positional offset must never cross a checkpoint — a resumed offset
+    would skip an untouched row that neither this backfill nor the incremental
+    task (seeded at `cutoff − 1s`) ever revisits.
+
+    With `watermark_resume` (list_members — requires a server-side ASC sort on
+    the model's cursor field in `extra_request_params`), each full page
+    checkpoints the max cursor seen; a resume re-anchors `SINCE_PARAM` at
+    `watermark − 1s`, re-reading the boundary second so same-second ties
+    behind a crash are never skipped — duplicates collapse under the
+    collection key. Without it (segments — the endpoint documents no sort, so
+    no order survives a resume gap), nothing is checkpointed and a resumed
+    backfill restarts the window from scratch. Page offsets stay local to a
+    single invocation either way.
     """
-    assert page is None or isinstance(page, int)
+    assert page is None or isinstance(page, str)
     assert isinstance(cutoff, datetime)
 
-    offset = page or 0
-    params: dict[str, str | int] = {
-        "count": MAX_PAGE_SIZE,
-        "offset": offset,
-        model.SINCE_PARAM: start_date.isoformat(),
-        model.BEFORE_PARAM: (cutoff - timedelta(seconds=1)).isoformat(),
-        **extra_request_params,
-    }
-
-    count = 0
-    page_gen = fetch_collection_page(
-        http,
-        base_url,
-        model.PATH_TEMPLATE.format(list_id=list_id),
-        model.ITEMS_KEY,
-        model,
-        params,
-        log,
+    since = (
+        datetime.fromisoformat(page) - timedelta(seconds=1)
+        if page is not None
+        else start_date
     )
 
-    async for item in page_gen:
-        yield item
-        count += 1
+    path = model.PATH_TEMPLATE.format(list_id=list_id)
+    offset = 0
+    watermark: datetime | None = None
 
-    # A full page means there may be more; a short page is the last one.
-    if count == MAX_PAGE_SIZE:
-        yield offset + count
+    while True:
+        count = 0
+        page_gen = fetch_collection_page(
+            http,
+            base_url,
+            path,
+            model.ITEMS_KEY,
+            model,
+            {
+                "count": MAX_PAGE_SIZE,
+                "offset": offset,
+                model.SINCE_PARAM: since.isoformat(),
+                model.BEFORE_PARAM: (cutoff - timedelta(seconds=1)).isoformat(),
+                **extra_request_params,
+            },
+            log,
+        )
+
+        async for item in page_gen:
+            yield item
+            count += 1
+            cursor = item.get_cursor()
+            if watermark is None or cursor > watermark:
+                watermark = cursor
+
+        offset += count
+        # A full page means there may be more; a short page is the last one.
+        if count < MAX_PAGE_SIZE:
+            return
+
+        if watermark_resume and watermark is not None:
+            yield watermark.isoformat()

--- a/source-mailchimp-native/source_mailchimp_native/resources.py
+++ b/source-mailchimp-native/source_mailchimp_native/resources.py
@@ -260,8 +260,12 @@ async def _patch_missing_subtask_states(
     await task.checkpoint(ConnectorState(bindingStateV1={binding.stateKey: state}))
 
 
-# Sweep params shared by both list_members subtasks: the ASC sort keeps the
-# walked prefix of a long backfill stable when rows change mid-walk.
+# Sweep params shared by both list_members subtasks. The ASC sort makes the
+# walk order deterministic among rows still in the window — it does NOT make
+# positions stable (an update moves a row out of a frozen window entirely,
+# renumbering the tail), which is why backfills resume by value watermark,
+# never by stored offset. It's also what makes the watermark meaningful:
+# `backfill_list_children` requires it for `watermark_resume`.
 _MEMBER_SORT: dict[str, str | int] = {
     "sort_field": "last_changed",
     "sort_dir": "ASC",
@@ -286,7 +290,7 @@ def incremental_list_children(
     (list_members, segments).
 
     Each stream fans out into per-(list, sweep) subtasks, every subtask with
-    its own incremental cursor and integer-offset backfill. list_members needs
+    its own incremental cursor and windowed backfill. list_members needs
     two sweeps per list because the unfiltered listing silently excludes
     archived members — and the sweeps' cursors must be independent: a member
     unarchived between the two sweeps of a shared-cursor walk would be missed
@@ -314,6 +318,7 @@ def incremental_list_children(
     def resource[T: MailchimpIncrementalChildEntity](
         model: type[T],
         subtasks: dict[str, _ListChildSubtask],
+        watermark_resume: bool,
     ) -> MailchimpResource:
         incremental_fetchers = {
             key: functools.partial(
@@ -334,6 +339,7 @@ def incremental_list_children(
                 model,
                 subtask.list_id,
                 subtask.request_params,
+                watermark_resume,
                 config.start_date,
             )
             for key, subtask in subtasks.items()
@@ -384,8 +390,11 @@ def incremental_list_children(
         )
 
     return [
-        resource(ListMember, member_subtasks),
-        resource(Segment, segment_subtasks),
+        # Members ride the probed `last_changed ASC` sort, so their backfills
+        # resume from a value watermark. The segments endpoint documents no
+        # sort, so its backfills carry no resume state and restart instead.
+        resource(ListMember, member_subtasks, watermark_resume=True),
+        resource(Segment, segment_subtasks, watermark_resume=False),
     ]
 
 

--- a/source-mailchimp-native/source_mailchimp_native/resources.py
+++ b/source-mailchimp-native/source_mailchimp_native/resources.py
@@ -263,9 +263,8 @@ async def _patch_missing_subtask_states(
 # Sweep params shared by both list_members subtasks. The ASC sort makes the
 # walk order deterministic among rows still in the window — it does NOT make
 # positions stable (an update moves a row out of a frozen window entirely,
-# renumbering the tail), which is why backfills resume by value watermark,
-# never by stored offset. It's also what makes the watermark meaningful:
-# `backfill_list_children` requires it for `watermark_resume`.
+# renumbering the tail), which is why backfills never checkpoint an offset
+# across invocations.
 _MEMBER_SORT: dict[str, str | int] = {
     "sort_field": "last_changed",
     "sort_dir": "ASC",
@@ -318,7 +317,6 @@ def incremental_list_children(
     def resource[T: MailchimpIncrementalChildEntity](
         model: type[T],
         subtasks: dict[str, _ListChildSubtask],
-        watermark_resume: bool,
     ) -> MailchimpResource:
         incremental_fetchers = {
             key: functools.partial(
@@ -339,7 +337,6 @@ def incremental_list_children(
                 model,
                 subtask.list_id,
                 subtask.request_params,
-                watermark_resume,
                 config.start_date,
             )
             for key, subtask in subtasks.items()
@@ -390,11 +387,8 @@ def incremental_list_children(
         )
 
     return [
-        # Members ride the probed `last_changed ASC` sort, so their backfills
-        # resume from a value watermark. The segments endpoint documents no
-        # sort, so its backfills carry no resume state and restart instead.
-        resource(ListMember, member_subtasks, watermark_resume=True),
-        resource(Segment, segment_subtasks, watermark_resume=False),
+        resource(ListMember, member_subtasks),
+        resource(Segment, segment_subtasks),
     ]
 
 

--- a/source-mailchimp-native/tests/test_backfill_resume.py
+++ b/source-mailchimp-native/tests/test_backfill_resume.py
@@ -1,0 +1,255 @@
+"""Offline tests for backfill resume semantics (no live API).
+
+These pin the value-watermark resume contract of `backfill_list_children` and
+`backfill_campaigns` against a canned Mailchimp emulation: `since_*` filters
+exclusively, `before_*` inclusively, and pages slice a sorted (or, for
+segments, insertion-ordered) row store. The regression case is the one that
+motivated the design: a row leaving the frozen window mid-backfill renumbers
+the tail, so a positional resume would skip an untouched row.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+from source_mailchimp_native.api.shared import (
+    MAX_PAGE_SIZE,
+    backfill_campaigns,
+    backfill_list_children,
+)
+from source_mailchimp_native.models import Campaign, ListMember, Segment
+
+LOG = logging.getLogger("test")
+
+BASE = datetime(2026, 1, 1, tzinfo=UTC)
+START_DATE = BASE - timedelta(days=1)
+CUTOFF = BASE + timedelta(days=1)
+
+
+class FakeMailchimp:
+    """Serves one collection endpoint from an in-memory row store.
+
+    Rows are dicts; `cursor_field` names the timestamp the `since_*`/`before_*`
+    params filter on (exclusive / inclusive respectively, matching the probed
+    boundary semantics). Honors `sort_field`/`sort_dir=ASC` when requested;
+    otherwise serves rows in store order, like the segments endpoint.
+    """
+
+    def __init__(self, items_key: str, cursor_field: str, rows: list[dict]):
+        self.items_key = items_key
+        self.cursor_field = cursor_field
+        self.rows = rows
+        self.requests: list[dict] = []
+
+    async def request_stream(self, log, url, method="GET", params=None, **kwargs):
+        params = dict(params or {})
+        self.requests.append(params)
+
+        rows = self.rows
+        for param, keep in [
+            (f"since_{self.cursor_field}", lambda c, bound: c > bound),
+            (f"before_{self.cursor_field}", lambda c, bound: c <= bound),
+        ]:
+            if param in params:
+                bound = datetime.fromisoformat(str(params[param]))
+                rows = [
+                    r
+                    for r in rows
+                    if keep(datetime.fromisoformat(r[self.cursor_field]), bound)
+                ]
+
+        if params.get("sort_field"):
+            assert params.get("sort_dir") == "ASC"
+            rows = sorted(rows, key=lambda r: r[params["sort_field"]])
+
+        offset, count = int(params["offset"]), int(params["count"])
+        body_bytes = json.dumps(
+            {self.items_key: rows[offset : offset + count], "total_items": len(rows)}
+        ).encode()
+
+        async def body():
+            yield body_bytes
+
+        return ({}, body)
+
+
+def member_row(i: int, last_changed: datetime) -> dict:
+    return {
+        "id": f"m{i:04}",
+        "list_id": "l1",
+        "email_address": f"m{i:04}@example.com",
+        "last_changed": last_changed.isoformat(),
+        "status": "subscribed",
+    }
+
+
+def make_members(n: int) -> list[dict]:
+    return [member_row(i, BASE + timedelta(seconds=i)) for i in range(n)]
+
+
+MEMBER_SORT: dict[str, str | int] = {"sort_field": "last_changed", "sort_dir": "ASC"}
+
+
+def drain_members(server: FakeMailchimp, page, *, stop_after_checkpoints=None):
+    """Run one backfill invocation; return (doc ids, checkpoints yielded).
+
+    `stop_after_checkpoints` closes the generator right after the Nth
+    checkpoint, emulating a crash whose resume starts from that checkpoint.
+    """
+
+    async def run():
+        ids, checkpoints = [], []
+        gen = backfill_list_children(
+            server,  # type: ignore[arg-type]
+            "https://test",
+            ListMember,
+            "l1",
+            MEMBER_SORT,
+            True,
+            START_DATE,
+            LOG,
+            page,
+            CUTOFF,
+        )
+        async for out in gen:
+            if isinstance(out, str):
+                checkpoints.append(out)
+                if stop_after_checkpoints and len(checkpoints) == stop_after_checkpoints:
+                    await gen.aclose()
+                    break
+            else:
+                ids.append(out.id)
+        return ids, checkpoints
+
+    return asyncio.run(run())
+
+
+def test_members_backfill_checkpoints_watermark_not_offset():
+    server = FakeMailchimp("members", "last_changed", make_members(2500))
+    ids, checkpoints = drain_members(server, None)
+
+    assert len(ids) == 2500 and len(set(ids)) == 2500
+    # One watermark per full page, none after the short final page, and each
+    # is the max last_changed of the rows walked so far — never an offset.
+    assert checkpoints == [
+        (BASE + timedelta(seconds=999)).isoformat(),
+        (BASE + timedelta(seconds=1999)).isoformat(),
+    ]
+    # Offsets advance only within the invocation, anchored to one since value.
+    assert [(p["offset"], p["since_last_changed"]) for p in server.requests] == [
+        (i * MAX_PAGE_SIZE, START_DATE.isoformat()) for i in range(3)
+    ]
+
+
+def test_members_resume_reanchors_since_at_watermark_minus_1s():
+    server = FakeMailchimp("members", "last_changed", make_members(2500))
+    watermark = BASE + timedelta(seconds=999)
+
+    ids, _ = drain_members(server, watermark.isoformat())
+
+    # since is exclusive at watermark − 1s, so the boundary second re-reads:
+    # rows 999.. return, duplicates collapsing under the collection key.
+    first = server.requests[0]
+    assert first["offset"] == 0
+    assert first["since_last_changed"] == (watermark - timedelta(seconds=1)).isoformat()
+    assert ids[0] == "m0999" and ids[-1] == "m2499"
+
+
+def test_members_row_leaving_window_mid_backfill_skips_nothing():
+    """The C1 regression: a member updated after a crash's last checkpoint
+    leaves the frozen window and renumbers the tail. A positional resume
+    (the old `offset + count` cursor) would skip the row that slid across
+    the boundary; the watermark resume must re-emit it."""
+    server = FakeMailchimp("members", "last_changed", make_members(2500))
+
+    first_ids, checkpoints = drain_members(server, None, stop_after_checkpoints=1)
+    assert len(first_ids) == 1000
+
+    # Mid-backfill churn inside the already-walked prefix: the update stamps
+    # a cursor past the cutoff, so the row exits the window server-side.
+    server.rows[100]["last_changed"] = (CUTOFF + timedelta(hours=1)).isoformat()
+
+    resumed_ids, _ = drain_members(server, checkpoints[0])
+
+    # Every row appears in one run or the other: the churned row was already
+    # emitted pre-crash (its post-churn version belongs to the incremental
+    # task), and nothing else may go missing.
+    assert set(first_ids) | set(resumed_ids) == {f"m{i:04}" for i in range(2500)}
+    assert "m0100" not in resumed_ids  # left the window server-side
+    # In particular the innocent bystander a stale offset would have skipped:
+    assert "m1000" in resumed_ids
+
+
+def test_segments_backfill_never_checkpoints():
+    rows = [
+        {
+            "id": i,
+            "list_id": "l1",
+            "updated_at": (BASE + timedelta(seconds=i)).isoformat(),
+        }
+        for i in range(1500)
+    ]
+    server = FakeMailchimp("segments", "updated_at", rows)
+
+    async def run():
+        outs = [
+            out
+            async for out in backfill_list_children(
+                server,  # type: ignore[arg-type]
+                "https://test",
+                Segment,
+                "l1",
+                {},
+                False,
+                START_DATE,
+                LOG,
+                None,
+                CUTOFF,
+            )
+        ]
+        return outs
+
+    outs = asyncio.run(run())
+
+    # No sort on the endpoint means no order survives a resume gap, so the
+    # whole window drains in one invocation with zero cross-invocation state.
+    assert not any(isinstance(out, str) for out in outs)
+    assert sorted(out.id for out in outs) == list(range(1500))
+
+
+def test_campaigns_backfill_checkpoints_watermark():
+    rows = [
+        {"id": f"c{i:04}", "create_time": (BASE + timedelta(seconds=i)).isoformat()}
+        for i in range(1500)
+    ]
+    server = FakeMailchimp("campaigns", "create_time", rows)
+
+    async def run(page):
+        ids, checkpoints = [], []
+        async for out in backfill_campaigns(
+            server,  # type: ignore[arg-type]
+            "https://test",
+            START_DATE,
+            LOG,
+            page,
+            CUTOFF,
+        ):
+            (checkpoints if isinstance(out, str) else ids).append(
+                out if isinstance(out, str) else out.id
+            )
+        return ids, checkpoints
+
+    ids, checkpoints = asyncio.run(run(None))
+    assert len(ids) == 1500
+    assert checkpoints == [(BASE + timedelta(seconds=999)).isoformat()]
+
+    # A resume re-anchors since_create_time one second before the watermark.
+    server.requests.clear()
+    resumed_ids, _ = asyncio.run(run(checkpoints[0]))
+    assert server.requests[0]["offset"] == 0
+    assert (
+        server.requests[0]["since_create_time"]
+        == (BASE + timedelta(seconds=998)).isoformat()
+    )
+    assert resumed_ids[0] == "c0999"

--- a/source-mailchimp-native/tests/test_backfill_resume.py
+++ b/source-mailchimp-native/tests/test_backfill_resume.py
@@ -1,11 +1,14 @@
-"""Offline tests for backfill resume semantics (no live API).
+"""Offline tests for backfill checkpoint semantics (no live API).
 
-These pin the value-watermark resume contract of `backfill_list_children` and
-`backfill_campaigns` against a canned Mailchimp emulation: `since_*` filters
-exclusively, `before_*` inclusively, and pages slice a sorted (or, for
-segments, insertion-ordered) row store. The regression case is the one that
-motivated the design: a row leaving the frozen window mid-backfill renumbers
-the tail, so a positional resume would skip an untouched row.
+A backfill window is frozen, but rows *leave* it mid-walk (an update or
+deletion), renumbering every later row — so a positional offset must never
+cross a checkpoint: a resumed offset would skip an untouched row that the
+incremental task never revisits. These tests pin the resulting contract:
+backfills drain their whole window in a single invocation and yield no
+PageCursor at all, keeping offsets local to that invocation.
+
+The canned server emulates the probed boundary semantics: `since_*` filters
+exclusively, `before_*` inclusively.
 """
 
 import asyncio
@@ -18,7 +21,7 @@ from source_mailchimp_native.api.shared import (
     backfill_campaigns,
     backfill_list_children,
 )
-from source_mailchimp_native.models import Campaign, ListMember, Segment
+from source_mailchimp_native.models import ListMember, Segment
 
 LOG = logging.getLogger("test")
 
@@ -30,10 +33,10 @@ CUTOFF = BASE + timedelta(days=1)
 class FakeMailchimp:
     """Serves one collection endpoint from an in-memory row store.
 
-    Rows are dicts; `cursor_field` names the timestamp the `since_*`/`before_*`
-    params filter on (exclusive / inclusive respectively, matching the probed
-    boundary semantics). Honors `sort_field`/`sort_dir=ASC` when requested;
-    otherwise serves rows in store order, like the segments endpoint.
+    `cursor_field` names the timestamp the `since_*`/`before_*` params filter
+    on (exclusive / inclusive respectively, matching the probed boundary
+    semantics). Honors `sort_field`/`sort_dir=ASC` when requested; otherwise
+    serves rows in store order, like the segments endpoint.
     """
 
     def __init__(self, items_key: str, cursor_field: str, rows: list[dict]):
@@ -74,114 +77,54 @@ class FakeMailchimp:
         return ({}, body)
 
 
-def member_row(i: int, last_changed: datetime) -> dict:
-    return {
-        "id": f"m{i:04}",
-        "list_id": "l1",
-        "email_address": f"m{i:04}@example.com",
-        "last_changed": last_changed.isoformat(),
-        "status": "subscribed",
-    }
-
-
-def make_members(n: int) -> list[dict]:
-    return [member_row(i, BASE + timedelta(seconds=i)) for i in range(n)]
-
-
-MEMBER_SORT: dict[str, str | int] = {"sort_field": "last_changed", "sort_dir": "ASC"}
-
-
-def drain_members(server: FakeMailchimp, page, *, stop_after_checkpoints=None):
-    """Run one backfill invocation; return (doc ids, checkpoints yielded).
-
-    `stop_after_checkpoints` closes the generator right after the Nth
-    checkpoint, emulating a crash whose resume starts from that checkpoint.
-    """
+def test_members_backfill_drains_window_and_never_checkpoints():
+    rows = [
+        {
+            "id": f"m{i:04}",
+            "list_id": "l1",
+            "email_address": f"m{i:04}@example.com",
+            "last_changed": (BASE + timedelta(seconds=i)).isoformat(),
+            "status": "subscribed",
+        }
+        for i in range(2500)
+    ]
+    server = FakeMailchimp("members", "last_changed", rows)
 
     async def run():
-        ids, checkpoints = [], []
-        gen = backfill_list_children(
-            server,  # type: ignore[arg-type]
-            "https://test",
-            ListMember,
-            "l1",
-            MEMBER_SORT,
-            True,
-            START_DATE,
-            LOG,
-            page,
-            CUTOFF,
+        return [
+            out
+            async for out in backfill_list_children(
+                server,  # type: ignore[arg-type]
+                "https://test",
+                ListMember,
+                "l1",
+                {"sort_field": "last_changed", "sort_dir": "ASC"},
+                START_DATE,
+                LOG,
+                None,
+                CUTOFF,
+            )
+        ]
+
+    outs = asyncio.run(run())
+
+    assert [out.id for out in outs] == [f"m{i:04}" for i in range(2500)]
+    assert not any(isinstance(out, (str, int, dict)) for out in outs)
+    # Offsets stay local to the single invocation, over one frozen window.
+    assert [
+        (p["offset"], p["since_last_changed"], p["before_last_changed"])
+        for p in server.requests
+    ] == [
+        (
+            i * MAX_PAGE_SIZE,
+            START_DATE.isoformat(),
+            (CUTOFF - timedelta(seconds=1)).isoformat(),
         )
-        async for out in gen:
-            if isinstance(out, str):
-                checkpoints.append(out)
-                if stop_after_checkpoints and len(checkpoints) == stop_after_checkpoints:
-                    await gen.aclose()
-                    break
-            else:
-                ids.append(out.id)
-        return ids, checkpoints
-
-    return asyncio.run(run())
-
-
-def test_members_backfill_checkpoints_watermark_not_offset():
-    server = FakeMailchimp("members", "last_changed", make_members(2500))
-    ids, checkpoints = drain_members(server, None)
-
-    assert len(ids) == 2500 and len(set(ids)) == 2500
-    # One watermark per full page, none after the short final page, and each
-    # is the max last_changed of the rows walked so far — never an offset.
-    assert checkpoints == [
-        (BASE + timedelta(seconds=999)).isoformat(),
-        (BASE + timedelta(seconds=1999)).isoformat(),
-    ]
-    # Offsets advance only within the invocation, anchored to one since value.
-    assert [(p["offset"], p["since_last_changed"]) for p in server.requests] == [
-        (i * MAX_PAGE_SIZE, START_DATE.isoformat()) for i in range(3)
+        for i in range(3)
     ]
 
 
-def test_members_resume_reanchors_since_at_watermark_minus_1s():
-    server = FakeMailchimp("members", "last_changed", make_members(2500))
-    watermark = BASE + timedelta(seconds=999)
-
-    ids, _ = drain_members(server, watermark.isoformat())
-
-    # since is exclusive at watermark − 1s, so the boundary second re-reads:
-    # rows 999.. return, duplicates collapsing under the collection key.
-    first = server.requests[0]
-    assert first["offset"] == 0
-    assert first["since_last_changed"] == (watermark - timedelta(seconds=1)).isoformat()
-    assert ids[0] == "m0999" and ids[-1] == "m2499"
-
-
-def test_members_row_leaving_window_mid_backfill_skips_nothing():
-    """The C1 regression: a member updated after a crash's last checkpoint
-    leaves the frozen window and renumbers the tail. A positional resume
-    (the old `offset + count` cursor) would skip the row that slid across
-    the boundary; the watermark resume must re-emit it."""
-    server = FakeMailchimp("members", "last_changed", make_members(2500))
-
-    first_ids, checkpoints = drain_members(server, None, stop_after_checkpoints=1)
-    assert len(first_ids) == 1000
-
-    # Mid-backfill churn inside the already-walked prefix: the update stamps
-    # a cursor past the cutoff, so the row exits the window server-side.
-    server.rows[100]["last_changed"] = (CUTOFF + timedelta(hours=1)).isoformat()
-
-    resumed_ids, _ = drain_members(server, checkpoints[0])
-
-    # Every row appears in one run or the other: the churned row was already
-    # emitted pre-crash (its post-churn version belongs to the incremental
-    # task), and nothing else may go missing.
-    assert set(first_ids) | set(resumed_ids) == {f"m{i:04}" for i in range(2500)}
-    assert "m0100" not in resumed_ids  # left the window server-side
-    # In particular the innocent bystander a stale offset would have skipped:
-    assert "m1000" in resumed_ids
-
-
-def test_segments_backfill_never_checkpoints():
+def test_segments_backfill_drains_window_and_never_checkpoints():
     rows = [
         {
             "id": i,
@@ -193,7 +136,7 @@ def test_segments_backfill_never_checkpoints():
     server = FakeMailchimp("segments", "updated_at", rows)
 
     async def run():
-        outs = [
+        return [
             out
             async for out in backfill_list_children(
                 server,  # type: ignore[arg-type]
@@ -201,55 +144,41 @@ def test_segments_backfill_never_checkpoints():
                 Segment,
                 "l1",
                 {},
-                False,
                 START_DATE,
                 LOG,
                 None,
                 CUTOFF,
             )
         ]
-        return outs
 
     outs = asyncio.run(run())
 
-    # No sort on the endpoint means no order survives a resume gap, so the
-    # whole window drains in one invocation with zero cross-invocation state.
-    assert not any(isinstance(out, str) for out in outs)
     assert sorted(out.id for out in outs) == list(range(1500))
+    assert not any(isinstance(out, (str, int, dict)) for out in outs)
 
 
-def test_campaigns_backfill_checkpoints_watermark():
+def test_campaigns_backfill_drains_window_and_never_checkpoints():
     rows = [
         {"id": f"c{i:04}", "create_time": (BASE + timedelta(seconds=i)).isoformat()}
         for i in range(1500)
     ]
     server = FakeMailchimp("campaigns", "create_time", rows)
 
-    async def run(page):
-        ids, checkpoints = [], []
-        async for out in backfill_campaigns(
-            server,  # type: ignore[arg-type]
-            "https://test",
-            START_DATE,
-            LOG,
-            page,
-            CUTOFF,
-        ):
-            (checkpoints if isinstance(out, str) else ids).append(
-                out if isinstance(out, str) else out.id
+    async def run():
+        return [
+            out
+            async for out in backfill_campaigns(
+                server,  # type: ignore[arg-type]
+                "https://test",
+                START_DATE,
+                LOG,
+                None,
+                CUTOFF,
             )
-        return ids, checkpoints
+        ]
 
-    ids, checkpoints = asyncio.run(run(None))
-    assert len(ids) == 1500
-    assert checkpoints == [(BASE + timedelta(seconds=999)).isoformat()]
+    outs = asyncio.run(run())
 
-    # A resume re-anchors since_create_time one second before the watermark.
-    server.requests.clear()
-    resumed_ids, _ = asyncio.run(run(checkpoints[0]))
-    assert server.requests[0]["offset"] == 0
-    assert (
-        server.requests[0]["since_create_time"]
-        == (BASE + timedelta(seconds=998)).isoformat()
-    )
-    assert resumed_ids[0] == "c0999"
+    assert [out.id for out in outs] == [f"c{i:04}" for i in range(1500)]
+    assert not any(isinstance(out, (str, int, dict)) for out in outs)
+    assert [p["offset"] for p in server.requests] == [0, 1000]


### PR DESCRIPTION
Fixes finding **C1** from the #4895 review: backfill offsets checkpointed across invocations over a mutable/unsorted result set silently and permanently lose documents.

## The bug

`backfill_list_children` and `backfill_campaigns` checkpointed a positional offset (`yield offset + count`) that the next invocation resumed from. Nothing new enters a frozen backfill window, but rows *leave* it mid-walk:

- **list_members**: an update stamps `last_changed > cutoff`, removing the row from the window server-side and renumbering every later row. A resume at the stored offset skips an untouched neighbor whose `last_changed` is still inside `(start_date, cutoff − 1s]` — pre-cutoff time the incremental task (seeded at `cutoff − 1s`) never revisits. Permanent loss.
- **segments**: same, worse — the endpoint documents no sort at all, so even the walk order under the offset was unverified.
- **campaigns**: `create_time` is immutable, but a deletion mid-backfill still renumbers; recoverable only by the daily scheduled backfill.

The comments asserting the ASC sort "keeps the walked prefix stable" claimed the opposite of the truth (order among surviving rows is stable; membership and positions are not) and are rewritten.

## The fix

Backfills now yield **no PageCursor at all**: each one drains its whole frozen window in a single invocation with offsets kept local to that invocation (per `FETCH-CHECKPOINT-STABLE-STATE`), and an interrupted backfill restarts its window. A re-read costs only duplicates the collection key collapses; a skipped row is lost for good.

## Testing

- New offline unit tests (`tests/test_backfill_resume.py`) drive all three backfills against a canned Mailchimp emulation with the probed boundary semantics (`since_*` exclusive, `before_*` inclusive), asserting full-window drains and that no cursor of any kind is ever yielded.
- `mypy`: identical pre-existing errors before/after (no new ones).
- `pytest`: new tests plus spec/discover snapshots pass. `test_capture` currently fails **identically at the base commit** (verified via stash): the two slowest grandchild streams (`interests`, `segment_members`) intermittently miss the 10s `flowctl preview` window — the pre-existing live-timing flake already flagged in the review, unrelated to this change.

Based on `nlazo/source-mailchimp-native` so it merges into PR #4895.