### PR TITLE
estuary-cdk: log when no bindings are enabled

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
+++ b/estuary-cdk/estuary_cdk/capture/base_capture_connector.py
@@ -248,7 +248,12 @@ class BaseCaptureConnector(
                         self._transactor,
                         catalog_task_name=open.capture.name,
                     )
-                    log.event.status("Capture started")
+
+                    message = "Capture started."
+                    if len(open.capture.bindings) < 1:
+                        message += " No bindings are enabled."
+                    log.event.status(message)
+
                     await capture(task)
             except* TerminateTaskGroup:
                 pass  # Expected when enforce_shutdown terminates the task group


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've too often (i.e. more than once) spent time investigating why a capture is not moving data when the root cause is simply there are no bindings enabled. This log / connector status should make that situation more obvious, either when looking in the logs or looking at the Connector Status in the dashboard.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
