### PR TITLE
source-sqlserver{,ct}: discovery query cache use improvements

### DIFF
--- a/source-sqlserver-ct/CHANGELOG.md
+++ b/source-sqlserver-ct/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-07-30
 
+### Fixed
+- Discovery queries are now shaped so that SQL Server reuses a single cached
+  query plan across repeated discovery passes, rather than compiling a new plan
+  for every chunk of tables every time. On instances hosting many databases the
+  previous behavior could exhaust query compile memory and drive the server to
+  sustained high CPU, blocking unrelated queries.
+
 ### Changed
 - Backfill resume keys for `DATETIME2`, `SMALLDATETIME`, `DATETIMEOFFSET` and `DATE`
   primary-key columns are now bound as typed datetime parameters rather than as

--- a/source-sqlserver-ct/discovery.go
+++ b/source-sqlserver-ct/discovery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/estuary/connectors/go/tableglob"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/invopop/jsonschema"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -97,12 +98,23 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 // This disjunction-of-equalities form plans as per-table index seeks on the
 // system catalogs, but only so long as discoveryChunkSize is kept smallish.
 // Currently we use 100 and that's probably in the sweet spot.
+//
+// Arguments are bound as nvarchar(max) rather than as plain Go strings, so that
+// the parameter type signature stays identical regardless of how long the
+// identifiers are. go-mssqldb otherwise sizes each string parameter to the value
+// it happens to carry (makeStrParam sets ti.Size = len(res.buffer)), and that
+// declaration forms part of SQL Server's plan cache key, so binding them plainly
+// would declare as '(@p1 nvarchar(3), @p2 nvarchar(23), ...)' and every distinct
+// combination of identifier lengths would compile a plan of its own. Since each
+// of those plans is only ever used once it would also be a prime eviction
+// candidate. A constant declaration lets one cached plan serve every chunk
+// holding the same number of tables.
 func tableIDsPredicate(schemaCol, tableCol string, tables []sqlcapture.TableID, startArg int) (string, []any) {
 	var terms = make([]string, len(tables))
 	var args = make([]any, 0, len(tables)*2)
 	for i, t := range tables {
 		terms[i] = fmt.Sprintf("(%s = @p%d AND %s = @p%d)", schemaCol, startArg+2*i, tableCol, startArg+2*i+1)
-		args = append(args, t.Schema, t.Table)
+		args = append(args, mssqldb.NVarCharMax(t.Schema), mssqldb.NVarCharMax(t.Table))
 	}
 	return "(" + strings.Join(terms, " OR ") + ")", args
 }

--- a/source-sqlserver-ct/discovery.go
+++ b/source-sqlserver-ct/discovery.go
@@ -85,6 +85,30 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 	return false
 }
 
+// padChunk repeats the final table until the chunk holds exactly
+// discoveryChunkSize entries, so that a trailing partial chunk generates the
+// same query text as a full one and shares its cached plan.
+//
+// Repeating a table is fine. The predicate is a disjunction of equalities,
+// so the extra terms match rows which already matched and the result set is
+// unchanged.
+//
+// Callers should only do this when the table list actually spans more than one
+// chunk. A capture whose bindings all fit in a single chunk already issues just
+// one query shape, so padding it out would add redundant predicate terms
+// without consolidating anything.
+func padChunk(chunk []sqlcapture.TableID) []sqlcapture.TableID {
+	if len(chunk) == 0 || len(chunk) >= discoveryChunkSize {
+		return chunk
+	}
+	var padded = make([]sqlcapture.TableID, discoveryChunkSize)
+	copy(padded, chunk)
+	for i := len(chunk); i < discoveryChunkSize; i++ {
+		padded[i] = chunk[len(chunk)-1]
+	}
+	return padded
+}
+
 // tableIDsPredicate builds a WHERE-clause predicate matching any of the
 // specified tables, using the given column expressions for the schema and
 // table names. The returned clause has the form
@@ -108,7 +132,7 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 // combination of identifier lengths would compile a plan of its own. Since each
 // of those plans is only ever used once it would also be a prime eviction
 // candidate. A constant declaration lets one cached plan serve every chunk
-// holding the same number of tables.
+// holding the same number of tables. padChunk handles the trailing partial one.
 func tableIDsPredicate(schemaCol, tableCol string, tables []sqlcapture.TableID, startArg int) (string, []any) {
 	var terms = make([]string, len(tables))
 	var args = make([]any, 0, len(tables)*2)
@@ -141,10 +165,18 @@ func (db *sqlserverDatabase) ListTables(ctx context.Context) ([]sqlcapture.Table
 // about the specified tables. The per-table metadata queries are chunked into
 // batches so that discovery scales to databases with very large catalogs.
 func (db *sqlserverDatabase) DiscoverTableDetails(ctx context.Context, requested []sqlcapture.TableID) (map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, error) {
+	// When the list spans several chunks the trailing partial chunk is padded so
+	// that every chunk yields the same query text.
+	var padPartialChunk = len(requested) > discoveryChunkSize
+
 	var tableMap = make(map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, len(requested))
 	for i := 0; i < len(requested); i += discoveryChunkSize {
 		var end = min(i+discoveryChunkSize, len(requested))
-		if err := db.extendTableDetails(ctx, tableMap, requested[i:end]); err != nil {
+		var chunk = requested[i:end]
+		if padPartialChunk {
+			chunk = padChunk(chunk)
+		}
+		if err := db.extendTableDetails(ctx, tableMap, chunk); err != nil {
 			return nil, err
 		}
 	}

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-07-30
 
+### Fixed
+- Discovery queries are now shaped so that SQL Server reuses a single cached
+  query plan across repeated discovery passes, rather than compiling a new plan
+  for every chunk of tables every time. On instances hosting many databases the
+  previous behavior could exhaust query compile memory and drive the server to
+  sustained high CPU, blocking unrelated queries.
+
 ### Changed
 - Backfill resume keys for `DATETIME2`, `SMALLDATETIME`, `DATETIMEOFFSET` and `DATE`
   primary-key columns are now bound as typed datetime parameters rather than as

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -86,6 +86,30 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 	return false
 }
 
+// padChunk repeats the final table until the chunk holds exactly
+// discoveryChunkSize entries, so that a trailing partial chunk generates the
+// same query text as a full one and shares its cached plan.
+//
+// Repeating a table is fine. The predicate is a disjunction of equalities,
+// so the extra terms match rows which already matched and the result set is
+// unchanged.
+//
+// Callers should only do this when the table list actually spans more than one
+// chunk. A capture whose bindings all fit in a single chunk already issues just
+// one query shape, so padding it out would add redundant predicate terms
+// without consolidating anything.
+func padChunk(chunk []sqlcapture.TableID) []sqlcapture.TableID {
+	if len(chunk) == 0 || len(chunk) >= discoveryChunkSize {
+		return chunk
+	}
+	var padded = make([]sqlcapture.TableID, discoveryChunkSize)
+	copy(padded, chunk)
+	for i := len(chunk); i < discoveryChunkSize; i++ {
+		padded[i] = chunk[len(chunk)-1]
+	}
+	return padded
+}
+
 // tableIDsPredicate builds a WHERE-clause predicate matching any of the
 // specified tables, using the given column expressions for the schema and
 // table names. The returned clause has the form
@@ -109,7 +133,7 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 // combination of identifier lengths would compile a plan of its own. Since each
 // of those plans is only ever used once it would also be a prime eviction
 // candidate. A constant declaration lets one cached plan serve every chunk
-// holding the same number of tables.
+// holding the same number of tables. padChunk handles the trailing partial one.
 func tableIDsPredicate(schemaCol, tableCol string, tables []sqlcapture.TableID, startArg int) (string, []any) {
 	var terms = make([]string, len(tables))
 	var args = make([]any, 0, len(tables)*2)
@@ -153,10 +177,18 @@ func (db *sqlserverDatabase) DiscoverTableDetails(ctx context.Context, requested
 		}
 	}
 
+	// When the list spans several chunks the trailing partial chunk is padded so
+	// that every chunk yields the same query text.
+	var padPartialChunk = len(requested) > discoveryChunkSize
+
 	var tableMap = make(map[sqlcapture.StreamID]*sqlcapture.DiscoveryInfo, len(requested))
 	for i := 0; i < len(requested); i += discoveryChunkSize {
 		var end = min(i+discoveryChunkSize, len(requested))
-		if err := db.extendTableDetails(ctx, tableMap, requested[i:end]); err != nil {
+		var chunk = requested[i:end]
+		if padPartialChunk {
+			chunk = padChunk(chunk)
+		}
+		if err := db.extendTableDetails(ctx, tableMap, chunk); err != nil {
 			return nil, err
 		}
 	}

--- a/source-sqlserver/discovery.go
+++ b/source-sqlserver/discovery.go
@@ -12,6 +12,7 @@ import (
 	"github.com/estuary/connectors/go/tableglob"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/invopop/jsonschema"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -98,12 +99,23 @@ func matchesAnyPattern(patterns []*tableglob.Pattern, t sqlcapture.TableID) bool
 // This disjunction-of-equalities form plans as per-table index seeks on the
 // system catalogs, but only so long as discoveryChunkSize is kept smallish.
 // Currently we use 100 and that's probably in the sweet spot.
+//
+// Arguments are bound as nvarchar(max) rather than as plain Go strings, so that
+// the parameter type signature stays identical regardless of how long the
+// identifiers are. go-mssqldb otherwise sizes each string parameter to the value
+// it happens to carry (makeStrParam sets ti.Size = len(res.buffer)), and that
+// declaration forms part of SQL Server's plan cache key, so binding them plainly
+// would declare as '(@p1 nvarchar(3), @p2 nvarchar(23), ...)' and every distinct
+// combination of identifier lengths would compile a plan of its own. Since each
+// of those plans is only ever used once it would also be a prime eviction
+// candidate. A constant declaration lets one cached plan serve every chunk
+// holding the same number of tables.
 func tableIDsPredicate(schemaCol, tableCol string, tables []sqlcapture.TableID, startArg int) (string, []any) {
 	var terms = make([]string, len(tables))
 	var args = make([]any, 0, len(tables)*2)
 	for i, t := range tables {
 		terms[i] = fmt.Sprintf("(%s = @p%d AND %s = @p%d)", schemaCol, startArg+2*i, tableCol, startArg+2*i+1)
-		args = append(args, t.Schema, t.Table)
+		args = append(args, mssqldb.NVarCharMax(t.Schema), mssqldb.NVarCharMax(t.Table))
 	}
 	return "(" + strings.Join(terms, " OR ") + ")", args
 }

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -86,6 +86,15 @@ func (c *Capture) bindingTableIDs() []TableID {
 	for _, binding := range c.Bindings {
 		ids = append(ids, TableID{Schema: binding.Resource.Namespace, Table: binding.Resource.Stream})
 	}
+	// Sort so the returned results are in a stable order. Most notably, this
+	// helps increase query plan cache hit rates for discovery implementations
+	// that chunk the list into multiple discovery queries.
+	slices.SortFunc(ids, func(a, b TableID) int {
+		if n := strings.Compare(a.Schema, b.Schema); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Table, b.Table)
+	})
 	return ids
 }
 


### PR DESCRIPTION
**Regression?**

No.

**Description:**

After rolling out the chunked discovery query behavior as part of https://github.com/estuary/connectors/pull/4872, a user running 1,000+ captures against single-tenant databases on one SQL Server instance saw it driven to sustained ~99% CPU with blocking chains hundreds of sessions deep. They identified that the server was spending all of its CPU compiling query plans for our discovery queries.

Chunked discovery (ade7654) filters each query by a disjunction of (schema, table) equalities. The statement text is identical across runs, but sp_executesql keys its cached plan on the statement text plus the parameter declaration, and `go-mssqldb` sizes every string parameter to the length of the value it carries. So the declaration is a function of the customer's table names, and could be something like:
```
  (@p1 nvarchar(3),@p2 nvarchar(27),@p3 nvarchar(3),@p4 nvarchar(16),...)
```
Compounding it, `bindingTableIDs` iterates a map, so the list is reshuffled on every rediscovery pass. The net effect was there was essentially one compiled plan per execution and none were ever reused.

This PR improves query plan cache re-use for chunked discovery queries by:
- `sqlcapture`: sorting `bindingTableIDs` output.
- Binding identifiers as `mssqldb.NVarCharMax` in our chunked discovery queries. This makes the declaration constant regardless of name length.
- Padding the trailing chunk. A list that doesn't divide evenly into `discoveryChunkSize` ends with a short chunk whose text has fewer terms, so it caches its own plan. Repeating the final table makes every chunk's text identical - X OR X is X, so results are unchanged. This padding is only applied when the list actually spans more than one chunk.

**Notes for reviewers:**

See this [Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1785361977655109) for more context around the escalation that motivated this change.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
