### PR TITLE
materialize-s3-iceberg: fix integration test namespace location

### DIFF
--- a/materialize-s3-iceberg/driver_test.go
+++ b/materialize-s3-iceberg/driver_test.go
@@ -1208,7 +1208,7 @@ func createTestWarehouse(t *testing.T, cfg config) {
 			},
 			"storageConfigInfo": map[string]any{
 				"storageType":      "S3",
-				"allowedLocations": []string{"s3://" + cfg.Bucket + "/"},
+				"allowedLocations": []string{baseLocation + "/"},
 				"roleArn":          "arn:aws:iam::000000000000:role/dummy",
 				"region":           cfg.Region,
 				// Client-visible endpoint (host port mapped from rustfs).


### PR DESCRIPTION
**Description:**

The integration test has been failing recently, I believe it started when we switched to iceberg-go:
```
driver_test.go:133: pre-creating namespace "tests": IllegalArgumentException: Namespace tests has a custom location, which is not enabled. Expected a location in: [s3://test-warehouse/tests/]. Got location: s3://test-warehouse/warehouse/tests/]
```

**Workflow steps:**

No changes

**Documentation links affected:**

None

**Notes for reviewers:**

None

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
