### PR TITLE
source-zendesk-support-native: fix incremental cursor pagination dropping whole pages

### DIFF
--- a/source-zendesk-support-native/CHANGELOG.md
+++ b/source-zendesk-support-native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-08-05
+
+### Fixed
+- `ticket_metric_events`, `ticket_skips`, and `ticket_activities` no longer drop the majority of records during incremental replication. Each poll discarded an entire page of results and often failed to advance its cursor, so these streams captured only a small fraction of new records once the initial backfill completed. Backfill was unaffected. Existing captures should backfill these bindings to recover the records that were missed.

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -295,7 +295,7 @@ async def fetch_incremental_cursor_paginated_resources(
 
 
         for resource in response.resources:
-            resource_dt = _str_to_dt(getattr(response.resources[0], cursor_field))
+            resource_dt = _str_to_dt(getattr(resource, cursor_field))
             if resource_dt > last_seen_dt:
                 last_seen_dt = resource_dt
 

--- a/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -313,7 +313,6 @@
         "ticket_redaction": false,
         "ticket_tag_editing": false,
         "twitter_search_access": false,
-        "update_api_settings": false,
         "update_user_own_alias": false,
         "update_user_own_name": false,
         "update_user_own_signature": false,

--- a/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-zendesk-support/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -873,7 +873,6 @@
         "ticket_redaction": false,
         "ticket_tag_editing": false,
         "twitter_search_access": false,
-        "update_api_settings": false,
         "update_user_own_alias": false,
         "update_user_own_name": false,
         "update_user_own_signature": false,


### PR DESCRIPTION
**Regression?**

No.

**Description:**

In `fetch_incremental_cursor_paginated_resources`, we should only yield resources whose cursors are newer than the `log_cursor`. However, there's a bug in the code: we have been using the cursor from the first resource on each page to determine if _all_ resources on a page should be yielded. That's incorrect and causes the connector to miss substantial amounts of data during incremental replication since most of the time, there's a single page of results newer than the `log_cursor` & the first result on the page will always have the same cursor as the `log_cursor`

This PR fixes this by making the determination of "should this resource be yielded?" and the `last_seen_dt` advancement off of each resource's own cursor, not the cursor of the first resource in a page.

Additionally, update the capture snapshots for both `source-zendesk-support` and `source-zendesk-support-native` to remove a field the API no longer includes.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
