### PR TITLE
source-sqlserver: more misc. improvements

### DIFF
--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -495,6 +495,10 @@ func (db *mysqlDatabase) RediscoveryInterval() time.Duration {
 	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
+func (db *mysqlDatabase) ReplicationPollingInterval() time.Duration {
+	return 0 // Binlog replication events arrive continuously rather than being polled for.
+}
+
 func (db *mysqlDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// As a special case, the solitary value '*.*' means that nothing should be
 	// backfilled. This makes certain sorts of operation which would otherwise

--- a/source-oracle/main.go
+++ b/source-oracle/main.go
@@ -369,6 +369,12 @@ func (db *oracleDatabase) RediscoveryInterval() time.Duration {
 	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
+func (db *oracleDatabase) ReplicationPollingInterval() time.Duration {
+	// Replication events are produced by polling the logs on a fixed interval, so a
+	// stream-to-fence cycle can't complete any faster than that.
+	return pollInterval
+}
+
 func encodeKeyFDB(key any, colType oracleColumnType) (tuple.TupleElement, error) {
 	switch key := key.(type) {
 	case [16]uint8:

--- a/source-postgres/main.go
+++ b/source-postgres/main.go
@@ -541,6 +541,10 @@ func (db *postgresDatabase) RediscoveryInterval() time.Duration {
 	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
 
+func (db *postgresDatabase) ReplicationPollingInterval() time.Duration {
+	return 0 // Logical replication events arrive continuously rather than being polled for.
+}
+
 func (db *postgresDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 	// Allow the setting "*.*" to skip backfilling any tables.
 	if db.config.Advanced.SkipBackfills == "*.*" {

--- a/source-sqlserver-ct/main.go
+++ b/source-sqlserver-ct/main.go
@@ -374,3 +374,20 @@ func (db *sqlserverDatabase) RequestTxIDs(schema, table string) {}
 func (db *sqlserverDatabase) RediscoveryInterval() time.Duration {
 	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
+
+func (db *sqlserverDatabase) ReplicationPollingInterval() time.Duration {
+	// Reported for consistency with source-sqlserver rather than out of necessity. Unlike the
+	// CDC connector, whose cycle can only end once a polling pass reports a commit position at
+	// or past the fence, this connector's stream-to-fence loop is bounded by the fence duration
+	// itself and polls within it, so its cycles don't lengthen with the polling interval. That
+	// interval is also validated to be no greater than sqlcapture.StreamingFenceInterval, which
+	// keeps the resulting threshold close to the default in any case.
+	//
+	// Validation has already rejected unparseable values and SetDefaults fills in an empty one,
+	// so a failure here can only mean we have no better estimate than the default threshold.
+	var interval, err = time.ParseDuration(db.config.Advanced.PollingInterval)
+	if err != nil {
+		return 0
+	}
+	return interval
+}

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-07-31
 
 ### Fixed
+- The startup check for whether CDC is enabled now binds the database name as a
+  query parameter instead of splicing it into the statement, so every capture
+  issues the same query rather than one plan's worth of work per database name.
 - Automatic change table cleanup now binds its watermark as a query parameter
   instead of formatting it into the statement. Every cleanup call previously
   produced a statement SQL Server had never seen before, so it compiled a plan

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 2026-07-31
 
 ### Fixed
+- Automatic change table cleanup now binds its watermark as a query parameter
+  instead of formatting it into the statement. Every cleanup call previously
+  produced a statement SQL Server had never seen before, so it compiled a plan
+  for each one, used it once and discarded it. This only affected captures with
+  `change_table_cleanup` enabled.
 - The polling query which checks each CDC capture instance for new changes now
   lists those instances in a stable order. It was previously assembled in map
   iteration order, so its text differed on every polling cycle and SQL Server

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # source-sqlserver
 
+## 2026-07-31
+
+### Fixed
+- The polling query which checks each CDC capture instance for new changes now
+  lists those instances in a stable order. It was previously assembled in map
+  iteration order, so its text differed on every polling cycle and SQL Server
+  compiled a new plan for it each time instead of reusing a cached one.
+
 ## 2026-07-30
 
 ### Added

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -7,6 +7,13 @@
   lists those instances in a stable order. It was previously assembled in map
   iteration order, so its text differed on every polling cycle and SQL Server
   compiled a new plan for it each time instead of reusing a cached one.
+- Replication diagnostics are no longer collected on every streaming cycle when
+  a large `polling_interval` is configured. A streaming cycle cannot finish any
+  faster than one polling interval, so the fixed five minute threshold for
+  treating a cycle as unexpectedly long was exceeded on every cycle, and each
+  capture then repeatedly ran a set of queries against server-wide metadata.
+  The threshold is now that five minute grace period on top of the configured
+  polling interval.
 
 ## 2026-07-30
 

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -389,3 +389,15 @@ func (db *sqlserverDatabase) RequestTxIDs(schema, table string) {}
 func (db *sqlserverDatabase) RediscoveryInterval() time.Duration {
 	return sqlcapture.ParseRediscoveryInterval(db.config.Advanced.RediscoveryInterval)
 }
+
+func (db *sqlserverDatabase) ReplicationPollingInterval() time.Duration {
+	// A stream-to-fence cycle ends when a polling cycle reports a commit position at or past
+	// the fence, so it can't complete any faster than the CDC polling interval. Validation has
+	// already rejected unparseable values and SetDefaults fills in an empty one, so a failure
+	// here can only mean we have no better estimate than the default threshold.
+	var interval, err = time.ParseDuration(db.config.Advanced.PollingInterval)
+	if err != nil {
+		return 0
+	}
+	return interval
+}

--- a/source-sqlserver/prerequisites.go
+++ b/source-sqlserver/prerequisites.go
@@ -145,7 +145,8 @@ func (db *sqlserverDatabase) prerequisiteCDCEnabled(ctx context.Context) error {
 
 func isCDCEnabled(ctx context.Context, conn *sql.DB, dbName string) (bool, error) {
 	var cdcEnabled bool
-	if err := conn.QueryRowContext(ctx, fmt.Sprintf(`SELECT is_cdc_enabled FROM sys.databases WHERE name = '%s';`, dbName)).Scan(&cdcEnabled); err != nil {
+	const query = `SELECT is_cdc_enabled FROM sys.databases WHERE name = @p1;`
+	if err := conn.QueryRowContext(ctx, query, mssqldb.NVarCharMax(dbName)).Scan(&cdcEnabled); err != nil {
 		return false, fmt.Errorf("unable to query CDC status of database %q: %w", dbName, err)
 	}
 	return cdcEnabled, nil

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -1370,15 +1370,7 @@ func cdcGetDDLHistory(ctx context.Context, conn *sql.DB) (map[sqlcapture.StreamI
 // time. If we ever hit a scaling limit here we can implement chunking, but so far that doesn't
 // appear to be necessary.
 func cdcGetInstanceMaxLSNs(ctx context.Context, conn *sql.DB, instanceNames []string) (map[string]LSN, error) {
-	var subqueries []string
-	for idx, instanceName := range instanceNames {
-		// TODO(wgd): It would probably be a good idea to properly quote the CDC table name instead of just splatting
-		// the instance name into the query string. But currently we don't do that for backfills or for the actual
-		// replication polling query, so it would be premature to worry about it only here.
-		var subquery = fmt.Sprintf("SELECT %d AS idx, MAX(__$start_lsn) AS lsn FROM [cdc].[%s_CT]", idx, instanceName)
-		subqueries = append(subqueries, subquery)
-	}
-	var query = strings.Join(subqueries, " UNION ALL ")
+	var query, sortedInstanceNames = cdcInstanceMaxLSNsQuery(instanceNames)
 
 	rows, err := conn.QueryContext(ctx, query)
 	if err != nil {
@@ -1393,10 +1385,10 @@ func cdcGetInstanceMaxLSNs(ctx context.Context, conn *sql.DB, instanceNames []st
 		if err := rows.Scan(&index, &instanceMaxLSN); err != nil {
 			return nil, fmt.Errorf("error scanning result: %w", err)
 		}
-		if index < 0 || index >= len(instanceNames) {
-			return nil, fmt.Errorf("internal error: result index %d out of range for instance list %q", index, len(instanceNames))
+		if index < 0 || index >= len(sortedInstanceNames) {
+			return nil, fmt.Errorf("internal error: result index %d out of range for instance list of length %d", index, len(sortedInstanceNames))
 		}
-		var instanceName = instanceNames[index]
+		var instanceName = sortedInstanceNames[index]
 		log.WithFields(log.Fields{
 			"instance": instanceName,
 			"lsn":      instanceMaxLSN,
@@ -1404,6 +1396,25 @@ func cdcGetInstanceMaxLSNs(ctx context.Context, conn *sql.DB, instanceNames []st
 		results[instanceName] = instanceMaxLSN
 	}
 	return results, rows.Err()
+}
+
+// cdcInstanceMaxLSNsQuery builds the union query used by cdcGetInstanceMaxLSNs, and returns it
+// along with the ordered instance names which the `idx` column of each result row indexes into.
+//
+// The instance names are sorted so that the generated query text is stable across polling cycles.
+func cdcInstanceMaxLSNsQuery(instanceNames []string) (string, []string) {
+	var sorted = slices.Clone(instanceNames)
+	slices.Sort(sorted)
+
+	var subqueries []string
+	for idx, instanceName := range sorted {
+		// TODO(wgd): It would probably be a good idea to properly quote the CDC table name instead of just splatting
+		// the instance name into the query string. But currently we don't do that for backfills or for the actual
+		// replication polling query, so it would be premature to worry about it only here.
+		var subquery = fmt.Sprintf("SELECT %d AS idx, MAX(__$start_lsn) AS lsn FROM [cdc].[%s_CT]", idx, instanceName)
+		subqueries = append(subqueries, subquery)
+	}
+	return strings.Join(subqueries, " UNION ALL "), sorted
 }
 
 func cdcCleanupChangeTable(ctx context.Context, conn *sql.DB, instanceName string, belowLSN LSN) error {

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -19,6 +19,7 @@ import (
 	"github.com/estuary/connectors/go/encrow"
 	"github.com/estuary/connectors/sqlcapture"
 	"github.com/google/uuid"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -1420,8 +1421,10 @@ func cdcInstanceMaxLSNsQuery(instanceNames []string) (string, []string) {
 func cdcCleanupChangeTable(ctx context.Context, conn *sql.DB, instanceName string, belowLSN LSN) error {
 	log.WithFields(log.Fields{"instance": instanceName, "lsn": fmt.Sprintf("%X", belowLSN)}).Debug("cleaning change table")
 
-	var query = fmt.Sprintf("EXEC sys.sp_cdc_cleanup_change_table @capture_instance = @p1, @low_water_mark = 0x%X; ", belowLSN)
-	if _, err := conn.ExecContext(ctx, query, instanceName); err != nil {
+	// Bind the instance name and watermark as parameters to improve query plan cache
+	// hit rate when making cleanup queries.
+	const query = "EXEC sys.sp_cdc_cleanup_change_table @capture_instance = @p1, @low_water_mark = @p2;"
+	if _, err := conn.ExecContext(ctx, query, mssqldb.NVarCharMax(instanceName), belowLSN); err != nil {
 		return fmt.Errorf("error cleaning capture instance %q below LSN %X: %w", instanceName, belowLSN, err)
 	}
 	return nil

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -251,6 +251,22 @@ func ParseRediscoveryInterval(interval string) time.Duration {
 	return parsed
 }
 
+// streamingDiagnosticsThreshold returns how long a single streaming cycle must run before it's
+// considered to have gone on for an unexpectedly long time and replication diagnostics are
+// collected.
+//
+// Diagnostics are more expensive than the progress logging they're interleaved with, since
+// for some connectors they query server-wide metadata, so they mustn't fire on cycles which are
+// slow due to their configuration. A polling connector can't complete a cycle any faster than one
+// polling period, so the threshold is that period plus a fixed grace interval rather than a
+// fixed duration on its own.
+func (c *Capture) streamingDiagnosticsThreshold() time.Duration {
+	if interval := c.Database.ReplicationPollingInterval(); interval > 0 {
+		return streamingProgressInterval + interval
+	}
+	return streamingProgressInterval
+}
+
 // Run is the top level entry point of the capture process.
 func (c *Capture) Run(ctx context.Context) (err error) {
 	// Fetch detailed schema info for the tables that this capture's bindings
@@ -666,23 +682,35 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 	// so the two callers of logProgress never overlap on the shared interval state.
 	var progressDone = make(chan struct{})
 	var progressWG sync.WaitGroup
-	var progressTicks int
+	var cycleStarted = time.Now()
+	var diagnosticTicks int
 	progressWG.Go(func() {
 		var ticker = time.NewTicker(streamingProgressInterval)
 		defer ticker.Stop()
+		// Diagnostics are gated on a separate, generally longer threshold than progress
+		// logging, and repeat less often than it once a cycle exceeds that threshold.
+		var diagnosticsAfter = c.streamingDiagnosticsThreshold()
 		for {
 			select {
 			case <-progressDone:
 				return
 			case <-ticker.C:
 				logProgress("processing replication events")
-				log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
-				// Dump goroutine stacks on the first tick and every fifth tick thereafter
-				// to help with investigations into potentially stalled captures.
-				if progressTicks%5 == 0 {
-					dumpGoroutineStacks()
+				if time.Since(cycleStarted) < diagnosticsAfter {
+					continue
 				}
-				progressTicks++
+				// Collect diagnostics and dump goroutine stacks on the first tick past the
+				// threshold and every fifth tick thereafter, to help with investigations
+				// into potentially stalled captures. The first report is the informative
+				// one and later ones mostly serve to show that a stalled capture is still
+				// stalled, so they don't need to be as frequent as progress logging.
+				var shouldRunDiagnostics = diagnosticTicks%5 == 0
+				diagnosticTicks++
+				if !shouldRunDiagnostics {
+					continue
+				}
+				log.Warn("replication streaming has been ongoing for an unexpectedly long amount of time, running replication diagnostics")
+				dumpGoroutineStacks()
 				if err := c.Database.ReplicationDiagnostics(ctx); err != nil {
 					log.WithField("err", err).Error("replication diagnostics error")
 				}

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -303,6 +303,14 @@ type Database interface {
 	// load on their server. Implement it with ParseRediscoveryInterval.
 	RediscoveryInterval() time.Duration
 
+	// ReplicationPollingInterval returns how long a streaming cycle may legitimately spend
+	// waiting for the replication stream to deliver its next commit event, or zero for
+	// connectors whose replication events arrive continuously. A polling connector cannot
+	// finish a stream-to-fence cycle any faster than one polling period, so the threshold
+	// past which a long-running cycle is treated as anomalous scales with this value rather
+	// than being a fixed duration which a large polling interval would exceed every cycle.
+	ReplicationPollingInterval() time.Duration
+
 	// The collection key which should be suggested if discovery fails to find suitable
 	// primary key. This should be some property or combination of properties in the
 	// source metadata which encodes the database change sequence.


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes various changes focused on reducing the CPU load `source-sqlserver` captures place on users' servers, either by reducing unneeded queries (ex: checking diagnostics every 5 minutes when there's a 10 minute polling interval) or allowing queries to be more easily cached by stabilizing the components that are used to construct the query plan cache key.

### `sqlcapture`
  - scale the long-streaming diagnostics threshold with the polling interval.

### `source-sqlserver`
- sort capture instances in the max-LSN polling query.
- bind the change table cleanup watermark as a parameter.
- parameterize the database name in the CDC-enabled check.

See individual commits for more details.

For a single capture, these changes probably won't have a big impact, but they should help reduce CPU load at least a little bit when users have 1,000+ captures pointing at the same server.

**Notes for reviewers:**

See [this Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1785361977655109) and #4946 for context on the motivation for these changes.

Since the plan cache is server wide, I'm hoping even these little improvements help reduce eviction of our plans for the other queries the connector makes, like the chunked discovery queries.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
