### PR TITLE
materialize-databricks: refuse to run a partial-range shard without scale_out

### DIFF
--- a/materialize-databricks/CHANGELOG.md
+++ b/materialize-databricks/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-08-04
+
+### Changed
+- A task scaled out to multiple shards now fails to start unless the
+  `scale_out` feature flag is enabled, instead of running in a mode that
+  could crash-loop on concurrent `COPY INTO` operations or silently lose
+  documents when shards are scaled back down. Tasks running a single shard
+  are unaffected. If you see this error, enable the `scale_out` feature
+  flag (requires runtime v2) or scale the task back to a single shard.

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -240,6 +240,31 @@ func (d *transactor) mergePeerStatePatches(patches []json.RawMessage) error {
 	return nil
 }
 
+// validateShardRange refuses to run a shard that covers only part of the
+// keyspace — i.e. one shard of a scaled-out task — unless the scale_out
+// feature flag is enabled. Without the flag every shard emits its checkpoint
+// as a full-document state replacement of top-level stateKeys, so under the
+// v2 runtime's single consolidated state document concurrent shards clobber
+// each other's staged-but-unacknowledged work (silent data loss on scale-down,
+// estuary/connectors#4987), and each shard executes its own staged queries, so
+// after a split both children re-run the parent's identical COPY INTO
+// concurrently and crash-loop on Databricks' duplicated-files guard
+// (estuary/connectors#4986). Only the scale_out mode partitions state into
+// disjoint per-range merge patches with a single executing shard, so failing
+// loudly here is the only safe response.
+func validateShardRange(scaleOut bool, keyBegin, keyEnd uint32) error {
+	if scaleOut || (keyBegin == 0 && keyEnd == math.MaxUint32) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"this shard covers key range %08x-%08x rather than the full keyspace, meaning the task has been scaled out to multiple shards, "+
+			"but the scale_out feature flag is not enabled: running multiple shards without it can clobber staged work and silently lose documents. "+
+			"Enable the scale_out feature flag (requires runtime v2), or scale the task back down to a single shard",
+		keyBegin, keyEnd,
+	)
+}
+
 func newTransactor(
 	ctx context.Context,
 	materializationName string,
@@ -266,6 +291,10 @@ func newTransactor(
 	var keyBegin, keyEnd uint32 = 0, math.MaxUint32
 	if open.Range != nil {
 		keyBegin, keyEnd = open.Range.KeyBegin, open.Range.KeyEnd
+	}
+
+	if err := validateShardRange(featureFlags["scale_out"], keyBegin, keyEnd); err != nil {
+		return nil, err
 	}
 
 	var d = &transactor{

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -328,3 +328,15 @@ func TestAcknowledge(t *testing.T) {
 		require.Error(t, err) // no longer a recovery apply
 	})
 }
+
+func TestValidateShardRange(t *testing.T) {
+	// A shard covering the full keyspace is a single-shard task and is fine in
+	// either mode; a partial-range shard requires scale_out.
+	require.NoError(t, validateShardRange(false, 0, 0xffffffff))
+	require.NoError(t, validateShardRange(true, 0, 0xffffffff))
+	require.NoError(t, validateShardRange(true, 0, 0x7fffffff))
+	require.NoError(t, validateShardRange(true, 0x80000000, 0xffffffff))
+
+	require.ErrorContains(t, validateShardRange(false, 0, 0x7fffffff), "scale_out")
+	require.ErrorContains(t, validateShardRange(false, 0x80000000, 0xffffffff), "80000000-ffffffff")
+}


### PR DESCRIPTION
Closes #4986, closes #4987.

## Root cause (common to both issues)

Both reported failures came from a task running **multiple shards without the `scale_out` feature flag** (the `materialize-consistency` suite runs the connector with `testdata/config.local.yaml`, whose `feature_flags` do not include `scale_out`).

`newTransactor` now refuses to open a shard whose key range covers less than the full keyspace when `scale_out` is disabled, with an actionable error: enable the `scale_out` feature flag (requires runtime v2), or scale the task back to a single shard. Single-shard tasks are unaffected in either mode.

## Testing

`TestValidateShardRange` unit test; `go build`, `go vet`, and the existing `driver_state_test.go` suite pass.