### PR TITLE
source-boilerplate: Log when no bindings are enabled

### DIFF
--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -167,7 +167,10 @@ func (s *ConnectorServer) Capture(stream pc.Connector_CaptureServer) error {
 			}
 		case request.Open != nil:
 			log.WithField("eventType", "connectorStatus").Info("Starting capture")
-			return s.Connector.Pull(request.Open, &PullOutput{Connector_CaptureServer: stream})
+			return s.Connector.Pull(request.Open, &PullOutput{
+				Connector_CaptureServer: stream,
+				NumBindings:             len(request.Open.Capture.Bindings),
+			})
 		default:
 			return fmt.Errorf("unexpected request %#v", request)
 		}
@@ -181,6 +184,11 @@ type PullOutput struct {
 	sync.Mutex
 	pc.Connector_CaptureServer
 
+	// NumBindings is the number of enabled bindings the capture was opened
+	// with. A capture with zero bindings will sit idle without producing any
+	// documents, which is worth mentioning in the startup status message.
+	NumBindings int
+
 	reused struct {
 		msg pc.Response          // Preallocated message to avoid allocations in Document()
 		doc pc.Response_Captured // Preallocated captured document to avoid allocations in Document()
@@ -193,7 +201,14 @@ type PullOutput struct {
 
 // Ready sends a PullResponse_Opened message to indicate that the capture has started.
 func (out *PullOutput) Ready(explicitAcknowledgements bool) error {
-	log.WithField("eventType", "connectorStatus").Info("Capture started")
+	if out.NumBindings == 0 {
+		log.WithField("eventType", "connectorStatus").Info("Capture started, no bindings are enabled")
+	} else {
+		log.WithFields(log.Fields{
+			"eventType": "connectorStatus",
+			"bindings":  out.NumBindings,
+		}).Info("Capture started")
+	}
 	out.Lock()
 	defer out.Unlock()
 	if err := out.Send(&pc.Response{

--- a/source-boilerplate/testing/testing.go
+++ b/source-boilerplate/testing/testing.go
@@ -191,6 +191,7 @@ func (cs *CaptureSpec) Capture(ctx context.Context, t testing.TB, callback func(
 
 	stream := &boilerplate.PullOutput{
 		Connector_CaptureServer: adapter,
+		NumBindings:             len(cs.Bindings),
 	}
 
 	if cs.CaptureDelay > 0 {

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -417,7 +417,7 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		Name:     string(open.Capture.Name),
 		Bindings: bindings,
 		State:    &state,
-		Output:   &boilerplate.PullOutput{Connector_CaptureServer: stream},
+		Output:   stream,
 		Database: db,
 	}
 


### PR DESCRIPTION
**Description:**

Going along with https://github.com/estuary/connectors/pull/5004, which added shutdown messages to various captures which shut down when there are zero bindings, and https://github.com/estuary/connectors/pull/5008 which added startup-time logging to the CDK, this adds similar startup logging to Go captures using `source-boilerplate`.

Since the way ready signals are emitted is a bit indirect here, this required adding a binding-count field to the `PullOutput` struct which the `Ready()` method consults, but I think that's fine.