### PR TITLE
docs(materialize-snowflake): document clustering resource config

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/Snowflake.md
+++ b/docs/reference/Connectors/materialization-connectors/Snowflake.md
@@ -161,6 +161,7 @@ Use the below properties to configure a Snowflake materialization, which will di
 | **`/table`** | Table | Table name | string | Required |
 | `/schema` | Alternative Schema | Alternative schema for this table | string |  |
 | `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates) | boolean |  |
+| `/clustering` | Clustering Keys | Comma-separated list of column names to use as the [clustering key](#clustering-keys) for Snowflake Automatic Clustering. Leave empty to disable clustering. | string |  |
 
 ### Sample
 
@@ -283,6 +284,26 @@ This is because most materializations tend to be roughly chronological over time
 
 This means that updates of keys `/date, /user_id` will need to physically read far fewer rows as compared to a key like `/user_id`,
 because those rows will tend to live in the same micro-partitions, and Snowflake is able to cheaply prune micro-partitions that aren't relevant to the transaction.
+
+### Clustering keys
+
+In addition to choosing a good collection key, you can explicitly enable [Snowflake Automatic Clustering](https://docs.snowflake.com/en/user-guide/tables-clustering-keys) on a per-binding basis using the `clustering` resource configuration property. This is an advanced option, recommended only for large tables that are queried with selective filters on the clustered columns, since automatic clustering consumes additional Snowflake credits.
+
+Set `clustering` to a comma-separated list of column names:
+
+```yaml
+bindings:
+  - resource:
+      table: ${table_name}
+      clustering: date, user_id
+    source: ${PREFIX}/${source_collection}
+```
+
+Keep in mind:
+
+* Only literal materialized column names are supported. SQL expressions or functions (for example `TRUNC(user_id, -5)`) are not accepted.
+* The clustering key is applied, and re-applied, every time the materialization restarts, republishes, or backfills, not only when the table is first created. You can add, change, or remove clustering at any time by updating this property and republishing.
+* If you leave `clustering` empty, the connector checks for an existing clustering key on the table and drops it. Clustering keys applied manually in Snowflake, outside this property, will be removed the next time the materialization restarts.
 
 ### Snowpipe Streaming
 


### PR DESCRIPTION
**Description:**

Documents the `clustering` resource config property on materialize-snowflake bindings. This property has existed since April 2026 (per-binding Snowflake Automatic Clustering) but was never documented on docs.estuary.dev.

**Workflow steps:**

No behavior change, docs only. Adds the `/clustering` row to the bindings properties table and a new "Clustering keys" subsection under Performance considerations covering: literal-column-only support (no SQL expressions), that the key is applied/re-applied on every restart/republish/backfill (not just table creation), and that leaving the field blank causes the connector to drop any existing clustering key on the table, including one applied manually in Snowflake.

**Documentation links affected:**

- `docs/reference/Connectors/materialization-connectors/Snowflake.md` (this PR)

**Notes for reviewers:**

Came out of a support ticket (Flock Freight, Pylon #4735) where the customer found this field with no docs. Verified against `materialize-snowflake/snowflake.go` at HEAD. Slack thread: https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1785994466373499

A related feature request (expression-based clustering keys, e.g. `TRUNC()`) is tracked separately in estuary/connectors#5012, and an unrelated bug found while reading this code path is in estuary/connectors#5013. This PR documents today's behavior only; will update if #5012 ships.

**Checklist:**

- [x] Docs-only change, no CHANGELOG entry needed.