### PR TITLE
source-sqlserver{,ct}: bind datetime backfill resume keys as datetime parameters

### DIFF
--- a/go/capture/sqlserver/backfill/backfill.go
+++ b/go/capture/sqlserver/backfill/backfill.go
@@ -3,6 +3,7 @@ package backfill
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/estuary/connectors/go/capture/sqlserver/datatypes"
 	"github.com/estuary/connectors/sqlcapture"
@@ -35,6 +36,13 @@ func BuildBackfillQuery(
 			if len(resumeKey) != len(keyColumns) {
 				return "", nil, fmt.Errorf("expected %d resume-key values but got %d", len(keyColumns), len(resumeKey))
 			}
+			for idx, colName := range keyColumns {
+				var retyped, err = retypeResumeKey(resumeKey[idx], columnTypes[colName])
+				if err != nil {
+					return "", nil, fmt.Errorf("error preparing resume key for %q: %w", streamID, err)
+				}
+				resumeKey[idx] = retyped
+			}
 			var query = buildScanQuery(false, keyColumns, columnTypes, schema, table, chunkSize)
 			return query, resumeKey, nil
 		}
@@ -44,6 +52,51 @@ func BuildBackfillQuery(
 	default:
 		return "", nil, fmt.Errorf("invalid backfill mode %q", state.Mode)
 	}
+}
+
+// retypeResumeKey converts a resume key value back into a Go type which the driver will
+// bind as the column's own SQL type.
+//
+// EncodeKeyFDB formats datetime values with time.Format so that serialized row keys sort
+// correctly as FDB tuples. Binding that string straight back into a chunk query
+// leaves SQL Server comparing a datetime column against an nvarchar parameter. The
+// disjunctive shape of the resume predicate combined with that implicit conversion
+// stops the optimizer from recognizing that `k1 > @p1` and `k1 = @p1 AND k2 > @p2`
+// share a lower bound. Unable to derive a seek range, it scans from the start of the
+// index instead, and every chunk re-reads the already backfilled portion of the table.
+// So, we use retypeResumeKey to convert the resume key so SQL Server does not perform
+// an implicit conversion and the optimizer decides to seek instead of scan.
+//
+// DATETIME and TIME are deliberately excluded:
+//
+//   - DATETIME is a lossy-encoding problem. DatetimeKeyEncoding keeps only three
+//     fractional digits and Go truncates them, but the column resolves to
+//     1/300s, so a stored .003333 is persisted as .003.
+//
+//   - TIME is a parameter-type problem. A Go time.Time is always a date as well as a
+//     time, so the driver can only send it as DATETIMEOFFSET, and SQL Server has no
+//     implicit conversion between TIME and DATETIMEOFFSET.
+func retypeResumeKey(value any, columnType any) (any, error) {
+	var text, isText = value.(string)
+	if !isText {
+		return value, nil
+	}
+
+	var layout string
+	switch columnType {
+	case "smalldatetime":
+		layout = datatypes.DatetimeKeyEncoding
+	case "datetime2", "datetimeoffset", "date":
+		layout = datatypes.SortableRFC3339Nano
+	default:
+		return value, nil
+	}
+
+	var parsed, err = time.Parse(layout, text)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %v resume key %q: %w", columnType, text, err)
+	}
+	return parsed, nil
 }
 
 // keylessScanQuery builds a query for scanning a table without a primary key.

--- a/go/capture/sqlserver/backfill/backfill_test.go
+++ b/go/capture/sqlserver/backfill/backfill_test.go
@@ -1,0 +1,67 @@
+package backfill
+
+import (
+	"testing"
+	"time"
+
+	"github.com/estuary/connectors/go/capture/sqlserver/datatypes"
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/stretchr/testify/require"
+)
+
+var textColumn = &datatypes.TextColumnType{
+	Type:      "varchar",
+	Collation: "SQL_Latin1_General_CP1_CI_AS",
+	FullType:  "varchar(32)",
+	MaxLength: 32,
+}
+
+// TestResumeKeyBinding checks what Go type each key column's resume value is bound as.
+// Datetime keys must arrive as a time.Time: binding the serialized string instead leaves
+// SQL Server comparing the column against an nvarchar parameter, and the implicit
+// conversion that introduces costs the chunk query its index seek. See retypeResumeKey.
+func TestResumeKeyBinding(t *testing.T) {
+	// Whole seconds, so every encoding round-trips exactly and equality is meaningful.
+	var reference = time.Date(2020, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name       string
+		columnType any
+		key        any
+		wantBound  any
+	}{
+		{"datetime2 binds as a time", "datetime2", reference, reference},
+		{"smalldatetime binds as a time", "smalldatetime", reference, reference},
+		{"datetimeoffset binds as a time", "datetimeoffset", reference, reference},
+		{"date binds as a time", "date", reference, reference},
+
+		// Types left alone on purpose; see retypeResumeKey. DATETIME's key encoding
+		// truncates to milliseconds while the column resolves to 1/300s, so binding a
+		// precise value would place the resume key below the row it came from and the
+		// backfill would re-read it forever.
+		{"datetime binds unchanged", "datetime", reference, reference.Format(datatypes.DatetimeKeyEncoding)},
+		{"time binds unchanged", "time", reference, reference.Format(datatypes.SortableRFC3339Nano)},
+
+		// Types whose values already round-trip usefully.
+		{"int binds unchanged", "int", int64(1723), int64(1723)},
+		{"text binds unchanged", textColumn, "some value", "some value"},
+		{"numeric binds unchanged", "numeric", "12345.12059", "12345.12059"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := datatypes.EncodeKeyFDB(tc.key, tc.columnType)
+			require.NoError(t, err)
+			packed, err := sqlcapture.PackTuple([]tuple.TupleElement{encoded, 7})
+			require.NoError(t, err)
+
+			_, args, err := BuildBackfillQuery(&sqlcapture.TableState{
+				Mode:       sqlcapture.TableStatePreciseBackfill,
+				KeyColumns: []string{"k", "node"},
+				Scanned:    packed,
+			}, "dbo", "events", map[string]any{"k": tc.columnType, "node": "int"}, 1000)
+			require.NoError(t, err)
+			require.Len(t, args, 2)
+			require.Equal(t, tc.wantBound, args[0])
+		})
+	}
+}

--- a/go/capture/sqlserver/tests/datatypes.go
+++ b/go/capture/sqlserver/tests/datatypes.go
@@ -23,6 +23,7 @@ func TestDatatypes(t *testing.T, setup testSetupFunc) {
 	t.Run("MiscTypes", func(t *testing.T) { testMiscTypes(t, setup) })
 	t.Run("NotNullTypes", func(t *testing.T) { testNotNullTypes(t, setup) })
 	t.Run("ScanKeyTypes", func(t *testing.T) { testScanKeyTypes(t, setup) })
+	t.Run("CompositeScanKey", func(t *testing.T) { testCompositeScanKey(t, setup) })
 	t.Run("OversizedFields", func(t *testing.T) { testOversizedFields(t, setup) })
 	t.Run("BitNotNullDeletion", func(t *testing.T) { testBitNotNullDeletion(t, setup) })
 	t.Run("RowversionTypes", func(t *testing.T) { testRowversionTypes(t, setup) })
@@ -296,6 +297,21 @@ func testScanKeyTypes(t *testing.T, setup testSetupFunc) {
 			"('1991-08-31T12:35:00', 'Data 1')",
 			"('2000-01-01T01:01:00', 'Data 2')",
 		}},
+		{"DateTime2", "DATETIME2", []string{
+			"('1991-08-31T12:34:54.1234567', 'Data 0')",
+			"('1991-08-31T12:34:54.7654321', 'Data 1')",
+			"('2000-01-01T01:01:01', 'Data 2')",
+		}},
+		{"Date", "DATE", []string{
+			"('1991-08-31', 'Data 0')",
+			"('1991-09-01', 'Data 1')",
+			"('2000-01-01', 'Data 2')",
+		}},
+		{"Time", "TIME", []string{
+			"('00:00:00', 'Data 0')",
+			"('12:34:54.1234567', 'Data 1')",
+			"('23:59:59.9999999', 'Data 2')",
+		}},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
 			var db, tc = setup(t)
@@ -308,6 +324,21 @@ func testScanKeyTypes(t *testing.T, setup testSetupFunc) {
 			cupaloy.SnapshotT(t, tc.Transcript.String())
 		})
 	}
+}
+
+func testCompositeScanKey(t *testing.T, setup testSetupFunc) {
+	var db, tc = setup(t)
+	db.CreateTable(t, `<NAME>`, `(k SMALLDATETIME, k2 INTEGER, v TEXT, PRIMARY KEY (k, k2))`)
+	db.Exec(t, `INSERT INTO <NAME> VALUES
+		('1991-08-31T12:34:00', 1, 'Data 0'),
+		('1991-08-31T12:34:00', 2, 'Data 1'),
+		('1991-08-31T12:34:00', 3, 'Data 2'),
+		('2000-01-01T01:01:00', 1, 'Data 3')`)
+
+	require.NoError(t, tc.Capture.EditConfig("advanced.backfill_chunk_size", 1))
+	tc.Discover("Discover Tables")
+	tc.Run("Backfill", -1)
+	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
 
 // TestOversizedFields tests the behavior of the connector when it encounters

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-CompositeScanKey
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-CompositeScanKey
@@ -1,0 +1,92 @@
+sql> CREATE TABLE dbo.Datatypes_CompositeScanKey_333023 (k SMALLDATETIME, k2 INTEGER, v TEXT, PRIMARY KEY (k, k2))
+sql> INSERT INTO dbo.Datatypes_CompositeScanKey_333023 VALUES
+		('1991-08-31T12:34:00', 1, 'Data 0'),
+		('1991-08-31T12:34:00', 2, 'Data 1'),
+		('1991-08-31T12:34:00', 3, 'Data 2'),
+		('2000-01-01T01:01:00', 1, 'Data 3')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_compositescankey_333023
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 1,
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 2,
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 3,
+    "v": "Data 2"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:00Z",
+    "k2": 1,
+    "v": "Data 3"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_CompositeScanKey_333023": {
+      "backfilled": 4,
+      "key_columns": [
+        "k",
+        "k2"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-Date
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-Date
@@ -1,0 +1,67 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_Date_387616 (k DATE PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_Date_387616 VALUES ('1991-08-31', 'Data 0'), ('1991-09-01', 'Data 1'), ('2000-01-01', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-09-01",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_Date_387616": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-DateTime2
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-DateTime2
@@ -1,0 +1,67 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_DateTime2_334144 (k DATETIME2 PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_DateTime2_334144 VALUES ('1991-08-31T12:34:54.1234567', 'Data 0'), ('1991-08-31T12:34:54.7654321', 'Data 1'), ('2000-01-01T01:01:01', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:54.1234567Z",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:54.7654321Z",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:01Z",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_DateTime2_334144": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-Time
+++ b/source-sqlserver-ct/.snapshots/TestDatatypes-ScanKeyTypes-Time
@@ -1,0 +1,67 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_Time_404671 (k TIME PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_Time_404671 VALUES ('00:00:00', 'Data 0'), ('12:34:54.1234567', 'Data 1'), ('23:59:59.9999999', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "00:00:00",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "12:34:54.1234567",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "schema": "dbo",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "23:59:59.9999999",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_Time_404671": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver-ct/CHANGELOG.md
+++ b/source-sqlserver-ct/CHANGELOG.md
@@ -1,5 +1,16 @@
 # source-sqlserver-ct
 
+## 2026-07-30
+
+### Changed
+- Backfill resume keys for `DATETIME2`, `SMALLDATETIME`, `DATETIMEOFFSET` and `DATE`
+  primary-key columns are now bound as typed datetime parameters rather than as
+  formatted strings. Comparing a datetime column against a string parameter left an
+  implicit conversion inside the chunk query's resume predicate, which prevented SQL
+  Server from using an index seek on tables whose primary key has more than one
+  column. Each chunk instead rescanned every row it had already read, so backfills of
+  large tables progressed more and more slowly as they went on.
+
 ## 2026-07-22
 
 ### Added

--- a/source-sqlserver/.snapshots/TestDatatypes-CompositeScanKey
+++ b/source-sqlserver/.snapshots/TestDatatypes-CompositeScanKey
@@ -1,0 +1,100 @@
+sql> CREATE TABLE dbo.Datatypes_CompositeScanKey_333023 (k SMALLDATETIME, k2 INTEGER, v TEXT, PRIMARY KEY (k, k2))
+sql> INSERT INTO dbo.Datatypes_CompositeScanKey_333023 VALUES
+		('1991-08-31T12:34:00', 1, 'Data 0'),
+		('1991-08-31T12:34:00', 2, 'Data 1'),
+		('1991-08-31T12:34:00', 3, 'Data 2'),
+		('2000-01-01T01:01:00', 1, 'Data 3')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_compositescankey_333023
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 1,
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 2,
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:00Z",
+    "k2": 3,
+    "v": "Data 2"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_compositescankey_333023",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_CompositeScanKey_333023"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:00Z",
+    "k2": 1,
+    "v": "Data 3"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_CompositeScanKey_333023": {
+      "backfilled": 4,
+      "key_columns": [
+        "k",
+        "k2"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-Date
+++ b/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-Date
@@ -1,0 +1,73 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_Date_387616 (k DATE PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_Date_387616 VALUES ('1991-08-31', 'Data 0'), ('1991-09-01', 'Data 1'), ('2000-01-01', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-09-01",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_date_387616",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Date_387616"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_Date_387616": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-DateTime2
+++ b/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-DateTime2
@@ -1,0 +1,73 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_DateTime2_334144 (k DATETIME2 PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_DateTime2_334144 VALUES ('1991-08-31T12:34:54.1234567', 'Data 0'), ('1991-08-31T12:34:54.7654321', 'Data 1'), ('2000-01-01T01:01:01', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:54.1234567Z",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "1991-08-31T12:34:54.7654321Z",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_datetime2_334144",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_DateTime2_334144"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "2000-01-01T01:01:01Z",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_DateTime2_334144": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-Time
+++ b/source-sqlserver/.snapshots/TestDatatypes-ScanKeyTypes-Time
@@ -1,0 +1,73 @@
+sql> CREATE TABLE dbo.Datatypes_ScanKeyTypes_Time_404671 (k TIME PRIMARY KEY, v TEXT)
+sql> INSERT INTO dbo.Datatypes_ScanKeyTypes_Time_404671 VALUES ('00:00:00', 'Data 0'), ('12:34:54.1234567', 'Data 1'), ('23:59:59.9999999', 'Data 2')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671
+=== Run: Backfill ===
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "00:00:00",
+    "v": "Data 0"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "12:34:54.1234567",
+    "v": "Data 1"
+  }
+]
+[
+  "acmeCo/test_capture/dbo/datatypes_scankeytypes_time_404671",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "lsn": "",
+        "schema": "dbo",
+        "seqval": "REDACTED",
+        "snapshot": true,
+        "table": "Datatypes_ScanKeyTypes_Time_404671"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "k": "23:59:59.9999999",
+    "v": "Data 2"
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "dbo%2FDatatypes_ScanKeyTypes_Time_404671": {
+      "backfilled": 3,
+      "key_columns": [
+        "k"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -1,5 +1,16 @@
 # source-sqlserver
 
+## 2026-07-30
+
+### Changed
+- Backfill resume keys for `DATETIME2`, `SMALLDATETIME`, `DATETIMEOFFSET` and `DATE`
+  primary-key columns are now bound as typed datetime parameters rather than as
+  formatted strings. Comparing a datetime column against a string parameter left an
+  implicit conversion inside the chunk query's resume predicate, which prevented SQL
+  Server from using an index seek on tables whose primary key has more than one
+  column. Each chunk instead rescanned every row it had already read, so backfills of
+  large tables progressed more and more slowly as they went on.
+
 ## 2026-07-23
 
 ### Changed


### PR DESCRIPTION
**Regression?**

No

**Description:**

Backfill chunks resume with `WHERE (k1 > @p1) OR (k1 = @p1 AND k2 > @p2)` when there's more than a single key column. Datetime resume keys were bound as strings - `EncodeKeyFDB` formats them with `time.Format` so they sort correctly as FDB tuples - leaving SQL Server comparing a datetime column against an `nvarchar` parameter. That implicit conversion step combined with the disjunctive predicate stopped the optimizer from deriving a seek range, so every chunk scanned from the start of the index and re-read everything that had already been backfilled.

This PR fixes this by parsing the value back into a `time.Time` before binding it so the comparison is datetime-to-datetime. This lets the optimizer decide to seek instead of scan. I tested this out locally, and on a 4M-row table with a two-column key, the chunk at row 3.9M went from reading 3,950,000 rows to 50,000 rows (which was the chunk size).

I also added a few more test cases for `testScanKeyTypes` in `sqlserver/tests/datatypes.go` so we have snapshots covering the various datetime types that someone might use as table keys.

See individual commits for more details.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
