### PR TITLE
source-azure-blob-storage: Add secret annotation to ConnectionString

### DIFF
--- a/source-azure-blob-storage/.snapshots/TestAzureBlobStore_getConfigSchema
+++ b/source-azure-blob-storage/.snapshots/TestAzureBlobStore_getConfigSchema
@@ -74,6 +74,7 @@
             "ConnectionString": {
               "description": "The connection string used to authenticate with Azure Blob Storage.",
               "order": 0,
+              "secret": true,
               "title": "Connection String",
               "type": "string"
             },

--- a/source-azure-blob-storage/CHANGELOG.md
+++ b/source-azure-blob-storage/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2026-08-05
+
+### Fixed
+- The `Connection String` credential field is now marked as secret, so the
+  dashboard masks its value and encrypts it when the configuration is saved.
+  Previously the connection string, which includes the storage account key, was
+  stored as plain text. Existing captures will be encrypted the next time their
+  configuration is saved.

--- a/source-azure-blob-storage/main.go
+++ b/source-azure-blob-storage/main.go
@@ -364,6 +364,7 @@ func getConfigSchema(parserSchema json.RawMessage) json.RawMessage {
 								"type":        "string",
 								"title":       "Connection String",
 								"description": "The connection string used to authenticate with Azure Blob Storage.",
+								"secret":      true,
 								"order":       0,
 							},
 							"storageAccountName": map[string]any{


### PR DESCRIPTION
**Description:**

The connection string embeds the storage account's full AccountKey, so it should be annotated as secret.

I believe this is trivially backwards-compatible, since runtime decryption collapses `"foobar"` and `"foobar_sops"` values together and isn't too picky about which form was present in the encrypted config or whether that lines up with the schema annotations.

**Workflow steps:**

The annotation will take effect going forward, the next time a task spec is published. Any currently-impacted specs should probably be republished.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
