### PR TITLE
source-postgres: fix read-only captures stalling when captured tables are quiet

### DIFF
--- a/go/capture/blackbox/capture.go
+++ b/go/capture/blackbox/capture.go
@@ -581,8 +581,17 @@ func (tc *TranscriptCapture) DiscoverFull(description string) []json.RawMessage 
 }
 
 func (tc *TranscriptCapture) Run(description string, sessions int) []byte {
+	return tc.RunWithContext(context.Background(), description, sessions)
+}
+
+// RunWithContext is Run with a caller-provided context bounding how long the capture may
+// run. When the context expires the capture process is killed and the resulting error is
+// recorded in the transcript, so a capture which stops making progress shows up as an
+// ordinary transcript difference instead of hanging until the test binary's own timeout,
+// which would panic and discard the results of every other test in the package.
+func (tc *TranscriptCapture) RunWithContext(ctx context.Context, description string, sessions int) []byte {
 	fmt.Fprintf(tc.Transcript, "=== Run: %s ===\n", description)
-	result, err := tc.Capture.Run(sessions)
+	result, err := tc.Capture.RunWithContext(ctx, sessions)
 	if err != nil {
 		fmt.Fprintf(tc.Transcript, "error: %v\n\n", err)
 		return nil

--- a/source-postgres/.snapshots/TestReadOnlyCaptureIdleFence
+++ b/source-postgres/.snapshots/TestReadOnlyCaptureIdleFence
@@ -70,6 +70,17 @@ acmeCo/test_capture/test/readonlycaptureidlefence_936845
 }
 sql> INSERT INTO test.unwatched_909099 VALUES (0, 'unwatched')
 === Run: Idle Fence ===
-error: flowctl preview failed: signal: killed
-
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "test%2Freadonlycaptureidlefence_936845": {
+      "backfilled": 3,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
 

--- a/source-postgres/.snapshots/TestReadOnlyCaptureIdleFence
+++ b/source-postgres/.snapshots/TestReadOnlyCaptureIdleFence
@@ -1,0 +1,75 @@
+sql> CREATE TABLE test.readonlycaptureidlefence_936845 (id INTEGER PRIMARY KEY, data VARCHAR(2000))
+sql> INSERT INTO test.readonlycaptureidlefence_936845 VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')
+sql> CREATE TABLE test.unwatched_909099 (id INTEGER PRIMARY KEY, data VARCHAR(2000))
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/readonlycaptureidlefence_936845
+=== Run: Initial Backfill ===
+[
+  "acmeCo/test_capture/test/readonlycaptureidlefence_936845",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "readonlycaptureidlefence_936845"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "A",
+    "id": 0
+  }
+]
+[
+  "acmeCo/test_capture/test/readonlycaptureidlefence_936845",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "readonlycaptureidlefence_936845"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "bbb",
+    "id": 1
+  }
+]
+[
+  "acmeCo/test_capture/test/readonlycaptureidlefence_936845",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "readonlycaptureidlefence_936845"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "CDEFGH",
+    "id": 2
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "test%2Freadonlycaptureidlefence_936845": {
+      "backfilled": 3,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+sql> INSERT INTO test.unwatched_909099 VALUES (0, 'unwatched')
+=== Run: Idle Fence ===
+error: flowctl preview failed: signal: killed
+
+

--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-31
+
+### Fixed
+- Captures with `read_only_capture` enabled no longer stall when the source
+  database writes WAL for tables which aren't being captured.
+
 ## 2026-07-30
 
 ### Added

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -879,3 +879,55 @@ func TestBackfillPriority(t *testing.T) {
 	tc.Run("Backfill 3 (Low Priority)", transactionCountBaseline+1)  // Run until everything else is backfilled
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
+
+// TestReadOnlyCaptureIdleFence exercises a read-only capture whose own tables are silent while
+// the server keeps writing WAL for a table outside the publication.
+//
+// Read-only captures skip the watermark write which normally guarantees a commit past each
+// fence, and the fence position comes from the server-wide flush LSN, so nothing the capture
+// can observe is guaranteed to arrive after it. Such a fence can only be satisfied by the
+// server reporting its decoding position in a keepalive; before that was implemented the
+// capture would wait here indefinitely.
+func TestReadOnlyCaptureIdleFence(t *testing.T) {
+	var db, tc = blackboxTestSetup(t)
+	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
+	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
+
+	// A table the capture never sees: its name doesn't match the discovery filter, and the
+	// publication is scoped below so that its changes are never decoded for us either. The
+	// default test publication is FOR ALL TABLES, under which writes to any table produce a
+	// commit which would satisfy the fence through the ordinary path.
+	var unwatched = testSchemaName + `.unwatched_` + uniqueTableID(t, "unwatched")
+	db.CreateTable(t, unwatched, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
+	t.Cleanup(func() {
+		db.QuietExec(t, `DROP PUBLICATION IF EXISTS flow_publication`)
+		db.QuietExec(t, `CREATE PUBLICATION flow_publication FOR ALL TABLES`)
+		db.QuietExec(t, `ALTER PUBLICATION flow_publication SET (publish_via_partition_root = true)`)
+	})
+	db.QuietExec(t, `DROP PUBLICATION IF EXISTS flow_publication`)
+	db.QuietExec(t, `CREATE PUBLICATION flow_publication FOR TABLE <NAME>`)
+
+	// When the bounded run below expires it kills flowctl, which does not reap the connector
+	// it launched, so a failing run leaves a process holding the replication slot and every
+	// later test in the package fails to start replication. Release it so that a regression
+	// here fails this test alone.
+	t.Cleanup(func() {
+		db.QuietExec(t, `SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots
+			WHERE slot_name = 'flow_slot' AND active`)
+	})
+
+	require.NoError(t, tc.Capture.EditConfig("advanced.read_only_capture", true))
+	tc.Discover("Discover Tables")
+	tc.Run("Initial Backfill", transactionCountBaseline+1)
+
+	// Advance the server's WAL past the capture's cursor using only writes it will never
+	// observe, then verify that the next capture still reaches its fence and shuts down.
+	// This run is bounded because the regression it guards against is an indefinite wait:
+	// without a deadline a failure hangs until the test binary's timeout and panics, taking
+	// every other test in the package down with it. A successful run takes a second or two.
+	db.Exec(t, `INSERT INTO `+unwatched+` VALUES (0, 'unwatched')`)
+	var ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	tc.RunWithContext(ctx, "Idle Fence", transactionCountBaseline)
+	cupaloy.SnapshotT(t, tc.Transcript.String())
+}

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -929,5 +929,10 @@ func TestReadOnlyCaptureIdleFence(t *testing.T) {
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	tc.RunWithContext(ctx, "Idle Fence", transactionCountBaseline)
+
+	// Cursor values are redacted from the snapshot, and "0/0" matches that redaction, so the
+	// position the fence checkpointed has to be asserted separately from it.
+	require.NotContains(t, string(tc.Capture.Checkpoint), `"cursor":"0/0"`, "the fence should have checkpointed the position it reached")
+
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }

--- a/source-postgres/keepalive_fence_test.go
+++ b/source-postgres/keepalive_fence_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/estuary/connectors/sqlcapture"
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// The replication protocol framing needed to drive relayChanges directly. Only the message
+// shapes these tests send are implemented; see the PostgreSQL protocol message formats and
+// the pgoutput logical replication message formats for the layouts.
+
+// copyData wraps a payload in a CopyData message: a type byte, a big-endian length which
+// counts itself but not the type byte, and the payload.
+func copyData(payload []byte) []byte {
+	var msg = []byte{MessageTypeCopyData, 0, 0, 0, 0}
+	binary.BigEndian.PutUint32(msg[1:5], uint32(4+len(payload)))
+	return append(msg, payload...)
+}
+
+func keepaliveMessage(serverWALEnd pglogrepl.LSN, replyRequested bool) []byte {
+	var payload = make([]byte, 18)
+	payload[0] = pglogrepl.PrimaryKeepaliveMessageByteID
+	binary.BigEndian.PutUint64(payload[1:9], uint64(serverWALEnd))
+	binary.BigEndian.PutUint64(payload[9:17], 0) // ServerTime
+	if replyRequested {
+		payload[17] = 1
+	}
+	return copyData(payload)
+}
+
+// xlogData wraps pgoutput message bytes in an XLogData message.
+func xlogData(walStart pglogrepl.LSN, walData []byte) []byte {
+	var payload = make([]byte, 25, 25+len(walData))
+	payload[0] = pglogrepl.XLogDataByteID
+	binary.BigEndian.PutUint64(payload[1:9], uint64(walStart))
+	binary.BigEndian.PutUint64(payload[9:17], uint64(walStart)) // ServerWALEnd
+	binary.BigEndian.PutUint64(payload[17:25], 0)               // ServerTime
+	return copyData(append(payload, walData...))
+}
+
+func beginMessage(finalLSN pglogrepl.LSN) []byte {
+	var msg = make([]byte, 21)
+	msg[0] = byte(pglogrepl.MessageTypeBegin)
+	binary.BigEndian.PutUint64(msg[1:9], uint64(finalLSN))
+	binary.BigEndian.PutUint64(msg[9:17], 0)  // CommitTime
+	binary.BigEndian.PutUint32(msg[17:21], 1) // Xid
+	return msg
+}
+
+func commitMessage(commitLSN, txnEndLSN pglogrepl.LSN) []byte {
+	var msg = make([]byte, 26)
+	msg[0] = byte(pglogrepl.MessageTypeCommit)
+	msg[1] = 0 // Flags
+	binary.BigEndian.PutUint64(msg[2:10], uint64(commitLSN))
+	binary.BigEndian.PutUint64(msg[10:18], uint64(txnEndLSN))
+	binary.BigEndian.PutUint64(msg[18:26], 0) // CommitTime
+	return msg
+}
+
+// newFenceTestStream returns a replicationStream reading from an in-memory connection, plus
+// the server end of that connection to write messages into.
+//
+// The stream is only equipped for the keepalive, BEGIN and COMMIT messages these tests send.
+// Change events would need typeMap, the tables maps and db, none of which are set here.
+func newFenceTestStream(t *testing.T) (*replicationStream, net.Conn) {
+	t.Helper()
+	var serverConn, clientConn = net.Pipe()
+	t.Cleanup(func() { serverConn.Close(); clientConn.Close() })
+
+	var stream = &replicationStream{
+		conn:  &pgconn.HijackedConn{Conn: clientConn},
+		rxbuf: make([]byte, 0, 4096),
+	}
+	stream.reused.commitEvent = new(postgresCommitEvent)
+	return stream, serverConn
+}
+
+// writeScript sends each message in order. The connection is deliberately left open: closing
+// either end of a net.Pipe makes SetReadDeadline fail with ErrClosedPipe rather than letting
+// the relay see a clean EOF, so tests which expect the relay to keep running assert on their
+// context deadline instead.
+func writeScript(t *testing.T, conn net.Conn, script ...[]byte) {
+	t.Helper()
+	go func() {
+		for _, msg := range script {
+			if _, err := conn.Write(msg); err != nil {
+				return // The relay stopped reading; the assertions will catch it.
+			}
+		}
+	}()
+}
+
+// drain consumes anything the connector writes back. Without it a standby status update,
+// which is written with no deadline, would block forever on the unbuffered pipe.
+func drain(conn net.Conn) {
+	go func() { io.Copy(io.Discard, conn) }()
+}
+
+// fenceTestContext bounds a relay so that a regression fails the test rather than hanging the
+// package. No test should ever reach this deadline.
+func fenceTestContext(t *testing.T) context.Context {
+	t.Helper()
+	var ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// unknownMessage is an unrecognised CopyData message, which relayChanges rejects outright. Ending
+// a script with it proves the messages before it were consumed: a test which expects the relay to
+// keep running can assert on this error rather than on a timeout, which would also pass if nothing
+// were ever delivered.
+func unknownMessage() []byte { return copyData([]byte{'Z'}) }
+
+// TestKeepaliveFenceGuard drives relayChanges over an in-memory connection to check which
+// keepalives are allowed to satisfy a fence.
+//
+// A keepalive proves the server has decoded past the position it reports, but says nothing
+// about whether we are between transactions, and the server does deliver keepalives partway
+// through a transaction's output. Completing a fence there would checkpoint a cursor inside
+// a transaction. This asserts that the mid-transaction keepalive is ignored: the fence is
+// satisfied only by the one which follows the commit, and the commit event reaches the
+// callback first. Drop the nextTxnFinalLSN term from the guard and no commit is ever seen.
+//
+// The satisfying keepalive reports exactly the fence position, which is the case that occurs
+// in production: the fence comes from pg_current_wal_flush_lsn() and on a quiet server the
+// server's decoding position converges to precisely that. Weaken the comparison to a strict
+// greater-than and this fence is never reached.
+func TestKeepaliveFenceGuard(t *testing.T) {
+	const fenceLSN = pglogrepl.LSN(0x1000)
+	const txnCommitLSN = pglogrepl.LSN(0x2000)
+	const txnEndLSN = txnCommitLSN + 0x40 // Distinct, so the cursor can't accidentally match.
+
+	var stream, serverConn = newFenceTestStream(t)
+	drain(serverConn)
+	writeScript(t, serverConn,
+		keepaliveMessage(fenceLSN-1, false),                            // below the fence
+		xlogData(txnCommitLSN, beginMessage(txnCommitLSN)),             // transaction opens
+		keepaliveMessage(fenceLSN+1, false),                            // past the fence, mid-transaction
+		xlogData(txnCommitLSN, commitMessage(txnCommitLSN, txnEndLSN)), // transaction closes
+		keepaliveMessage(fenceLSN, false),                              // exactly at the fence
+	)
+
+	var events []postgresCommitEvent
+	var err = stream.relayChanges(fenceTestContext(t), fenceLSN, func(event sqlcapture.DatabaseEvent) error {
+		// Commit events are a reused object, so record a copy rather than the pointer.
+		if commit, ok := event.(*postgresCommitEvent); ok {
+			events = append(events, *commit)
+		}
+		return nil
+	})
+
+	require.ErrorIs(t, err, errFenceReachedByKeepalive)
+	require.Len(t, events, 1, "the fence should have been satisfied by the keepalive after the commit, not the one during the transaction")
+	require.Equal(t, txnEndLSN, events[0].CommitLSN, "the cursor should be the transaction's end LSN")
+}
+
+// TestKeepaliveRepliesBeforeSatisfyingFence checks that a reply-requested keepalive which also
+// satisfies the fence is answered before the relay stops. Reordering the guard above the reply
+// handling would leave the server waiting on a reply we never sent.
+func TestKeepaliveRepliesBeforeSatisfyingFence(t *testing.T) {
+	const fenceLSN = pglogrepl.LSN(0x1000)
+
+	var stream, serverConn = newFenceTestStream(t)
+	var replies = make(chan []byte, 4)
+	go func() {
+		var buf = make([]byte, 256)
+		for {
+			var n, err = serverConn.Read(buf)
+			if n > 0 {
+				replies <- append([]byte(nil), buf[:n]...)
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	writeScript(t, serverConn, keepaliveMessage(fenceLSN, true))
+
+	var err = stream.relayChanges(fenceTestContext(t), fenceLSN, func(event sqlcapture.DatabaseEvent) error {
+		return nil
+	})
+	require.ErrorIs(t, err, errFenceReachedByKeepalive)
+
+	select {
+	case reply := <-replies:
+		require.GreaterOrEqual(t, len(reply), 6, "short read of the standby status update")
+		require.Equal(t, byte(MessageTypeCopyData), reply[0])
+		require.Equal(t, byte(pglogrepl.StandbyStatusUpdateByteID), reply[5], "expected a Standby Status Update")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the reply-requested keepalive was not answered before the fence completed")
+	}
+}
+
+// TestKeepaliveBelowFenceDoesNotSatisfyIt checks that a keepalive short of the fence leaves the
+// relay running rather than completing the fence.
+func TestKeepaliveBelowFenceDoesNotSatisfyIt(t *testing.T) {
+	const fenceLSN = pglogrepl.LSN(0x1000)
+
+	var stream, serverConn = newFenceTestStream(t)
+	drain(serverConn)
+	writeScript(t, serverConn,
+		keepaliveMessage(fenceLSN-1, false),
+		keepaliveMessage(fenceLSN-0x800, false),
+		unknownMessage(),
+	)
+
+	var err = stream.relayChanges(fenceTestContext(t), fenceLSN, func(event sqlcapture.DatabaseEvent) error {
+		return nil
+	})
+	require.ErrorContains(t, err, "unknown CopyData message", "the relay should have consumed both keepalives and kept running")
+	require.NotErrorIs(t, err, errFenceReachedByKeepalive)
+}
+
+// TestZeroFenceIgnoresKeepalives covers the timed streaming phase, which passes a zero fence
+// because it has no fence to reach yet and ends on its own deadline. Dropping the fenceLSN > 0
+// term from the guard would turn every keepalive into a fence completion there, which the timed
+// phase's error handling does not expect.
+func TestZeroFenceIgnoresKeepalives(t *testing.T) {
+	var stream, serverConn = newFenceTestStream(t)
+	drain(serverConn)
+	writeScript(t, serverConn,
+		keepaliveMessage(0x4000, false),
+		keepaliveMessage(0x8000, false),
+		unknownMessage(),
+	)
+
+	var err = stream.relayChanges(fenceTestContext(t), 0, func(event sqlcapture.DatabaseEvent) error {
+		return nil
+	})
+	require.ErrorContains(t, err, "unknown CopyData message", "the relay should have consumed both keepalives and kept running")
+	require.NotErrorIs(t, err, errFenceReachedByKeepalive, "a zero fence must never be satisfied by a keepalive")
+}

--- a/source-postgres/replication.go
+++ b/source-postgres/replication.go
@@ -61,6 +61,13 @@ var slotInUseRe = regexp.MustCompile(`replication slot ".*" is active for PID`)
 // liveness timeout, indicating a likely silently disconnected connection.
 var errReceiveTimeout = fmt.Errorf("no replication messages received from server within %s", replicationStreamReceiveTimeout)
 
+// errFenceReachedByKeepalive is returned by relayChanges when the server reports, via a
+// Primary Keepalive Message, that it has decoded past the fence position it was given.
+// This is a successful outcome rather than a failure, in the manner of io.EOF: callers
+// which pass a fence position must handle it. See the keepalive handling in relayChanges
+// for why it satisfies a fence.
+var errFenceReachedByKeepalive = errors.New("fence position reached via keepalive message")
+
 const standbyStatusInterval = 10 * time.Second
 
 var (
@@ -314,7 +321,7 @@ func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.D
 		logrus.WithField("cursor", latestCommitLSN).Debug("beginning timed streaming phase")
 		var relayCtx, cancelRelayCtx = context.WithTimeout(ctx, fenceAfter)
 		defer cancelRelayCtx()
-		if err := s.relayChanges(relayCtx, func(event sqlcapture.DatabaseEvent) error {
+		if err := s.relayChanges(relayCtx, 0, func(event sqlcapture.DatabaseEvent) error { // No fence yet, this phase ends on the timeout.
 			if err := callback(event); err != nil {
 				return err
 			}
@@ -365,13 +372,14 @@ func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.D
 		}
 	}
 
-	// Stream replication events until the fence is reached. Liveness is enforced inside
-	// relayChanges via replicationStreamReceiveTimeout.
+	// Stream replication events until the fence is reached, either by observing a commit at
+	// or past it or by the server reporting that it has decoded past it. Liveness is enforced
+	// inside relayChanges via replicationStreamReceiveTimeout.
 	var relayCtx, cancelRelayCtx = context.WithCancelCause(ctx)
 	var fenceReached = errors.New("fenced reached")
 	defer cancelRelayCtx(nil)
 
-	if err := s.relayChanges(relayCtx, func(event sqlcapture.DatabaseEvent) error {
+	if err := s.relayChanges(relayCtx, fenceLSN, func(event sqlcapture.DatabaseEvent) error {
 		if err := callback(event); err != nil {
 			return err
 		}
@@ -390,7 +398,15 @@ func (s *replicationStream) StreamToFence(ctx context.Context, fenceAfter time.D
 			}
 		}
 		return nil
-	}); errors.Is(err, context.Canceled) {
+	}); errors.Is(err, errFenceReachedByKeepalive) {
+		// The server decoded past the fence without producing any events for us, so we're at
+		// a valid position between transactions and can emit a synthetic commit event just
+		// like the already-at-fence case above.
+		logrus.WithField("cursor", fenceLSN.String()).Debug("finished fenced streaming phase via keepalive")
+		s.previousFenceLSN = fenceLSN
+		*s.reused.commitEvent = postgresCommitEvent{CommitLSN: fenceLSN}
+		return callback(s.reused.commitEvent)
+	} else if errors.Is(err, context.Canceled) {
 		if cause := context.Cause(relayCtx); !errors.Is(cause, fenceReached) {
 			return cause
 		}
@@ -470,7 +486,13 @@ func (s *replicationStream) StartReplication(ctx context.Context, discovery map[
 	}
 }
 
-func (s *replicationStream) relayChanges(ctx context.Context, callback func(event sqlcapture.DatabaseEvent) error) error {
+// relayChanges receives replication messages and dispatches decoded events to the callback
+// until the context is canceled or an error occurs.
+//
+// A nonzero fenceLSN asks the relay to also stop as soon as the server reports having decoded
+// past that position, returning errFenceReachedByKeepalive. Callers which aren't streaming
+// toward a fence pass zero.
+func (s *replicationStream) relayChanges(ctx context.Context, fenceLSN pglogrepl.LSN, callback func(event sqlcapture.DatabaseEvent) error) error {
 	// Bound the time we will wait for any message from the server so that a silently dead
 	// connection (e.g. a NAT or middlebox dropping the TCP session without sending RST) is
 	// detected instead of blocking forever. We expect Primary Keepalive Messages from the
@@ -524,12 +546,40 @@ func (s *replicationStream) relayChanges(ctx context.Context, callback func(even
 		var xld pglogrepl.XLogData
 		switch data[0] {
 		case pglogrepl.PrimaryKeepaliveMessageByteID:
-			if pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(data[1:]); err != nil {
+			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(data[1:])
+			if err != nil {
 				return fmt.Errorf("error parsing keepalive: %w", err)
-			} else if pkm.ReplyRequested {
+			}
+			if pkm.ReplyRequested {
 				if err := s.sendStandbyStatusUpdate(false); err != nil {
 					return fmt.Errorf("error sending standby status update: %w", err)
 				}
+			}
+
+			// A keepalive reports how far the server has decoded, and it is queued behind
+			// everything the server decided to send us from below that position. So one at
+			// or past the fence proves that no published change before the fence is still in
+			// flight, which satisfies the fence just as well as observing a commit past it.
+			// This is the only thing which can satisfy a fence when the database produces no
+			// changes to captured tables, since a read-only capture can't force one by
+			// writing a watermark.
+			//
+			// It only satisfies the fence between transactions, hence the nextTxnFinalLSN
+			// check. The server assigns its reported position after processing a record, but
+			// emits a transaction's whole output while processing that transaction's commit
+			// record, so throughout the emission the reported position is the boundary before
+			// the commit and can already be past the fence. Keepalives do reach us in that
+			// window: the server stops mid-emission to process replies both when the socket is
+			// backed up and, independently, once half of wal_sender_timeout has passed without
+			// it reading one. That timer is not disarmed by our sending, because it only
+			// advances when the server actually processes a reply, which it cannot do while
+			// inside the decode. It covers a long transaction whose changes are all filtered
+			// out, where the server is sending us nothing at all. Our standby status updates
+			// request a reply, so it answers one with a keepalive. Completing a fence there
+			// would checkpoint a cursor inside a transaction, so the half already emitted would
+			// be sent again when replication resumed from it.
+			if fenceLSN > 0 && s.nextTxnFinalLSN == 0 && pkm.ServerWALEnd >= fenceLSN {
+				return errFenceReachedByKeepalive
 			}
 			continue // Keep looking for something we care about.
 		case pglogrepl.XLogDataByteID:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

A fence is set from `pg_current_wal_flush_lsn()` - a server-wide position - but can only be satisfied by a commit to a table we capture. Write-mode captures manufacture one via the watermark write; `read_only_capture` skips it. When a source's captured tables are quieter than the instance, the fence is never reached and the capture blocks in `StreamToFence` indefinitely.

The checkpoint sits behind that fence, so the runtime can't end the session to rotate IAM credentials either. They expire, the pool dies, and when the fence finally clears the capture crashes on its next query. I'm pretty sure that's the sequence of events that led to the `SQLSTATE 28000` error reported in this [Slack thread](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1785522487203939).

Observed in production: fence target 2.25 GiB of WAL ahead of the capture's position, stalls of 60 minutes to 5 hours.

To fix this, we're now checking keepalive messages to see how far the server has decoded. Primary keepalive messages are queued behind everything it sent from below that position, so one at or past the fence proves no published change before the fence is still in flight. The connector was already parsing these messages and discarding the position. Now it uses it, and an idle fence clears in seconds.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
