### PR TITLE
source-iterable-native: emit sourced schemas for all streams

### DIFF
--- a/source-iterable-native/CHANGELOG.md
+++ b/source-iterable-native/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2026-08-05
+
+### Fixed
+- Bindings now report a source-defined schema for their key fields, which raises the
+  number of fields a collection's inferred schema can track from 1,000 to 10,000.

--- a/source-iterable-native/source_iterable_native/models.py
+++ b/source-iterable-native/source_iterable_native/models.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Annotated, ClassVar, TypeVar
+from typing import Annotated, Any, ClassVar, TypeVar
 
 import xxhash
 from pydantic import AwareDatetime, BaseModel, Field, ValidationInfo, model_validator
@@ -146,11 +146,24 @@ class EventTypes(StrEnum):
     WHATSAPP_USAGE_INFO = "whatsAppUsageInfo"
 
 
+def build_sourced_schema(key_properties: dict[str, Any]) -> dict[str, Any]:
+    """Build a stream's sourced schema from the key fields it needs to preserve.
+
+    Everything uniform across connectors — `_meta`, closure, `required`, and
+    default string and numeric bounds — is filled in by the CDK's
+    `with_sourced_schema_defaults()`, so a stream states only its key fields.
+    """
+    return {"properties": key_properties}
+
+
 class IterableResource(BaseDocument, extra="allow"):
     name: ClassVar[str]
     path: ClassVar[str]
     interval: ClassVar[timedelta] = timedelta(minutes=15)
     disable: ClassVar[bool] = False
+    # Key fields to name in this stream's sourced schema. Streams keyed on
+    # /_meta/row_id need nothing beyond the _meta block.
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {}
 
 
 TIterableResource = TypeVar(name="TIterableResource", bound=IterableResource)
@@ -195,6 +208,10 @@ class ListUsers(IterableResource):
     interval: ClassVar[timedelta] = timedelta(hours=24)
     schedule: ClassVar[str] = "55 23 * * *"
     disable: ClassVar[bool] = True
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        "list_id": {"type": "integer"},
+        "user_id": {"type": "string"},
+    }
 
     list_id: int
     user_id: str
@@ -228,6 +245,9 @@ class Campaigns(ResourceWithId):
     name: ClassVar[str] = "campaigns"
     path: ClassVar[str] = "campaigns"
     interval: ClassVar[timedelta] = timedelta(minutes=5)
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        "id": {"type": "integer"},
+    }
 
     createdAt: int
     updatedAt: int
@@ -255,6 +275,11 @@ class CampaignMetrics(BaseCSVRow):
     path: ClassVar[str] = "campaigns/metrics"
     interval: ClassVar[timedelta] = timedelta(minutes=15)
     disable: ClassVar[bool] = False
+    # CampaignMetrics descends from BaseCSVRow rather than IterableResource,
+    # so it declares KEY_PROPERTIES itself.
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        "id": {"type": "integer"},
+    }
 
     id: int
 
@@ -343,6 +368,11 @@ class EventValidationContext:
 
 class Events(ExportResource):
     name: ClassVar[str] = "events"
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        # A 128 bit hash rendered as hex is always exactly 32 characters.
+        "_estuary_id": {"type": "string", "minLength": 32, "maxLength": 32},
+        "eventType": {"type": "string"},
+    }
 
     createdAt: AwareDatetime
     eventType: str
@@ -422,6 +452,9 @@ class BaseUsers(ExportResource):
 
 class UsersWithIds(BaseUsers):
     primary_key: ClassVar[str] = "itblUserId"
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        "itblUserId": {"type": "string"},
+    }
 
     itblUserId: str
 
@@ -432,6 +465,9 @@ class UsersWithIds(BaseUsers):
 
 class UsersWithEmails(BaseUsers):
     primary_key: ClassVar[str] = "email"
+    KEY_PROPERTIES: ClassVar[dict[str, Any]] = {
+        "email": {"type": "string"},
+    }
 
     email: str
 

--- a/source-iterable-native/source_iterable_native/resources.py
+++ b/source-iterable-native/source_iterable_native/resources.py
@@ -27,6 +27,7 @@ from .models import (
     CampaignMetrics,
     Campaigns,
     Channels,
+    ConnectorState,
     EndpointConfig,
     EventTypes,
     Events,
@@ -42,6 +43,7 @@ from .models import (
     Templates,
     UsersWithEmails,
     UsersWithIds,
+    build_sourced_schema,
 )
 from .shared import EPOCH, now
 
@@ -106,7 +108,7 @@ def full_refresh_resources(
         log: Logger, http: HTTPMixin, config: EndpointConfig
 ) -> list[Resource]:
 
-    def open(
+    async def open(
             stream: type[IterableResource],
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
@@ -114,6 +116,9 @@ def full_refresh_resources(
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(stream.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         if issubclass(stream, Templates):
             snapshot_fn = functools.partial(snapshot_templates, http, stream)
         else:
@@ -153,7 +158,7 @@ def users(
         config: EndpointConfig,
         export_job_manager: ExportJobManager,
 ) -> Resource:
-    def open(
+    async def open(
             stream: type[BaseUsers],
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
@@ -161,6 +166,9 @@ def users(
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(stream.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         open_binding(
             binding,
             binding_index,
@@ -227,7 +235,7 @@ def events(
         config: EndpointConfig,
         export_job_manager: ExportJobManager,
 ) -> Resource:
-    def open(
+    async def open(
             stream: type[ExportResource],
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
@@ -235,6 +243,9 @@ def events(
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(stream.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         open_binding(
             binding,
             binding_index,
@@ -318,13 +329,16 @@ def campaigns(
         http: HTTPMixin,
         config: EndpointConfig,
 ) -> Resource:
-    def open(
+    async def open(
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(Campaigns.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         open_binding(
             binding,
             binding_index,
@@ -364,13 +378,16 @@ def campaign_metrics(
         http: HTTPMixin,
         config: EndpointConfig,
 ) -> Resource:
-    def open(
+    async def open(
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(CampaignMetrics.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         open_binding(
             binding,
             binding_index,
@@ -403,13 +420,16 @@ def list_users(
     http: HTTPMixin,
     config: EndpointConfig,
 ) -> Resource:
-    def open(
+    async def open(
             binding: CaptureBinding[ResourceConfigWithSchedule],
             binding_index: int,
             state: ResourceState,
             task: Task,
             all_bindings
     ):
+        task.sourced_schema(binding_index, build_sourced_schema(ListUsers.KEY_PROPERTIES))
+        await task.checkpoint(state=ConnectorState())
+
         open_binding(
             binding,
             binding_index,

--- a/source-iterable-native/tests/test_sourced_schemas.py
+++ b/source-iterable-native/tests/test_sourced_schemas.py
@@ -1,0 +1,82 @@
+"""Checks on the sourced schema each stream declares.
+
+Only what this connector decides is checked here. Everything uniform across
+connectors — the `_meta` block, closure, `required`, and default bounds — is filled
+in by `with_sourced_schema_defaults()` and covered by
+`estuary-cdk/tests/test_sourced_schema_defaults.py`. The schema under test is
+composed through that same function, so these assertions hold against what the
+runtime actually receives.
+"""
+
+from typing import Any
+
+import pytest
+from estuary_cdk.capture.task import with_sourced_schema_defaults
+
+from source_iterable_native.models import (
+    CampaignMetrics,
+    Campaigns,
+    Channels,
+    Events,
+    ListUsers,
+    Lists,
+    MessageTypes,
+    MetadataTables,
+    Templates,
+    UsersWithEmails,
+    UsersWithIds,
+    build_sourced_schema,
+)
+
+
+# Every stream paired with the collection key declared for it in resources.py.
+# The pointers are duplicated here on purpose: a stream whose key fields aren't
+# named in its sourced schema can have those fields squashed out of the inferred
+# schema, silently dropping the key columns from downstream materializations.
+STREAM_KEYS: list[tuple[type, list[str]]] = [
+    (Channels, ["/_meta/row_id"]),
+    (MessageTypes, ["/_meta/row_id"]),
+    (MetadataTables, ["/_meta/row_id"]),
+    (Templates, ["/_meta/row_id"]),
+    (Lists, ["/_meta/row_id"]),
+    (ListUsers, ["/list_id", "/user_id"]),
+    (UsersWithEmails, ["/email"]),
+    (UsersWithIds, ["/itblUserId"]),
+    (Events, ["/_estuary_id", "/eventType"]),
+    (Campaigns, ["/id"]),
+    (CampaignMetrics, ["/id"]),
+]
+
+STREAM_IDS = [stream.__name__ for stream, _ in STREAM_KEYS]
+
+
+def sourced_schema(stream: type) -> dict[str, Any]:
+    """The schema the runtime receives for a stream, as resources.py emits it."""
+    return with_sourced_schema_defaults(build_sourced_schema(stream.KEY_PROPERTIES))
+
+
+def resolve_pointer(schema: dict[str, Any], pointer: str) -> dict[str, Any] | None:
+    """Resolve a JSON pointer through a schema's `properties`, or None if absent."""
+    node = schema
+    for token in pointer.lstrip("/").split("/"):
+        properties = node.get("properties", {})
+        if token not in properties:
+            return None
+        node = properties[token]
+    return node
+
+
+@pytest.mark.parametrize("stream,keys", STREAM_KEYS, ids=STREAM_IDS)
+def test_names_every_key_field(stream: type, keys: list[str]):
+    schema = sourced_schema(stream)
+
+    for pointer in keys:
+        node = resolve_pointer(schema, pointer)
+        assert node is not None, f"{stream.__name__} key {pointer} is not named"
+        assert "type" in node, f"{stream.__name__} key {pointer} declares no type"
+
+    for pointer in keys:
+        root_property = pointer.lstrip("/").split("/")[0]
+        assert root_property in schema["required"], (
+            f"{stream.__name__} does not require {root_property}"
+        )


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Every binding now reports a sourced schema naming `_meta` and its key fields. The emission of a sourced schema causes the control plane to raise the inferred-schema complexity limit from 1,000 to 10,000 locations. It turns out that Iterable's events can contain over 1,000+ locations, so a higher complexity limit is necessary to avoid pruning locations from the inferred schema.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
