### PR TITLE
source-zendesk-support-native: read the cursor field from each resource

### DIFF
--- a/source-zendesk-support-native/CHANGELOG.md
+++ b/source-zendesk-support-native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-08-05
+
+### Fixed
+- `ticket_metric_events`, `ticket_skips`, and `ticket_activities` no longer drop most documents during incremental replication. Previously, only events that overflowed past the first page of each polling cycle were captured (~5% of the stream on a busy account). Backfills were not affected. Existing captures should re-backfill these bindings to recover the missing history.

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -295,7 +295,7 @@ async def fetch_incremental_cursor_paginated_resources(
 
 
         for resource in response.resources:
-            resource_dt = _str_to_dt(getattr(response.resources[0], cursor_field))
+            resource_dt = _str_to_dt(getattr(resource, cursor_field))
             if resource_dt > last_seen_dt:
                 last_seen_dt = resource_dt
 

--- a/source-zendesk-support-native/tests/test_incremental_cursor_paginated.py
+++ b/source-zendesk-support-native/tests/test_incremental_cursor_paginated.py
@@ -1,0 +1,98 @@
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from source_zendesk_support_native.api import fetch_incremental_cursor_paginated_resources
+from source_zendesk_support_native.models import FilterParam, TicketMetricEventsResponse
+
+log = logging.getLogger(__name__)
+
+CURSOR = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def _event(id: int, time: str) -> dict[str, Any]:
+    return {
+        "id": id,
+        "ticket_id": id * 10,
+        "metric": "reply_time",
+        "instance_id": 1,
+        "type": "fulfill",
+        "time": time,
+    }
+
+
+class MockHTTP:
+    """Minimal mock that queues JSON responses for http.request calls."""
+
+    def __init__(self) -> None:
+        self._queue: list[bytes] = []
+
+    def queue(self, response: dict[str, Any]) -> None:
+        self._queue.append(json.dumps(response).encode())
+
+    async def request(self, log: Any, url: str, **kwargs: Any) -> bytes:
+        return self._queue.pop(0)
+
+
+async def _run(http: MockHTTP) -> tuple[set[int], datetime | None]:
+    """Returns the yielded resource ids and the last yielded checkpoint."""
+    ids: set[int] = set()
+    checkpoint: datetime | None = None
+    generator = fetch_incremental_cursor_paginated_resources(
+        http,  # type: ignore[arg-type]
+        "subdomain",
+        "incremental/ticket_metric_events",
+        FilterParam.START_TIME,
+        "time",
+        TicketMetricEventsResponse,
+        log,
+        CURSOR,
+    )
+    async for result in generator:
+        if isinstance(result, datetime):
+            checkpoint = result
+        else:
+            ids.add(result.id)
+    return ids, checkpoint
+
+
+@pytest.mark.asyncio
+class TestFetchIncrementalCursorPaginatedResources:
+    async def test_each_resource_evaluated_by_its_own_cursor_field(self):
+        # start_time is inclusive: the first resource is a boundary duplicate.
+        http = MockHTTP()
+        http.queue({
+            "ticket_metric_events": [
+                _event(1, "2026-07-01T00:00:00Z"),
+                _event(2, "2026-07-01T00:00:10Z"),
+                _event(3, "2026-07-01T00:00:20Z"),
+            ],
+            "meta": {"has_more": True, "after_cursor": "cursor-page-2"},
+        })
+        http.queue({
+            "ticket_metric_events": [_event(4, "2026-07-01T00:00:30Z")],
+            "meta": {"has_more": False},
+        })
+
+        ids, checkpoint = await _run(http)
+
+        assert ids == {2, 3, 4}
+        assert checkpoint == datetime(2026, 7, 1, 0, 0, 30, tzinfo=UTC)
+
+    async def test_cursor_advances_on_single_page_starting_at_the_cursor(self):
+        http = MockHTTP()
+        http.queue({
+            "ticket_metric_events": [
+                _event(1, "2026-07-01T00:00:00Z"),
+                _event(2, "2026-07-01T00:00:10Z"),
+            ],
+            "meta": {"has_more": False},
+        })
+
+        ids, checkpoint = await _run(http)
+
+        assert ids == {2}
+        assert checkpoint == datetime(2026, 7, 1, 0, 0, 10, tzinfo=UTC)


### PR DESCRIPTION
**Regression?**

No. The line is unchanged since at least February 2025.

**Description:**

`fetch_incremental_cursor_paginated_resources` reads the cursor timestamp from `response.resources[0]` instead of each resource. Since `start_time` is inclusive, the first page of every poll matches the cursor and is dropped whole, so only documents that spill into a second page get captured. Affects `ticket_metric_events`, `ticket_skips`, and `ticket_activities`.

On our production capture this dropped ~95% of `ticket_metric_events` once the backfill handed over to incremental replication (validated by id against Zendesk's incremental export API). Support thread: https://estuary-dev.slack.com/archives/C06R0CVD0KZ/p1785968145292899

The fix reads the cursor field from the loop variable, matching the already-correct backfill path.

**Documentation links affected:**

None.

**Notes for reviewers:**

Adds the connector's first `CHANGELOG.md`. Existing captures need a re-backfill of the affected bindings to recover dropped documents.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
