### PR TITLE
source-dynamics-365-finance-and-operations: read CSVs written across a column addition

### DIFF
--- a/estuary-cdk/estuary_cdk/incremental_csv_processor.py
+++ b/estuary-cdk/estuary_cdk/incremental_csv_processor.py
@@ -76,6 +76,24 @@ _SURPLUS_COLUMNS_KEY = object()
 _MISSING_COLUMN = object()
 
 
+def _dialect_kwargs(config: CSVConfig) -> dict[str, Any]:
+    """Build the csv dialect kwargs shared by both processors."""
+    kwargs: dict[str, Any] = {
+        'delimiter': config.delimiter,
+        'quotechar': config.quotechar,
+        'doublequote': config.doublequote,
+        'skipinitialspace': config.skipinitialspace,
+        'lineterminator': config.lineterminator,
+        'quoting': config.quoting,
+        'strict': config.strict,
+    }
+
+    if config.escapechar is not None:
+        kwargs['escapechar'] = config.escapechar
+
+    return kwargs
+
+
 class _AsyncByteReader(aiocsv.protocols.WithAsyncRead):
     """Internal class that handles incremental decoding for aiocsv."""
 
@@ -237,18 +255,7 @@ class IncrementalCSVProcessor(Generic[T]):
         """
         async_reader = _AsyncByteReader(self.byte_iterator, self.config.encoding)
 
-        reader_kwargs = {
-            'delimiter': self.config.delimiter,
-            'quotechar': self.config.quotechar,
-            'doublequote': self.config.doublequote,
-            'skipinitialspace': self.config.skipinitialspace,
-            'lineterminator': self.config.lineterminator,
-            'quoting': self.config.quoting,
-            'strict': self.config.strict,
-        }
-
-        if self.config.escapechar is not None:
-            reader_kwargs['escapechar'] = self.config.escapechar
+        reader_kwargs = _dialect_kwargs(self.config)
 
         if self.fieldnames is not None:
             reader_kwargs['fieldnames'] = self.fieldnames
@@ -284,3 +291,79 @@ class IncrementalCSVProcessor(Generic[T]):
                 f"CSV row {reader.line_num} has {expected - missing} columns but "
                 f"{expected} were expected."
             )
+
+
+class IncrementalCSVRowProcessor:
+    """
+    Process a stream of CSV bytes incrementally, yielding each row's cells.
+
+    This is a lower level counterpart to IncrementalCSVProcessor. It parses
+    rows but does not bind cells to field names, so it has no notion of an
+    expected column count and performs no column count validation.
+
+    Use it for sources whose rows can legitimately differ in width from the
+    schema describing them, where deciding which widths are acceptable - and
+    how to bind cells to names once they are - requires knowledge of the source
+    that only the connector has. Callers take on that responsibility in full:
+    binding cells to names positionally is silently wrong when a row is not the
+    width you assume, so validate widths before binding.
+
+    Prefer IncrementalCSVProcessor whenever a row's width is expected to match
+    its schema. It validates that for you and yields named rows.
+
+    Example usage:
+    ```python
+    async for cells in IncrementalCSVRowProcessor(byte_iterator):
+        cells[0]  # cells is list[str]
+    ```
+    """
+
+    def __init__(
+        self,
+        byte_iterator: AsyncGenerator[bytes, None],
+        config: CSVConfig | None = None,
+    ):
+        """
+        Initialize the processor with byte iterator and optional CSV configuration.
+
+        Args:
+            byte_iterator: Async generator of CSV byte chunks
+            config: Optional CSV configuration options
+        """
+        self.byte_iterator = byte_iterator
+        self.config = config or CSVConfig()
+        self._row_iterator: AsyncGenerator[list[str], None] | None = None
+
+    def __aiter__(self) -> "IncrementalCSVRowProcessor":
+        return self
+
+    async def __anext__(self) -> list[str]:
+        if self._row_iterator is None:
+            self._row_iterator = self._process_stream()
+
+        return await self._row_iterator.__anext__()
+
+    async def _process_stream(self) -> AsyncGenerator[list[str], None]:
+        """
+        Internal method to process the byte stream and yield CSV records.
+
+        Yields:
+            list[str]: Complete CSV records as lists of cells
+
+        Raises:
+            CSVProcessingError: When CSV data is malformed or cannot be parsed
+        """
+        async_reader = _AsyncByteReader(self.byte_iterator, self.config.encoding)
+
+        reader_kwargs = _dialect_kwargs(self.config)
+
+        try:
+            reader = aiocsv.AsyncReader(async_reader, **reader_kwargs)
+            async for row in reader:
+                # aiocsv's dict reader skips blank lines; do the same here so
+                # callers don't have to distinguish a blank line from a row.
+                if not row:
+                    continue
+                yield row
+        except csv.Error as e:
+            raise CSVProcessingError(f"Failed to parse CSV data: {str(e)}", config=reader_kwargs) from e

--- a/estuary-cdk/tests/test_incremental_csv_processor.py
+++ b/estuary-cdk/tests/test_incremental_csv_processor.py
@@ -1,10 +1,12 @@
 import pytest
+import csv
 import asyncio
 from typing import Any, AsyncGenerator
 from pydantic import BaseModel
 
 from estuary_cdk.incremental_csv_processor import (
     IncrementalCSVProcessor,
+    IncrementalCSVRowProcessor,
     CSVConfig,
     CSVProcessingError,
 )
@@ -468,6 +470,23 @@ Bob,35,Chicago"""
         assert rows[2].name == "Bob" and rows[2].age == "35" and rows[2].city == "Chicago"
 
     @pytest.mark.asyncio
+    async def test_escapechar_is_honored(self):
+        """The dict reader's dialect kwargs are built by _dialect_kwargs too,
+        so escapechar has to survive that path as well."""
+        config = CSVConfig(escapechar="\\", quoting=csv.QUOTE_NONE)
+        chunk_iterator = self.create_byte_chunk_iterator(
+            "name,age,city\n" + r"a\,b,25,NYC", chunk_size=7
+        )
+        processor = IncrementalCSVProcessor(chunk_iterator, BasicRecord, config)
+
+        rows: list[BasicRecord] = []
+        async for row in processor:
+            rows.append(row)
+
+        assert len(rows) == 1
+        assert rows[0].name == "a,b" and rows[0].age == "25"
+
+    @pytest.mark.asyncio
     async def test_basic_dict_processing(self):
         """Test basic CSV processing without a Pydantic model yields dicts."""
         csv_data = """name,age,city
@@ -504,3 +523,94 @@ Jane,invalid_age,false,N/A"""
         # All values should be strings - no type conversion
         assert rows[0] == {"name": "John", "age": "25", "active": "true", "score": "99.5"}
         assert rows[1] == {"name": "Jane", "age": "invalid_age", "active": "false", "score": "N/A"}
+
+
+class TestIncrementalCSVRowProcessor:
+    """Test suite for the positional processor, which yields a row's cells
+    without binding them to field names or validating the column count."""
+
+    async def create_byte_chunk_iterator(self, data: str, chunk_size: int = 10, encoding: str = 'utf-8') -> AsyncGenerator[bytes, None]:
+        """Helper to create async byte chunk iterator."""
+        data_bytes = data.encode(encoding)
+        for i in range(0, len(data_bytes), chunk_size):
+            chunk = data_bytes[i:i + chunk_size]
+            yield chunk
+            await asyncio.sleep(0.001)
+
+    async def collect(self, data: str, chunk_size: int = 10, config: CSVConfig | None = None) -> list[list[str]]:
+        processor = IncrementalCSVRowProcessor(
+            self.create_byte_chunk_iterator(data, chunk_size=chunk_size), config
+        )
+        return [row async for row in processor]
+
+    @pytest.mark.asyncio
+    async def test_yields_lists_of_cells(self):
+        """Rows are yielded as lists, with no header handling."""
+        rows = await self.collect("John,25,New York\nJane,30,Los Angeles")
+
+        assert rows == [
+            ["John", "25", "New York"],
+            ["Jane", "30", "Los Angeles"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ragged_rows_are_yielded_unchanged(self):
+        """Rows of differing widths are yielded as-is. Deciding whether a width
+        is acceptable is the caller's job, so nothing is padded or rejected."""
+        rows = await self.collect("a,b,c\nd,e\nf,g,h,i")
+
+        assert rows == [["a", "b", "c"], ["d", "e"], ["f", "g", "h", "i"]]
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_are_skipped(self):
+        """Blank lines are skipped, matching the dict reader's behavior."""
+        rows = await self.collect("a,b\n\nc,d\n")
+
+        assert rows == [["a", "b"], ["c", "d"]]
+
+    @pytest.mark.asyncio
+    async def test_multibyte_characters_split_across_chunks(self):
+        """A chunk size that splits multi-byte characters still decodes."""
+        rows = await self.collect("café,naïve\n日本語,Ünïcödé", chunk_size=3)
+
+        assert rows == [["café", "naïve"], ["日本語", "Ünïcödé"]]
+
+    @pytest.mark.asyncio
+    async def test_quoted_fields_with_embedded_delimiters_and_newlines(self):
+        rows = await self.collect('"a,b","c\nd",e\n"say ""hi""",f,g')
+
+        assert rows == [["a,b", "c\nd", "e"], ['say "hi"', "f", "g"]]
+
+    @pytest.mark.asyncio
+    async def test_custom_delimiter(self):
+        rows = await self.collect("a|b|c\nd|e|f", config=CSVConfig(delimiter="|"))
+
+        assert rows == [["a", "b", "c"], ["d", "e", "f"]]
+
+    @pytest.mark.asyncio
+    async def test_row_of_empty_quoted_fields_is_not_skipped(self):
+        """Only genuinely blank lines are skipped. A row whose single field is
+        an empty string is a row, and a positional caller must see it - it is
+        one cell wide, not zero."""
+        rows = await self.collect('a,b\n""\nc,d')
+
+        assert rows == [["a", "b"], [""], ["c", "d"]]
+
+    @pytest.mark.asyncio
+    async def test_escapechar_is_honored(self):
+        """Escapechar reaches the parser through _dialect_kwargs."""
+        rows = await self.collect(
+            r"a\,b,c", config=CSVConfig(escapechar="\\", quoting=csv.QUOTE_NONE)
+        )
+
+        assert rows == [["a,b", "c"]]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_yields_nothing(self):
+        assert await self.collect("") == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_csv_raises(self):
+        """Parse errors still surface as CSVProcessingError."""
+        with pytest.raises(CSVProcessingError, match="Failed to parse CSV data"):
+            await self.collect('a,"unclosed,b\nc,d', config=CSVConfig(strict=True))

--- a/source-dynamics-365-finance-and-operations/CHANGELOG.md
+++ b/source-dynamics-365-finance-and-operations/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-07-31
+
+### Fixed
+- Captures no longer fail when Synapse Link appends a column to a table partway through writing a CSV. Rows written before the append are narrower than the folder's `model.json` describes, and a single CSV can hold rows of both widths. The appended columns are now left absent from the older rows rather than failing the capture. Rows whose columns cannot be aligned for any other reason still fail. A row is rejected when it stops before `IsDelete`, when it has more columns than the schema names, or when it is narrower than an earlier row in the same file, which indicates an interrupted export truncated it rather than that it predates an appended column. Errors now identify the CSV and the row number within it.
+
+### Added
+- The connector now checks that a table's columns are only ever appended to, by requiring each folder's schema to begin with the whole of the previously seen one. Reading a row narrower than its schema depends on that being true, so a table whose columns are instead inserted, reordered or removed no longer has its narrower rows read, since their values could land under the wrong column names. Full width rows are unaffected and continue to be captured; a column rename, which changes no positions, is logged rather than treated as an error.
+
 ## 2026-07-17
 
 ### Fixed

--- a/source-dynamics-365-finance-and-operations/README.md
+++ b/source-dynamics-365-finance-and-operations/README.md
@@ -48,7 +48,7 @@ Schema metadata is provided through `model.json` files at two levels:
 - **Root Level**: Contains the current global schema for all tables, used for discovering available tables
 - **Timestamp Folder Level**: Contains schema metadata as it existed during that time period, allowing for schema evolution tracking
 
-The schema can evolve over time as tables are modified in Dynamics 365, so different timestamp folders may have different schemas for the same table.
+The schema can evolve over time as tables are modified in Dynamics 365, so different timestamp folders may have different schemas for the same table. A folder level `model.json` is written when the folder finalizes, so it can also describe columns that rows written earlier in that same folder do not have - see [Schema Evolution Within a Folder](#schema-evolution-within-a-folder).
 
 ### General structure
 ```json
@@ -78,11 +78,44 @@ The schema can evolve over time as tables are modified in Dynamics 365, so diffe
 CSV files are located in subdirectories named after the table: `[timestamp-folder]/[TableName]/[filename].csv`
 - Multiple CSV files may exist per table within a timestamp folder.
 - Files contain no column headers. Column definitions are found only in the corresponding `model.json`.
+- A file is appended to over the course of the folder's interval rather than written all at once. In one folder we observed `2026.csv` created before `2025.csv` but modified after it.
 
-### Standard Columns
-Every CSV file includes these system-generated metadata columns:
-- `Id` - Unique identifier for the row
-- `IsDelete` - Boolean flag set to `true` for deletions, absent for inserts/updates.
+### Column Order
+
+Cells are bound to column names by position, following the order in which `model.json` lists the table's attributes. Every table observed lays its rows out the same way:
+
+```
+Id, SinkCreatedOn, SinkModifiedOn, [table's own columns...], versionnumber, createdon, modifiedon, IsDelete, [appended columns...]
+```
+
+- `Id` - Unique identifier for the row.
+- `SinkCreatedOn` / `SinkModifiedOn` - When the change was written to the data lake. These use a non-ISO format, e.g. `4/14/2026 8:21:50 PM`, unlike the table's own `dateTime` columns.
+- `versionnumber` - Commit sequence number from the source system, and the ordering primitive for repeated changes to the same `Id`. Within one `Id` it never decreases down a file, though it can repeat, which is why `SinkModifiedOn` serves as a tiebreaker. `SinkModifiedOn` is what increases down a file regardless of `Id`, since it reflects the order Synapse Link wrote the rows, and that is the ordering the column-count invariant below relies on.
+- `IsDelete` - Set to `True` for deletions and left empty otherwise. The column itself is always present.
+
+`IsDelete` terminates this standard block.
+
+### Schema Evolution Within a Folder
+
+Columns added to a table in Dynamics 365 after its initial export are appended after `IsDelete`, so an entity's attribute list is effectively ordered by when each column was added.
+
+Because a CSV is appended to across the folder's interval, a file can be written across one of these additions. **Rows within a single file can therefore have different widths**: rows written before the addition lack the new trailing columns, rows written after have them. The folder's `model.json` is finalized at the end of the interval and records only the post-addition schema, so it can describe more columns than some rows in that same folder contain.
+
+### How the Connector Decides a Row Is Safe to Read
+
+Since CSVs are headerless, a row carries no evidence of which column any given cell belongs to. The connector cannot tell a harmlessly absent trailing column from a column dropped mid-row, which would shift every subsequent value into the wrong field. Misalignment can only be inferred from signals a correctly aligned row would not produce:
+
+1. **Width, per row.** A row may be narrower than `model.json` declares, but only down to `IsDelete` - making it a prefix of the declared schema, with the appended columns left absent. A row that stops before `IsDelete`, or has more cells than `model.json` names, fails the capture. See `api.bind_row`.
+2. **Width, per file.** Row widths within a file may only increase, since rows are appended in the order Synapse Link writes them and a column is added once. A row narrower than one already seen therefore did not come from an append - it was truncated, most likely by an interrupted export, or a column was removed from the table partway through the file. See `api.read_csv_rows`.
+3. **The append-only property itself.** Each folder's schema for a table must begin with the whole of the last one seen for it. An append satisfies that; an insertion, reorder or removal does not, since all three move a column to a different position. See `api.TableSchemaHistory`.
+
+Checks 1 and 2 are width signals, which is all a headerless row offers, and both are only sound while columns are appended rather than inserted. Check 3 watches that premise directly rather than trying to infer a misaligned row from its contents, and withdraws permission to bind narrow rows once it stops holding. It costs no extra requests. The connector already walks a table's folders in order and builds each one's schema, so the previous schema is simply the last one it built.
+
+A schema change that breaks the property is only *fatal* where the property is relied upon - binding a row narrower than the schema. A rename breaks the prefix relation while shifting nothing, so full-width rows still bind correctly and continue to be captured; the change is logged as a warning instead. Only a narrow row arriving after the property broke raises.
+
+Two limits are worth stating. The check only observes schema changes that occur while the connector is running, so a table that stopped being append-only before the current cursor is already reflected in both schemas being compared and goes unnoticed. And the first folder of a sweep after a restart has no predecessor in memory, so it is unchecked.
+
+A row that fails any of these stops that table's capture with an error naming the folder, file and row number. There is no skip path, unlike a folder missing its `model.json`: the same folder is re-read on the next attempt, so the failure persists until the underlying data or the connector changes. That is deliberate - the alternative is writing values whose column is unknown.
 
 ## Change Data Capture Mechanics
 

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/adls_gen2_client.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/adls_gen2_client.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator, Any, Optional
 from pydantic import BaseModel, Field, computed_field
 
 from estuary_cdk.http import HTTPSession
-from estuary_cdk.incremental_csv_processor import IncrementalCSVProcessor
+from estuary_cdk.incremental_csv_processor import IncrementalCSVRowProcessor
 from estuary_cdk.incremental_json_processor import IncrementalJsonProcessor
 
 
@@ -119,13 +119,13 @@ class ADLSGen2Client:
     async def stream_csv(
         self,
         path: str,
-        field_names: list[str],
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncGenerator[list[str], None]:
         """
-        Stream and parse a CSV file, yielding dict rows.
+        Stream and parse a CSV file, yielding each row's cells.
 
-        Transformations applied:
-        - Empty strings converted to None
+        Cells are left unbound to field names. Synapse Link CSVs are headerless
+        and a row can be narrower than the schema describing it, so binding is
+        the caller's responsibility.
         """
         url_without_sas = f"{self.base_url}/{self.filesystem}/{path}"
 
@@ -137,10 +137,5 @@ class ADLSGen2Client:
 
         _, body = await self.http.request_stream(self.log, url)
 
-        async for row in IncrementalCSVProcessor(body(), fieldnames=field_names):
-            # Convert empty strings to None
-            for key, value in row.items():
-                if value == "":
-                    row[key] = None
-
+        async for row in IncrementalCSVRowProcessor(body()):
             yield row

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -102,12 +102,15 @@ class RowSchemaMismatchError(Exception):
     from signals that a correctly aligned row would never produce:
 
     - a width outside the range a row may legitimately have (see bind_row),
-    - a width narrower than an earlier row in the same file (see read_csv_rows).
+    - a width narrower than an earlier row in the same file (see read_csv_rows),
+    - a narrow row in a table whose columns stopped being append-only (see
+      TableSchemaHistory and read_csv_rows).
 
-    Both are width signals, which is all a headerless row offers. They rest on
-    Synapse Link only ever appending columns to the end of a row, which is what
-    makes a row narrower than its schema a prefix of it rather than a
-    misaligned row.
+    The first two are width signals, which is all a headerless row offers.
+    Both rest on Synapse Link only ever appending columns to the end of a row.
+    The third check watches that assumption as the capture runs rather than
+    inferring from the rows, and withdraws permission to bind narrow rows
+    once that assumption stops holding.
 
     Rows merely narrower than the schema because they predate an appended
     column are expected and do not raise.
@@ -458,9 +461,10 @@ class TableSchemaHistory:
     Note this assumes the folder level model.json and the per-table one under
     TRICKLE_FEED_SERVICE_DIR list a table's attributes in the same order, since
     get_table_metadata falls back to the latter. If they ever disagree, the
-    fallback looks like a reorder, and is reported as one in two folders rather
-    than one: the folder using the fallback, and the folder after it, which is
-    compared against the fallback's order once it becomes the baseline.
+    fallback looks like a reorder, and narrow rows are refused in two folders
+    rather than one: the folder using the fallback, and the folder after it,
+    which is compared against the fallback's order once it becomes the
+    baseline.
     """
 
     def __init__(self) -> None:
@@ -537,21 +541,25 @@ async def read_csvs_in_folder(
             ) from err
         raise
 
-    # Reported rather than raised, because a schema can break the append-only
-    # property without any row being read wrongly - a rename shifts nothing, so
-    # every row still binds to the right positions.
+    # Reported rather than raised here, because a schema can break the
+    # append-only property without any row being read wrongly - a rename shifts
+    # nothing, so every row still binds to the right positions. It only becomes
+    # fatal where the property is actually depended on, which is why it is
+    # handed to read_csv_rows rather than acted on now.
     schema_violation = schema_history.observe(folder, table_metadata.field_names)
 
     if schema_violation is not None:
         log.warning(
             "This table's columns changed in a way other than being appended to. "
-            "Rows narrower than the schema may no longer line up with it.",
+            "Rows narrower than the schema cannot be read while that holds, since "
+            "they may no longer line up with it.",
             {"folder": folder, "table": table_name, "detail": schema_violation},
         )
 
     def open_csv(csv: ADLSPathMetadata) -> AsyncGenerator[TransformedRow, None]:
         return read_csv_rows(
-            client.stream_csv(csv.name), table_metadata, csv.name, log
+            client.stream_csv(csv.name), table_metadata, csv.name, log,
+            schema_violation,
         )
 
     async for row in stream_folder_rows(csvs, open_csv):
@@ -563,10 +571,18 @@ async def read_csv_rows(
     table_metadata: TableMetadata,
     csv_name: str,
     log: Logger,
+    schema_violation: str | None,
 ) -> AsyncGenerator[TransformedRow, None]:
     """
     Bind and transform one CSV's rows, enforcing the invariants that hold
     across a file rather than within a single row.
+
+    `schema_violation` describes how this table's columns changed other than by
+    being appended to, if TableSchemaHistory saw that happen, and is None
+    otherwise. A narrow row is only safe to bind as a prefix while columns are
+    append-only, so its presence makes narrow rows an error rather than the
+    expected consequence of an append. Rows at the full width are unaffected -
+    they line up with the schema whatever changed.
 
     Row widths within a file may only increase. Rows are appended in the order
     Synapse Link writes them to the lake, and the schema change that adds a
@@ -611,6 +627,19 @@ async def read_csv_rows(
 
         widest_row_seen = len(values)
 
+        row = bind_row(values, table_metadata, csv_name, row_number)
+
+        if len(values) < declared_columns and schema_violation is not None:
+            raise RowSchemaMismatchError(
+                csv_name,
+                row_number,
+                f"row has {len(values)} of this table's {declared_columns} columns, "
+                f"which would normally mean it predates the columns appended since "
+                f"it was written. That cannot be assumed here: {schema_violation}. "
+                f"Binding the row would risk reading its values under the wrong "
+                f"column names",
+            )
+
         if not logged_narrow_row and len(values) < declared_columns:
             logged_narrow_row = True
             log.info(
@@ -625,11 +654,7 @@ async def read_csv_rows(
                 },
             )
 
-        yield transform_row(
-            bind_row(values, table_metadata, csv_name, row_number),
-            table_metadata.boolean_fields,
-            csv_name,
-        )
+        yield transform_row(row, table_metadata.boolean_fields, csv_name)
 
 
 def bind_row(

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -143,6 +143,29 @@ def _find_entity(entities: list[dict], table_name: str) -> dict | None:
 
 
 def _table_metadata_from_entity(entity: dict) -> TableMetadata:
+    # Every table Synapse Link exports carries a boolean IsDelete, and the
+    # connector depends on it. It determines each row's operation and orders
+    # upserts ahead of deletes within a folder. Both checks fail loudly here
+    # rather than downstream.
+    is_delete_attr = next(
+        (attr for attr in entity["attributes"] if attr["name"] == IS_DELETE), None
+    )
+
+    if is_delete_attr is None:
+        raise ValueError(
+            f"Table {entity['name']} has no {IS_DELETE} column in its model.json "
+            f"entity. Every Synapse Link table is expected to have one, and the "
+            f"connector cannot determine a row's operation without it."
+        )
+
+    if is_delete_attr["dataType"] != AttributeDataType.BOOLEAN:
+        raise ValueError(
+            f"Table {entity['name']} declares its {IS_DELETE} column as "
+            f"{is_delete_attr['dataType']!r} rather than 'boolean' in its "
+            f"model.json entity. The connector cannot determine a row's operation "
+            f"unless {IS_DELETE} is converted to a boolean."
+        )
+
     return TableMetadata(
         name=entity["name"],
         field_names=[attr["name"] for attr in entity["attributes"]],

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -101,9 +101,10 @@ class RowSchemaMismatchError(Exception):
     Misalignment therefore can't be detected directly; it can only be inferred
     from signals that a correctly aligned row would never produce:
 
-    - a width outside the range a row may legitimately have (see bind_row).
+    - a width outside the range a row may legitimately have (see bind_row),
+    - a width narrower than an earlier row in the same file (see read_csv_rows).
 
-    That is a width signal, which is all a headerless row offers. It rests on
+    Both are width signals, which is all a headerless row offers. They rest on
     Synapse Link only ever appending columns to the end of a row, which is what
     makes a row narrower than its schema a prefix of it rather than a
     misaligned row.
@@ -489,17 +490,51 @@ async def read_csv_rows(
     log: Logger,
 ) -> AsyncGenerator[TransformedRow, None]:
     """
-    Bind and transform one CSV's rows.
+    Bind and transform one CSV's rows, enforcing the invariants that hold
+    across a file rather than within a single row.
+
+    Row widths within a file may only increase. Rows are appended in the order
+    Synapse Link writes them to the lake, and the schema change that adds a
+    column is observed by the exporter, so every row written before an append
+    precedes every row written after it. A row narrower than one already seen
+    therefore did not come from an append.
+
+    Note the ordering that matters here is the export's, not the source's.
+    SinkModifiedOn is non-decreasing across a whole file. versionnumber is
+    non-decreasing only within a single Id - across Ids it carries no ordering,
+    and adjacent rows have been observed going backwards - so it cannot stand
+    in for write order here, however well it orders changes to one row.
+
+    This is what distinguishes an old row from a truncated one, which bind_row
+    alone cannot do: an export interrupted mid-write leaves a final row cut
+    short, and its width can easily land within the range bind_row accepts.
+    Such a row would otherwise be captured with a partial value in its last
+    column and its remaining columns silently dropped.
 
     Row numbers in errors count data rows from 1. They are not line numbers -
     blank lines are skipped upstream and quoted values may span lines.
     """
     declared_columns = len(table_metadata.field_names)
+    widest_row_seen = 0
     logged_narrow_row = False
     row_number = 0
 
     async for values in rows:
         row_number += 1
+
+        if len(values) < widest_row_seen:
+            raise RowSchemaMismatchError(
+                csv_name,
+                row_number,
+                f"row has {len(values)} columns after an earlier row in the same "
+                f"file had {widest_row_seen}. Column counts within a CSV only ever "
+                f"increase, as Synapse Link appends columns added to the table, so "
+                f"this row did not come from such an append. An export interrupted "
+                f"mid-write would leave a final row cut short like this; so would a "
+                f"column being removed from the table partway through the file",
+            )
+
+        widest_row_seen = len(values)
 
         if not logged_narrow_row and len(values) < declared_columns:
             logged_narrow_row = True

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -19,6 +19,7 @@ from estuary_cdk.http import HTTPError
 
 from .adls_gen2_client import ADLSGen2Client, ADLSPathMetadata
 from .models import (
+    AttributeDataType,
     ModelDotJson,
     TableMetadata,
 )
@@ -59,6 +60,9 @@ TransformedRow = dict[str, str | bool | None | dict[str, str]]
 # as an fallback when the folder level model.json was written but
 # truncated (see get_table_metadata).
 TRICKLE_FEED_SERVICE_DIR = "Microsoft.Athena.TrickleFeedService"
+
+# Flags a row as a deletion.
+IS_DELETE = "IsDelete"
 
 
 class ModelFormat(StrEnum):
@@ -144,7 +148,7 @@ def _table_metadata_from_entity(entity: dict) -> TableMetadata:
         field_names=[attr["name"] for attr in entity["attributes"]],
         boolean_fields=frozenset(
             attr["name"] for attr in entity["attributes"]
-            if attr["dataType"] == "boolean"
+            if attr["dataType"] == AttributeDataType.BOOLEAN
         ),
     )
 
@@ -298,7 +302,7 @@ async def _read_upsert_file(
 ) -> AsyncGenerator[TransformedRow, None]:
     """Yield rows, raising if any is a delete."""
     async for row in rows:
-        if row["IsDelete"] is True:
+        if row[IS_DELETE] is True:
             raise RuntimeError(
                 f"{csv_name} contains a delete row after upserts. "
                 f"Each CSV must contain only deletes or non-deletes."
@@ -312,7 +316,7 @@ async def _read_delete_file(
 ) -> AsyncGenerator[TransformedRow, None]:
     """Yield rows, raising if any is not a delete (file was classified as deletes)."""
     async for row in rows:
-        if row["IsDelete"] is not True:
+        if row[IS_DELETE] is not True:
             raise RuntimeError(
                 f"{csv_name} contains a non-delete row after deletes. "
                 f"Each CSV must contain only deletes or non-deletes."
@@ -358,7 +362,7 @@ async def stream_folder_rows(
         except StopAsyncIteration:
             continue
 
-        if first_row["IsDelete"] is True:
+        if first_row[IS_DELETE] is True:
             deferred_csvs.append(csv)
             await stream.aclose()
             continue
@@ -438,7 +442,7 @@ def transform_row(row: dict[str, str | None], boolean_fields: frozenset[str], cs
         result[field_name] = value.lower() == "true" if value else False
 
     result["_meta"] = {
-        "op": "d" if result.get("IsDelete") else "u",
+        "op": "d" if result.get(IS_DELETE) else "u",
         "source_file": csv_name,
     }
 

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -3,7 +3,7 @@ from bisect import bisect_right
 from datetime import datetime, timedelta, UTC
 from enum import StrEnum
 from logging import Logger
-from typing import AsyncGenerator, Callable, Literal, cast, overload
+from typing import AsyncGenerator, AsyncIterator, Callable, Literal, cast, overload
 
 import orjson
 
@@ -61,7 +61,9 @@ TransformedRow = dict[str, str | bool | None | dict[str, str]]
 # truncated (see get_table_metadata).
 TRICKLE_FEED_SERVICE_DIR = "Microsoft.Athena.TrickleFeedService"
 
-# Flags a row as a deletion.
+# Flags a row as a deletion, and terminates the block of columns that every
+# exported row carries. Columns after it were appended to the table later, so
+# its position also marks how narrow a row may legitimately be.
 IS_DELETE = "IsDelete"
 
 
@@ -88,6 +90,33 @@ class TableSchemaUnavailableError(Exception):
         super().__init__(
             f"No usable schema for the table in timestamp folder {folder}: {detail}."
         )
+
+
+class RowSchemaMismatchError(Exception):
+    """Raised when a CSV row's cells cannot be bound to the field names
+    declared for its table.
+
+    Synapse Link CSVs are headerless, so cells are bound to names by position
+    and a row carries no evidence of which column any given cell belongs to.
+    Misalignment therefore can't be detected directly; it can only be inferred
+    from signals that a correctly aligned row would never produce:
+
+    - a width outside the range a row may legitimately have (see bind_row).
+
+    That is a width signal, which is all a headerless row offers. It rests on
+    Synapse Link only ever appending columns to the end of a row, which is what
+    makes a row narrower than its schema a prefix of it rather than a
+    misaligned row.
+
+    Rows merely narrower than the schema because they predate an appended
+    column are expected and do not raise.
+    """
+
+    def __init__(self, csv_name: str, row_number: int, detail: str):
+        self.csv_name = csv_name
+        self.row_number = row_number
+        self.detail = detail
+        super().__init__(f"Cannot read row {row_number} of {csv_name}: {detail}.")
 
 
 # model.json metadata files are not updated after they're written.
@@ -143,6 +172,8 @@ def _find_entity(entities: list[dict], table_name: str) -> dict | None:
 
 
 def _table_metadata_from_entity(entity: dict) -> TableMetadata:
+    field_names = [attr["name"] for attr in entity["attributes"]]
+
     # Every table Synapse Link exports carries a boolean IsDelete, and the
     # connector depends on it. It determines each row's operation and orders
     # upserts ahead of deletes within a folder. Both checks fail loudly here
@@ -166,13 +197,16 @@ def _table_metadata_from_entity(entity: dict) -> TableMetadata:
             f"unless {IS_DELETE} is converted to a boolean."
         )
 
+    is_delete_index = field_names.index(IS_DELETE)
+
     return TableMetadata(
         name=entity["name"],
-        field_names=[attr["name"] for attr in entity["attributes"]],
+        field_names=field_names,
         boolean_fields=frozenset(
             attr["name"] for attr in entity["attributes"]
             if attr["dataType"] == AttributeDataType.BOOLEAN
         ),
+        min_row_width=is_delete_index + 1,
     )
 
 
@@ -440,13 +474,114 @@ async def read_csvs_in_folder(
         raise
 
     def open_csv(csv: ADLSPathMetadata) -> AsyncGenerator[TransformedRow, None]:
-        async def gen() -> AsyncGenerator[TransformedRow, None]:
-            async for raw_row in client.stream_csv(csv.name, table_metadata.field_names):
-                yield transform_row(raw_row, table_metadata.boolean_fields, csv.name)
-        return gen()
+        return read_csv_rows(
+            client.stream_csv(csv.name), table_metadata, csv.name, log
+        )
 
     async for row in stream_folder_rows(csvs, open_csv):
         yield row
+
+
+async def read_csv_rows(
+    rows: AsyncIterator[list[str]],
+    table_metadata: TableMetadata,
+    csv_name: str,
+    log: Logger,
+) -> AsyncGenerator[TransformedRow, None]:
+    """
+    Bind and transform one CSV's rows.
+
+    Row numbers in errors count data rows from 1. They are not line numbers -
+    blank lines are skipped upstream and quoted values may span lines.
+    """
+    declared_columns = len(table_metadata.field_names)
+    logged_narrow_row = False
+    row_number = 0
+
+    async for values in rows:
+        row_number += 1
+
+        if not logged_narrow_row and len(values) < declared_columns:
+            logged_narrow_row = True
+            log.info(
+                "CSV contains rows written before columns were appended to "
+                "this table. Those columns are absent from such rows.",
+                {
+                    "csv": csv_name,
+                    "table": table_metadata.name,
+                    "row columns": len(values),
+                    "declared columns": declared_columns,
+                    "absent columns": table_metadata.field_names[len(values):],
+                },
+            )
+
+        yield transform_row(
+            bind_row(values, table_metadata, csv_name, row_number),
+            table_metadata.boolean_fields,
+            csv_name,
+        )
+
+
+def bind_row(
+    values: list[str],
+    table_metadata: TableMetadata,
+    csv_name: str,
+    row_number: int,
+) -> dict[str, str | None]:
+    """
+    Bind a headerless CSV row's cells to their field names by position.
+
+    Synapse Link appends columns added to a table after its initial export to
+    the end of every row, past the standard metadata block that ends with
+    IsDelete. A CSV can be written across such an append - rows written before
+    it are narrower than rows written after, within the same file - while the
+    folder's model.json describes only the schema as of finalization. Those
+    narrower rows are a prefix of the declared schema, so their cells still
+    bind correctly and the appended columns are left absent rather than
+    fabricated as null.
+
+    Any other width means the positions no longer line up: a row that stops
+    inside the standard block is misaligned, and a row with more cells than the
+    schema names has data we cannot label. Both raise.
+
+    Width is the only signal available here, so this cannot prove alignment.
+    A column inserted before IsDelete rather than appended after it would
+    leave an older row inside the accepted width range while shifting every
+    cell past the insertion point, and would be bound without complaint. See
+    RowSchemaMismatchError for why that is an accepted risk.
+
+    Empty cells are converted to None.
+    """
+    field_names = table_metadata.field_names
+
+    if len(values) > len(field_names):
+        raise RowSchemaMismatchError(
+            csv_name,
+            row_number,
+            f"row has {len(values)} columns but this folder's model.json declares "
+            f"only {len(field_names)} for {table_metadata.name}, leaving "
+            f"{len(values) - len(field_names)} with no field name to bind to",
+        )
+
+    if len(values) < table_metadata.min_row_width:
+        raise RowSchemaMismatchError(
+            csv_name,
+            row_number,
+            f"row has {len(values)} columns, but every {table_metadata.name} row is "
+            f"at least {table_metadata.min_row_width} columns wide - the columns up "
+            f"to and including {IS_DELETE}. Only columns appended after {IS_DELETE} "
+            f"may be absent from a row, so this row cannot be aligned to the "
+            f"{len(field_names)} columns declared in this folder's model.json",
+        )
+
+    # zip stops at the shorter of the two, so a row predating an appended
+    # column simply leaves that column's name unbound.
+    row = {
+        name: value if value != "" else None
+        for name, value in zip(field_names, values)
+    }
+
+    return row
 
 
 def transform_row(row: dict[str, str | None], boolean_fields: frozenset[str], csv_name: str) -> TransformedRow:
@@ -461,7 +596,11 @@ def transform_row(row: dict[str, str | None], boolean_fields: frozenset[str], cs
     result = cast(TransformedRow, row)
 
     for field_name in boolean_fields:
-        value = row.get(field_name)
+        # A row predating an appended column has no cell for it. Leave the
+        # column absent instead of fabricating a False for it.
+        if field_name not in row:
+            continue
+        value = row[field_name]
         result[field_name] = value.lower() == "true" if value else False
 
     result["_meta"] = {

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/api.py
@@ -434,11 +434,74 @@ async def stream_folder_rows(
             yield row
 
 
+class TableSchemaHistory:
+    """Remembers the schema last seen for a table so consecutive folders can be
+    compared.
+
+    Binding a row narrower than its folder's model.json relies on Synapse Link
+    only ever appending columns: that is what makes the narrow row a prefix of
+    the declared schema rather than a misaligned one. This watches that
+    property hold as the capture runs. Each folder's schema must begin with the
+    whole of the previously seen one, which an append satisfies and an
+    insertion, reorder or removal does not - all three move a column to a
+    different position, and position is all that binding has to go on.
+
+    Comparing against the last schema *seen* rather than the immediately
+    preceding folder is fine: a table only appears in folders where it changed,
+    and the prefix relation is transitive, so skipped folders cannot hide a
+    violation.
+
+    This only observes changes that happen while the connector is running.
+    A schema that stopped being append-only before the current cursor is
+    already reflected in both schemas being compared, so it goes unnoticed.
+
+    Note this assumes the folder level model.json and the per-table one under
+    TRICKLE_FEED_SERVICE_DIR list a table's attributes in the same order, since
+    get_table_metadata falls back to the latter. If they ever disagree, the
+    fallback looks like a reorder, and is reported as one in two folders rather
+    than one: the folder using the fallback, and the folder after it, which is
+    compared against the fallback's order once it becomes the baseline.
+    """
+
+    def __init__(self) -> None:
+        self._previous: list[str] | None = None
+        self._previous_folder: str | None = None
+
+    def observe(self, folder: str, field_names: list[str]) -> str | None:
+        """Record this folder's schema, returning a description of how it
+        breaks the append-only property, or None if it upholds it."""
+        previous, previous_folder = self._previous, self._previous_folder
+        self._previous = field_names
+        self._previous_folder = folder
+
+        if previous is None or field_names[:len(previous)] == previous:
+            return None
+
+        divergence = next(
+            (i for i, (a, b) in enumerate(zip(previous, field_names)) if a != b),
+            min(len(previous), len(field_names)),
+        )
+        now = (
+            repr(field_names[divergence])
+            if divergence < len(field_names)
+            else "nothing - the column is gone"
+        )
+
+        return (
+            f"the schema in {previous_folder} had {len(previous)} columns and this "
+            f"folder's has {len(field_names)}, but column {divergence} changed from "
+            f"{previous[divergence]!r} to {now}. Columns are expected to only ever "
+            f"be appended to the end, which would leave the earlier schema intact "
+            f"as a prefix of this one"
+        )
+
+
 async def read_csvs_in_folder(
     folder: str,
     table_name: str,
     client: ADLSGen2Client,
     log: Logger,
+    schema_history: TableSchemaHistory,
 ) -> AsyncGenerator[TransformedRow, None]:
     folder_contents = await get_folder_contents_for_table(folder, table_name, client)
 
@@ -473,6 +536,18 @@ async def read_csvs_in_folder(
                 folder, "folder level model.json is missing"
             ) from err
         raise
+
+    # Reported rather than raised, because a schema can break the append-only
+    # property without any row being read wrongly - a rename shifts nothing, so
+    # every row still binds to the right positions.
+    schema_violation = schema_history.observe(folder, table_metadata.field_names)
+
+    if schema_violation is not None:
+        log.warning(
+            "This table's columns changed in a way other than being appended to. "
+            "Rows narrower than the schema may no longer line up with it.",
+            {"folder": folder, "table": table_name, "detail": schema_violation},
+        )
 
     def open_csv(csv: ADLSPathMetadata) -> AsyncGenerator[TransformedRow, None]:
         return read_csv_rows(
@@ -676,6 +751,7 @@ def should_wait_for_finalization(next_folder: str, now: datetime) -> bool:
 async def fetch_changes(
     client: ADLSGen2Client,
     table_name: str,
+    schema_history: TableSchemaHistory,
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[dict | LogCursor, None]:
@@ -694,7 +770,9 @@ async def fetch_changes(
         async with FOLDER_PROCESSING_SEMAPHORE:
             log.debug(f"Reading CSVs in {folder}/{table_name}.")
             try:
-                async for row in read_csvs_in_folder(folder, table_name, client, log):
+                async for row in read_csvs_in_folder(
+                    folder, table_name, client, log, schema_history
+                ):
                     yield row
             except TableSchemaUnavailableError as err:
                 # The folder has table data but no usable schema for this table.

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/models.py
@@ -250,3 +250,9 @@ class TableMetadata:
     # Pre-computed set of boolean field names for efficient conversion.
     # Avoids iterating all fields per row - only iterate boolean fields.
     boolean_fields: frozenset[str]
+    # Narrowest row that can still be bound: the number of columns up to and
+    # including IsDelete, which every row carries. Columns past IsDelete were
+    # appended to the table after its initial export, so rows written before an
+    # append lack them and are legitimately narrower than the schema. A row
+    # narrower than this is misaligned rather than merely old.
+    min_row_width: int

--- a/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
+++ b/source-dynamics-365-finance-and-operations/source_dynamics_365_finance_and_operations/resources.py
@@ -16,7 +16,7 @@ from .models import (
 )
 
 from .adls_gen2_client import ADLSGen2Client
-from .api import fetch_model_dot_json, fetch_changes, ModelFormat
+from .api import fetch_model_dot_json, fetch_changes, ModelFormat, TableSchemaHistory
 
 
 EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
@@ -65,6 +65,11 @@ def resources(
                 fetch_changes,
                 adls_client,
                 model.name,
+                # Owned by the binding rather than a single sweep, so the
+                # append-only check spans consecutive sweeps too. It starts
+                # empty on restart, leaving that sweep's first folder
+                # unchecked.
+                TableSchemaHistory(),
             )
         )
 

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -268,6 +268,22 @@ class TestReadCsvRows:
         assert rows[2]["app_c"] == "3"
 
     @pytest.mark.asyncio
+    async def test_narrowing_row_raises(self):
+        """A row narrower than one already seen did not come from an append,
+        so it is a row truncated by an interrupted export."""
+        with pytest.raises(RowSchemaMismatchError, match="only ever increase"):
+            await self.read([
+                ["a", "ts", "", "1", "2", "3"],
+                ["b", "ts", "", "1"],
+            ])
+
+    @pytest.mark.asyncio
+    async def test_equal_widths_are_not_treated_as_narrowing(self):
+        rows = await self.read([["a", "ts", ""], ["b", "ts", ""]])
+
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
     async def test_rows_are_transformed(self):
         """Rows arrive transformed, with booleans converted and _meta set."""
         rows = await self.read([["a", "ts", "True"], ["b", "ts", "True"]])
@@ -304,6 +320,30 @@ class TestReadCsvRows:
 
         assert excinfo.value.row_number == 3
 
+    @pytest.mark.asyncio
+    async def test_width_state_is_per_file_not_per_folder(self):
+        """stream_folder_rows reads a deferred delete file twice, once to
+        classify it and once to emit it, and reads other files in between.
+        Width is tracked per read, so a wide upsert file cannot make a
+        legitimately narrow delete file look truncated on its second pass -
+        which is what a folder-scoped counter would do here."""
+        log = logging.getLogger("test-d365-api")
+        rows_by_csv = {
+            "deletes.csv": [["b", "ts", "True"]],
+            "upserts.csv": [["a", "ts", "", "1", "2", "3"]],
+        }
+
+        def open_csv(csv: ADLSPathMetadata) -> AsyncGenerator[TransformedRow, None]:
+            async def values() -> AsyncGenerator[list[str], None]:
+                for row in rows_by_csv[csv.name]:
+                    yield row
+            return read_csv_rows(values(), self.METADATA, csv.name, log)
+
+        csvs = [fake_csv("deletes.csv"), fake_csv("upserts.csv")]
+        result = await collect(stream_folder_rows(csvs, open_csv))
+
+        assert [(r["Id"], r["IsDelete"]) for r in result] == [("a", False), ("b", True)]
+        assert "app_c" not in result[1]
 
 
 class TestCsvBytesToDocuments:
@@ -374,6 +414,15 @@ class TestCsvBytesToDocuments:
         assert rows[0]["Id"] == "a,1"
         assert rows[0]["app_a"] == "quoted, value"
 
+    @pytest.mark.asyncio
+    async def test_truncated_final_row_raises(self):
+        """An export cut off mid-write leaves a short final row whose width is
+        inside the range bind_row alone would accept."""
+        with pytest.raises(RowSchemaMismatchError, match="only ever increase"):
+            await self.read(
+                "a,ts,,1,2,3\r\n"
+                "b,ts,,1\r\n"
+            )
 
 
 class TestTableMetadataFromEntity:

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -6,18 +6,23 @@ import orjson
 import pytest
 
 from estuary_cdk.http import HTTPError
+from estuary_cdk.incremental_csv_processor import IncrementalCSVRowProcessor
 from source_dynamics_365_finance_and_operations.adls_gen2_client import ADLSPathMetadata
 from source_dynamics_365_finance_and_operations.api import (
     SETTLE_DELAY,
     TRICKLE_FEED_SERVICE_DIR,
+    RowSchemaMismatchError,
     TableSchemaUnavailableError,
     TransformedRow,
     _table_metadata_from_entity,
+    bind_row,
     get_table_metadata,
+    read_csv_rows,
     should_wait_for_finalization,
     stream_folder_rows,
     transform_row,
 )
+from source_dynamics_365_finance_and_operations.models import TableMetadata
 from source_dynamics_365_finance_and_operations.shared import str_to_dt
 
 
@@ -144,6 +149,276 @@ class TestTransformRow:
         assert "_meta" in row
 
 
+class TestBindRow:
+    """Tests for binding a headerless CSV row's cells to field names.
+
+    Synapse Link appends columns added to a table after its initial export to
+    the end of every row, past IsDelete. A CSV written across such an append
+    holds rows of both widths, so rows can be narrower than the folder's
+    model.json declares."""
+
+    # Three appended columns, so a row can legitimately fall short by more
+    # than one - the shape real tables have (prodtable spans 110..118
+    # columns, salesline 267..291).
+    _FIELD_NAMES = ["Id", "SinkModifiedOn", "IsDelete", "app_a", "app_b", "app_c"]
+    METADATA = TableMetadata(
+        name="prodtable",
+        field_names=_FIELD_NAMES,
+        boolean_fields=frozenset({"IsDelete"}),
+        # Derived the way _table_metadata_from_entity derives it, so the
+        # fixture cannot drift from what the connector would compute.
+        min_row_width=_FIELD_NAMES.index("IsDelete") + 1,
+    )
+
+    def test_full_width_row(self):
+        row = bind_row(["abc", "ts", "", "1", "2", "3"], self.METADATA, CSV_NAME, 1)
+
+        assert row == {
+            "Id": "abc", "SinkModifiedOn": "ts", "IsDelete": None,
+            "app_a": "1", "app_b": "2", "app_c": "3",
+        }
+
+    @pytest.mark.parametrize("absent", [1, 2, 3])
+    def test_rows_predating_appended_columns_omit_them(self, absent: int):
+        """A row written before the last `absent` columns were added binds its
+        cells and leaves those columns absent rather than null."""
+        width = len(self.METADATA.field_names) - absent
+        row = bind_row(["abc", "ts", ""] + ["x"] * (width - 3), self.METADATA, CSV_NAME, 1)
+
+        assert len(row) == width
+        assert [f for f in self.METADATA.field_names if f not in row] == \
+            self.METADATA.field_names[width:]
+
+    def test_narrowest_legal_row_is_min_row_width(self):
+        row = bind_row(["abc", "ts", "True"], self.METADATA, CSV_NAME, 1)
+
+        assert row == {"Id": "abc", "SinkModifiedOn": "ts", "IsDelete": "True"}
+
+    def test_empty_cells_become_none(self):
+        row = bind_row(["", "", "True", "", "", ""], self.METADATA, CSV_NAME, 1)
+
+        assert row == {
+            "Id": None, "SinkModifiedOn": None, "IsDelete": "True",
+            "app_a": None, "app_b": None, "app_c": None,
+        }
+
+    def test_row_narrower_than_min_row_width_raises(self):
+        """Truncation reaching past IsDelete means the cells no longer line up,
+        so it must not be read as a row predating an append."""
+        with pytest.raises(RowSchemaMismatchError, match="at least 3 columns wide"):
+            bind_row(["abc", "ts"], self.METADATA, CSV_NAME, 1)
+
+    def test_row_wider_than_schema_raises(self):
+        """Extra cells have no field name to bind to."""
+        with pytest.raises(RowSchemaMismatchError, match="no field name to bind to"):
+            bind_row(["abc", "ts", "", "1", "2", "3", "surplus"], self.METADATA, CSV_NAME, 1)
+
+    def test_error_names_the_csv(self):
+        with pytest.raises(RowSchemaMismatchError, match=CSV_NAME):
+            bind_row(["abc", "ts"], self.METADATA, CSV_NAME, 1)
+
+    def test_transform_row_leaves_absent_boolean_absent(self):
+        """An appended boolean column absent from an older row must not be
+        fabricated as False."""
+        metadata = TableMetadata(
+            name="prodtable",
+            field_names=["Id", "IsDelete", "appended_flag"],
+            boolean_fields=frozenset({"IsDelete", "appended_flag"}),
+            min_row_width=2,
+        )
+
+        row = transform_row(
+            bind_row(["abc", ""], metadata, CSV_NAME, 1), metadata.boolean_fields, CSV_NAME
+        )
+
+        assert "appended_flag" not in row
+        assert row["IsDelete"] is False
+        assert row["_meta"] == {"op": "u", "source_file": CSV_NAME}
+
+
+class TestReadCsvRows:
+    """Tests for the invariants that hold across a file rather than within a
+    single row."""
+
+    METADATA = TestBindRow.METADATA
+
+    async def as_values(self, rows: list[list[str]]) -> AsyncGenerator[list[str], None]:
+        for row in rows:
+            yield row
+
+    async def read(self, rows: list[list[str]]) -> list[TransformedRow]:
+        log = logging.getLogger("test-d365-api")
+        return [
+            row async for row in
+            read_csv_rows(self.as_values(rows), self.METADATA, CSV_NAME, log)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_widening_rows_are_read(self):
+        """The observed shape: narrow rows predating an append, then wider
+        rows once the column exists."""
+        rows = await self.read([
+            ["a", "ts", ""],
+            ["b", "ts", ""],
+            ["c", "ts", "", "1", "2", "3"],
+        ])
+
+        assert [r["Id"] for r in rows] == ["a", "b", "c"]
+        assert "app_c" not in rows[0]
+        assert rows[2]["app_c"] == "3"
+
+    @pytest.mark.asyncio
+    async def test_rows_are_transformed(self):
+        """Rows arrive transformed, with booleans converted and _meta set."""
+        rows = await self.read([["a", "ts", "True"], ["b", "ts", "True"]])
+
+        assert rows[0]["IsDelete"] is True
+        assert rows[0]["_meta"] == {"op": "d", "source_file": CSV_NAME}
+
+    @pytest.mark.asyncio
+    async def test_empty_file_yields_nothing(self):
+        assert await self.read([]) == []
+
+    @pytest.mark.asyncio
+    async def test_every_row_narrow_is_read(self):
+        """A file written entirely before an append is uniformly narrow, which
+        is legal - widths never decrease."""
+        rows = await self.read([["a", "ts", ""], ["b", "ts", ""], ["c", "ts", ""]])
+
+        assert [r["Id"] for r in rows] == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_first_row_narrower_than_min_row_width_raises(self):
+        with pytest.raises(RowSchemaMismatchError, match="at least 3 columns wide"):
+            await self.read([["a", "ts"]])
+
+    @pytest.mark.asyncio
+    async def test_error_reports_the_row_number(self):
+        """The row number is what makes a failure findable in a large CSV."""
+        with pytest.raises(RowSchemaMismatchError, match="row 3 of") as excinfo:
+            await self.read([
+                ["a", "ts", ""],
+                ["b", "ts", ""],
+                ["c", "ts", "", "1", "2", "3", "surplus"],
+            ])
+
+        assert excinfo.value.row_number == 3
+
+
+
+class TestCsvBytesToDocuments:
+    """Covers the seam between the CDK's positional parser and the connector's
+    binding: raw bytes in, capture documents out."""
+
+    METADATA = TestBindRow.METADATA
+
+    async def chunks(self, data: str, size: int = 7) -> AsyncGenerator[bytes, None]:
+        """Small chunks, so rows straddle chunk boundaries as they do over HTTP."""
+        raw = data.encode("utf-8")
+        for i in range(0, len(raw), size):
+            yield raw[i:i + size]
+
+    async def read(self, data: str) -> list[TransformedRow]:
+        log = logging.getLogger("test-d365-api")
+        return [
+            row async for row in read_csv_rows(
+                IncrementalCSVRowProcessor(self.chunks(data)),
+                self.METADATA,
+                CSV_NAME,
+                log,
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_mixed_width_file(self):
+        """The shape of a variable width CSV: narrow rows written before a column
+        was appended, then wider rows once it existed."""
+        rows = await self.read(
+            "a,ts,\r\n"
+            "b,ts,True\r\n"
+            "c,ts,,1,2,3\r\n"
+        )
+
+        assert [r["Id"] for r in rows] == ["a", "b", "c"]
+        assert "app_c" not in rows[0] and "app_c" not in rows[1]
+        assert rows[1]["_meta"]["op"] == "d"
+        assert rows[2]["app_c"] == "3"
+
+    @pytest.mark.asyncio
+    async def test_several_columns_appended_during_one_interval(self):
+        """Columns can be added at different points within a single export
+        interval, so one file can hold rows of three or more widths. Each row
+        binds the prefix of the schema that existed when it was written."""
+        rows = await self.read(
+            "a,ts,\r\n"
+            "b,ts,,1\r\n"
+            "c,ts,,1,2\r\n"
+            "d,ts,,1,2,3\r\n"
+        )
+
+        absent = [
+            [f for f in self.METADATA.field_names if f not in r] for r in rows
+        ]
+        assert absent == [
+            ["app_a", "app_b", "app_c"],
+            ["app_b", "app_c"],
+            ["app_c"],
+            [],
+        ]
+        assert [r["Id"] for r in rows] == ["a", "b", "c", "d"]
+
+    @pytest.mark.asyncio
+    async def test_quoted_values_spanning_chunks(self):
+        rows = await self.read('"a,1",ts,,"quoted, value",2,3\r\n')
+
+        assert rows[0]["Id"] == "a,1"
+        assert rows[0]["app_a"] == "quoted, value"
+
+
+
+class TestTableMetadataFromEntity:
+    """Tests for locating how narrow a row may be from model.json."""
+
+    def test_min_row_width_ends_at_is_delete(self):
+        metadata = _table_metadata_from_entity({
+            "name": "prodtable",
+            "attributes": [
+                {"name": "Id", "dataType": "guid"},
+                {"name": "IsDelete", "dataType": "boolean"},
+                {"name": "delta_custom", "dataType": "int64"},
+            ],
+        })
+
+        assert metadata.field_names == ["Id", "IsDelete", "delta_custom"]
+        assert metadata.min_row_width == 2
+        assert metadata.boolean_fields == frozenset({"IsDelete"})
+
+    def test_entity_with_non_boolean_is_delete_raises(self):
+        """A string IsDelete would stay out of boolean_fields, leaving every
+        delete row reading as an upsert with no error at all."""
+        with pytest.raises(ValueError, match="rather than 'boolean'"):
+            _table_metadata_from_entity({
+                "name": "odd",
+                "attributes": [
+                    {"name": "Id", "dataType": "guid"},
+                    {"name": "IsDelete", "dataType": "string"},
+                ],
+            })
+
+    def test_entity_without_is_delete_raises(self):
+        """IsDelete determines a row's operation and orders upserts ahead of
+        deletes, so a table lacking it cannot be read at all. Fail here with an
+        explanation rather than downstream on a KeyError."""
+        with pytest.raises(ValueError, match="no IsDelete column"):
+            _table_metadata_from_entity({
+                "name": "odd",
+                "attributes": [
+                    {"name": "Id", "dataType": "guid"},
+                    {"name": "other", "dataType": "string"},
+                ],
+            })
+
+
 def fake_csv(name: str) -> ADLSPathMetadata:
     """Build an ADLSPathMetadata."""
     return ADLSPathMetadata(
@@ -258,6 +533,29 @@ class TestStreamFolderRows:
         result = await collect(stream_folder_rows(csvs, factory))
         assert [(r["Id"], r["versionnumber"]) for r in result] == [("A", "10")]
 
+    @pytest.mark.asyncio
+    async def test_narrow_delete_row_is_still_deferred(self):
+        """A delete predating an appended column is narrower than the schema.
+        IsDelete is bound in every legal row width, so such a row is still
+        recognized as a delete and deferred to pass 2."""
+        metadata = TestBindRow.METADATA
+
+        def build(values: list[str]) -> TransformedRow:
+            return transform_row(
+                bind_row(values, metadata, CSV_NAME, 1), metadata.boolean_fields, CSV_NAME
+            )
+
+        csvs = [fake_csv("deletes.csv"), fake_csv("upserts.csv")]
+        factory = make_factory({
+            "deletes.csv": [build(["A", "ts", "True"])],
+            "upserts.csv": [build(["A", "ts", "", "1", "2", "3"])],
+        })
+
+        result = await collect(stream_folder_rows(csvs, factory))
+
+        assert [(r["Id"], r["IsDelete"]) for r in result] == [("A", False), ("A", True)]
+        assert "app_c" not in result[1]
+
 
 def entity(name: str) -> dict:
     """A model.json entity with the standard metadata columns plus one boolean."""
@@ -352,42 +650,6 @@ class TestGetTableMetadata:
             await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
 
 
-class TestTableMetadataFromEntity:
-    """Tests for the IsDelete column the connector requires of every table."""
-
-    def test_boolean_is_delete_is_accepted(self):
-        metadata = _table_metadata_from_entity({
-            "name": "prodtable",
-            "attributes": [
-                {"name": "Id", "dataType": "guid"},
-                {"name": "IsDelete", "dataType": "boolean"},
-            ],
-        })
-
-        assert metadata.boolean_fields == frozenset({"IsDelete"})
-
-    def test_entity_without_is_delete_raises(self):
-        """IsDelete determines a row's operation and orders upserts ahead of
-        deletes, so a table lacking it cannot be read at all."""
-        with pytest.raises(ValueError, match="no IsDelete column"):
-            _table_metadata_from_entity({
-                "name": "odd",
-                "attributes": [{"name": "Id", "dataType": "guid"}],
-            })
-
-    def test_entity_with_non_boolean_is_delete_raises(self):
-        """A string IsDelete would stay out of boolean_fields, leaving every
-        delete row reading as an upsert with no error at all."""
-        with pytest.raises(ValueError, match="rather than 'boolean'"):
-            _table_metadata_from_entity({
-                "name": "odd",
-                "attributes": [
-                    {"name": "Id", "dataType": "guid"},
-                    {"name": "IsDelete", "dataType": "string"},
-                ],
-            })
-
-
 class TestShouldWaitForFinalization:
     """Tests for the settle-window decision used when a timestamp folder has
     table data but no model.json."""
@@ -414,4 +676,3 @@ class TestShouldWaitForFinalization:
     def test_just_under_settle_delay_is_waited_on(self):
         now = str_to_dt(self.SUCCESSOR) + SETTLE_DELAY - timedelta(seconds=1)
         assert should_wait_for_finalization(self.SUCCESSOR, now) is True
-

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -19,6 +19,7 @@ from source_dynamics_365_finance_and_operations.api import (
     bind_row,
     get_table_metadata,
     read_csv_rows,
+    read_csvs_in_folder,
     should_wait_for_finalization,
     stream_folder_rows,
     transform_row,
@@ -251,7 +252,7 @@ class TestReadCsvRows:
         log = logging.getLogger("test-d365-api")
         return [
             row async for row in
-            read_csv_rows(self.as_values(rows), self.METADATA, CSV_NAME, log)
+            read_csv_rows(self.as_values(rows), self.METADATA, CSV_NAME, log, None)
         ]
 
     @pytest.mark.asyncio
@@ -338,7 +339,7 @@ class TestReadCsvRows:
             async def values() -> AsyncGenerator[list[str], None]:
                 for row in rows_by_csv[csv.name]:
                     yield row
-            return read_csv_rows(values(), self.METADATA, csv.name, log)
+            return read_csv_rows(values(), self.METADATA, csv.name, log, None)
 
         csvs = [fake_csv("deletes.csv"), fake_csv("upserts.csv")]
         result = await collect(stream_folder_rows(csvs, open_csv))
@@ -422,6 +423,137 @@ class TestTableSchemaHistory:
         assert history.observe("2026-01-01T02.00.00Z", inserted + ["added"]) is None
 
 
+class TestNarrowRowsUnderASchemaViolation:
+    """A narrow row is only bindable as a prefix while columns are append-only.
+    Once that stops holding, narrow rows become an error - but full-width rows
+    still line up with the schema whatever changed, so they are unaffected."""
+
+    METADATA = TestBindRow.METADATA
+    VIOLATION = "column 2 changed from 'IsDelete' to 'color'"
+
+    async def read(self, rows: list[list[str]], violation: str | None):
+        log = logging.getLogger("test-d365-api")
+
+        async def values():
+            for row in rows:
+                yield row
+
+        return [
+            row async for row in
+            read_csv_rows(values(), self.METADATA, CSV_NAME, log, violation)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_narrow_row_raises_when_the_property_broke(self):
+        with pytest.raises(RowSchemaMismatchError, match="cannot be assumed here"):
+            await self.read([["a", "ts", ""]], self.VIOLATION)
+
+    @pytest.mark.asyncio
+    async def test_the_error_carries_the_violation(self):
+        with pytest.raises(RowSchemaMismatchError, match="changed from 'IsDelete'"):
+            await self.read([["a", "ts", ""]], self.VIOLATION)
+
+    @pytest.mark.asyncio
+    async def test_full_width_rows_are_unaffected(self):
+        """A rename breaks the prefix relation without shifting anything, so a
+        folder with no narrow rows must keep capturing."""
+        rows = await self.read([["a", "ts", "", "1", "2", "3"]], self.VIOLATION)
+
+        assert [r["Id"] for r in rows] == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_narrow_rows_are_read_when_the_property_holds(self):
+        rows = await self.read([["a", "ts", ""]], None)
+
+        assert [r["Id"] for r in rows] == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_an_illegal_width_is_reported_over_the_violation(self):
+        """A row stopping before IsDelete is misaligned whatever the schema
+        did, so it earns the specific width error rather than being lumped in
+        with rows that are merely untrustworthy."""
+        with pytest.raises(RowSchemaMismatchError, match="at least 3 columns wide"):
+            await self.read([["a", "ts"]], self.VIOLATION)
+
+    @pytest.mark.asyncio
+    async def test_a_surplus_width_is_reported_over_the_violation(self):
+        with pytest.raises(RowSchemaMismatchError, match="no field name to bind to"):
+            await self.read([["a", "ts", "", "1", "2", "3", "s"]], self.VIOLATION)
+
+
+class FakeCsvClient:
+    """Serves one folder: its listing, its model.json and one CSV's cells."""
+
+    def __init__(self, folder: str, table: str, attributes: list[dict],
+                 rows: list[list[str]]):
+        self.folder, self.table, self.rows = folder, table, rows
+        self._model = orjson.dumps({
+            "name": "cdm",
+            "entities": [{
+                "$type": "LocalEntity", "name": table, "description": "",
+                "attributes": attributes,
+            }],
+        })
+        self.log = logging.getLogger("test-d365-api")
+
+    async def list_paths(self, directory=None, recursive=False):
+        yield fake_csv(f"{self.folder}/{self.table}/data.csv")
+
+    async def read_file(self, path: str) -> bytes:
+        if path == f"{self.folder}/model.json":
+            return self._model
+        raise HTTPError("The specified path does not exist.", 404)
+
+    async def stream_csv(self, path: str):
+        for row in self.rows:
+            yield row
+
+
+class TestSchemaHistoryReachesTheRows:
+    """read_csvs_in_folder has to observe the schema and hand the result to
+    read_csv_rows. Without that wiring the checks in TableSchemaHistory would
+    be computed and dropped."""
+
+    FOLDER = "2026-01-01T00.00.00Z"
+    EARLIER = "2025-12-31T23.00.00Z"
+    ATTRIBUTES = [
+        {"name": "Id", "dataType": "guid"},
+        {"name": "inserted", "dataType": "string"},
+        {"name": "IsDelete", "dataType": "boolean"},
+        {"name": "appended", "dataType": "int64"},
+    ]
+
+    def client(self) -> FakeCsvClient:
+        # One narrow row - three of the four declared columns.
+        return FakeCsvClient(self.FOLDER, "prodtable", self.ATTRIBUTES, [["a", "", ""]])
+
+    @pytest.mark.asyncio
+    async def test_narrow_row_refused_after_a_column_was_inserted(self):
+        client = self.client()
+        history = TableSchemaHistory()
+        # The earlier folder had no "inserted" column, so this folder's schema
+        # does not begin with it - a column landed in the middle.
+        history.observe(self.EARLIER, ["Id", "IsDelete", "appended"])
+
+        with pytest.raises(RowSchemaMismatchError, match="cannot be assumed here"):
+            await collect(read_csvs_in_folder(
+                self.FOLDER, "prodtable", client, client.log, history
+            ))
+
+    @pytest.mark.asyncio
+    async def test_narrow_row_read_when_columns_were_only_appended(self):
+        client = self.client()
+        history = TableSchemaHistory()
+        history.observe(self.EARLIER, ["Id", "inserted", "IsDelete"])
+
+        rows = await collect(read_csvs_in_folder(
+            self.FOLDER, "prodtable", client, client.log, history
+        ))
+
+        assert [r["Id"] for r in rows] == ["a"]
+        assert "appended" not in rows[0]
+
+
 class TestCsvBytesToDocuments:
     """Covers the seam between the CDK's positional parser and the connector's
     binding: raw bytes in, capture documents out."""
@@ -442,6 +574,7 @@ class TestCsvBytesToDocuments:
                 self.METADATA,
                 CSV_NAME,
                 log,
+                None,
             )
         ]
 

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -12,6 +12,7 @@ from source_dynamics_365_finance_and_operations.api import (
     SETTLE_DELAY,
     TRICKLE_FEED_SERVICE_DIR,
     RowSchemaMismatchError,
+    TableSchemaHistory,
     TableSchemaUnavailableError,
     TransformedRow,
     _table_metadata_from_entity,
@@ -344,6 +345,81 @@ class TestReadCsvRows:
 
         assert [(r["Id"], r["IsDelete"]) for r in result] == [("a", False), ("b", True)]
         assert "app_c" not in result[1]
+
+
+class TestTableSchemaHistory:
+    """Watches the premise the width rules rest on: that columns are only ever
+    appended to the end of a row."""
+
+    BASE = ["Id", "qty", "IsDelete", "notes"]
+
+    def test_first_schema_has_nothing_to_compare_against(self):
+        history = TableSchemaHistory()
+
+        assert history.observe("2026-01-01T00.00.00Z", self.BASE) is None
+
+    def test_appending_upholds_the_property(self):
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        assert history.observe("2026-01-01T01.00.00Z", self.BASE + ["added"]) is None
+
+    def test_unchanged_schema_upholds_the_property(self):
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        assert history.observe("2026-01-01T01.00.00Z", list(self.BASE)) is None
+
+    def test_insertion_is_reported(self):
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        violation = history.observe(
+            "2026-01-01T01.00.00Z", ["Id", "qty", "color", "IsDelete", "notes"]
+        )
+
+        assert violation is not None
+        assert "column 2 changed from 'IsDelete' to 'color'" in violation
+        assert "2026-01-01T00.00.00Z" in violation
+
+    def test_reorder_is_reported(self):
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        assert history.observe(
+            "2026-01-01T01.00.00Z", ["qty", "Id", "IsDelete", "notes"]
+        ) is not None
+
+    def test_removal_is_reported(self):
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        violation = history.observe("2026-01-01T01.00.00Z", ["Id", "qty", "IsDelete"])
+
+        assert violation is not None
+        assert "the column is gone" in violation
+
+    def test_skipped_folders_cannot_hide_a_violation(self):
+        """A table only appears in folders where it changed, so comparisons can
+        span several folders. The prefix relation is transitive, so an
+        insertion followed by an append is still caught."""
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+
+        assert history.observe(
+            "2026-01-01T05.00.00Z",
+            ["Id", "qty", "color", "IsDelete", "notes", "added"],
+        ) is not None
+
+    def test_comparison_is_against_the_last_schema_seen(self):
+        """After a violation the new schema becomes the baseline, so a
+        subsequent append is not reported again."""
+        history = TableSchemaHistory()
+        history.observe("2026-01-01T00.00.00Z", self.BASE)
+        inserted = ["Id", "qty", "color", "IsDelete", "notes"]
+        assert history.observe("2026-01-01T01.00.00Z", inserted) is not None
+
+        assert history.observe("2026-01-01T02.00.00Z", inserted + ["added"]) is None
 
 
 class TestCsvBytesToDocuments:
@@ -725,3 +801,4 @@ class TestShouldWaitForFinalization:
     def test_just_under_settle_delay_is_waited_on(self):
         now = str_to_dt(self.SUCCESSOR) + SETTLE_DELAY - timedelta(seconds=1)
         assert should_wait_for_finalization(self.SUCCESSOR, now) is True
+

--- a/source-dynamics-365-finance-and-operations/tests/test_api.py
+++ b/source-dynamics-365-finance-and-operations/tests/test_api.py
@@ -12,6 +12,7 @@ from source_dynamics_365_finance_and_operations.api import (
     TRICKLE_FEED_SERVICE_DIR,
     TableSchemaUnavailableError,
     TransformedRow,
+    _table_metadata_from_entity,
     get_table_metadata,
     should_wait_for_finalization,
     stream_folder_rows,
@@ -266,7 +267,7 @@ def entity(name: str) -> dict:
         "description": "",
         "attributes": [
             {"name": "Id", "dataType": "guid"},
-            {"name": "IsDelete", "dataType": "string"},
+            {"name": "IsDelete", "dataType": "boolean"},
             {"name": "IsActive", "dataType": "boolean"},
         ],
     }
@@ -308,7 +309,7 @@ class TestGetTableMetadata:
         metadata = await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
         assert metadata.name == self.TABLE
         assert metadata.field_names == ["Id", "IsDelete", "IsActive"]
-        assert metadata.boolean_fields == frozenset({"IsActive"})
+        assert metadata.boolean_fields == frozenset({"IsActive", "IsDelete"})
 
     @pytest.mark.asyncio
     async def test_falls_back_to_per_table_model_json_when_truncated(self):
@@ -349,6 +350,42 @@ class TestGetTableMetadata:
         })
         with pytest.raises(TableSchemaUnavailableError, match="does not describe the table"):
             await get_table_metadata(self.TIMESTAMP, self.TABLE, client, client.log)
+
+
+class TestTableMetadataFromEntity:
+    """Tests for the IsDelete column the connector requires of every table."""
+
+    def test_boolean_is_delete_is_accepted(self):
+        metadata = _table_metadata_from_entity({
+            "name": "prodtable",
+            "attributes": [
+                {"name": "Id", "dataType": "guid"},
+                {"name": "IsDelete", "dataType": "boolean"},
+            ],
+        })
+
+        assert metadata.boolean_fields == frozenset({"IsDelete"})
+
+    def test_entity_without_is_delete_raises(self):
+        """IsDelete determines a row's operation and orders upserts ahead of
+        deletes, so a table lacking it cannot be read at all."""
+        with pytest.raises(ValueError, match="no IsDelete column"):
+            _table_metadata_from_entity({
+                "name": "odd",
+                "attributes": [{"name": "Id", "dataType": "guid"}],
+            })
+
+    def test_entity_with_non_boolean_is_delete_raises(self):
+        """A string IsDelete would stay out of boolean_fields, leaving every
+        delete row reading as an upsert with no error at all."""
+        with pytest.raises(ValueError, match="rather than 'boolean'"):
+            _table_metadata_from_entity({
+                "name": "odd",
+                "attributes": [
+                    {"name": "Id", "dataType": "guid"},
+                    {"name": "IsDelete", "dataType": "string"},
+                ],
+            })
 
 
 class TestShouldWaitForFinalization:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We observed a capture failing with an error stating `CSV row N has X columns but Y were expected`. It turns out that it's possible for Synapse Link to write headerless CSVs with variable row widths, and that error is indicating that rows in a CSV file don't all have the same number of columns as the headers that were provided to the `IncrementalCSVProcessor`.

What appears to be happening is that when a column is added to a table, Synapse Link starts writing it at the end of every row. And if that happens while a CSV is actively being written to, the file ends up with narrow rows before the column addition & wide rows after (ex: The first few rows have 117 columns -> D365 adds a new column -> the remaining rows have 118 columns). A timestamp folder's `model.json` is written at the end of the interval & describes the wider shape, and the connector was (intentionally) choking on the narrow rows.

To fix this, the connector now treats narrow rows as a prefix of the total column set, where the rows are bound sequentially to bound sequentially to the field names in the order `model.json` lists the table's attributes, stopping when the row runs out of cells. The columns a narrow row lacks are left absent from the document rather than set to null. This works because Synapse Link appears to only ever appends a new column to the end of a row, after `IsDelete` - which makes a narrow row exactly the declared schema truncated on the right, so every cell it does have still lines up with the correct field name. Based on my investigation of a source system that contains headerless, variable width CSVs, this appears to be safe handling.

The scope of this PR includes:
- Adding a new `IncrementalCSVRowProcessor` to the CDK that incrementally reads rows from a CSV without binding them to any field names. This means the connector needs to do the field name binding itself, but it also allows more flexibility for handling these hopefully rare headerless, variable width CSV situations.
- Updating `source-dynamics-365-finance-and-operations` to use the new `IncrementalCSVRowProcessor` and bind field names to rows. This allows the connector to handle the column addition scenario described above that resulted in a variable width CSV & no longer choke on it.
- Adding a lot of guardrails and checks for the class of problems that are no longer checked for automatically by `IncrementalCSVProcessor`. Stuff like rows that are too narrow, rows that are too wide, decreasing row widths in a file, new columns no longer being append only. We want to know if/when this happens so we can investigate further and determine how to handle whenever an odd CSV situation happens again.

**Notes for reviewers:**

Best reviewed commit-by-commit. The essence of the changes are "use a subset of the `model.json` schema to parse narrow rows and add a lot of guardrails to detect when that's probably not safe to do so" but spread out over a few commits to hopefully make them more digestible.

Tested with `flowctl preview`. Confirmed the connector now successfully processes the variable width CSV that it previously crashed on.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
