### PR TITLE
docs: reconcile OpenSearch and materialize-hubspot pages missed by the first pass

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/Elasticsearch/Elasticsearch.md
+++ b/docs/reference/Connectors/materialization-connectors/Elasticsearch/Elasticsearch.md
@@ -17,7 +17,7 @@ To use this connector, you'll need:
 - At least one Estuary collection
 
 :::tip
-If you haven't yet captured your data from its external source, start at the beginning of the [guide to create a dataflow](../../../guides/create-dataflow.md). You'll be referred back to this connector-specific documentation at the appropriate steps.
+If you haven't yet captured your data from its external source, start at the beginning of the [guide to create a dataflow](/guides/create-dataflow). You'll be referred back to this connector-specific documentation at the appropriate steps.
 :::
 
 ## Configuration
@@ -81,9 +81,9 @@ You must configure your Elasticsearch cluster to allow connections from Estuary.
 
 Alternatively, you can allow secure connections via SSH tunneling. To do so:
 
-1. Refer to the [guide](../../../../guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+1. Refer to the [guide](/guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
 
-2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](../../../concepts/connectors.md#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
+2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](/concepts/connectors/#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
 
 ## Delta updates
 
@@ -111,9 +111,9 @@ The options supported currently are:
   :::note
 
   Fields with `type: string` will have `keyword` index mappings created for
-  them only they are part of the key.
+  them only if they are part of the key.
 
-An example JSON configuration for this field configurations is shown below:
+An example JSON configuration for this field configuration is shown below:
 
 ```json
 {

--- a/docs/reference/Connectors/materialization-connectors/Elasticsearch/opensearch.md
+++ b/docs/reference/Connectors/materialization-connectors/Elasticsearch/opensearch.md
@@ -1,0 +1,143 @@
+---
+description: Materialize data collections into indices in an OpenSearch cluster. Configure connector authentication, hard deletes, number of replicas, and delta updates.
+---
+
+# OpenSearch
+
+This connector materializes Estuary collections into indices in an OpenSearch cluster.
+
+## Prerequisites
+
+To use this connector, you'll need:
+
+- An OpenSearch cluster with a known endpoint
+- The role used to connect to OpenSearch must have at least the following privileges:
+  - **Cluster privilege** of `monitor`
+  - For each index to be created: `read`, `write`, `view_index_metadata`, and `create_index`. When creating **Index privileges**, you can use a wildcard `"*"` to grant the privileges to all indices.
+- At least one Estuary collection
+
+## Configuration
+
+To use this connector, begin with data in one or more Estuary collections.
+Use the properties below to configure an OpenSearch materialization, which will direct the contents of these Estuary collections into OpenSearch indices.
+
+**Authentication**
+
+You can authenticate to OpenSearch using either a username and password, or using an API key.
+
+The connector will automatically create an OpenSearch index for each binding of the materialization with index mappings for each selected field of the binding. It uses the last component of the collection name as the name of the index by default. You can customize the name of the index using the `index` property in the resource configuration for each binding.
+
+### Properties
+
+#### Endpoint
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/endpoint`** | Endpoint | Endpoint host or URL. Must start with http:// or https:// and may include the port. | string | Required |
+| `/hardDelete` | Hard Delete | If enabled, items deleted in the source will also be deleted from the destination. By default, deletions are tracked via `_meta/op` (soft delete). | boolean | `false` |
+| **`/credentials`** | Credentials | Either must include username/password or API key properties. | object | Required |
+| `/credentials/username` | Username | Username for authentication. | string |  |
+| `/credentials/password` | Password | Password for authentication. | string |  |
+| `/credentials/apiKey` | API Key | API key for authentication. Must be the 'encoded' API key credentials, which is the Base64-encoding of the UTF-8 representation of the id and api_key joined by a colon (:). | string |  |
+| `/advanced/number_of_replicas` | Index Replicas | The number of replicas to create new indices with. Leave blank to use the cluster default. | integer |  |
+
+#### Bindings
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- |
+| **`/index`** | index | Name of the OpenSearch index to store the materialization results. | string | Required |
+| `/delta_updates` | Delta updates | Whether to use standard or [delta updates](#delta-updates). | boolean | `false` |
+| `/number_of_shards` | Number of shards | The number of shards to create the index with. Leave blank to use the cluster default. | integer | `1` |
+
+### Sample
+
+```yaml
+materializations:
+  PREFIX/mat_name:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-opensearch:v3
+        config:
+          endpoint: https://cluster-id.us-east-1.aws.domain:1234
+          credentials:
+            username: estuary_user
+            password: secret
+        bindings:
+          - resource:
+              index: my-opensearch-index
+            source: PREFIX/source_collection
+```
+
+## Setup
+
+You must configure your OpenSearch cluster to allow connections from Estuary. It may be necessary to [allowlist the Estuary IP addresses](/reference/allow-ip-addresses).
+
+Alternatively, you can allow secure connections via SSH tunneling. To do so:
+
+1. Refer to the [guide](/guides/connect-network/) to configure an SSH server on the cloud platform of your choice.
+
+2. Configure your connector as described in the [configuration](#configuration) section above, with the addition of the `networkTunnel` stanza to enable the SSH tunnel, if using. See [Connecting to endpoints on secure networks](/concepts/connectors/#connecting-to-endpoints-on-secure-networks) for additional details and a sample.
+
+## Delta updates
+
+This connector supports both standard and delta updates. You must choose an option for each binding.
+
+[Learn more about delta updates](/concepts/materialization/#delta-updates) and the implications of using each update type.
+
+## Field Configuration
+
+Materialized fields can be configured through their [field
+selection](/concepts/materialization/#projected-fields). This can be
+changed by updating the JSON in the **Advanced Specification Editor** in the
+dashboard or by using `flowctl` to edit the specification directly. See [edit
+a materialization](/guides/edit-data-flows/#edit-a-materialization) for
+more details.
+
+The options supported currently are:
+- **routing**: A single key field may be selected for routing documents to index
+  shards. The value of this field is used as the `routing` parameter in all
+  operations performed by the connector.
+- **mapping**: This object can be used to set the `type` and optionally a
+  `format` for a field to be used for the index mapping.  This can be useful to
+  map a string field as a `keyword` or to set the `format` for a `date` field.
+
+:::note
+Fields with `type: string` will have `keyword` index mappings created for
+them only if they are part of the key.
+
+OpenSearch also uses the `flat_object` type mapping instead of `flattened`.
+:::
+
+An example JSON configuration for this field configuration is shown below:
+
+```json
+{
+  "bindings": [
+    {
+      "resource": {
+        "index": "my-opensearch-index"
+      },
+      "source": "PREFIX/source_collection",
+      "fields": {
+        "require": {
+          "myKey": {
+            "routing": true
+          },
+          "stringOrIntegerField": {
+            "mapping": {
+              "type": "keyword"
+            }
+          },
+          "unixTimestamp": {
+            "mapping": {
+              "type": "date",
+              "format": "epoch_seconds"
+            }
+          }
+        },
+        "recommended": true
+      }
+    }
+  ]
+}
+```

--- a/docs/reference/Connectors/materialization-connectors/README.md
+++ b/docs/reference/Connectors/materialization-connectors/README.md
@@ -88,7 +88,7 @@ In the future, other open-source materialization connectors from third parties c
   * [Configuration](./apache-iceberg/dremio.md)
   * Package - ghcr.io/estuary/materialize-dremio:v1
 * Elasticsearch
-  * [Configuration](./Elasticsearch.md)
+  * [Configuration](./Elasticsearch/Elasticsearch.md)
   * Package — ghcr.io/estuary/materialize-elasticsearch:v3
 * Google BigQuery
   * [Configuration](./BigQuery.md)
@@ -117,6 +117,9 @@ In the future, other open-source materialization connectors from third parties c
 * HTTP Webhook
   * [Configuration](./http-webhook.md)
   * Package - ghcr.io/estuary/materialize-webhook:v1
+* HubSpot
+  * [Configuration](./hubspot.md)
+  * Package - ghcr.io/estuary/materialize-hubspot:v1
 * Imply Polaris
   * [Configuration](./Dekaf/imply-polaris.md)
 * Materialize
@@ -133,6 +136,9 @@ In the future, other open-source materialization connectors from third parties c
 * MySQL Heatwave
   * [Configuration](./mysql-heatwave.md)
   * Package - ghcr.io/estuary/materialize-mysql-heatwave:v2
+* OpenSearch
+  * [Configuration](./Elasticsearch/opensearch.md)
+  * Package - ghcr.io/estuary/materialize-opensearch:v3
 * Pinecone
   * [Configuration](./pinecone.md)
   * Package — ghcr.io/estuary/materialize-pinecone:v1

--- a/docs/reference/Connectors/materialization-connectors/hubspot.md
+++ b/docs/reference/Connectors/materialization-connectors/hubspot.md
@@ -1,0 +1,155 @@
+---
+description: Materialize collections to HubSpot CRM objects such as Contacts, Companies, and Deals for reverse-ETL workflows.
+---
+
+# HubSpot
+
+The HubSpot connector writes to HubSpot CRM objects such as Contacts,
+Companies, and Deals.
+
+## Prerequisites
+
+- A HubSpot account.
+- For each target object type, the HubSpot properties you intend to populate
+  must already exist. It is recommended to create a dedicated property group to
+  organize them.
+- One property on each object type to use as the match property.
+
+## Match Property
+
+HubSpot record IDs are assigned automatically and cannot be set by the
+connector. To match incoming documents to existing records, the connector
+compares the HubSpot record against the **collection key**.
+
+:::important
+Using a **unique** property as the match key is strongly recommended.
+
+Non-unique properties require a search to determine whether a record exists.
+Due to HubSpot search API limitations, using a non-unique match property can
+result in duplicate records.
+:::
+
+To determine if a property is unique, navigate in the HubSpot webapp to `Settings
+/ Data Management / Properties` and check in the Property Rules if "require unique
+values for this property" is enabled.  Alternatively, look at the [object
+definition][] or use the [Properties API][] to list items with `hasUniqueValue`
+set to `true`.
+
+If there is no existing unique property that is suitable, it is recommended to
+create a new property with "require unique values" set.
+
+## Property name mapping
+
+Collection field names are mapped to HubSpot property names automatically
+similarly to how HubSpot generates property names: the field name is
+lowercased, leading underscores are removed as well as other symbols
+characters, and if the field begins with a number it will be prefixed with
+`n`. Names are truncated to 100 characters.
+
+## Deletions
+
+Hard deletes are not supported. To track deletions, ensure your collection
+documents include the `/_meta/op` field and create a corresponding `meta_op`
+property in HubSpot.
+
+Backfills do not remove existing HubSpot records.
+
+## Enumerations
+
+HubSpot enumeration properties require values from a pre-defined set. If a
+document field contains a value not in the allowed set, the materialization
+will return an error like:
+
+```
+HOWDY was not one of the allowed options: [IN_PROGRESS, NEW, UNQUALIFIED, ...]
+```
+
+Ensure your collection data (or a derivation that shapes it) only produces
+values valid for enumeration properties.
+
+## Configuration
+
+You can configure connectors either in the Estuary web app or by directly
+editing the Data Flow specification file. See [connectors][using-connectors] to
+learn more.
+
+
+### Properties
+
+#### Endpoint
+
+| Property                  | Title                      | Description                                          | Type                        | Required/Default |
+| ------------------------- | -------------------------- | ---------------------------------------------------- | --------------------------- | ---------------- |
+| **`/credentials`**        | Authentication             | Credentials for authenticating with HubSpot.         | [Credentials](#credentials) | Required         |
+| `/advanced/limit`         | Request Limit              | Maximum API requests per second (excluding search).  | number                      | `10`             |
+| `/advanced/burst`         | Request Burst Count        | Burst request allowance (excluding search).          | integer                     | `100`            |
+| `/advanced/search_limit`  | Search Request Limit       | Maximum search API requests per second.              | number                      | `5`              |
+| `/advanced/search_burst`  | Search Request Burst Count | Burst search request allowance.                      | integer                     | `5`              |
+
+#### Credentials
+
+For production tasks, use the `OAuth2` authentication method.
+
+| Property                         | Title         | Description                                                         | Type   | Required/Default    |
+| -------------------------------- | ------------- | ------------------------------------------------------------------- | ------ | ------------------- |
+| **`/credentials/auth_type`**     | Auth Type     | Authentication method.                                              | string | Required: `OAuth2`  |
+| `/credentials/refresh_token`     | Refresh Token | OAuth2 refresh token. Managed automatically by the Estuary web app. | string | Required           |
+
+| Property                         | Title         | Description                                                        | Type   | Required/Default       |
+| -------------------------------- | ------------- | ------------------------------------------------------------------ | ------ | ---------------------- |
+| **`/credentials/auth_type`**     | Auth Type     | Authentication method.                                             | string | Required: `ServiceKey` |
+| **`/credentials/service_key`**   | Service Key   | HubSpot private app access token with the required scope grants.   | string | Required               |
+
+#### Bindings
+
+| Property             | Title        | Description                                              | Type                         | Required/Default  |
+| -------------------- | ------------ | -------------------------------------------------------- | ---------------------------- | ----------------- |
+| **`/object`**        | Object type  | The HubSpot CRM object type to materialize into.         | [CRM Object](#crm-objects)   | Required          |
+| `/delta_updates`     | Delta Update | Always `true` — this connector uses delta updates.       | boolean | `true` (read-only) |
+
+
+#### CRM Objects
+
+- Calls
+- Companies
+- Contacts
+- Deals
+- Emails
+- Line Items
+- Meetings
+- Postal Mail
+- Products
+- Quotes
+- Tasks
+- Tickets
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${MATERIALIZATION_NAME}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-hubspot:v1
+        config:
+          credentials:
+            auth_type: OAuth2
+            refresh_token: <secret>
+    bindings:
+      - source: ${PREFIX}/contacts
+        resource:
+          object: Contacts
+      - source: ${PREFIX}/companies
+        resource:
+          object: Companies
+```
+
+## Limitations
+
+- Materializing associations between CRM objects is not currently supported.
+- Sensitive and Highly Sensitive fields cannot be written to, as the connector
+  does not request the required scopes.
+
+[object definition]: https://developers.hubspot.com/docs/api-reference/latest/crm/objects/contacts/object-definition
+[Properties API]: https://developers.hubspot.com/docs/api-reference/latest/crm/properties/get-properties
+[using-connectors]: /concepts/connectors.md#using-connectors


### PR DESCRIPTION
## Context

While spiking a Cloudflare Workers deploy target for the docs migration (#20 on estuary/docs), Mike Danko diffed the flow/site and staging sitemaps and found 7 production URLs missing from this repo's `docs/reference/Connectors/`. Checked each one against git history:

- 5 of the 7 (`amazon-sqs-native`, `smartsheet`, `zuora`, `amazon-sns`, `google-spanner`) already exist on `main` here, added between 2026-07-05 and 2026-07-22. The hourly staging sync (`estuary/docs` `deploy.yml`, confirmed via a live run today) correctly tracks `main`'s tip, so those should already be serving on staging without a 404 — the sitemap diff that flagged them was most likely comparing against a stale build.
- The other 2 landed on flow/site after the first reconciliation pass's 2026-07-20 cutoff and were genuinely never migrated. This PR closes that gap.

## Changes

- `materialization-connectors/hubspot.md` — new, the HubSpot materialization connector (distinct from the HubSpot capture connectors already migrated).
- `materialization-connectors/Elasticsearch.md` → `materialization-connectors/Elasticsearch/Elasticsearch.md` — relocated to match flow/site's restructure into a category folder, content refreshed from flow/site (a couple of small typo fixes), links kept in the existing absolute-path style already used elsewhere in this repo (e.g. the Salesforce docs) since that's what resolves correctly once aggregated into `estuary/docs`.
- `materialization-connectors/Elasticsearch/opensearch.md` — new, the OpenSearch materialization connector.
- `materialization-connectors/README.md` — added HubSpot and OpenSearch entries, updated the Elasticsearch link path.

## Verification

Built the full `estuary/docs` site locally against this branch (real `docusaurus build`, not just a syntax check):
- All three URLs resolve at their intended paths, `.../materialization-connectors/Elasticsearch/` (unchanged, no doubled segment from the folder move), `.../Elasticsearch/opensearch/`, and `.../materialization-connectors/hubspot/`.
- No broken links introduced (one pre-existing, unrelated broken-anchor warning on a reduction-strategies page).
- README-derived category index links to all three correctly.