### PR TITLE
Dbn/materialize clickhouse shared batch buffer dup

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-06
+### Changed
+- Load batches are sent once a full batch is collected, instead of when the
+  load binding changes.  On tasks with many active bindings, this should
+  generally result in larger batch sizes.
+
 ## 2026-07-29
 
 ### Fixed

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -1,12 +1,14 @@
 package connector
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -525,34 +527,47 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	batchBytes := 0
 
 	flushBindings := func() error {
-		// Group batch records by Binding.
-		bindingBatch := make(map[int][][]any, len(t.bindings))
-		for _, item := range batch {
-			bindingBatch[item.Binding] = append(bindingBatch[item.Binding], item.Record)
+		if len(batch) == 0 {
+			return nil
 		}
 
-		for binding, records := range bindingBatch {
+		slices.SortFunc(batch, func(a, b batchItem) int {
+			return cmp.Compare(a.Binding, b.Binding)
+		})
+
+		begin := 0
+		for begin < len(batch) {
+			lastBinding := batch[begin].Binding
+			end := begin
+			for end < len(batch) && batch[end].Binding == lastBinding {
+				end++
+			}
+			items := batch[begin:end]
+
 			// PrepareBatch fails before any rows have been sent, so retrying a
 			// transient connection drop is a clean no-op on the ClickHouse side.
 			var chBatch chdriver.Batch
 			if err := transientRetryPolicy.retry(ctx, "preparing load batch", isTransientErr, func() (err error) {
-				chBatch, err = t.load.conn.PrepareBatch(ctx, t.bindings[binding].load.insertSQL)
+				chBatch, err = t.load.conn.PrepareBatch(ctx, t.bindings[lastBinding].load.insertSQL)
 				return err
 			}); err != nil {
-				return fmt.Errorf("preparing load batch for %s: %w", t.bindings[binding].target.Identifier, err)
+				return fmt.Errorf("preparing load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
 			}
-			for _, record := range records {
-				if err = chBatch.Append(record...); err != nil {
+
+			for _, item := range items {
+				if err = chBatch.Append(item.Record...); err != nil {
 					chBatch.Close()
-					return fmt.Errorf("appending load batch for %s: %w", t.bindings[binding].target.Identifier, err)
+					return fmt.Errorf("appending load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
 				}
 			}
 
 			if err = chBatch.Send(); err != nil {
 				chBatch.Close()
-				return fmt.Errorf("flushing load batch for %s: %w", t.bindings[binding].target.Identifier, err)
+				return fmt.Errorf("flushing load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
 			}
 			chBatch.Close()
+
+			begin = end
 		}
 		batch = batch[:0]
 		batchBytes = 0

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -550,19 +549,10 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 				}
 			}
 
-			start := time.Now()
-			fields := log.Fields{
-				"target":     t.bindings[binding].target.Identifier,
-				"batch_size": len(records),
-			}
-
 			if err = chBatch.Send(); err != nil {
 				chBatch.Close()
 				return fmt.Errorf("flushing load batch for %s: %w", t.bindings[binding].target.Identifier, err)
 			}
-
-			fields["elapsed"] = fmt.Sprintf("%.3fs", time.Since(start).Seconds())
-			log.WithFields(fields).Debug("flushed load batch")
 			chBatch.Close()
 		}
 		batch = batch[:0]

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -504,6 +504,11 @@ const (
 	batchBytesLimit = 10 * 1024 * 1024
 )
 
+type batchItem struct {
+	Binding int
+	Record  []any
+}
+
 func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) error) (err error) {
 	var ctx = it.Context()
 
@@ -518,44 +523,50 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	// before the join.
 	activeBindings := make(map[int]int64, len(t.bindings))
 	lastBinding := -1
-	batch := make([][]any, 0, maxBatchSize)
+	batch := make([]batchItem, 0, maxBatchSize)
 	batchBytes := 0
 
-	flushLastBinding := func() error {
-		if len(batch) == 0 || lastBinding < 0 {
-			return nil
+	flushBindings := func() error {
+		// Group batch records by Binding.
+		bindingBatch := make(map[int][][]any, len(t.bindings))
+		for _, item := range batch {
+			bindingBatch[item.Binding] = append(bindingBatch[item.Binding], item.Record)
 		}
-		// PrepareBatch fails before any rows have been sent, so retrying a
-		// transient connection drop is a clean no-op on the ClickHouse side.
-		var chBatch chdriver.Batch
-		if err := transientRetryPolicy.retry(ctx, "preparing load batch", isTransientErr, func() (err error) {
-			chBatch, err = t.load.conn.PrepareBatch(ctx, t.bindings[lastBinding].load.insertSQL)
-			return err
-		}); err != nil {
-			return fmt.Errorf("preparing load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
-		}
-		defer chBatch.Close()
-		for _, record := range batch {
-			if err = chBatch.Append(record...); err != nil {
-				return fmt.Errorf("appending load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
+
+		for binding, records := range bindingBatch {
+			// PrepareBatch fails before any rows have been sent, so retrying a
+			// transient connection drop is a clean no-op on the ClickHouse side.
+			var chBatch chdriver.Batch
+			if err := transientRetryPolicy.retry(ctx, "preparing load batch", isTransientErr, func() (err error) {
+				chBatch, err = t.load.conn.PrepareBatch(ctx, t.bindings[binding].load.insertSQL)
+				return err
+			}); err != nil {
+				return fmt.Errorf("preparing load batch for %s: %w", t.bindings[binding].target.Identifier, err)
 			}
-		}
+			for _, record := range records {
+				if err = chBatch.Append(record...); err != nil {
+					chBatch.Close()
+					return fmt.Errorf("appending load batch for %s: %w", t.bindings[binding].target.Identifier, err)
+				}
+			}
 
-		start := time.Now()
-		fields := log.Fields{
-			"target":           t.bindings[lastBinding].target.Identifier,
-			"batch_length":     len(batch),
-			"batch_size_bytes": batchBytes,
-		}
+			start := time.Now()
+			fields := log.Fields{
+				"target":     t.bindings[binding].target.Identifier,
+				"batch_size": len(records),
+			}
 
+			if err = chBatch.Send(); err != nil {
+				chBatch.Close()
+				return fmt.Errorf("flushing load batch for %s: %w", t.bindings[binding].target.Identifier, err)
+			}
+
+			fields["elapsed"] = fmt.Sprintf("%.3fs", time.Since(start).Seconds())
+			log.WithFields(fields).Debug("flushed load batch")
+			chBatch.Close()
+		}
 		batch = batch[:0]
 		batchBytes = 0
-		if err = chBatch.Send(); err != nil {
-			return fmt.Errorf("flushing load batch for %s: %w", t.bindings[lastBinding].target.Identifier, err)
-		}
-
-		fields["elapsed"] = fmt.Sprintf("%.3fs", time.Since(start).Seconds())
-		log.WithFields(fields).Info("flushed load batch")
 		return nil
 	}
 
@@ -579,9 +590,6 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 	for it.Next() {
 		if it.Binding != lastBinding {
-			if err = flushLastBinding(); err != nil {
-				return err
-			}
 			lastBinding = it.Binding
 
 			if _, found := activeBindings[it.Binding]; !found {
@@ -600,12 +608,12 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		if err != nil {
 			return fmt.Errorf("converting load key for %s: %w", b.target.Identifier, err)
 		}
-		batch = append(batch, converted)
+		batch = append(batch, batchItem{Binding: it.Binding, Record: converted})
 		batchBytes += len(it.PackedKey)
 		activeBindings[it.Binding]++
 
 		if len(batch) >= maxBatchSize || batchBytes >= batchBytesLimit {
-			if err = flushLastBinding(); err != nil {
+			if err = flushBindings(); err != nil {
 				return err
 			}
 		}
@@ -616,7 +624,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	if len(activeBindings) == 0 {
 		return nil
 	}
-	if err = flushLastBinding(); err != nil {
+	if err = flushBindings(); err != nil {
 		return err
 	}
 

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -521,7 +521,6 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	// load table this round, for verification against an authoritative count
 	// before the join.
 	activeBindings := make(map[int]int64, len(t.bindings))
-	lastBinding := -1
 	batch := make([]batchItem, 0, maxBatchSize)
 	batchBytes := 0
 
@@ -579,18 +578,14 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	}()
 
 	for it.Next() {
-		if it.Binding != lastBinding {
-			lastBinding = it.Binding
-
-			if _, found := activeBindings[it.Binding]; !found {
-				b := t.bindings[it.Binding]
-				// The load table exists (ensured at session start); truncate
-				// clears any keys left over from a previous round.
-				if err = t.load.conn.Exec(ctx, b.load.truncateSQL); err != nil {
-					return fmt.Errorf("truncating load stage table for %s: %w", b.target.Identifier, err)
-				}
-				activeBindings[it.Binding] = 0
+		if _, found := activeBindings[it.Binding]; !found {
+			b := t.bindings[it.Binding]
+			// The load table exists (ensured at session start); truncate
+			// clears any keys left over from a previous round.
+			if err = t.load.conn.Exec(ctx, b.load.truncateSQL); err != nil {
+				return fmt.Errorf("truncating load stage table for %s: %w", b.target.Identifier, err)
 			}
+			activeBindings[it.Binding] = 0
 		}
 
 		b := t.bindings[it.Binding]


### PR DESCRIPTION
**Description:**

Duplicate of 5022, checking if this will fix the CI workflow not triggering.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
