### PR TITLE
source-sqlserver{,ct}: add re-discovery config knob & other re-discovery interval adjustments

### DIFF
--- a/scripts/obfuscation/config_allowlist.txt
+++ b/scripts/obfuscation/config_allowlist.txt
@@ -166,3 +166,4 @@ greetings
 skip_state
 fail_after
 exit_after
+rediscovery_interval

--- a/source-dynamodb/CHANGELOG.md
+++ b/source-dynamodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # source-dynamodb
 
-## v1, 2023-08-03
+## 2026-07-30
 
-- Beginning of changelog.
+### Changed
+- Captures no longer run discovery twice when they start up.
+- The timing of mid-capture rediscovery is now spread out rather than fixed, so
+  captures which started at the same moment no longer query the catalog in
+  lockstep every interval. The average rate of rediscovery is unchanged.

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -111,6 +111,13 @@
             "title": "Source Tag",
             "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
           },
+          "rediscovery_interval": {
+            "type": "string",
+            "title": "Rediscovery Interval",
+            "description": "How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified.",
+            "default": "15m",
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -147,11 +147,11 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 // Config tells the connector how to connect to the source database and
 // capture changes from it.
 type Config struct {
-	Address     string         `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User        string         `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password    string         `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Timezone    string         `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3"`
-	HistoryMode bool           `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4"`
+	Address     string `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
+	Timezone    string `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3"`
+	HistoryMode bool   `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4"`
 
 	DiscoveryFilters discoveryFilters `json:"discoveryFilters,omitempty" jsonschema:"title=Discovery Filters,description=Options that restrict which tables are visible to discovery."`
 	Advanced         advancedConfig   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
@@ -167,6 +167,7 @@ type advancedConfig struct {
 	BackfillChunkSize        int      `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
 	DiscoverSchemas          []string `json:"discover_schemas,omitempty" jsonschema:"title=Discovery Schema Selection,description=If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."`
 	SourceTag                string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
+	RediscoveryInterval      string   `json:"rediscovery_interval,omitempty" jsonschema:"title=Rediscovery Interval,default=15m,description=How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
 	FeatureFlags             string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 	StatementTimeout         string   `json:"statement_timeout,omitempty" jsonschema:"title=Statement Timeout,description=Overrides the default statement timeout used by the connector. The default of zero disables statement timeouts entirely.,enum=,enum=30s,enum=1m,enum=5m,enum=30m,default="`
 
@@ -207,6 +208,9 @@ func (c *Config) Validate() error {
 		if _, err := time.ParseDuration(c.Advanced.StatementTimeout); err != nil {
 			return fmt.Errorf("invalid statement timeout %q: %w", c.Advanced.StatementTimeout, err)
 		}
+	}
+	if err := sqlcapture.ValidateRediscoveryInterval(c.Advanced.RediscoveryInterval); err != nil {
+		return err
 	}
 	if err := c.DiscoveryFilters.Validate(); err != nil {
 		return err
@@ -485,6 +489,10 @@ func (db *mysqlDatabase) SourceMetadataSchema(writeSchema bool) *jsonschema.Sche
 
 func (db *mysqlDatabase) FallbackCollectionKey() []string {
 	return []string{"/_meta/source/cursor"}
+}
+
+func (db *mysqlDatabase) RediscoveryInterval() time.Duration {
+	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
 func (db *mysqlDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {

--- a/source-oracle/.snapshots/TestGeneric-SpecResponse
+++ b/source-oracle/.snapshots/TestGeneric-SpecResponse
@@ -85,6 +85,13 @@
             "title": "Source Tag",
             "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
           },
+          "rediscovery_interval": {
+            "type": "string",
+            "title": "Rediscovery Interval",
+            "description": "How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified.",
+            "default": "15m",
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-oracle/CHANGELOG.md
+++ b/source-oracle/CHANGELOG.md
@@ -1,4 +1,4 @@
-# source-mysql
+# Changelog
 
 ## 2026-07-30
 
@@ -8,8 +8,9 @@
   newly added tables. It defaults to 15 minutes.
 
 ### Changed
-- Captures no longer run discovery twice when they start up.
+- Captures no longer run discovery twice when they start up. Every restart
+  previously issued two rounds of catalog queries in quick succession, which was
+  most noticeable when many captures sharing a database all restarted at once.
 - The timing of mid-capture rediscovery is now spread out rather than fixed, so
   captures which started at the same moment no longer query the catalog in
   lockstep every interval. The average rate of rediscovery is unchanged.
-

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -174,6 +174,7 @@ type advancedConfig struct {
 	NodeID               uint32   `json:"node_id,omitempty" jsonschema:"title=Node ID,description=Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value."`
 	DictionaryMode       string   `json:"dictionary_mode,omitempty" jsonschema:"title=Dictionary Mode,description=How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to smart which automatically switches between the two modes based on requirements.,enum=extract,enum=online,enum=smart"`
 	SourceTag            string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
+	RediscoveryInterval  string   `json:"rediscovery_interval,omitempty" jsonschema:"title=Rediscovery Interval,default=15m,description=How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
 	FeatureFlags         string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
@@ -196,6 +197,10 @@ func (c *Config) Validate() error {
 
 	if !slices.Contains([]string{"", DictionaryModeExtract, DictionaryModeOnline, DictionaryModeSmart}, c.Advanced.DictionaryMode) {
 		return fmt.Errorf("dictionary mode must be one of %s or %s or %s", DictionaryModeExtract, DictionaryModeOnline, DictionaryModeSmart)
+	}
+
+	if err := sqlcapture.ValidateRediscoveryInterval(c.Advanced.RediscoveryInterval); err != nil {
+		return err
 	}
 
 	return nil
@@ -358,6 +363,10 @@ func (db *oracleDatabase) SourceMetadataSchema(writeSchema bool) *jsonschema.Sch
 
 func (db *oracleDatabase) FallbackCollectionKey() []string {
 	return []string{"/_meta/source/rs_id", "/_meta/source/ssn"}
+}
+
+func (db *oracleDatabase) RediscoveryInterval() time.Duration {
+	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
 func encodeKeyFDB(key any, colType oracleColumnType) (tuple.TupleElement, error) {

--- a/source-postgres/.snapshots/TestSpec
+++ b/source-postgres/.snapshots/TestSpec
@@ -262,6 +262,13 @@
             "title": "Source Tag",
             "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
           },
+          "rediscovery_interval": {
+            "type": "string",
+            "title": "Rediscovery Interval",
+            "description": "How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified.",
+            "default": "15m",
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-07-30
+
+### Added
+- New `rediscovery_interval` advanced option controls how often the connector
+  re-runs discovery while a capture is running, to notice schema changes and
+  newly added tables. It defaults to 15 minutes.
+
+### Changed
+- Captures no longer run discovery twice when they start up.
+- The timing of mid-capture rediscovery is now spread out rather than fixed, so
+  captures which started at the same moment no longer query the catalog in
+  lockstep every interval. The average rate of rediscovery is unchanged.
+
 ## 2026-07-21
 
 ### Added

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -172,6 +172,7 @@ type advancedConfig struct {
 	CaptureAsPartitions       bool     `json:"capture_as_partitions,omitempty" jsonschema:"title=Capture Partitioned Tables As Partitions,description=When set the capture will discover and capture partitioned tables as individual partitions rather than as a single root table. This requires the publication to be created without 'publish_via_partition_root'."`
 	DiscoverUnpublishedTables bool     `json:"discover_unpublished_tables,omitempty" jsonschema:"title=Discover Unpublished Tables,description=When set the capture will discover all tables including those not currently in the publication. Unpublished tables will be added to the publication at capture time if possible. Use with caution as this requires appropriate database permissions."`
 	SourceTag                 string   `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
+	RediscoveryInterval       string   `json:"rediscovery_interval,omitempty" jsonschema:"title=Rediscovery Interval,default=15m,description=How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
 	FeatureFlags              string   `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 	StatementTimeout          string   `json:"statement_timeout,omitempty" jsonschema:"title=Statement Timeout,description=Overrides the statement timeout used by the connector. Leave blank to use the default of 2 minutes. Set to '0' to disable statement timeouts entirely.,enum=,enum=0,enum=30s,enum=1m,enum=2m,enum=5m,enum=30m,default="`
 
@@ -297,6 +298,9 @@ func (c *Config) Validate() error {
 		if _, err := time.ParseDuration(c.Advanced.StatementTimeout); err != nil {
 			return fmt.Errorf("invalid statement timeout %q: %w", c.Advanced.StatementTimeout, err)
 		}
+	}
+	if err := sqlcapture.ValidateRediscoveryInterval(c.Advanced.RediscoveryInterval); err != nil {
+		return err
 	}
 	if err := c.DiscoveryFilters.Validate(); err != nil {
 		return err
@@ -531,6 +535,10 @@ func (db *postgresDatabase) SourceMetadataSchema(writeSchema bool) *jsonschema.S
 
 func (db *postgresDatabase) FallbackCollectionKey() []string {
 	return []string{"/_meta/source/loc/0", "/_meta/source/loc/1", "/_meta/source/loc/2"}
+}
+
+func (db *postgresDatabase) RediscoveryInterval() time.Duration {
+	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
 func (db *postgresDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {

--- a/source-snowflake/CHANGELOG.md
+++ b/source-snowflake/CHANGELOG.md
@@ -1,4 +1,9 @@
 # source-snowflake
 
-## v1, 2024-01-19
-- Beginning of changelog.
+## 2026-07-30
+
+### Changed
+- Captures no longer run discovery twice when they start up.
+- The timing of mid-capture rediscovery is now spread out rather than fixed, so
+  captures which started at the same moment no longer query the catalog in
+  lockstep every interval. The average rate of rediscovery is unchanged.

--- a/source-sqlserver-ct/.snapshots/TestSpec
+++ b/source-sqlserver-ct/.snapshots/TestSpec
@@ -107,6 +107,13 @@
             "title": "Source Tag",
             "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
           },
+          "rediscovery_interval": {
+            "type": "string",
+            "title": "Rediscovery Interval",
+            "description": "How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified.",
+            "default": "15m",
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-sqlserver-ct/CHANGELOG.md
+++ b/source-sqlserver-ct/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-07-30
 
+### Added
+- New `rediscovery_interval` advanced option controls how often the connector
+  re-runs discovery while a capture is running, to notice schema changes and
+  newly added tables. It defaults to 15 minutes.
+
 ### Fixed
 - Discovery queries are now shaped so that SQL Server reuses a single cached
   query plan across repeated discovery passes, rather than compiling a new plan
@@ -17,6 +22,10 @@
   Server from using an index seek on tables whose primary key has more than one
   column. Each chunk instead rescanned every row it had already read, so backfills of
   large tables progressed more and more slowly as they went on.
+- Captures no longer run discovery twice when they start up.
+- The timing of mid-capture rediscovery is now spread out rather than fixed, so
+  captures which started at the same moment no longer query the catalog in
+  lockstep every interval. The average rate of rediscovery is unchanged.
 
 ## 2026-07-22
 

--- a/source-sqlserver-ct/main.go
+++ b/source-sqlserver-ct/main.go
@@ -61,12 +61,13 @@ type Config struct {
 }
 
 type advancedConfig struct {
-	DiscoverNonEnabled bool   `json:"discover_tables_without_ct,omitempty" jsonschema:"title=Discover Tables Without Change Tracking,description=When set the connector will discover all tables even if they do not have Change Tracking enabled. By default only CT-enabled tables are discovered."`
-	SkipBackfills      string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
-	BackfillChunkSize  int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
-	PollingInterval    string `json:"polling_interval,omitempty" jsonschema:"title=Change Tracking Polling Interval,default=500ms,description=The interval at which the connector polls for Change Tracking changes. Accepts duration strings like '500ms' or '30s' or '1m'. Defaults to 500ms when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
-	SourceTag          string `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
-	FeatureFlags       string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
+	DiscoverNonEnabled  bool   `json:"discover_tables_without_ct,omitempty" jsonschema:"title=Discover Tables Without Change Tracking,description=When set the connector will discover all tables even if they do not have Change Tracking enabled. By default only CT-enabled tables are discovered."`
+	SkipBackfills       string `json:"skip_backfills,omitempty" jsonschema:"title=Skip Backfills,description=A comma-separated list of fully-qualified table names which should not be backfilled."`
+	BackfillChunkSize   int    `json:"backfill_chunk_size,omitempty" jsonschema:"title=Backfill Chunk Size,default=50000,description=The number of rows which should be fetched from the database in a single backfill query."`
+	PollingInterval     string `json:"polling_interval,omitempty" jsonschema:"title=Change Tracking Polling Interval,default=500ms,description=The interval at which the connector polls for Change Tracking changes. Accepts duration strings like '500ms' or '30s' or '1m'. Defaults to 500ms when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
+	SourceTag           string `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
+	RediscoveryInterval string `json:"rediscovery_interval,omitempty" jsonschema:"title=Rediscovery Interval,default=15m,description=How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
+	FeatureFlags        string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 }
 
 type tunnelConfig struct {
@@ -106,6 +107,9 @@ func (c *Config) Validate() error {
 		} else if parsedInterval > sqlcapture.StreamingFenceInterval {
 			return fmt.Errorf("invalid 'polling_interval' configuration %q: must not exceed %s", c.Advanced.PollingInterval, sqlcapture.StreamingFenceInterval)
 		}
+	}
+	if err := sqlcapture.ValidateRediscoveryInterval(c.Advanced.RediscoveryInterval); err != nil {
+		return err
 	}
 
 	if c.Advanced.SkipBackfills != "" {
@@ -366,3 +370,7 @@ func (db *sqlserverDatabase) FallbackCollectionKey() []string {
 }
 
 func (db *sqlserverDatabase) RequestTxIDs(schema, table string) {}
+
+func (db *sqlserverDatabase) RediscoveryInterval() time.Duration {
+	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
+}

--- a/source-sqlserver/.snapshots/TestSpec
+++ b/source-sqlserver/.snapshots/TestSpec
@@ -129,6 +129,13 @@
             "title": "Source Tag",
             "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
           },
+          "rediscovery_interval": {
+            "type": "string",
+            "title": "Rediscovery Interval",
+            "description": "How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified.",
+            "default": "15m",
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-07-30
 
+### Added
+- New `rediscovery_interval` advanced option controls how often the connector
+  re-runs discovery while a capture is running, to notice schema changes and
+  newly added tables. It defaults to 15 minutes.
+
 ### Fixed
 - Discovery queries are now shaped so that SQL Server reuses a single cached
   query plan across repeated discovery passes, rather than compiling a new plan
@@ -17,6 +22,10 @@
   Server from using an index seek on tables whose primary key has more than one
   column. Each chunk instead rescanned every row it had already read, so backfills of
   large tables progressed more and more slowly as they went on.
+- Captures no longer run discovery twice when they start up.
+- The timing of mid-capture rediscovery is now spread out rather than fixed, so
+  captures which started at the same moment no longer query the catalog in
+  lockstep every interval. The average rate of rediscovery is unchanged.
 
 ## 2026-07-23
 

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -92,6 +92,7 @@ type advancedConfig struct {
 	Filegroup                   string `json:"filegroup,omitempty" jsonschema:"title=CDC Instance Filegroup,description=When set the connector will create new CDC instances with the specified 'filegroup_name' argument. Has no effect if CDC instances are managed manually."`
 	RoleName                    string `json:"role_name,omitempty" jsonschema:"title=CDC Instance Access Role,description=When set the connector will create new CDC instances with the specified 'role_name' argument as the gating role. When unset the capture user name is used as the 'role_name' instead. Has no effect if CDC instances are managed manually."`
 	SourceTag                   string `json:"source_tag,omitempty" jsonschema:"title=Source Tag,description=When set the capture will add this value as the property 'tag' in the source metadata of each document."`
+	RediscoveryInterval         string `json:"rediscovery_interval,omitempty" jsonschema:"title=Rediscovery Interval,default=15m,description=How often the connector re-runs discovery while a capture is running to notice schema changes and newly added tables. Accepts duration strings like '15m' or '1h'. Defaults to 15m when unspecified." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$"`
 	FeatureFlags                string `json:"feature_flags,omitempty" jsonschema:"title=Feature Flags,description=This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."`
 	WatermarksTable             string `json:"watermarksTable,omitempty" jsonschema:"default=dbo.flow_watermarks,description=This property is deprecated for new captures as they will no longer use watermark writes by default. The name of the table used for watermark writes during backfills. Must be fully-qualified in '<schema>.<table>' form."`
 }
@@ -131,6 +132,9 @@ func (c *Config) Validate() error {
 		} else if parsedInterval < 100*time.Millisecond {
 			return fmt.Errorf("invalid 'polling_interval' configuration %q: must be at least 100ms", c.Advanced.PollingInterval)
 		}
+	}
+	if err := sqlcapture.ValidateRediscoveryInterval(c.Advanced.RediscoveryInterval); err != nil {
+		return err
 	}
 
 	if c.Advanced.WatermarksTable != "" && !strings.Contains(c.Advanced.WatermarksTable, ".") {
@@ -381,3 +385,7 @@ func (db *sqlserverDatabase) FallbackCollectionKey() []string {
 }
 
 func (db *sqlserverDatabase) RequestTxIDs(schema, table string) {}
+
+func (db *sqlserverDatabase) RediscoveryInterval() time.Duration {
+	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
+}

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -212,6 +212,8 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("error discovering database tables: %w", err)
 	} else if err := c.emitSourcedSchemas(discovery); err != nil {
 		return err
+	} else if err := c.emitState(); err != nil { // Emit state so any SourcedSchema changes commit immediately.
+		return err
 	}
 	for streamID, discoveryInfo := range discovery {
 		log.WithFields(log.Fields{
@@ -270,7 +272,12 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("error streaming until fence: %w", err)
 	}
 
-	var rediscoverAfter time.Time
+	// Activate any pending streams using the schema information already fetched during
+	// startup, then schedule the first rediscovery a full interval out.
+	if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
+		return fmt.Errorf("error initializing pending streams: %w", err)
+	}
+	var rediscoverAfter = nextRediscovery()
 	var periodicChecksAfter time.Time
 	for ctx.Err() == nil {
 		if time.Now().After(rediscoverAfter) {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -195,6 +195,14 @@ var (
 	ErrFenceNotReached = fmt.Errorf("replication stream closed before reaching fence")
 )
 
+// nextRediscovery returns the time at which a capture should next re-run discovery.
+//
+// The delay is jittered across an interval-wide window rather than being exactly
+// rediscoverInterval.
+func nextRediscovery() time.Time {
+	return time.Now().Add(rediscoverInterval/2 + time.Duration(rand.Int63n(int64(rediscoverInterval))))
+}
+
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {
 	// Fetch detailed schema info for the tables that this capture's bindings
@@ -279,7 +287,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 			if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
 				return fmt.Errorf("error initializing pending streams: %w", err)
 			}
-			rediscoverAfter = time.Now().Add(rediscoverInterval)
+			rediscoverAfter = nextRediscovery()
 		}
 
 		if time.Now().After(periodicChecksAfter) {

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -199,8 +199,56 @@ var (
 //
 // The delay is jittered across an interval-wide window rather than being exactly
 // rediscoverInterval.
-func nextRediscovery() time.Time {
-	return time.Now().Add(rediscoverInterval/2 + time.Duration(rand.Int63n(int64(rediscoverInterval))))
+func (c *Capture) nextRediscovery() time.Time {
+	var interval = c.rediscoveryInterval()
+	return time.Now().Add(interval/2 + time.Duration(rand.Int63n(int64(interval))))
+}
+
+// rediscoveryInterval returns how long this capture waits between rediscoveries.
+func (c *Capture) rediscoveryInterval() time.Duration {
+	if interval := c.Database.RediscoveryInterval(); interval > 0 {
+		return interval
+	}
+	return rediscoverInterval
+}
+
+const (
+	// minRediscoveryInterval and maxRediscoveryInterval bound a user-configured rediscovery
+	// interval. A year already means "effectively never rediscover", and staying far below the
+	// point where the jittered delay (which reaches 1.5x the interval) would overflow an int64
+	// duration keeps an absurdly large value from wrapping negative and thereby inverting into
+	// rediscovery on every pass of the capture loop.
+	minRediscoveryInterval = 1 * time.Minute
+	maxRediscoveryInterval = 365 * 24 * time.Hour
+)
+
+// ValidateRediscoveryInterval checks a connector's 'rediscovery_interval' config setting.
+// An empty value means "use the default interval" and is always valid.
+func ValidateRediscoveryInterval(interval string) error {
+	if interval == "" {
+		return nil
+	}
+	var parsed, err = time.ParseDuration(interval)
+	if err != nil {
+		return fmt.Errorf("invalid 'rediscovery_interval' configuration %q: %w", interval, err)
+	} else if parsed < minRediscoveryInterval {
+		return fmt.Errorf("invalid 'rediscovery_interval' configuration %q: must be at least %s", interval, minRediscoveryInterval)
+	} else if parsed > maxRediscoveryInterval {
+		return fmt.Errorf("invalid 'rediscovery_interval' configuration %q: must not exceed %s", interval, maxRediscoveryInterval)
+	}
+	return nil
+}
+
+// ParseRediscoveryInterval converts a 'rediscovery_interval' config setting into a duration
+// for connectors to implement Database.RediscoveryInterval with. Empty values yield zero,
+// meaning the default interval applies, and so do unparseable ones since a config which got
+// this far has already been accepted by ValidateRediscoveryInterval.
+func ParseRediscoveryInterval(interval string) time.Duration {
+	var parsed, err = time.ParseDuration(interval)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 // Run is the top level entry point of the capture process.
@@ -277,7 +325,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
 		return fmt.Errorf("error initializing pending streams: %w", err)
 	}
-	var rediscoverAfter = nextRediscovery()
+	var rediscoverAfter = c.nextRediscovery()
 	var periodicChecksAfter time.Time
 	for ctx.Err() == nil {
 		if time.Now().After(rediscoverAfter) {
@@ -294,7 +342,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 			if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
 				return fmt.Errorf("error initializing pending streams: %w", err)
 			}
-			rediscoverAfter = nextRediscovery()
+			rediscoverAfter = c.nextRediscovery()
 		}
 
 		if time.Now().After(periodicChecksAfter) {

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -295,6 +295,14 @@ type Database interface {
 	// HistoryMode returns whether history mode (non-associative reduction of events) is enabled
 	HistoryMode() bool
 
+	// RediscoveryInterval returns how long the capture should wait between mid-capture
+	// rediscovery passes, or zero to use the default interval. Rediscovery costs a handful of
+	// catalog queries per capture per interval, which is insignificant on its own but not when
+	// hundreds or thousands of captures share one source database, so connectors surface this
+	// as a config setting for those users to trade responsiveness to schema changes against
+	// load on their server. Implement it with ParseRediscoveryInterval.
+	RediscoveryInterval() time.Duration
+
 	// The collection key which should be suggested if discovery fails to find suitable
 	// primary key. This should be some property or combination of properties in the
 	// source metadata which encodes the database change sequence.


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes:
- adding some jitter to the `rediscoveryInterval` in `sqlcapture`
- not re-running discovery a second time right after starting up in `sqlcapture`
- making the rediscovery interval configurable for `sqlcapture` based connectors

See individual commits for more details.

**Notes for reviewers:**

See this [Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1785361977655109) for context on the motivation for these changes.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
