### PR TITLE
source-mongodb: Fix dropped collection type validation in Pull

### DIFF
--- a/source-mongodb/CHANGELOG.md
+++ b/source-mongodb/CHANGELOG.md
@@ -1,9 +1,8 @@
-# source-mongodb
+# Changelog
 
-## v2, 2024-04-10
-- Support for incremental backfills. This version is backward compatible with v1 captures that have
-  completed their backfills, but will error if upgrading a v1 capture with a backfill that is still
-  in progress.
+## 2026-08-05
 
-## v1, 2023-02-14
-- Beginning of changelog.
+### Fixed
+- Captures now report an `unsupported collection type` error at startup when a
+  captured database contains a collection of a type the connector does not
+  recognize, instead of silently treating it as a standard collection.

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -99,7 +99,8 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		}
 
 		for _, coll := range collections {
-			if collectionType := mongoCollectionType(coll.Type); err != nil {
+			var collectionType = mongoCollectionType(coll.Type)
+			if err := collectionType.validate(); err != nil {
 				return fmt.Errorf("unsupported collection type: %w", err)
 			} else if collectionType == mongoCollectionTypeTimeseries {
 				timeseriesCollections[resourceId(db, coll.Name)] = true


### PR DESCRIPTION
**Description:**

The collection type check in Pull didn't actually call `validate()` and instead was checking a stale `err` value from earlier which is provably nil (since the earlier error branch wasn't taken). This meant that error check was a no-op and presumably meant bad things for the handling of unrecognized collection types (if any of those exist?).

Fixed by copy-pasting the presumed-correct logic from the discovery path which calls `validate()` on the type and checks that error.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
