### PR TITLE
source-klaviyo: normalize space-separated datetimes in every stream

### DIFF
--- a/source-klaviyo/CHANGELOG.md
+++ b/source-klaviyo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-08-05
+
+### Fixed
+
+- Datetime values Klaviyo returns space-separated are now normalized to RFC3339 in every stream. Previously only `profiles` and `global_exclusions` were covered, so `campaigns`, `lists`, `metrics`, `flows`, `email_templates`, archived records, and the free-form `event_properties` of `events` kept the space-separated form, and materializations of fields inferred as `format: date-time` failed with `cannot parse ... as "T"`.
+- Free-text values that end in a newline are no longer mistaken for datetimes and rewritten.

--- a/source-klaviyo/source_klaviyo/streams.py
+++ b/source-klaviyo/source_klaviyo/streams.py
@@ -26,17 +26,20 @@ LAG = 110
 
 
 # Klaviyo emits some datetime fields (e.g. consent timestamps) space-separated
-# (e.g. "2026-06-23 00:15:23.918411+00:00") rather than RFC3339. When schema inference
-# tags such a field `format: date-time`, the collection advertises an RFC3339 contract
-# the value violates, breaking downstream consumers. Rather than enumerate the known
-# offenders (Klaviyo custom properties are free-form, so new ones surface unpredictably),
-# we normalize any string that matches the space-separated shape and leave everything
-# else untouched. The anchored regex is what keeps free-text values (e.g. "May 5, 2021")
-# safe from mangling.
+# (e.g. "2026-06-23 00:15:23.918411+00:00") rather than RFC3339. When schema
+# inference tags such a field `format: date-time`, the collection advertises an
+# RFC3339 contract the value violates, breaking downstream consumers. Rather
+# than enumerate the known offenders (Klaviyo custom properties are free-form,
+# so new ones surface unpredictably), we normalize any string that matches the
+# space-separated shape and leave everything else untouched. The anchored regex
+# is what keeps free-text values (e.g. "May 5, 2021") safe from mangling; \Z
+# rather than $ is what keeps a trailing newline from being silently dropped.
 #
-# Matches the observed Klaviyo format "YYYY-MM-DD HH:MM:SS[.ffffff]+HH:MM".
+# Matches the observed Klaviyo format "YYYY-MM-DD HH:MM:SS[.ffffff][+HH:MM]". The UTC
+# offset is optional because the `events` stream previously normalized its cursor with an
+# unconditional str.replace, which did not require one.
 _SPACE_SEPARATED_DATETIME_RE = re.compile(
-    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2}:\d{2})$"
+    r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2}:\d{2})?\Z"
 )
 
 
@@ -45,7 +48,7 @@ def _normalize_datetime(value: str) -> str:
     if not match:
         return value
     date, time, tz = match.groups()
-    return f"{date}T{time}{tz}"
+    return f"{date}T{time}{tz or ''}"
 
 
 def _normalize_datetimes(data: Any) -> None:
@@ -136,6 +139,10 @@ class KlaviyoStream(HttpStream, ABC):
     def map_record(self, record: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         """Subclasses can override this to apply custom mappings to a record"""
 
+        # Normalize before the cursor is copied up, so the copy carries the RFC3339 form.
+        # SemiIncrementalKlaviyoStream compares cursors as strings against state written
+        # as isoformat(), where a space-separated value sorts below its normalized twin.
+        _normalize_datetimes(record)
         record[self.cursor_field] = record["attributes"][self.cursor_field]
         return record
 
@@ -372,11 +379,6 @@ class Profiles(IncrementalKlaviyoStream):
         params.update({"additional-fields[profile]": "predictive_analytics,subscriptions"})
         return params
 
-    def map_record(self, record: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        record = super().map_record(record)
-        _normalize_datetimes(record.get("attributes"))
-        return record
-
 
 class Campaigns(ArchivedRecordsMixin, IncrementalKlaviyoStream):
     """Docs: https://developers.klaviyo.com/en/v2023-06-15/reference/get_campaigns"""
@@ -479,8 +481,9 @@ class Events(IncrementalKlaviyoStream):
             self.record_amount = 0
 
         for record in response.json()["data"]:
-            record['datetime'] = record['attributes']['datetime'].replace(" ","T")
-            record['attributes']['datetime'] = record['attributes']['datetime'].replace(" ","T")
+            # map_record normalizes the whole record and copies the datetime cursor up.
+            # Event properties are free-form, so they carry space-separated datetimes too.
+            record = self.map_record(record)
 
             campaign_id = record["attributes"]['event_properties'].get("$message")
 

--- a/source-klaviyo/tests/test_streams.py
+++ b/source-klaviyo/tests/test_streams.py
@@ -15,6 +15,7 @@ from source_klaviyo.exceptions import KlaviyoBackoffError
 from source_klaviyo.streams import (
     ArchivedRecordsStream,
     Campaigns,
+    Events,
     GlobalExclusions,
     IncrementalKlaviyoStream,
     KlaviyoStream,
@@ -152,6 +153,43 @@ class TestKlaviyoStream:
             stream.backoff_time(response_mock)
         error_message = f"Stream some_stream has reached rate limit with 'Retry-After' of {float(retry_after)} seconds, exit from stream."
         assert str(e.value) == error_message
+
+    def test_map_record_normalizes_datetimes(self):
+        """Normalization hangs off the base map_record, so every stream gets it, not only the ones that override it."""
+
+        stream = SomeIncrementalStream(api_key=API_KEY, start_date=START_DATE.isoformat())
+        record = stream.map_record(
+            {
+                "type": "metric",
+                "id": "abc123",
+                "attributes": {
+                    "updated": "2026-06-23 00:15:23+00:00",
+                    "created": "2026-06-23 00:15:23.918411+00:00",
+                    # Klaviyo omits the UTC offset on some values.
+                    "last_seen": "2026-06-23 00:15:23",
+                    # Free-text values that merely contain spaces must be left alone.
+                    "favorite_month": "May 5, 2021",
+                    "status": "onboarding complete",
+                    # A trailing newline means it isn't a clean datetime; leave it untouched
+                    # rather than dropping the newline.
+                    "notes": "2026-06-23 00:15:23+00:00\n",
+                    "tags": ["2026-06-23 00:15:23+00:00", "plain tag"],
+                },
+            }
+        )
+        assert record["attributes"] == {
+            "updated": "2026-06-23T00:15:23+00:00",
+            "created": "2026-06-23T00:15:23.918411+00:00",
+            "last_seen": "2026-06-23T00:15:23",
+            "favorite_month": "May 5, 2021",
+            "status": "onboarding complete",
+            "notes": "2026-06-23 00:15:23+00:00\n",
+            "tags": ["2026-06-23T00:15:23+00:00", "plain tag"],
+        }
+        # The cursor is copied to the top level after normalization, so it carries the
+        # normalized value. SemiIncrementalKlaviyoStream compares cursors as strings
+        # against state written as isoformat(), and a space sorts below the "T".
+        assert record["updated"] == "2026-06-23T00:15:23+00:00"
 
 
 class TestIncrementalKlaviyoStream:
@@ -480,6 +518,55 @@ class TestGlobalExclusionsStream:
                     },
                 },
                 "updated": "2023-03-10T20:36:36+00:00",
+            }
+        ]
+
+
+class TestEventsStream:
+    def test_parse_response_normalizes_datetimes(self, mocker):
+        stream = Events(api_key=API_KEY, start_date=START_DATE.isoformat())
+        # _prepare_campaign() calls the API; seed its cache so parse_response skips it.
+        stream.record_amount = 0
+        stream.campaign_data = {"CAMPAIGN_ID"}
+        json = {
+            "data": [
+                {
+                    "type": "event",
+                    "id": "3rdp5zEXAMPLE",
+                    "attributes": {
+                        "datetime": "2026-06-23 00:15:23+00:00",
+                        "timestamp": 1750637723,
+                        "event_properties": {
+                            "$message": "CAMPAIGN_ID",
+                            "$flow": "FLOW_ID",
+                            # Event properties are free-form, so datetimes surface under
+                            # arbitrary keys alongside plain free text.
+                            "Last Opened": "2026-06-23 00:15:23.918411+00:00",
+                            "Favorite Month": "May 5, 2021",
+                        },
+                    },
+                },
+            ],
+            "links": {"self": "https://a.klaviyo.com/api/events/", "next": None, "prev": None},
+        }
+        records = list(stream.parse_response(mocker.Mock(json=mocker.Mock(return_value=json))))
+        assert records == [
+            {
+                "type": "event",
+                "id": "3rdp5zEXAMPLE",
+                "attributes": {
+                    "datetime": "2026-06-23T00:15:23+00:00",
+                    "timestamp": 1750637723,
+                    "event_properties": {
+                        "$message": "CAMPAIGN_ID",
+                        "$flow": "FLOW_ID",
+                        "Last Opened": "2026-06-23T00:15:23.918411+00:00",
+                        "Favorite Month": "May 5, 2021",
+                    },
+                },
+                "datetime": "2026-06-23T00:15:23+00:00",
+                "campaign_id": "CAMPAIGN_ID",
+                "flow_id": "FLOW_ID",
             }
         ]
 


### PR DESCRIPTION
**Description:**

Followup to https://github.com/estuary/connectors/pull/4742.

The earlier fix added the normalizer but called it from a single override on `Profiles`, so only `profiles` and `global_exclusions` were covered. Move the call onto the base `KlaviyoStream.map_record`, which every stream's `parse_response` routes through, and drop the now-redundant `Profiles` override. This mirrors the same fix on `source-klaviyo-native`, which hooks the shared base model for the same reason.

`Events.parse_response` overrides the base method and normalized its cursor by hand with an unconditional `str.replace(" ", "T")`, leaving its free-form `event_properties` alone. It now calls `map_record` instead. To keep that path's coverage, the UTC offset is optional in the regex; the old replace did not require one.

Two smaller corrections ride along, both in the ported normalizer:

- Anchor with `\Z` rather than `$`, so a value ending in a newline is no longer silently stripped of it.
- Normalize before the cursor is copied to the top level, so the copy carries the RFC3339 form. `SemiIncrementalKlaviyoStream` compares cursors as strings against state written as `isoformat()`, where a space sorts below the `T`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
