### PR TITLE
source-klaviyo-native: normalize space-separated datetimes to RFC3339

### DIFF
--- a/source-klaviyo-native/CHANGELOG.md
+++ b/source-klaviyo-native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-07-30
+
+### Fixed
+- Datetime values Klaviyo returns space-separated (consent timestamps, the events datetime cursor, and custom properties) are now normalized to RFC3339, so materializations of fields inferred as `format: date-time` no longer fail with `cannot parse ... as "T"`.

--- a/source-klaviyo-native/source_klaviyo_native/models.py
+++ b/source-klaviyo-native/source_klaviyo_native/models.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar
@@ -22,14 +23,12 @@ def default_start_date():
 
 class ApiKey(AccessToken):
     credentials_title: Literal["API Key"] = Field(
-        default="API Key",
-        json_schema_extra={"type": "string", "order": 0}
+        default="API Key", json_schema_extra={"type": "string", "order": 0}
     )
     access_token: str = Field(
         title="API Key",
         json_schema_extra={"secret": True, "order": 1},
     )
-
 
 
 class EndpointConfig(BaseModel):
@@ -43,21 +42,26 @@ class EndpointConfig(BaseModel):
         discriminator="credentials_title",
         title="Authentication",
     )
+
     class Advanced(BaseModel):
-        window_size: Annotated[timedelta, Field(
-            description="Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
-            title="Window size",
-            default=timedelta(hours=1),
-            ge=timedelta(seconds=30),
-            le=timedelta(days=365),
-        )]
+        window_size: Annotated[
+            timedelta,
+            Field(
+                description="Date window size for the events backfill in ISO 8601 format. ex: P30D means 30 days, PT6H means 6 hours.",
+                title="Window size",
+                default=timedelta(hours=1),
+                ge=timedelta(seconds=30),
+                le=timedelta(days=365),
+            ),
+        ]
 
     advanced: Advanced = Field(
-        default_factory=Advanced, #type: ignore
+        default_factory=Advanced,  # type: ignore
         title="Advanced Config",
         description="Advanced settings for the connector.",
         json_schema_extra={"advanced": True},
     )
+
 
 ConnectorState = GenericConnectorState[ResourceState]
 
@@ -84,12 +88,58 @@ class CampaignType(StrEnum):
     MOBILE_PUSH = "mobile_push"
 
 
+# Klaviyo emits some datetime fields (e.g. consent timestamps) space-separated
+# (e.g. "2026-06-23 00:15:23.918411+00:00") rather than RFC3339. When schema
+# inference tags such a field `format: date-time`, the collection advertises an
+# RFC3339 contract the value violates, breaking downstream consumers. Rather
+# than enumerate the known offenders (Klaviyo custom properties are free-form,
+# so new ones surface unpredictably), we normalize any string that matches the
+# space-separated shape and leave everything else untouched. The anchored regex
+# is what keeps free-text values (e.g. "May 5, 2021") safe from mangling.
+#
+# Matches the observed Klaviyo format "YYYY-MM-DD HH:MM:SS[.ffffff]+HH:MM".
+_SPACE_SEPARATED_DATETIME_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2}:\d{2})\Z"
+)
+
+
+def _normalize_datetime(value: str) -> str:
+    match = _SPACE_SEPARATED_DATETIME_RE.match(value)
+    if not match:
+        return value
+    date, time, tz = match.groups()
+    return f"{date}T{time}{tz}"
+
+
+def _normalize_datetimes(data: Any) -> None:
+    """Recursively normalize space-separated datetime strings in place."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, str):
+                data[key] = _normalize_datetime(value)
+            elif isinstance(value, (dict, list)):
+                _normalize_datetimes(value)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            if isinstance(item, str):
+                data[i] = _normalize_datetime(item)
+            elif isinstance(item, (dict, list)):
+                _normalize_datetimes(item)
+
+
 class BaseStream(BaseDocument, extra="allow"):
     name: ClassVar[str]
     path: ClassVar[str]
     extra_params: ClassVar[dict[str, str | int] | None] = None
 
     id: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_space_separated_datetimes(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            _normalize_datetimes(values)
+        return values
 
 
 class IncrementalStream(BaseStream):
@@ -105,7 +155,7 @@ class IncrementalStream(BaseStream):
 
     def get_cursor_value(self) -> datetime:
         cursor_str: str = getattr(self.attributes, self.cursor_field.value)
-        return datetime.fromisoformat(cursor_str.replace('Z', '+00:00'))
+        return datetime.fromisoformat(cursor_str.replace("Z", "+00:00"))
 
 
 # Stream for validating credentials
@@ -119,12 +169,14 @@ class Metrics(BaseStream):
     name: ClassVar[str] = "metrics"
     path: ClassVar[str] = "metrics"
 
+
 class Tags(BaseStream):
     name: ClassVar[str] = "tags"
     path: ClassVar[str] = "tags"
     extra_params: ClassVar[dict[str, str]] = {
         "include": "tag-group",
     }
+
 
 class TagGroups(BaseStream):
     name: ClassVar[str] = "tag_groups"
@@ -138,9 +190,11 @@ class PushTokens(BaseStream):
         "include": "profile",
     }
 
+
 class Coupons(BaseStream):
     name: ClassVar[str] = "coupons"
     path: ClassVar[str] = "coupons"
+
 
 class CouponCodes(BaseStream):
     name: ClassVar[str] = "coupon_codes"
@@ -148,6 +202,7 @@ class CouponCodes(BaseStream):
     extra_params: ClassVar[dict[str, str]] = {
         "include": "coupon",
     }
+
 
 # Incremental streams
 class Campaigns(IncrementalStream):
@@ -161,13 +216,14 @@ class EmailCampaigns(Campaigns):
         f"equals(messages.channel,'{CampaignType.EMAIL}')",
     ]
 
+
 class EmailCampaignsArchived(Campaigns):
     # The Klaviyo API occasionally returns archived email campaigns in
     # slightly unsorted order despite the sort query parameter.
     assume_sorted: ClassVar[bool] = False
     additional_filters: ClassVar[list[str] | None] = [
         f"equals(messages.channel,'{CampaignType.EMAIL}')",
-        "equals(archived,true)"
+        "equals(archived,true)",
     ]
 
 
@@ -180,7 +236,7 @@ class SmsCampaigns(Campaigns):
 class SmsCampaignsArchived(Campaigns):
     additional_filters: ClassVar[list[str] | None] = [
         f"equals(messages.channel,'{CampaignType.SMS}')",
-        "equals(archived,true)"
+        "equals(archived,true)",
     ]
 
 
@@ -193,7 +249,7 @@ class MobilePushCampaigns(Campaigns):
 class MobilePushCampaignsArchived(Campaigns):
     additional_filters: ClassVar[list[str] | None] = [
         f"equals(messages.channel,'{CampaignType.MOBILE_PUSH}')",
-        "equals(archived,true)"
+        "equals(archived,true)",
     ]
 
 
@@ -204,9 +260,7 @@ class Flows(IncrementalStream):
 
 
 class FlowsArchived(Flows):
-    additional_filters: ClassVar[list[str] | None] = [
-        "equals(archived,true)"
-    ]
+    additional_filters: ClassVar[list[str] | None] = ["equals(archived,true)"]
 
 
 class Templates(IncrementalStream):

--- a/source-klaviyo-native/tests/test_models.py
+++ b/source-klaviyo-native/tests/test_models.py
@@ -1,0 +1,88 @@
+from source_klaviyo_native.models import Events, Metrics, Profiles
+
+
+def test_profiles_normalizes_space_separated_datetimes():
+    profile = Profiles.model_validate(
+        {
+            "type": "profile",
+            "id": "00AA0A0AA0AA000AAAAAAA0AA0",
+            "attributes": {
+                "email": "name@example.com",
+                "updated": "2023-03-10T20:36:36+00:00",
+                "properties": {
+                    # Documented consent field, and an arbitrary custom property that also
+                    # happens to be a space-separated datetime: both should be normalized.
+                    "$consent_timestamp": "2026-06-23 00:15:23.918411+00:00",
+                    "custom_signup_date": "2026-06-23 00:15:23+00:00",
+                    # Free-text custom properties that merely contain spaces must be left alone.
+                    "favorite_month": "May 5, 2021",
+                    "status": "onboarding complete",
+                    # A trailing newline means it isn't a clean datetime; leave it untouched
+                    # rather than dropping the newline.
+                    "notes": "2026-06-23 00:15:23+00:00\n",
+                    "tags": ["2026-06-23 00:15:23+00:00", "plain tag"],
+                },
+                "subscriptions": {
+                    "email": {
+                        "marketing": {
+                            "consent": "SUBSCRIBED",
+                            "consent_timestamp": "2026-06-23 00:15:23.918411+00:00",
+                        }
+                    },
+                },
+            },
+        }
+    )
+
+    properties = getattr(profile.attributes, "properties")
+    assert properties["$consent_timestamp"] == "2026-06-23T00:15:23.918411+00:00"
+    assert properties["custom_signup_date"] == "2026-06-23T00:15:23+00:00"
+    assert properties["favorite_month"] == "May 5, 2021"
+    assert properties["status"] == "onboarding complete"
+    assert properties["notes"] == "2026-06-23 00:15:23+00:00\n"
+    assert properties["tags"] == ["2026-06-23T00:15:23+00:00", "plain tag"]
+
+    subscriptions = getattr(profile.attributes, "subscriptions")
+    assert (
+        subscriptions["email"]["marketing"]["consent_timestamp"]
+        == "2026-06-23T00:15:23.918411+00:00"
+    )
+
+
+def test_events_normalizes_datetime_cursor_and_keeps_transform():
+    event = Events.model_validate(
+        {
+            "type": "event",
+            "id": "3rdp5zEXAMPLE",
+            "attributes": {
+                "datetime": "2026-06-23 00:15:23+00:00",
+                "timestamp": 1750637723,
+                "event_properties": {
+                    "$flow": "FLOW_ID",
+                    "Last Opened": "2026-06-23 00:15:23.918411+00:00",
+                },
+            },
+        }
+    )
+
+    assert getattr(event.attributes, "datetime") == "2026-06-23T00:15:23+00:00"
+    assert getattr(event.attributes, "event_properties")["Last Opened"] == (
+        "2026-06-23T00:15:23.918411+00:00"
+    )
+    # The pre-existing Events validator that hoists flow/campaign ids must still run.
+    assert getattr(event, "flow_id") == "FLOW_ID"
+
+
+def test_full_refresh_stream_normalizes_space_separated_datetimes():
+    metric = Metrics.model_validate(
+        {
+            "type": "metric",
+            "id": "abc123",
+            "attributes": {
+                "name": "Clicked Email",
+                "created": "2026-06-23 00:15:23+00:00",
+            },
+        }
+    )
+
+    assert getattr(metric, "attributes")["created"] == "2026-06-23T00:15:23+00:00"


### PR DESCRIPTION
**Description:**

Klaviyo emits some datetime fields (consent timestamps, the events datetime cursor, free-form custom properties) space-separated rather than RFC3339 (e.g. `2026-06-23 00:15:23.918411+00:00`). Once schema inference tags such a field `format: date-time`, the value violates the collection's contract and materializations fail with `cannot parse ... as "T"`.

This adds a `mode="before"` model validator on `BaseStream` that recursively rewrites strings matching the anchored space-separated shape, ported from the legacy source-klaviyo fix (#4742) but hooked on the shared base model so full refresh, incremental, and events streams are all covered. Free-text values that merely contain spaces (e.g. `"May 5, 2021"`) are left alone — the anchored regex only matches the full space-separated datetime shape.

Closes #4765.

**Workflow steps:**

No user action required. Existing captures pick up the normalization on the next connector update; affected fields flow through as RFC3339 from then on.

**Documentation links affected:**

None — no config, binding, or workflow changes; the normalization is internal to document parsing.

**Notes for reviewers:**

Tested with unit tests (`tests/test_models.py`): matching strings at the top level and nested in dicts/lists are rewritten, free-text strings with spaces and near-miss shapes are untouched.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.