### PR TITLE
source-zuora: capture foreign keys by selecting related-object ids

### DIFF
--- a/source-zuora/CHANGELOG.md
+++ b/source-zuora/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-04
+
+### Added
+- Exports now select each object's related-object ids, so documents carry the
+  foreign keys that let them be joined to the objects they belong to
+  (`InvoiceItem.InvoiceId`, `RatePlan.SubscriptionId`, `Invoice.AccountId`, ...).
+  Each joinable related object contributes one `<Name>.Id` to the query, landing in documents as `<Name>Id`.
+
 ## 2026-07-22
 
 ### Changed

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -134,7 +134,10 @@ async def fetch_object_fields(
     log: Logger,
     object_name: str,
 ) -> list[str]:
-    """Return the exportable field names for a Zuora object."""
+    """Return every field name to select when exporting a Zuora object. This includes
+    its own exportable fields plus the `<RelatedObject>.Id` joins that carry its foreign
+    keys.
+    """
     url = f"{base_url}/v1/describe/{object_name}"
     described = _parse_describe_object(
         await http.request(log, url, headers=VERSION_HEADERS)
@@ -148,6 +151,14 @@ async def fetch_object_fields(
         {
             "object": object_name,
             "exportable_fields": described.exportable_field_names,
+            "joined_id_fields": [
+                f"{name}.Id" for name in described.joinable_object_names
+            ],
+            "excluded_related_objects": [
+                name
+                for name in described.related_object_names
+                if name not in described.joinable_object_names
+            ],
             "excluded_fields": {
                 f.name: {"selectable": f.selectable, "contexts": f.contexts}
                 for f in described.fields
@@ -155,7 +166,7 @@ async def fetch_object_fields(
             },
         },
     )
-    return described.exportable_field_names
+    return described.query_field_names
 
 
 def _parse_describe_object(response_bytes: bytes) -> DescribeObject:
@@ -182,6 +193,13 @@ def _parse_describe_object(response_bytes: bytes) -> DescribeObject:
     return DescribeObject(
         name=name_el.text if name_el is not None and name_el.text else "",
         fields=fields,
+        # Relationships live in their own section rather than among <fields>, and
+        # each is joinable in an export query as `<name>.Id`.
+        related_object_names=[
+            related_name_el.text
+            for related_name_el in root.findall("./related-objects/object/name")
+            if related_name_el.text
+        ],
     )
 
 
@@ -229,7 +247,7 @@ async def _export_window(
             after=window_start, before=window_end,
         )
         try:
-            async for row in manager.export_rows(query):
+            async for row in manager.export_rows(query, object_name):
                 doc = model.model_validate(row)
                 cursor = doc.get_cursor()
                 if (
@@ -350,7 +368,7 @@ async def fetch_page(
         )
         count = 0
         try:
-            async for row in manager.export_rows(query):
+            async for row in manager.export_rows(query, object_name):
                 doc = model.model_validate(row)
                 if resume_id is not None and doc.Id <= resume_id:
                     # `Id >` resume is only correct if ORDER BY Id is a stable
@@ -412,5 +430,5 @@ async def fetch_snapshot(
     with Export ZOQL's LIMIT/OFFSET (first-N plus skip rows) to complete it in chunks.
     """
     query = build_query(object_name, fields)
-    async for row in manager.export_rows(query):
+    async for row in manager.export_rows(query, object_name):
         yield BaseCSVRow.model_validate(row)

--- a/source-zuora/source_zuora/export_manager.py
+++ b/source-zuora/source_zuora/export_manager.py
@@ -82,6 +82,21 @@ class ExportTooLargeError(Exception):
     """
 
 
+def _column_to_field(column: str, object_name: str) -> str:
+    """Map an export CSV column header to the field name documents carry.
+
+    With useQueryLabels every header is "<Object>.<Field>", for both the exported
+    object's own columns and any joined related object's. An own column drops the
+    prefix so it matches its describe name ("Account.Id" of an Account export ->
+    "Id"), while a joined column keeps it as a flattened name ("Account.Id" of an
+    Invoice export -> "AccountId").
+    """
+    prefix, _, field = column.partition(".")
+    if not field:
+        return column
+    return field if prefix == object_name else f"{prefix}{field}"
+
+
 class ExportManager:
     """Runs Zuora AQuA (Aggregate Query API) export jobs in stateless mode.
 
@@ -102,11 +117,21 @@ class ExportManager:
         self.base_url = base_url
         self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_EXPORTS)
 
-    async def export_rows(self, query: str) -> AsyncGenerator[dict, None]:
+    async def export_rows(
+        self,
+        query: str,
+        object_name: str,
+    ) -> AsyncGenerator[dict, None]:
+        """Run `query` and stream its rows, keyed by field name.
+
+        object_name is the object `query` selects FROM. It's needed to tell an
+        own column apart from a joined one when naming fields (see
+        _column_to_field).
+        """
         # Each segment file is a self-contained CSV with its own header row, so
         # streaming them back-to-back through per-file processors is seamless.
         for file_id in await self._run_job(query):
-            async for row in self._fetch_results(file_id):
+            async for row in self._fetch_results(file_id, object_name):
                 yield row
 
     async def _run_job(self, query: str) -> list[str]:
@@ -232,7 +257,11 @@ class ExportManager:
             job_id=job_id,
         )
 
-    async def _fetch_results(self, file_id: str) -> AsyncGenerator[dict, None]:
+    async def _fetch_results(
+        self,
+        file_id: str,
+        object_name: str,
+    ) -> AsyncGenerator[dict, None]:
         url = f"{self.base_url}/v1/files/{file_id}"
         try:
             _resp_headers, body_factory = await self.http.request_stream(
@@ -244,7 +273,7 @@ class ExportManager:
                     f"Export file {file_id} exceeds Zuora's size limit"
                 ) from err
             raise
+        # Keyed by header name, never by position. Zuora does not return columns
+        # in the order the query selected them.
         async for row in IncrementalCSVProcessor(body_factory()):
-            # Zuora prefixes every CSV column with "ObjectName.". Strip it so
-            # fields match the describe names (e.g. "Id", not "Account.Id").
-            yield {k.split(".", 1)[-1]: v for k, v in row.items()}
+            yield {_column_to_field(k, object_name): v for k, v in row.items()}

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -137,14 +137,54 @@ class DescribeField(BaseModel, extra="allow"):
         return self.selectable and "export" in self.contexts
 
 
+# Related objects that must never be joined, even though describe advertises them.
+UNJOINABLE_OBJECTS: frozenset[str] = frozenset({"SubscriptionStatusHistory"})
+
+
 class DescribeObject(BaseModel, extra="allow"):
     """A GET /v1/describe/{object} response."""
     name: str = ""
     fields: list[DescribeField] = Field(default_factory=list)
+    related_object_names: list[str] = Field(default_factory=list)
 
     @property
     def exportable_field_names(self) -> list[str]:
         return [f.name for f in self.fields if f.is_exportable]
+
+    @property
+    def joinable_object_names(self) -> list[str]:
+        """The related objects whose Id this object's export can select.
+
+        Three kinds of relationship are dropped:
+        1. a self-reference, because `<Self>.Id` would duplicate the object's
+           own Id column.
+        2. the UNJOINABLE_OBJECTS that fail the export job outright.
+        3.  any relationship the object already exposes as a scalar `<Name>Id` field.
+        """
+        own_field_names = set(self.exportable_field_names)
+        return [
+            name
+            for name in self.related_object_names
+            if name != self.name
+            and name not in UNJOINABLE_OBJECTS
+            and f"{name}Id" not in own_field_names
+        ]
+
+    @property
+    def query_field_names(self) -> list[str]:
+        """Every field an export of this object selects. Its own exportable
+        fields, then `<RelatedObject>.Id` for each joinable related object.
+
+        Export ZOQL exposes an object's foreign keys only as joins on the
+        related object rather than as scalar `<Related>Id` fields, and describe
+        lists those relationships in `<related-objects>` instead of `<fields>`.
+        Selecting only `<fields>` therefore yields rows with no way to reference
+        what they belong to: an InvoiceItem with no InvoiceId, a RatePlan with
+        no SubscriptionId.
+        """
+        return self.exportable_field_names + [
+            f"{name}.Id" for name in self.joinable_object_names
+        ]
 
 
 class CatalogObject(BaseModel, extra="allow"):

--- a/source-zuora/tests/test_capture.py
+++ b/source-zuora/tests/test_capture.py
@@ -65,7 +65,7 @@ class FakeManager:
         self.too_large_over_rows = too_large_over_rows
         self.queries: list[str] = []
 
-    async def export_rows(self, query: str):
+    async def export_rows(self, query: str, object_name: str):
         self.queries.append(query)
         lo = re.search(rf"{self.cursor_field} >= '([^']+)'", query)
         hi = re.search(rf"{self.cursor_field} < '([^']+)'", query)
@@ -415,7 +415,7 @@ async def test_fetch_page_id_engine_ordering_violation_raises():
     # `Id >` resume is only dupe-free if ORDER BY Id is a stable total order;
     # out-of-order rows must kill the backfill rather than risk skipped records.
     class UnorderedManager:
-        async def export_rows(self, query):
+        async def export_rows(self, query, object_name):
             yield {"Id": "aa02", "UpdatedDate": "2020-01-02T00:00:00Z"}
             yield {"Id": "aa01", "UpdatedDate": "2020-01-01T00:00:00Z"}
 
@@ -495,7 +495,7 @@ async def test_fetch_snapshot_too_large_propagates():
     # A snapshot has no time cursor, so it can't be bisected — a too-large export
     # surfaces loudly rather than being silently truncated.
     class TooBig:
-        async def export_rows(self, query):
+        async def export_rows(self, query, object_name):
             raise ExportTooLargeError("too big")
             yield  # unreachable; makes this an async generator
 

--- a/source-zuora/tests/test_describe.py
+++ b/source-zuora/tests/test_describe.py
@@ -1,9 +1,10 @@
 """Unit tests for discovery/describe parsing in source_zuora.api and the
 export-context filtering on the describe models.
 
-These cover the XML parsing, the default-closed `<contexts>` export filter, and
-the `./fields/field` scoping that ignores nested <field>s — logic that the
-spec/capture tests don't touch.
+These cover the XML parsing, the default-closed `<contexts>` export filter, the
+`./fields/field` scoping that ignores nested <field>s, and the
+`<related-objects>` -> `<Name>.Id` join expansion — logic that the spec/capture
+tests don't touch.
 """
 
 import logging
@@ -11,7 +12,7 @@ import logging
 import pytest
 
 from source_zuora import api
-from source_zuora.models import DescribeField
+from source_zuora.models import UNJOINABLE_OBJECTS, DescribeField, DescribeObject
 
 _LOG = logging.getLogger("test")
 
@@ -94,6 +95,62 @@ def test_parse_describe_object_ignores_nested_stray_fields():
     assert "StrayNestedField" not in obj.exportable_field_names
 
 
+# --- related objects / joined Id fields ----------------------------------------
+
+
+def test_parse_describe_object_extracts_related_object_names():
+    obj = api._parse_describe_object(_DESCRIBE_XML)
+    assert obj.related_object_names == ["Contact"]
+
+
+def test_query_field_names_appends_joined_ids_after_own_fields():
+    obj = api._parse_describe_object(_DESCRIBE_XML)
+    assert obj.query_field_names == ["Id", "UpdatedDate", "Contact.Id"]
+
+
+def test_joinable_object_names_drops_self_reference():
+    # `<Self>.Id` duplicates the object's own Id column, and stripping its prefix
+    # would collide with it.
+    obj = DescribeObject(name="Account", related_object_names=["Account", "Contact"])
+    assert obj.joinable_object_names == ["Contact"]
+    assert obj.query_field_names == ["Contact.Id"]
+
+
+def test_joinable_object_names_drops_relationships_already_exposed_as_a_field():
+    # `Account.Id` would flatten to "AccountId" and shadow the object's own
+    # AccountId column, so the cheaper scalar field wins and the join is dropped.
+    xml = b"""<object><name>Invoice</name><fields>
+      <field><name>Id</name><selectable>true</selectable>
+        <contexts><context>export</context></contexts></field>
+      <field><name>AccountId</name><selectable>true</selectable>
+        <contexts><context>export</context></contexts></field>
+    </fields>
+    <related-objects>
+      <object href="a"><name>Account</name></object>
+      <object href="b"><name>BillToContact</name></object>
+    </related-objects></object>"""
+    obj = api._parse_describe_object(xml)
+    assert obj.joinable_object_names == ["BillToContact"]
+    assert obj.query_field_names == ["Id", "AccountId", "BillToContact.Id"]
+
+
+def test_joinable_object_names_drops_unjoinable_objects():
+    # Joining these fails the whole export job, so they never reach a query.
+    unjoinable = next(iter(UNJOINABLE_OBJECTS))
+    obj = DescribeObject(name="Subscription", related_object_names=[unjoinable, "Account"])
+    assert obj.joinable_object_names == ["Account"]
+
+
+def test_parse_describe_object_without_related_objects_yields_own_fields_only():
+    xml = b"""<object><name>Obj</name><fields>
+      <field><name>Id</name><selectable>true</selectable>
+        <contexts><context>export</context></contexts></field>
+    </fields></object>"""
+    obj = api._parse_describe_object(xml)
+    assert obj.related_object_names == []
+    assert obj.query_field_names == ["Id"]
+
+
 def test_parse_describe_object_skips_fields_without_a_name():
     xml = b"""<object><name>Obj</name><fields>
       <field><selectable>true</selectable><contexts><context>export</context></contexts></field>
@@ -140,10 +197,10 @@ class _FakeHTTP:
 
 
 @pytest.mark.asyncio
-async def test_describe_object_returns_exportable_field_names():
+async def test_describe_object_returns_exportable_and_joined_field_names():
     http = _FakeHTTP(_DESCRIBE_XML)
     fields = await api.fetch_object_fields("https://rest.zuora.com", http, _LOG, "Account")
-    assert fields == ["Id", "UpdatedDate"]
+    assert fields == ["Id", "UpdatedDate", "Contact.Id"]
     assert http.urls == ["https://rest.zuora.com/v1/describe/Account"]
 
 

--- a/source-zuora/tests/test_export_manager.py
+++ b/source-zuora/tests/test_export_manager.py
@@ -197,8 +197,56 @@ async def test_poll_times_out(monkeypatch):
 @pytest.mark.asyncio
 async def test_fetch_results_strips_object_prefix():
     http = FakeHTTP(downloads={"file1": b"Account.Id,Account.Name\n1,Acme\n"})
-    rows = [r async for r in _mgr(http)._fetch_results("file1")]
+    rows = [r async for r in _mgr(http)._fetch_results("file1", "Account")]
     assert rows == [{"Id": "1", "Name": "Acme"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_results_flattens_joined_columns_without_shadowing_id():
+    # A joined `<Related>.Id` must become "<Related>Id". Stripping the prefix the
+    # way an own column is stripped would land every join on "Id" and overwrite
+    # the document's own key with an unrelated object's id.
+    http = FakeHTTP(
+        downloads={
+            "file1": b"Invoice.Id,Invoice.InvoiceNumber,Account.Id,BillToContact.Id\n"
+            b"inv1,INV-1,acc1,con1\n"
+        }
+    )
+    rows = [r async for r in _mgr(http)._fetch_results("file1", "Invoice")]
+    assert rows == [
+        {
+            "Id": "inv1",
+            "InvoiceNumber": "INV-1",
+            "AccountId": "acc1",
+            "BillToContactId": "con1",
+        }
+    ]
+
+
+# --- _column_to_field ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column, object_name, expected",
+    [
+        # Own columns drop the prefix so they match their describe names.
+        ("Invoice.Id", "Invoice", "Id"),
+        ("Invoice.AccountId", "Invoice", "AccountId"),
+        # Joined columns keep the related object as a flattened name.
+        ("Account.Id", "Invoice", "AccountId"),
+        ("AccountReceivableAccountingCode.Id", "InvoiceItem",
+         "AccountReceivableAccountingCodeId"),
+        # An object whose name is a prefix of another's must not be confused for
+        # it: an InvoiceItem export's own columns say "InvoiceItem.", while
+        # "Invoice." is the join.
+        ("InvoiceItem.Id", "InvoiceItem", "Id"),
+        ("Invoice.Id", "InvoiceItem", "InvoiceId"),
+        # A header without a prefix is passed through rather than mangled.
+        ("Id", "Account", "Id"),
+    ],
+)
+def test_column_to_field(column, object_name, expected):
+    assert em._column_to_field(column, object_name) == expected
 
 
 # A too-large 403 carries the max-object-size XML marker in its body, which the
@@ -215,7 +263,7 @@ _TOO_LARGE_403 = HTTPError(
 async def test_fetch_results_403_with_marker_raises_too_large():
     http = FakeHTTP(downloads={"file1": _TOO_LARGE_403})
     with pytest.raises(ExportTooLargeError):
-        [r async for r in _mgr(http)._fetch_results("file1")]
+        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
 
 
 @pytest.mark.asyncio
@@ -233,7 +281,7 @@ async def test_fetch_results_403_without_marker_propagates():
         }
     )
     with pytest.raises(HTTPError) as exc:
-        [r async for r in _mgr(http)._fetch_results("file1")]
+        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
     assert not isinstance(exc.value, ExportTooLargeError)
 
 
@@ -241,7 +289,7 @@ async def test_fetch_results_403_without_marker_propagates():
 async def test_fetch_results_other_http_error_propagates():
     http = FakeHTTP(downloads={"file1": HTTPError("server error", 500)})
     with pytest.raises(HTTPError):
-        [r async for r in _mgr(http)._fetch_results("file1")]
+        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
 
 
 # --- export_rows (end to end) --------------------------------------------------
@@ -254,7 +302,7 @@ async def test_export_rows_submit_poll_stream():
         polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
         downloads={"file1": b"Account.Id\n7\n"},
     )
-    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
+    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
     assert rows == [{"Id": "7"}]
 
 
@@ -272,7 +320,7 @@ async def test_export_rows_concatenates_segments_in_order():
             "s2": b"Account.Id\n3\n",
         },
     )
-    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
+    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
     assert rows == [{"Id": "1"}, {"Id": "2"}, {"Id": "3"}]
     assert http.downloaded_file_ids == ["s1", "s2"]
 
@@ -284,7 +332,7 @@ async def test_export_rows_pins_api_version_header():
         polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
         downloads={"file1": b"Account.Id\n7\n"},
     )
-    _ = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account")]
+    _ = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
     # submit + poll (request) and download (request_stream) all carry the pin
     assert http.request_headers  # submit + poll happened
     assert all(


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Exports selected only the fields `/describe` lists under `<fields>`, which omitted every foreign key on every object: an `InvoiceItem` with no `InvoiceId`, an `Invoice` with no `AccountId`. Export ZOQL exposes foreign keys only as joins on the related object, and `/describe` lists those relationships in their own section rather than among `<fields>`. Each joinable relationship now contributes one `<Name>.Id` to the query and nothing else since the related entities are captured as their own bindings.

Joined columns land as `<Name>Id`. That means a column can no longer be named by stripping its `<Object>.` prefix unconditionally: every joined `<Related>.Id` would strip to `Id` and overwrite the document's own key. A prefix is now stripped only when it names the object being exported.

Skipped are self-references, relationships the object already exposes as a scalar `<Name>Id` field, and `SubscriptionStatusHistory`, which joins only under a mandatory `WHERE` bound on its effective-date range that would constrain the parent query and drop parent rows.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
