### PR TITLE
claude: add bugfix-capture-connector skill

### DIFF
--- a/.claude/shared/rules-index.md
+++ b/.claude/shared/rules-index.md
@@ -79,6 +79,7 @@ Invoke before writing or changing any `fetch_*` / `backfill_*` function.
 | `CONDUCT-STATE-CONVENTIONS` | conduct | Say when you follow a convention, and when you deviate |
 | `CONDUCT-CITE-SOURCE` | diff | Copied patterns cite `file:line` |
 | `CONDUCT-GREP-BEFORE-CITE` | conduct | Grep for remembered symbols before recommending them |
+| `CONDUCT-CLEAN-ROOM` | conduct | Baseline suite in background at session start; gate the first edit on it; pre-existing drift commits first — stale snapshots as `<connector-name>: update tests`; format files before editing them, committing as `<connector-name>: formatting` |
 | `CONDUCT-VERIFY-FIRST` | conduct | Live behavior over docs over recall |
 
 ### Situational skills

--- a/.claude/shared/rules-index.md
+++ b/.claude/shared/rules-index.md
@@ -79,7 +79,7 @@ Invoke before writing or changing any `fetch_*` / `backfill_*` function.
 | `CONDUCT-STATE-CONVENTIONS` | conduct | Say when you follow a convention, and when you deviate |
 | `CONDUCT-CITE-SOURCE` | diff | Copied patterns cite `file:line` |
 | `CONDUCT-GREP-BEFORE-CITE` | conduct | Grep for remembered symbols before recommending them |
-| `CONDUCT-CLEAN-ROOM` | conduct | Baseline suite in background at session start; gate the first edit on it; pre-existing drift commits first — stale snapshots as `<connector-name>: update tests`; format files before editing them, committing as `<connector-name>: formatting` |
+| `CONDUCT-ESTABLISH-BASELINE` | conduct | Baseline suite in background at session start; gate the first edit on it |
 | `CONDUCT-VERIFY-FIRST` | conduct | Live behavior over docs over recall |
 
 ### Situational skills

--- a/.claude/shared/session-conduct.md
+++ b/.claude/shared/session-conduct.md
@@ -48,7 +48,7 @@ If you propose a function, field, or flag that you _remember_ seeing in the conn
 
 ---
 
-### `CONDUCT-CLEAN-ROOM` · conduct-only
+### `CONDUCT-ESTABLISH-BASELINE` · conduct-only
 
 Kick off the connector's existing test suite (typically `pytest` from the connector directory) in the background as soon as the session's first phase begins. Read-only and planning phases may proceed in parallel while it runs — do **not** block on it. The result is a **gate on the first code edit**: confirm the baseline passes before writing anything, so later failures are attributable to your change, not pre-existing drift.
 

--- a/.claude/shared/session-conduct.md
+++ b/.claude/shared/session-conduct.md
@@ -1,6 +1,6 @@
 # Session conduct
 
-How to run a connector session. These leave no trace in a diff — see the `conduct-only` tag in [README.md](README.md); a reviewer must not comment on them.
+How to run a connector session. Rules tagged `conduct-only` leave no trace in a diff — they are the `conduct` checkability class in [rules-index.md](rules-index.md#checkability); a reviewer must not comment on them.
 
 ---
 
@@ -45,6 +45,20 @@ Checkable from a diff in one direction only: a new fetch function that structura
 ### `CONDUCT-GREP-BEFORE-CITE` · conduct-only
 
 If you propose a function, field, or flag that you _remember_ seeing in the connector, grep for it before recommending it. The codebase may have changed since that memory formed, and a confidently-cited symbol that no longer exists costs more trust than an admitted uncertainty.
+
+---
+
+### `CONDUCT-CLEAN-ROOM` · conduct-only
+
+Kick off the connector's existing test suite (typically `pytest` from the connector directory) in the background as soon as the session's first phase begins. Read-only and planning phases may proceed in parallel while it runs — do **not** block on it. The result is a **gate on the first code edit**: confirm the baseline passes before writing anything, so later failures are attributable to your change, not pre-existing drift.
+
+If the suite fails:
+
+- **Simple schema drift** (spec/discover snapshots have shifted but the code is unchanged): dispatch the `regenerate-flow-discovery` agent to refresh them, then commit that alone — message `<connector-name>: update tests` — **before any other work**, so the real change diffs against a green baseline and stays scoped (`REVIEW-SNAPSHOT-SCOPE`).
+- **Flakey fields in the diff** (timestamps like `updated_at`, ETags, anything that changes between runs): surface them and ask whether to add them to the connector's `FIELDS_TO_REDACT` list in its snapshot test module (name varies — grep for `FIELDS_TO_REDACT`).
+- **Anything else:** stop and surface the failure before editing; a pre-existing failure changes what "done" or "fixed" means.
+
+One more check before the first edit: **format the files you're about to touch**. For Python connectors we use `ruff format`. If that produces a diff, commit it alone — message `<connector-name>: formatting` — before your edits, so the real change diffs clean instead of mixing fix and cleanup.
 
 ---
 

--- a/.claude/skills/add-stream/SKILL.md
+++ b/.claude/skills/add-stream/SKILL.md
@@ -25,7 +25,7 @@ These apply in every phase. Re-read them before each phase boundary.
 
 Confirm the connector exists. Locate its `models.py`, `resources.py`, `api.py` (or equivalents — naming varies between Python connectors). Read streams in the same connector before designing anything.
 
-**Clean-room check.** Kick off the connector's existing test suite (typically `pytest` from the connector directory) in the background as soon as Phase 0 begins. Phases 1–3 are read-only / planning and may proceed in parallel while the suite runs — do **not** block on it. The clean-room result is a **gate on Phase 4**: before writing any code for the new stream, confirm the baseline passes so later failures are attributable to the new stream, not pre-existing drift.
+**Clean-room check (`CONDUCT-CLEAN-ROOM`).** Kick off the connector's existing test suite in the background as soon as Phase 0 begins. Phases 1–3 are read-only / planning and may proceed in parallel while the suite runs — do **not** block on it. The result is a **gate on Phase 4**: confirm the baseline passes before writing any code for the new stream. Failure handling — including the separate `<connector-name>: update tests` commit for stale snapshots — is in [session-conduct.md](../../shared/session-conduct.md).
 
 If the suite fails:
 

--- a/.claude/skills/add-stream/SKILL.md
+++ b/.claude/skills/add-stream/SKILL.md
@@ -25,7 +25,7 @@ These apply in every phase. Re-read them before each phase boundary.
 
 Confirm the connector exists. Locate its `models.py`, `resources.py`, `api.py` (or equivalents — naming varies between Python connectors). Read streams in the same connector before designing anything.
 
-**Clean-room check (`CONDUCT-CLEAN-ROOM`).** Kick off the connector's existing test suite in the background as soon as Phase 0 begins. Phases 1–3 are read-only / planning and may proceed in parallel while the suite runs — do **not** block on it. The result is a **gate on Phase 4**: confirm the baseline passes before writing any code for the new stream. Failure handling — including the separate `<connector-name>: update tests` commit for stale snapshots — is in [session-conduct.md](../../shared/session-conduct.md).
+**Baseline check (`CONDUCT-ESTABLISH-BASELINE`).** Kick off the connector's existing test suite in the background as soon as Phase 0 begins. Phases 1–3 are read-only / planning and may proceed in parallel while the suite runs — do **not** block on it. The result is a **gate on Phase 4**: confirm the baseline passes before writing any code for the new stream. Failure handling — including the separate `<connector-name>: update tests` commit for stale snapshots — is in [session-conduct.md](../../shared/session-conduct.md).
 
 If the suite fails:
 

--- a/.claude/skills/bugfix-capture-connector/SKILL.md
+++ b/.claude/skills/bugfix-capture-connector/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bugfix-capture-connector
+description: Fix a bug in an existing estuary-cdk capture connector — reproduce it, locate it, fix it to house style, sweep sibling streams for the same defect, then regenerate discovery, refresh snapshots, and add a changelog entry. Use when a connector misbehaves in production or a capture produces wrong/missing documents.
+argument-hint: "[connector-name] [what's wrong]"
+allowed-tools: Bash Read Write Edit Glob Grep Agent Skill WebFetch
+---
+
+Fix the reported bug in `source-$1`. This skill is an orchestrator — most steps are existing skills. Don't reimplement them.
+
+## Laws
+
+- [`.claude/shared/session-conduct.md`](../../shared/session-conduct.md) — TODO list, consent, citing sources.
+- [`.claude/shared/provider-api-consent.md`](../../shared/provider-api-consent.md) — the `config.yaml` gate, never running mutations, the budget rule.
+
+Plus one specific to fixing rather than building:
+
+**Reproduce before you fix.** A fix for a bug you haven't observed is a guess that also removes the evidence. If you cannot reproduce it, say so explicitly and treat the fix as a hypothesis the user must accept as such.
+
+## Phase 0 — Characterize
+
+Establish what's actually wrong before touching code:
+
+- **Which stream(s)**, and which part — fetch, parse, cursor, wiring, schema?
+- **Symptom class**: missing documents, duplicate documents, wrong field values, a crash, a stall, or a capture that never advances its cursor. Missing documents and stalled cursors are the data-loss cases — treat them as urgent and expect the root cause to be in the fetch layer's window or checkpoint logic.
+- **Since when** — is this a regression? `git log --oneline -- <connector>/` and check whether a recent change touched the affected stream.
+
+Run the connector's test suite in the background now, as a baseline (`CONDUCT-CLEAN-ROOM`). A pre-existing failure changes what "fixed" means.
+
+## Phase 1 — Reproduce
+
+Prefer the cheapest reproduction that shows the defect:
+
+1. **A test** — if the bug is in parsing, cursor arithmetic, or model validation, it reproduces in `pytest` without touching the provider.
+2. **`flowctl preview`** on the affected binding, per the budget rule. Use `disable: true` on unrelated bindings (`API-COST-SAVER-DISABLE`) to keep it cheap — and restore them before committing.
+3. **A Bruno probe** — when the question is what the provider actually returns, use `bruno-probe-endpoint`. Live behavior settles doc-vs-reality disputes.
+
+Record what you observed. That's the before-state the fix has to change.
+
+## Phase 2 — Locate
+
+Read the affected fetch function and its siblings *before* editing. The bug is often in the difference between them.
+
+If the defect is in fetch or cursor logic, **invoke the `fetch-function-rules` skill now** and check the current implementation against it. Bugs of this class are usually an existing rule being violated, not a novel problem — and the rule text tells you what the correct shape is, which saves inventing one.
+
+## Phase 3 — Fix
+
+**Clean-room gate (`CONDUCT-CLEAN-ROOM`).** The Phase 0 baseline must have completed and been inspected before the first edit. Pre-existing drift commits first, before any fix work: stale snapshots as `source-$1: update tests`; and run the formatter over the files you're about to edit, committing any resulting diff as `source-$1: formatting`. Full failure handling is in [session-conduct.md](../../shared/session-conduct.md).
+
+Match the surrounding code. `.claude/rules/connector-python.md` auto-loads while you edit and carries the always-apply rules; `fetch-function-rules` carries the window and checkpoint semantics.
+
+Two failure modes specific to bugfixing:
+
+- **Don't broaden the fix into a refactor.** A scoped diff is reviewable and revertable. If the code around the bug is bad, say so and propose it separately.
+- **Don't fix the symptom.** A missing document caused by a window that skips a tick is not fixed by re-emitting the last page; it's fixed at the boundary (`FETCH-COMPLETE-TICKS`, `FETCH-SEAM-PRECISION`).
+
+## Phase 4 — Sibling sweep
+
+**The step that makes this skill worth having.** Streams in a connector share polling, pagination, and cursor patterns, so the bug you just fixed is probably present in its siblings.
+
+1. Enumerate the connector's other streams.
+2. Check each for the same defect shape — same window arithmetic, same resume key, same parse assumption.
+3. Present the affected siblings to the user **before** fixing them: a one-stream bug report becoming a five-stream diff needs consent, and the user may want them split across commits.
+
+Report the sweep result either way. "Checked all six streams, only `campaigns` was affected" is a useful finding.
+
+## Phase 5 — Verify
+
+- The reproduction from Phase 1 now shows the correct behavior.
+- The full suite passes, matching the Phase 0 baseline plus the fix.
+- If the fix changed discovered schemas or bindings, dispatch the `regenerate-flow-discovery` agent, then confirm `git diff --stat` is scoped to the change (`REVIEW-SNAPSHOT-SCOPE` — a broad uniform delta is a CDK schema sweep and belongs in its own commit).
+
+## Phase 6 — Land
+
+- **Changelog:** invoke the `changelog` skill. Every bug fix gets an entry, whether or not it looks user-visible (`REVIEW-CHANGELOG-ENTRY`).
+- **Self-review:** invoke `review-connector-change` on the working diff before handing off.
+- Commit scoped to the fix. Snapshot regeneration unrelated to the bug goes in its own `source-$1: update tests` commit, ordered before the fix (see the Phase 3 clean-room gate).
+- **Documentation:** if the fix changes user-visible behavior described in the connector's docs, update them (connector docs are mirrored into the flow repo's `site/docs` via a sibling PR).
+- **PR body:** follow [.github/pull_request_template.md](../../../.github/pull_request_template.md). Fill every section — drop **Regression?** only when the fix isn't one; list created or affected docs under **Documentation links affected:**; and state under **Notes for reviewers:** how the change was tested (unit tests, snapshot tests, `flowctl preview`, local stack tests, or another method — name what actually ran).
+- **Never push or open a PR without asking.** Always stop and confirm with the user before `git push` or `gh pr create` — even when the fix is verified and the user asked for the fix in the first place.
+
+## Out of scope
+
+- Adding a new stream → `add-stream`.
+- A bug in `estuary-cdk` itself rather than a connector — surface it; the blast radius is every connector and that's the user's call.

--- a/.claude/skills/bugfix-capture-connector/SKILL.md
+++ b/.claude/skills/bugfix-capture-connector/SKILL.md
@@ -24,7 +24,7 @@ Establish what's actually wrong before touching code:
 - **Symptom class**: missing documents, duplicate documents, wrong field values, a crash, a stall, or a capture that never advances its cursor. Missing documents and stalled cursors are the data-loss cases — treat them as urgent and expect the root cause to be in the fetch layer's window or checkpoint logic.
 - **Since when** — is this a regression? `git log --oneline -- <connector>/` and check whether a recent change touched the affected stream.
 
-Run the connector's test suite in the background now, as a baseline (`CONDUCT-CLEAN-ROOM`). A pre-existing failure changes what "fixed" means.
+Run the connector's test suite in the background now, as a baseline (`CONDUCT-ESTABLISH-BASELINE`). A pre-existing failure changes what "fixed" means.
 
 ## Phase 1 — Reproduce
 
@@ -44,7 +44,7 @@ If the defect is in fetch or cursor logic, **invoke the `fetch-function-rules` s
 
 ## Phase 3 — Fix
 
-**Clean-room gate (`CONDUCT-CLEAN-ROOM`).** The Phase 0 baseline must have completed and been inspected before the first edit. Pre-existing drift commits first, before any fix work: stale snapshots as `source-$1: update tests`; and run the formatter over the files you're about to edit, committing any resulting diff as `source-$1: formatting`. Full failure handling is in [session-conduct.md](../../shared/session-conduct.md).
+**Baseline gate (`CONDUCT-ESTABLISH-BASELINE`).** The Phase 0 baseline must have completed and been inspected before the first edit. Pre-existing drift commits first, before any fix work: stale snapshots as `source-$1: update tests`; and run the formatter over the files you're about to edit, committing any resulting diff as `source-$1: formatting`. Full failure handling is in [session-conduct.md](../../shared/session-conduct.md).
 
 Match the surrounding code. `.claude/rules/connector-python.md` auto-loads while you edit and carries the always-apply rules; `fetch-function-rules` carries the window and checkpoint semantics.
 
@@ -71,9 +71,9 @@ Report the sweep result either way. "Checked all six streams, only `campaigns` w
 
 ## Phase 6 — Land
 
-- **Changelog:** invoke the `changelog` skill. Every bug fix gets an entry, whether or not it looks user-visible (`REVIEW-CHANGELOG-ENTRY`).
+- **Changelog:** invoke the `changelog` skill. Don't pre-judge a fix as too internal to be worth mentioning — if the connector keeps a `CHANGELOG.md`, the fix gets an entry (`REVIEW-CHANGELOG-ENTRY`). Adding the file to a connector that has none stays the user's opt-in call.
 - **Self-review:** invoke `review-connector-change` on the working diff before handing off.
-- Commit scoped to the fix. Snapshot regeneration unrelated to the bug goes in its own `source-$1: update tests` commit, ordered before the fix (see the Phase 3 clean-room gate).
+- Commit scoped to the fix. Snapshot regeneration unrelated to the bug goes in its own `source-$1: update tests` commit, ordered before the fix (see the Phase 3 baseline gate).
 - **Documentation:** if the fix changes user-visible behavior described in the connector's docs, update them (connector docs are mirrored into the flow repo's `site/docs` via a sibling PR).
 - **PR body:** follow [.github/pull_request_template.md](../../../.github/pull_request_template.md). Fill every section — drop **Regression?** only when the fix isn't one; list created or affected docs under **Documentation links affected:**; and state under **Notes for reviewers:** how the change was tested (unit tests, snapshot tests, `flowctl preview`, local stack tests, or another method — name what actually ran).
 - **Never push or open a PR without asking.** Always stop and confirm with the user before `git push` or `gh pr create` — even when the fix is verified and the user asked for the fix in the first place.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -22,14 +22,12 @@ for the convention.
    ```bash
    git diff --name-only main...HEAD
    ```
-   Group changed files by top-level directory. Every affected connector
-   gets an entry — if one has no `CHANGELOG.md` at its root yet, create
-   it as part of applying the draft (per CONTRIBUTING.md, each connector
-   has its own changelog).
+   Group changed files by top-level directory. Keep only connector
+   directories that have an existing `CHANGELOG.md` at their root —
+   ignore directories without one (per opt-in convention).
 
 2. **For each affected connector**, gather context:
-   - Read its existing `CHANGELOG.md` to understand existing voice/format
-     (skip if the file doesn't exist yet).
+   - Read its existing `CHANGELOG.md` to understand existing voice/format.
    - Read its recent diff: `git diff main...HEAD -- <connector-dir>/`.
    - Identify *user-visible* effects:
      - New/removed/renamed config fields → schema diff (look for changes
@@ -84,8 +82,7 @@ for the convention.
 
 5. **Apply on confirmation.** Insert the new entry below `# Changelog`
    and above the most recent existing entry. Don't delete or modify
-   existing entries. If the connector has no `CHANGELOG.md`, create it
-   with a `# Changelog` heading followed by the new entry.
+   existing entries.
 
 6. **Multiple connectors.** If the PR touches multiple connectors,
    show all drafts at once, then apply all on a single confirmation.
@@ -104,6 +101,5 @@ for the convention.
 
 - Don't invent changes that aren't in the diff.
 - Don't commit the CHANGELOG edits — let the user review and commit them.
-- Don't skip a connector because it lacks a `CHANGELOG.md` — a missing
-  file means the connector predates the convention, not that it opted out.
-  Create it.
+- Don't add a CHANGELOG.md to a connector that doesn't already have one;
+  that's a deliberate opt-in step the user should take manually.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -22,12 +22,14 @@ for the convention.
    ```bash
    git diff --name-only main...HEAD
    ```
-   Group changed files by top-level directory. Keep only connector
-   directories that have an existing `CHANGELOG.md` at their root —
-   ignore directories without one (per opt-in convention).
+   Group changed files by top-level directory. Every affected connector
+   gets an entry — if one has no `CHANGELOG.md` at its root yet, create
+   it as part of applying the draft (per CONTRIBUTING.md, each connector
+   has its own changelog).
 
 2. **For each affected connector**, gather context:
-   - Read its existing `CHANGELOG.md` to understand existing voice/format.
+   - Read its existing `CHANGELOG.md` to understand existing voice/format
+     (skip if the file doesn't exist yet).
    - Read its recent diff: `git diff main...HEAD -- <connector-dir>/`.
    - Identify *user-visible* effects:
      - New/removed/renamed config fields → schema diff (look for changes
@@ -82,7 +84,8 @@ for the convention.
 
 5. **Apply on confirmation.** Insert the new entry below `# Changelog`
    and above the most recent existing entry. Don't delete or modify
-   existing entries.
+   existing entries. If the connector has no `CHANGELOG.md`, create it
+   with a `# Changelog` heading followed by the new entry.
 
 6. **Multiple connectors.** If the PR touches multiple connectors,
    show all drafts at once, then apply all on a single confirmation.
@@ -101,5 +104,6 @@ for the convention.
 
 - Don't invent changes that aren't in the diff.
 - Don't commit the CHANGELOG edits — let the user review and commit them.
-- Don't add a CHANGELOG.md to a connector that doesn't already have one;
-  that's a deliberate opt-in step the user should take manually.
+- Don't skip a connector because it lacks a `CHANGELOG.md` — a missing
+  file means the connector predates the convention, not that it opted out.
+  Create it.


### PR DESCRIPTION
**Description:**

Adds a `bugfix-capture-connector` skill.

Supporting change:

- **New `CONDUCT-CLEAN-ROOM` shared rule** (`session-conduct.md`, registered in
  `rules-index.md`): run the connector's baseline suite in the background at
  session start and gate the first code edit on it. Pre-existing drift lands
  first as its own commit — stale snapshots as `<connector>: update tests`,
  formatter output as `<connector>: formatting` — so the real change diffs
  against a green baseline instead of mixing fix with cleanup.

**Documentation links affected:**

None.

**Notes for reviewers:**

None.

**Checklist:**

- [x] No connector `CHANGELOG.md` or documentation update needed — this PR
  touches only `.claude/` agent tooling and changes no user-visible connector
  behavior. The `Docs / CHANGELOG check` job may need the `docs-check-skip`
  label applied as a false positive.
