### PR TITLE
source-(various): Shutdown logging when there are zero bindings

### DIFF
--- a/source-bigquery-batch/driver.go
+++ b/source-bigquery-batch/driver.go
@@ -304,6 +304,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-db2-batch/driver.go
+++ b/source-db2-batch/driver.go
@@ -377,6 +377,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -198,8 +198,10 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		return fmt.Errorf("outputting prevState checkpoint: %w", err)
 	}
 
+	// Nothing to stream or poll, so exit rather than idle forever. This connector
+	// normally runs indefinitely, so report the reason for an otherwise silent exit.
 	if len(allBindings) == 0 {
-		// No bindings to capture.
+		log.Info("capture has no enabled bindings, shutting down")
 		return nil
 	}
 

--- a/source-mysql-batch/driver.go
+++ b/source-mysql-batch/driver.go
@@ -304,6 +304,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-oracle-batch/driver.go
+++ b/source-oracle-batch/driver.go
@@ -300,6 +300,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -388,6 +388,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-redshift-batch/driver.go
+++ b/source-redshift-batch/driver.go
@@ -296,6 +296,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err

--- a/source-snowflake/capture.go
+++ b/source-snowflake/capture.go
@@ -206,6 +206,14 @@ func (c *capture) Run(ctx context.Context) error {
 			}
 		}
 	}
+
+	// This connector always exits after polling each binding once and is then
+	// restarted, but it's helpful to distinguish "no bindings" from "all done".
+	if len(activeKeys) == 0 {
+		log.Info("no bindings to poll, shutting down")
+	} else {
+		log.WithField("bindings", len(activeKeys)).Info("polled all bindings, shutting down")
+	}
 	return nil
 }
 

--- a/source-sqlserver-batch/driver.go
+++ b/source-sqlserver-batch/driver.go
@@ -340,6 +340,14 @@ func (s *captureState) Validate() error {
 }
 
 func (c *capture) Run(ctx context.Context) error {
+	// With no enabled bindings there are no polling workers, so we'd fall through the
+	// empty worker group and exit silently. This connector normally runs forever, so
+	// report the reason.
+	if len(c.Bindings) == 0 {
+		log.Info("capture has no enabled bindings, shutting down")
+		return nil
+	}
+
 	// Always discover and output SourcedSchemas once at startup.
 	if err := c.emitSourcedSchemas(ctx); err != nil {
 		return err


### PR DESCRIPTION
**Description:**

Adds informational logging to several connectors (source-mongodb, source-snowflake, and source-*-batch) when there are zero enabled bindings. Each of these connectors would previously shut down in this case (MongoDB intentionally as a special case, Snowflake because it always shuts down after polling each binding, and the batch SQL connectors because if you wait on an empty worker group it returns immediately), but now we'll actually be saying _why_ they're shutting down.

Among other things, this fixes https://github.com/estuary/connectors/issues/5001