### PR TITLE
estuary-cdk: apply defaults to sourced schemas

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/document.py
+++ b/estuary-cdk/estuary_cdk/capture/document.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 from pydantic import BaseModel, Field
 
 
@@ -13,6 +13,27 @@ class BaseDocument(BaseModel, extra="allow"):
             default=-1,
             description="Row ID of the Document, counting up from zero, or -1 if not known",
         )
+
+        @classmethod
+        def sourced_schema(cls) -> dict[str, Any]:
+            """The `_meta` sub-schema to nest under `properties` when building a SourcedSchema."""
+            return {
+                "additionalProperties": False,
+                "type": "object",
+                "properties": {
+                    "op": {
+                        "type": "string",
+                        "enum": ["c", "u", "d"],
+                        "minLength": 1,
+                        "maxLength": 1,
+                    },
+                    "row_id": {"type": "integer", "minimum": 1, "maximum": 1},
+                    # Connectors never emit uuid. The runtime adds it to
+                    # every captured document.
+                    "uuid": {"type": "string", "minLength": 36, "maxLength": 36},
+                },
+                "required": ["uuid", "op", "row_id"],
+            }
 
     meta_: Meta = Field(
         default_factory=lambda: BaseDocument.Meta(op="u"),

--- a/estuary-cdk/estuary_cdk/capture/task.py
+++ b/estuary-cdk/estuary_cdk/capture/task.py
@@ -13,7 +13,7 @@ import xxhash
 from pydantic import Field
 
 from estuary_cdk.capture.connector_status import ConnectorStatus
-from estuary_cdk.capture.document import AssociatedDocument
+from estuary_cdk.capture.document import AssociatedDocument, BaseDocument
 
 from ..flow import (
     ConnectorSpec,
@@ -47,6 +47,112 @@ class Response(GenericModel, Generic[EndpointConfig, ResourceConfig, ConnectorSt
     captured: response.Captured | None = None
     sourcedSchema: response.SourcedSchema | None = None
     checkpoint: response.Checkpoint[ConnectorState] | None = None
+
+
+# Bounds applied to SourcedSchema locations that don't declare their own. They
+# start deliberately tight because inference widens them to fit real data
+# (maxLength and maximum grow, minLength and minimum shrink).
+DEFAULT_STRING_BOUNDS = {"minLength": 1, "maxLength": 1}
+DEFAULT_NUMERIC_BOUNDS = {"minimum": 1, "maximum": 1}
+
+
+def with_sourced_schema_defaults(schema: dict[str, Any]) -> dict[str, Any]:
+    """Fill in everything a SourcedSchema must state but a connector may have left out.
+
+    The runtime unions a SourcedSchema into the collection's inferred schema, and
+    that union only ever widens. A constraint the SourcedSchema doesn't assert is
+    dropped from the result rather than treated as unknown. SourcedSchemas
+    therefore have to be maximally restrictive. That's easy to get subtly wrong by
+    hand, so defaults are applied centrally:
+
+    - `_meta` and its subfields that are common across all capture connectors.
+    - `type: object` and `additionalProperties: False` on the root and wherever
+      properties are declared. The runtime rejects a SourcedSchema that isn't
+      closed, and a captured document is always an object.
+    - `required`, covering every declared property. Inference relaxes this for real
+      when a document turns up without the field.
+    - length and range bounds, which materializations size columns from.
+
+    Whatever the connector already declared wins, so one that knows better - a truer
+    bound, its own `_meta` - keeps it. The input is left unmodified.
+    """
+
+    def normalize(location: dict[str, Any]) -> dict[str, Any]:
+        out = dict(location)
+
+        for keyword in ("properties", "patternProperties", "$defs", "definitions"):
+            if isinstance(subschemas := out.get(keyword), dict):
+                out[keyword] = {
+                    name: normalize(s) if isinstance(s, dict) else s
+                    for name, s in subschemas.items()
+                }
+
+        for keyword in ("oneOf", "anyOf", "allOf", "prefixItems"):
+            if isinstance(subschemas := out.get(keyword), list):
+                out[keyword] = [
+                    normalize(s) if isinstance(s, dict) else s for s in subschemas
+                ]
+
+        # `items` may be a single schema or a tuple of them, and
+        # `additionalProperties` is usually the boolean False.
+        for keyword in ("items", "additionalProperties"):
+            match out.get(keyword):
+                case dict() as subschema:
+                    out[keyword] = normalize(subschema)
+                case list() as subschemas:
+                    out[keyword] = [
+                        normalize(s) if isinstance(s, dict) else s for s in subschemas
+                    ]
+
+        # A location declaring properties is an object, and must be a closed one.
+        if out.get("properties") or out.get("patternProperties"):
+            out = {"type": "object", **out, "additionalProperties": False}
+
+        if properties := out.get("properties"):
+            required = out.get("required", [])
+            out["required"] = [
+                *required,
+                *(name for name in properties if name not in required),
+            ]
+
+        declared = out.get("type", [])
+        types = {declared} if isinstance(declared, str) else set(declared)
+
+        # Length bounds constrain only string values and range bounds only numeric
+        # ones, so a union of both types carries both sets.
+        if "string" in types:
+            out = {**DEFAULT_STRING_BOUNDS, **out}
+        if types & {"integer", "number"}:
+            out = {**DEFAULT_NUMERIC_BOUNDS, **out}
+
+        return out
+
+    # The root-only defaults are applied before the walk so that the `_meta` they add
+    # is treated like any other location. Captured documents are always objects, so
+    # the root's type is forced rather than defaulted.
+    root = dict(schema)
+    root["type"] = "object"
+
+    # `_meta` is a shared location. `uuid` is stamped onto every captured document by
+    # the runtime. `op` and `row_id` are added by the CDK, and a connector
+    # may carry its own fields alongside them. So the standard subfields are merged
+    # in one by one.
+    default_meta = BaseDocument.Meta.sourced_schema()
+    properties = root.get("properties", {})
+    declared_meta = properties.get("_meta", {})
+    root["properties"] = {
+        **properties,
+        "_meta": {
+            **default_meta,
+            **declared_meta,
+            "properties": {
+                **default_meta["properties"],
+                **declared_meta.get("properties", {}),
+            },
+        },
+    }
+
+    return normalize(root)
 
 
 def orjson_default(obj):
@@ -180,7 +286,7 @@ class _BaseTask:
         b = (
             Response(
                 sourcedSchema=response.SourcedSchema(
-                    binding=binding_index, schema_json=schema
+                    binding=binding_index, schema_json=with_sourced_schema_defaults(schema)
                 )
             )
             .model_dump_json(by_alias=True, exclude_unset=True)

--- a/estuary-cdk/tests/test_sourced_schema_defaults.py
+++ b/estuary-cdk/tests/test_sourced_schema_defaults.py
@@ -1,0 +1,242 @@
+from estuary_cdk.capture.document import BaseDocument
+from estuary_cdk.capture.task import (
+    DEFAULT_NUMERIC_BOUNDS,
+    DEFAULT_STRING_BOUNDS,
+    with_sourced_schema_defaults,
+)
+
+STRING_MIN = DEFAULT_STRING_BOUNDS["minLength"]
+STRING_MAX = DEFAULT_STRING_BOUNDS["maxLength"]
+NUMERIC_MIN = DEFAULT_NUMERIC_BOUNDS["minimum"]
+NUMERIC_MAX = DEFAULT_NUMERIC_BOUNDS["maximum"]
+
+
+def test_a_bare_schema_gets_every_default():
+    out = with_sourced_schema_defaults({"properties": {"s": {"type": "string"}}})
+
+    assert out["type"] == "object"
+    assert out["additionalProperties"] is False
+    assert out["properties"]["_meta"] == BaseDocument.Meta.sourced_schema()
+    assert sorted(out["required"]) == ["_meta", "s"]
+    assert out["properties"]["s"] == {
+        "type": "string",
+        "minLength": STRING_MIN,
+        "maxLength": STRING_MAX,
+    }
+
+
+def test_the_root_type_is_forced_to_object():
+    # A captured document is always an object, so unlike a nested location the
+    # root's declared type is overridden rather than defaulted.
+    out = with_sourced_schema_defaults({"type": ["object", "null"], "properties": {}})
+
+    assert out["type"] == "object"
+    assert out["additionalProperties"] is False
+
+
+def test_numeric_and_boolean_locations():
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "i": {"type": "integer"},
+                "n": {"type": "number"},
+                "b": {"type": "boolean"},
+            }
+        }
+    )
+
+    assert out["properties"]["i"] == {
+        "type": "integer",
+        "minimum": NUMERIC_MIN,
+        "maximum": NUMERIC_MAX,
+    }
+    assert out["properties"]["n"]["maximum"] == NUMERIC_MAX
+    # Booleans have nothing to bound.
+    assert out["properties"]["b"] == {"type": "boolean"}
+
+
+def test_what_the_connector_declared_wins():
+    own_meta = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {"source_file": {"type": "string"}},
+    }
+    out = with_sourced_schema_defaults(
+        {
+            "type": "object",
+            "properties": {
+                "_meta": own_meta,
+                "id": {"type": "string", "minLength": 15, "maxLength": 18},
+                "lat": {"type": "number", "minimum": -90, "maximum": 90},
+            },
+        }
+    )
+
+    # A connector's own `_meta` field survives, alongside the standard subfields.
+    assert sorted(out["properties"]["_meta"]["properties"]) == [
+        "op",
+        "row_id",
+        "source_file",
+        "uuid",
+    ]
+    assert out["properties"]["id"]["minLength"] == 15
+    assert out["properties"]["id"]["maxLength"] == 18
+    assert out["properties"]["lat"]["minimum"] == -90
+    assert out["properties"]["lat"]["maximum"] == 90
+
+
+def test_a_declared_meta_still_gets_the_runtime_owned_uuid():
+    # `uuid` is the one `_meta` subfield a connector never controls: the runtime
+    # stamps it onto every captured document. So a connector that declared `_meta`
+    # for its own reasons must still come out asserting `uuid`.
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "id": {"type": "string"},
+                "_meta": {
+                    "type": "object",
+                    "properties": {"row_id": {"type": "integer"}},
+                    "required": ["row_id"],
+                },
+            }
+        }
+    )
+    meta = out["properties"]["_meta"]
+    default_uuid = BaseDocument.Meta.sourced_schema()["properties"]["uuid"]
+
+    assert meta["additionalProperties"] is False
+    assert "row_id" in meta["properties"]
+    assert meta["properties"]["uuid"] == default_uuid
+    assert "uuid" in meta["required"]
+
+
+def test_a_declared_meta_gains_the_standard_subfields_alongside_its_own():
+    # source-dynamics-365-finance-and-operations declares `_meta` to describe a
+    # `source_file` field of its own. Merging is per subfield, so its declaration
+    # wins for the subfield it names and the ones it leaves out are filled in.
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "_meta": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "source_file": {"type": "string", "maxLength": 1},
+                    },
+                    "required": ["source_file"],
+                },
+            }
+        }
+    )
+    meta = out["properties"]["_meta"]
+    default_meta = BaseDocument.Meta.sourced_schema()
+
+    assert sorted(meta["properties"]) == ["op", "row_id", "source_file", "uuid"]
+    assert sorted(meta["required"]) == ["op", "row_id", "source_file", "uuid"]
+
+    # The subfield it declared wins wholesale, and is still completed in place.
+    assert meta["properties"]["source_file"] == {
+        "type": "string",
+        "minLength": STRING_MIN,
+        "maxLength": 1,
+    }
+
+    # The ones it didn't name come from the CDK untouched.
+    assert meta["properties"]["op"] == default_meta["properties"]["op"]
+    assert meta["properties"]["row_id"] == default_meta["properties"]["row_id"]
+    assert meta["properties"]["uuid"] == default_meta["properties"]["uuid"]
+
+
+def test_partially_declared_bounds_are_completed():
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "s": {"type": "string", "maxLength": 64},
+                "i": {"type": "integer", "minimum": -1},
+            }
+        }
+    )
+
+    assert out["properties"]["s"] == {
+        "type": "string",
+        "minLength": STRING_MIN,
+        "maxLength": 64,
+    }
+    assert out["properties"]["i"] == {
+        "type": "integer",
+        "minimum": -1,
+        "maximum": NUMERIC_MAX,
+    }
+
+
+def test_union_typed_locations_get_every_applicable_bound():
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "nullable": {"type": ["string", "null"]},
+                "any": {"type": ["string", "number", "boolean"]},
+            }
+        }
+    )
+
+    nullable = out["properties"]["nullable"]
+    assert nullable["minLength"] == STRING_MIN and "minimum" not in nullable
+
+    # Length bounds constrain only the string values and range bounds only the
+    # numeric ones, so a union of both carries both.
+    any_typed = out["properties"]["any"]
+    assert any_typed["minLength"] == STRING_MIN
+    assert any_typed["maximum"] == NUMERIC_MAX
+
+    # A declared union is never narrowed to a bare object.
+    assert nullable["type"] == ["string", "null"]
+
+
+def test_every_nested_location_is_reached():
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {
+                "nested": {"properties": {"deep": {"type": "string"}}},
+                "list": {"type": "array", "items": {"type": "string"}},
+                "either": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            },
+            "patternProperties": {"^x-": {"type": "string"}},
+        }
+    )
+
+    nested = out["properties"]["nested"]
+    assert nested["type"] == "object"
+    assert nested["additionalProperties"] is False
+    assert nested["required"] == ["deep"]
+    assert nested["properties"]["deep"]["maxLength"] == STRING_MAX
+
+    assert out["properties"]["list"]["items"]["maxLength"] == STRING_MAX
+    assert out["properties"]["either"]["oneOf"][0]["maxLength"] == STRING_MAX
+    assert out["properties"]["either"]["oneOf"][1]["maximum"] == NUMERIC_MAX
+    assert out["patternProperties"]["^x-"]["maxLength"] == STRING_MAX
+
+
+def test_declared_required_entries_are_kept_and_extended():
+    out = with_sourced_schema_defaults(
+        {
+            "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+            "required": ["b"],
+        }
+    )
+
+    assert out["required"] == ["b", "a", "_meta"]
+
+
+def test_input_is_not_mutated():
+    # Connectors keep sourced schemas in module-level constants, so the input
+    # must survive being emitted more than once.
+    original = {
+        "type": "object",
+        "properties": {"nested": {"properties": {"s": {"type": "string"}}}},
+    }
+    with_sourced_schema_defaults(original)
+
+    assert original == {
+        "type": "object",
+        "properties": {"nested": {"properties": {"s": {"type": "string"}}}},
+    }

--- a/source-dynamics-365-finance-and-operations/CHANGELOG.md
+++ b/source-dynamics-365-finance-and-operations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-04
+
+### Fixed
+- Sourced schemas now declare length bounds on string fields and range bounds on numeric fields.
+
 ## 2026-07-31
 
 ### Fixed

--- a/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/constants.py
@@ -33,7 +33,6 @@ AD_ACCOUNT_SOURCED_SCHEMA = {
         "timezone_id": {"type": "number"},
         "timezone_offset_hours_utc": {"type": "number"},
     },
-    "required": ["id"],
 }
 
 
@@ -125,5 +124,4 @@ AD_CREATIVE_SOURCED_SCHEMA = {
         },
         "video_id": {"type": "string"},
     },
-    "required": ["id"],
 }

--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-04
+### Fixed
+- Sourced schemas now describe the `_meta` field.
+
 ## 2026-07-29
 ### Fixed
 - The `forms` binding now captures `captured`, `flow`, and `blog_comment` forms in

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -372,13 +372,6 @@ class BaseCRMObject(BaseDocument, extra="allow"):
                     "type": "string"
                 },
             },
-            "required": [
-                "archived",
-                "createdAt",
-                "id",
-                "properties",
-                "updatedAt",
-            ]
         }
 
         properties_schema = {
@@ -386,8 +379,6 @@ class BaseCRMObject(BaseDocument, extra="allow"):
             "type": "object",
             "properties": {},
         }
-
-        required_properties: list[str] = []
 
         for prop in properties:
             property_schema: dict[str, Any] = {
@@ -425,10 +416,8 @@ class BaseCRMObject(BaseDocument, extra="allow"):
                     continue
 
             properties_schema["properties"][prop.name] = property_schema
-            required_properties.append(prop.name)
 
         schema["properties"]["properties"] = properties_schema
-        schema["properties"]["properties"]["required"] = required_properties
         return schema
 
 

--- a/source-sage-intacct/CHANGELOG.md
+++ b/source-sage-intacct/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-04
+
+### Fixed
+- Sourced schemas now describe the `_meta` field.
+- Sourced schemas now declare length bounds on string fields and range bounds on numeric fields.
+
 ## 2026-07-22
 
 ### Fixed

--- a/source-sage-intacct/source_sage_intacct/sage.py
+++ b/source-sage-intacct/source_sage_intacct/sage.py
@@ -134,7 +134,6 @@ class SageRecord(BaseModel):
             "additionalProperties": False,
             "type": "object",
             "properties": {},
-            "required": [],
         }
 
         for field, datatype in zip(cls.field_names, cls.field_datatypes):
@@ -150,11 +149,15 @@ class SageRecord(BaseModel):
                     field_schema = {
                         "type": "string",
                         "format": "date",
+                        "minLength": 10,
+                        "maxLength": 10,
                     }
                 case "TIMESTAMP":
                     field_schema = {
                         "type": "string",
                         "format": "date-time",
+                        "minLength": 32,
+                        "maxLength": 32,
                     }
                 case "DECIMAL" | "CURRENCY" | "PERCENT":
                     field_schema = {
@@ -171,11 +174,9 @@ class SageRecord(BaseModel):
                     )
 
             schema["properties"][field] = field_schema
-            schema["required"].append(field)
 
         if cls.company_id:
             schema["properties"][COMPANY_ID_FIELD] = {"type": "string"}
-            schema["required"].append(COMPANY_ID_FIELD)
 
         return schema
 

--- a/source-salesforce-native/CHANGELOG.md
+++ b/source-salesforce-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-04
+
+### Fixed
+- Sourced schemas now mark every field they describe as required in addition to the `_meta` field.
+- Sourced schemas now declare length bounds on string fields and range bounds on numeric fields.
+
 ## 2026-07-22
 
 ### Changed

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -339,6 +339,14 @@ class ValidationContext:
         self.data_source = data_source
 
 
+# Bounds that Salesforce's own semantics pin down more tightly than the defaults
+# the CDK injects for any unbounded string or number.
+# Salesforce IDs are always either 15 or 18 characters.
+ID_BOUNDS = {"minLength": 15, "maxLength": 18}
+LATITUDE_BOUNDS = {"minimum": -90, "maximum": 90}
+LONGITUDE_BOUNDS = {"minimum": -180, "maximum": 180}
+
+
 class SalesforceRecord(BaseDocument, extra="allow"):
     field_details: ClassVar[FieldDetailsDict]
 
@@ -513,36 +521,51 @@ class SalesforceRecord(BaseDocument, extra="allow"):
                 "field_details must be set on the SalesforceRecord subclass before generating a sourced schema."
             )
 
-        schema = {
+        schema: dict[str, Any] = {
             "additionalProperties": False,
             "type": "object",
-            "properties": {}
+            "properties": {},
         }
 
         for field, details in cls.field_details.items():
             field_schema: dict[str, Any] = {}
             match details.soapType:
-                case SoapTypes.ID | SoapTypes.BASE64 | SoapTypes.STRING:
+                case SoapTypes.ID:
+                    field_schema = {"type": "string", **ID_BOUNDS}
+                case SoapTypes.BASE64 | SoapTypes.STRING:
                     field_schema = {"type": "string"}
                 case SoapTypes.BOOLEAN:
                     if details.custom:
-                        field_schema = {"type": "string"}
+                        # Cast to the string "true" or "false".
+                        field_schema = {
+                            "type": "string",
+                            "minLength": 4,
+                            "maxLength": 5,
+                        }
                     else:
                         field_schema = {"type": "boolean"}
                 case SoapTypes.DATE:
                     field_schema = {
                         "type": "string",
-                        "format": "date"
+                        "format": "date",
+                        "minLength": 10,
+                        "maxLength": 10,
                     }
                 case SoapTypes.DATETIME:
+                    # Bulk API responses carry a +0000 offset (28 characters),
+                    # while REST values are normalized to .000Z (24).
                     field_schema = {
                         "type": "string",
                         "format": "date-time",
+                        "minLength": 24,
+                        "maxLength": 28,
                     }
                 case SoapTypes.TIME:
                     field_schema = {
                         "type": "string",
                         "format": "time",
+                        "minLength": 13,
+                        "maxLength": 13,
                     }
                 case SoapTypes.INTEGER:
                     if details.custom:
@@ -568,21 +591,21 @@ class SalesforceRecord(BaseDocument, extra="allow"):
                             "city": {"type": "string"},
                             "country": {"type": "string"},
                             "geocodeAccuracy": {"type": "string"},
-                            "latitude": {"type": "number"},
-                            "longitude": {"type": "number"},
+                            "latitude": {"type": "number", **LATITUDE_BOUNDS},
+                            "longitude": {"type": "number", **LONGITUDE_BOUNDS},
                             "postalCode": {"type": "string"},
                             "state": {"type": "string"},
                             "street": {"type": "string"},
-                        }
+                        },
                     }
                 case SoapTypes.LOCATION:
                     field_schema = {
                         "additionalProperties": False,
                         "type": "object",
                         "properties": {
-                            "latitude": {"type": "number"},
-                            "longitude": {"type": "number"},
-                        }
+                            "latitude": {"type": "number", **LATITUDE_BOUNDS},
+                            "longitude": {"type": "number", **LONGITUDE_BOUNDS},
+                        },
                     }
                 case SoapTypes.ANY_TYPE:
                     field_schema = {


### PR DESCRIPTION
**Regression?**

No.

**Description:**

`SourcedSchema`s need to be maximally restrictive, and these earlier sourced schema implementations in various connectors were lax around whether `_meta` was required. The `minLength`, `maxLength`, and other keywords indicating the bounds of a field should be included as well, and they often weren't.

This PR's scope includes:
- adding a method to the CDK's `BaseDocument.Meta` class so generating the `_meta` portion of the sourced schemas is easier.
- automatically adding `_meta` information to sourced schemas for CDK based captures when it was omitted.
- automatically adding bounds for string and numeric fields in sourced schemas for CDK based captures when they're omitted.
- automatically marking every declared property as required.
- automatically setting `type: object` and `additionalProperties: False` on the root and on every location whose properties are declared. The runtime rejects a sourced schema that isn't closed, so this is a hard requirement.

The above automatic additions do not override fields that are already set, so captures can continue to customize the `_meta` and bounds in sourced schemas as needed. The two exceptions are the ones with no valid alternative: the root is
always an object, and an object whose properties are declared is always closed. 

Marking every field as required is likewise not opt-out. If a document is captured without one of those fields, schema inference will handle removing it from the `required` array.

Note: A connector that wants a nested object left open to spend inferred schema complexity points elsewhere can still do so by declaring it as `type: object` with no properties.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
