### PR TITLE
source-sqlserver{,ct}: run tests in parallel & stop waiting on the CDC worker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,16 @@ jobs:
           VARIANTS="${{ matrix.connector }} $(cat ${{ matrix.connector }}/VARIANTS 2>/dev/null || true)"
           echo ::set-output name=variants::${VARIANTS}
 
+      # Several steps below run `go test` on the runner instead of inside a Dockerfile, and
+      # without this they fetch the module graph and compile it cold. Gate on the same
+      # condition as the helper package test step.
+      - name: Set up Go with module and build caching
+        if: hashFiles(format('{0}/*.go', matrix.connector)) != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
       - name: Restore Flow binaries
         uses: ./.github/actions/restore-flow-binaries
 

--- a/go/capture/blackbox/capture.go
+++ b/go/capture/blackbox/capture.go
@@ -27,6 +27,13 @@ type Capture struct {
 	Checkpoint      json.RawMessage // Persistent checkpoint state between captures
 	DiscoveryFilter *regexp.Regexp  // Filter for discovered bindings (nil = no filtering)
 	Logger          func(...any)    // Log function (defaults to stderr, set to t.Log in tests)
+
+	// Env holds environment variables applied to each flowctl invocation, and so inherited
+	// by the connector process flowctl spawns. Settings which alter connector behavior have
+	// to live here rather than in the test process' own environment, because a test which
+	// mutated os.Environ() would alter the behavior of every other test running at the
+	// same time.
+	Env map[string]string
 }
 
 func New(baseYAML string) (*Capture, error) {
@@ -67,6 +74,7 @@ func New(baseYAML string) (*Capture, error) {
 		Catalog:    catalog,
 		Checkpoint: json.RawMessage(`{}`),
 		Logger:     defaultLogger,
+		Env:        make(map[string]string),
 	}, nil
 }
 
@@ -92,6 +100,9 @@ func (c *Capture) startFlowctl(ctx context.Context, args ...string) (*flowctlCmd
 	cmd := exec.CommandContext(ctx, "flowctl", append([]string{"--profile=testing"}, args...)...)
 	cmd.Dir = c.runRoot
 	cmd.Env = append(os.Environ(), "NO_COLOR=1", "LOG_FORMAT=json")
+	for name, value := range c.Env {
+		cmd.Env = append(cmd.Env, name+"="+value)
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/go/capture/blackbox/capture.go
+++ b/go/capture/blackbox/capture.go
@@ -418,6 +418,24 @@ func (c *Capture) RunWithContext(ctx context.Context, sessions int) ([]byte, err
 	return documents, nil
 }
 
+// SetLocalCommand replaces the command used to invoke local-endpoint captures in the
+// catalog. Tests use this to run a connector binary built once up front, rather than
+// having each of the hundreds of flowctl invocations in a suite re-link it via `go run`.
+func (c *Capture) SetLocalCommand(argv ...string) error {
+	for _, captureName := range gjson.GetBytes(c.Catalog, "captures.@keys").Array() {
+		var fullPath = `captures.` + captureName.String() + `.endpoint.local`
+		if !gjson.GetBytes(c.Catalog, fullPath).Exists() {
+			continue // Not a local endpoint, nothing to override
+		}
+		var result, err = sjson.SetBytes(c.Catalog, fullPath+`.command`, argv)
+		if err != nil {
+			return err
+		}
+		c.Catalog = result
+	}
+	return nil
+}
+
 // EditConfig modifies a property of the endpoint config(s) of all captures in the catalog.
 func (c *Capture) EditConfig(path string, val any) error {
 	for _, captureName := range gjson.GetBytes(c.Catalog, "captures.@keys").Array() {

--- a/go/capture/sqlserver/tests/basics.go
+++ b/go/capture/sqlserver/tests/basics.go
@@ -22,6 +22,7 @@ func TestBasics(t *testing.T, setup testSetupFunc) {
 
 // TestSimpleDiscovery exercises discovery of a single, simple table.
 func testSimpleDiscovery(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(a INTEGER PRIMARY KEY, b VARCHAR(2000), c REAL NOT NULL, d VARCHAR(255))`)
 	tc.DiscoverFull("Discover Tables")
@@ -30,6 +31,7 @@ func testSimpleDiscovery(t *testing.T, setup testSetupFunc) {
 
 // TestSimpleCapture exercises the simplest possible backfill of a small table.
 func testSimpleCapture(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
@@ -42,6 +44,7 @@ func testSimpleCapture(t *testing.T, setup testSetupFunc) {
 // initial table scan and the second capture will use replication to receive
 // additional inserts performed after the first capture.
 func testReplicationInserts(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
@@ -56,6 +59,7 @@ func testReplicationInserts(t *testing.T, setup testSetupFunc) {
 // initial table scan and the second capture will use replication to receive
 // additional inserts and row updates performed after the first capture.
 func testReplicationUpdates(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
@@ -72,6 +76,7 @@ func testReplicationUpdates(t *testing.T, setup testSetupFunc) {
 // initial table scan and the second capture will use replication to receive
 // additional inserts and deletions performed after the first capture.
 func testReplicationDeletes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
@@ -87,6 +92,7 @@ func testReplicationDeletes(t *testing.T, setup testSetupFunc) {
 // TestEmptyTable leaves the table empty during the initial table backfill
 // and only adds data after replication has begun.
 func testEmptyTable(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	tc.Discover("Discover Tables")
@@ -99,6 +105,7 @@ func testEmptyTable(t *testing.T, setup testSetupFunc) {
 // TestIgnoredStreams checks that replicated changes are only reported
 // for tables which are configured in the catalog.
 func testIgnoredStreams(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	db.CreateTable(t, `<NAME>_b`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -116,6 +123,7 @@ func testIgnoredStreams(t *testing.T, setup testSetupFunc) {
 // TestMultipleStreams exercises captures with multiple stream configured, as
 // well as adding/removing/re-adding a stream.
 func testMultipleStreams(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	db.CreateTable(t, `<NAME>_b`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -146,6 +154,7 @@ func testMultipleStreams(t *testing.T, setup testSetupFunc) {
 // TestMissingTable verifies that things fail cleanly if a capture
 // binding doesn't actually exist.
 func testMissingTable(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	db.CreateTable(t, `<NAME>_b`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -158,6 +167,7 @@ func testMissingTable(t *testing.T, setup testSetupFunc) {
 // TestPrimaryKeyOverride sets up a table with a primary key, but
 // then overrides that via the catalog configuration.
 func testPrimaryKeyOverride(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, name VARCHAR(32), value INTEGER)`)
 	// Names out of id order: charlie(1), alice(2), bob(3), dave(4)

--- a/go/capture/sqlserver/tests/capture.go
+++ b/go/capture/sqlserver/tests/capture.go
@@ -23,6 +23,7 @@ func TestCapture(t *testing.T, setup testSetupFunc) {
 }
 
 func testColumnNameQuoting(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `([id] INTEGER, [data] INTEGER, [CAPITALIZED] INTEGER, [unique] INTEGER, [type] INTEGER, PRIMARY KEY ([id], [data], [CAPITALIZED], [unique], [type]))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 0, 0, 0, 0), (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)`)
@@ -32,6 +33,7 @@ func testColumnNameQuoting(t *testing.T, setup testSetupFunc) {
 }
 
 func testTextCollation(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id VARCHAR(8) PRIMARY KEY, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES ('AAA', '1'), ('BBB', '2'), ('-J C', '3'), ('H R', '4')`)
@@ -43,6 +45,7 @@ func testTextCollation(t *testing.T, setup testSetupFunc) {
 // TestDiscoveryIrrelevantConstraints verifies that discovery works correctly
 // even when there are other non-primary-key constraints on a table.
 func testDiscoveryIrrelevantConstraints(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id VARCHAR(8) PRIMARY KEY, foo INTEGER UNIQUE, data TEXT)`)
 	tc.DiscoverFull("Discover Tables")
@@ -50,6 +53,7 @@ func testDiscoveryIrrelevantConstraints(t *testing.T, setup testSetupFunc) {
 }
 
 func testUUIDCaptureOrder(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id UNIQUEIDENTIFIER PRIMARY KEY, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES
@@ -79,6 +83,7 @@ func testManyTables(t *testing.T, setup testSetupFunc) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	t.Parallel()
 	var db, tc = setup(t)
 
 	// Create 20 tables
@@ -108,6 +113,7 @@ func testManyTables(t *testing.T, setup testSetupFunc) {
 }
 
 func testDeletedTextColumn(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, v_text TEXT NOT NULL, v_varchar VARCHAR(32), v_int INTEGER)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'zero', 'zero', 100), (1, 'one', 'one', 101)`)
@@ -121,6 +127,7 @@ func testDeletedTextColumn(t *testing.T, setup testSetupFunc) {
 }
 
 func testComputedColumn(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, a VARCHAR(32), b VARCHAR(32), computed AS ISNULL(a, ISNULL(b, 'default')))`)
 	tc.DiscoverFull("Discover Table Schema")
@@ -137,6 +144,13 @@ func testComputedColumn(t *testing.T, setup testSetupFunc) {
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
 
+// testDroppedAndRecreatedTable deliberately omits t.Parallel(). It asserts that a
+// recreated table's change history is still readable, which holds only while nothing else
+// is writing: under source-sqlserver-ct the change tracking version is database-wide, so a
+// concurrent writer advances it past the capture's saved cursor and the recreated table
+// reads as expired instead. source-sqlserver's CDC retention is per-capture-instance and
+// time-based, so it could parallelize this safely, but the suite takes the more
+// conservative of the two.
 func testDroppedAndRecreatedTable(t *testing.T, setup testSetupFunc) {
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -159,6 +173,7 @@ func testDroppedAndRecreatedTable(t *testing.T, setup testSetupFunc) {
 }
 
 func testPrimaryKeyUpdate(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'zero'), (1, 'one'), (2, 'two')`)
@@ -173,6 +188,7 @@ func testPrimaryKeyUpdate(t *testing.T, setup testSetupFunc) {
 }
 
 func testComputedPrimaryKey(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(actual_id INTEGER NOT NULL, data VARCHAR(32), id AS actual_id PRIMARY KEY)`)
 	tc.DiscoverFull("Discover Table Schema")
@@ -187,6 +203,7 @@ func testComputedPrimaryKey(t *testing.T, setup testSetupFunc) {
 
 // TestSourceTag verifies the output of a capture with /advanced/source_tag set
 func testSourceTag(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	require.NoError(t, tc.Capture.EditConfig("advanced.source_tag", "example_source_tag_1234"))

--- a/go/capture/sqlserver/tests/collation.go
+++ b/go/capture/sqlserver/tests/collation.go
@@ -16,6 +16,7 @@ func TestCollation(t *testing.T, setup testSetupFunc) {
 }
 
 func testVarcharKeyDiscovery(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id VARCHAR(32) PRIMARY KEY, data TEXT)`)
 	tc.DiscoverFull("Discover Tables")
@@ -37,6 +38,7 @@ func testCollatedCapture(t *testing.T, setup testSetupFunc) {
 
 	for _, columnType := range []string{"Char", "VarChar", "NChar", "NVarChar"} {
 		t.Run(columnType, func(t *testing.T) {
+			t.Parallel()
 			var db, tc = setup(t)
 			db.CreateTable(t, `<NAME>`, fmt.Sprintf(`(id %s(32) COLLATE SQL_Latin1_General_CP1_CI_AS PRIMARY KEY, data TEXT)`, columnType))
 			require.NoError(t, tc.Capture.EditConfig("advanced.backfill_chunk_size", 1))
@@ -59,6 +61,7 @@ func testCollatedCapture(t *testing.T, setup testSetupFunc) {
 // TestCaptureWithCompoundTextAndIntegerKey verifies that a table with a
 // compound primary key which mixes text and integers still works.
 func testCaptureWithCompoundTextAndIntegerKey(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(k1 VARCHAR(32), k2 INTEGER, k3 VARCHAR(8), k4 INTEGER, data TEXT, PRIMARY KEY (k1, k2, k3, k4))`)
 	require.NoError(t, tc.Capture.EditConfig("advanced.backfill_chunk_size", 1))

--- a/go/capture/sqlserver/tests/datatypes.go
+++ b/go/capture/sqlserver/tests/datatypes.go
@@ -31,6 +31,7 @@ func TestDatatypes(t *testing.T, setup testSetupFunc) {
 
 // TestIntegerTypes exercises integer column types.
 func testIntegerTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -55,6 +56,7 @@ func testIntegerTypes(t *testing.T, setup testSetupFunc) {
 
 // TestDecimalTypes exercises decimal and money column types.
 func testDecimalTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -79,6 +81,7 @@ func testDecimalTypes(t *testing.T, setup testSetupFunc) {
 
 // TestFloatingPointTypes exercises float and real column types.
 func testFloatingPointTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -102,6 +105,7 @@ func testFloatingPointTypes(t *testing.T, setup testSetupFunc) {
 
 // TestBooleanTypes exercises the bit column type.
 func testBooleanTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -123,6 +127,7 @@ func testBooleanTypes(t *testing.T, setup testSetupFunc) {
 
 // TestStringTypes exercises character and text column types.
 func testStringTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -149,6 +154,7 @@ func testStringTypes(t *testing.T, setup testSetupFunc) {
 
 // TestBinaryTypes exercises binary column types.
 func testBinaryTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -171,6 +177,7 @@ func testBinaryTypes(t *testing.T, setup testSetupFunc) {
 
 // TestTemporalTypes exercises date and time column types.
 func testTemporalTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	// Set timezone to America/Chicago to match the old test behavior
 	require.NoError(t, tc.Capture.EditConfig("timezone", "America/Chicago"))
@@ -199,6 +206,7 @@ func testTemporalTypes(t *testing.T, setup testSetupFunc) {
 
 // TestMiscTypes exercises uniqueidentifier, xml, and hierarchyid column types.
 func testMiscTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -222,6 +230,7 @@ func testMiscTypes(t *testing.T, setup testSetupFunc) {
 
 // TestNotNullTypes exercises NOT NULL variants of various types to verify schema generation.
 func testNotNullTypes(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(
 		id INTEGER PRIMARY KEY,
@@ -314,6 +323,7 @@ func testScanKeyTypes(t *testing.T, setup testSetupFunc) {
 		}},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
 			var db, tc = setup(t)
 			db.CreateTable(t, `<NAME>`, fmt.Sprintf(`(k %s PRIMARY KEY, v TEXT)`, testCase.ColumnType))
 			db.Exec(t, `INSERT INTO <NAME> VALUES `+strings.Join(testCase.Values, ", "))
@@ -327,6 +337,7 @@ func testScanKeyTypes(t *testing.T, setup testSetupFunc) {
 }
 
 func testCompositeScanKey(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(k SMALLDATETIME, k2 INTEGER, v TEXT, PRIMARY KEY (k, k2))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES
@@ -356,6 +367,7 @@ func testOversizedFields(t *testing.T, setup testSetupFunc) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, v_text TEXT, v_varchar VARCHAR(max), v_binary VARBINARY(max), v_xml XML)`)
 
@@ -378,6 +390,7 @@ func testOversizedFields(t *testing.T, setup testSetupFunc) {
 
 // TestBitNotNullDeletion exercises deletions from a table with BIT NOT NULL columns.
 func testBitNotNullDeletion(t *testing.T, setup testSetupFunc) {
+	t.Parallel()
 	var db, tc = setup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, v_a BIT, v_b BIT NOT NULL, v_c BIT NOT NULL DEFAULT 0, v_d BIT NOT NULL DEFAULT 1)`)
 
@@ -400,6 +413,7 @@ func testBitNotNullDeletion(t *testing.T, setup testSetupFunc) {
 func testRowversionTypes(t *testing.T, setup testSetupFunc) {
 	for _, columnType := range []string{"timestamp", "rowversion"} {
 		t.Run(columnType, func(t *testing.T) {
+			t.Parallel()
 			var db, tc = setup(t)
 			db.CreateTable(t, `<NAME>`, fmt.Sprintf(`(id INTEGER PRIMARY KEY, data VARCHAR(32), rv %s)`, columnType))
 

--- a/source-sqlserver-ct/capture_test.go
+++ b/source-sqlserver-ct/capture_test.go
@@ -13,6 +13,7 @@ import (
 // interesting because the LEFT OUTER JOIN with the source table produces NULLs
 // for non-key columns when the row no longer exists.
 func TestNullHandling(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(32))`)
 
@@ -33,6 +34,7 @@ func TestNullHandling(t *testing.T) {
 }
 
 func TestChangeTrackingDisabled(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'zero'), (1, 'one'), (2, 'two')`)
@@ -51,6 +53,7 @@ func TestChangeTrackingDisabled(t *testing.T) {
 // TestBackfillWithoutKey sets up a table with a primary key but configures
 // the binding to use the "Without Primary Key" backfill mode.
 func TestBackfillWithoutKey(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (0, 'A'), (1, 'bbb'), (2, 'CDEFGH')`)
@@ -65,6 +68,7 @@ func TestBackfillWithoutKey(t *testing.T) {
 // TestDiscoverOnlyEnabled tests discovery table filtering when only CT-enabled tables should be discovered.
 func TestDiscoverOnlyEnabled(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create three tables, one (table B) without change tracking
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -76,6 +80,7 @@ func TestDiscoverOnlyEnabled(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("DiscoverWithoutCT", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create three tables, one (table B) without change tracking
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -90,6 +95,7 @@ func TestDiscoverOnlyEnabled(t *testing.T) {
 }
 
 func TestKeylessDiscovery(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTableWithoutCT(t, `<NAME>`, `(a INTEGER, b VARCHAR(2000), c REAL NOT NULL, d VARCHAR(255))`)
 	tc.DiscoverFull("Discover Tables")

--- a/source-sqlserver-ct/collation_test.go
+++ b/source-sqlserver-ct/collation_test.go
@@ -44,6 +44,7 @@ func TestColumnCollations(t *testing.T) {
 	} {
 		var subtestName = fmt.Sprintf("%s_%s", tc.ColumnType, tc.CollationName)
 		t.Run(subtestName, func(t *testing.T) {
+			t.Parallel()
 			var db, _ = blackboxTestSetup(t)
 			var ctx = context.Background()
 			db.CreateTable(t, `<NAME>`, fmt.Sprintf(`(id %s(32) COLLATE %s PRIMARY KEY, data TEXT)`, tc.ColumnType, tc.CollationName))

--- a/source-sqlserver-ct/discovery_test.go
+++ b/source-sqlserver-ct/discovery_test.go
@@ -10,12 +10,14 @@ import (
 
 func TestSchemaWhitelist(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		tc.Discover("Discover Tables")
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("IncludeMatching", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{*testSchemaName}))
@@ -23,6 +25,7 @@ func TestSchemaWhitelist(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("IncludeNonmatching", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{"nonexistent_schema"}))
@@ -30,6 +33,7 @@ func TestSchemaWhitelist(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("Excluded", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.exclude_schemas", []string{*testSchemaName}))
@@ -40,6 +44,7 @@ func TestSchemaWhitelist(t *testing.T) {
 
 func TestTablePatterns(t *testing.T) {
 	var runSubcase = func(t *testing.T, patterns []string) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		var id = uniqueTableID(t)
 		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_alpha_evt", *testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)

--- a/source-sqlserver-ct/main_test.go
+++ b/source-sqlserver-ct/main_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -45,7 +46,36 @@ func TestMain(m *testing.M) {
 	// Set a 900MiB memory limit, same as we use in production.
 	debug.SetMemoryLimit(900 * 1024 * 1024)
 
-	os.Exit(m.Run())
+	os.Exit(runTests(m))
+}
+
+// connectorBinary is the path to the connector built by runTests, which every capture in
+// this package is pointed at. Empty when tests are skipped for lack of a database.
+var connectorBinary string
+
+// runTests builds the connector once and runs the suite against that binary. Each test
+// performs many flowctl invocations and each one spawns the connector, so building here
+// avoids paying `go run`'s link step hundreds of times over.
+//
+// Split out from TestMain because os.Exit would skip deferred cleanup of the build.
+func runTests(m *testing.M) int {
+	if os.Getenv("TEST_DATABASE") == "yes" {
+		buildDir, err := os.MkdirTemp("", "source-sqlserver-ct-build-*")
+		if err != nil {
+			log.WithField("err", err).Error("error creating build directory")
+			return 1
+		}
+		defer os.RemoveAll(buildDir)
+
+		connectorBinary = buildDir + "/connector"
+		var build = exec.Command("go", "build", "-o", connectorBinary, ".")
+		build.Stderr = os.Stderr
+		if err := build.Run(); err != nil {
+			log.WithField("err", err).Error("error building connector for tests")
+			return 1
+		}
+	}
+	return m.Run()
 }
 
 var documentSanitizers = []blackbox.JSONSanitizer{
@@ -79,6 +109,7 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	tc.Capture.Logger = t.Log
 	tc.Capture.DiscoveryFilter = regexp.MustCompile(uniqueID)
 	tc.Capture.Env["SHUTDOWN_AFTER_POLLING"] = "yes"
+	require.NoError(t, tc.Capture.SetLocalCommand(connectorBinary))
 	tc.DocumentSanitizers = documentSanitizers
 	tc.CheckpointSanitizers = checkpointSanitizers
 

--- a/source-sqlserver-ct/main_test.go
+++ b/source-sqlserver-ct/main_test.go
@@ -90,6 +90,15 @@ var checkpointSanitizers = []blackbox.JSONSanitizer{
 	{Matcher: regexp.MustCompile(`"cursor":{[^}]*}`), Replacement: `"cursor":"REDACTED"`},
 }
 
+// blackboxTestSetup prepares an isolated capture for a test. Isolation comes from the
+// table names and discovery filter both deriving from the test's own name, so tests
+// neither collide on tables nor observe each other's, which is what lets a test declare
+// itself parallel by calling t.Parallel().
+//
+// The minority of tests which alter database-wide state, such as role membership or
+// server configuration, must not overlap with anything else and so omit that call. Go
+// defers every parallel test until the sequential ones have finished, so these get the
+// database to themselves.
 func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.TranscriptCapture) {
 	t.Helper()
 
@@ -278,6 +287,7 @@ func uniqueTableID(t testing.TB, extra ...string) string {
 
 // TestSpec verifies the connector's spec output against a snapshot.
 func TestSpec(t *testing.T) {
+	t.Parallel()
 	var _, tc = blackboxTestSetup(t)
 	tc.Spec("Get Connector Spec")
 	cupaloy.SnapshotT(t, tc.Transcript.String())

--- a/source-sqlserver-ct/main_test.go
+++ b/source-sqlserver-ct/main_test.go
@@ -124,8 +124,17 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 		Database: *dbName,
 	}).ToURI()
 	t.Logf("opening control connection: addr=%q, user=%q", *dbControlAddress, *dbControlUser)
-	conn, err := sql.Open("sqlserver", controlURI)
+	connector, err := mssqldb.NewConnector(controlURI)
 	require.NoError(t, err)
+
+	// Lose deadlocks deliberately. Tests run concurrently, so one test setting up its
+	// tables can deadlock against another test's capture reading that same metadata. The
+	// connector under test does not retry those reads, and should not have to for the sake
+	// of our test harness, whereas this control connection retries cheaply. Volunteering as
+	// the victim keeps the contention on the side which can recover from it.
+	connector.SessionInitSQL = "SET DEADLOCK_PRIORITY LOW"
+
+	var conn = sql.OpenDB(connector)
 	t.Cleanup(func() { conn.Close() })
 
 	// Setup: Create database interface with <NAME> templating
@@ -161,17 +170,13 @@ func (db *sqlserverTestDatabase) Exec(t testing.TB, query string) {
 	if db.transcript != nil {
 		fmt.Fprintf(db.transcript, "sql> %s\n", query)
 	}
-	if _, err := db.conn.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("error executing control query %q: %v", query, err)
-	}
+	db.execWithDeadlockRetry(t, query)
 }
 
 func (db *sqlserverTestDatabase) QuietExec(t testing.TB, query string) {
 	t.Helper()
 	query = db.Expand(query)
-	if _, err := db.conn.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("error executing control query %q: %v", query, err)
-	}
+	db.execWithDeadlockRetry(t, query)
 }
 
 // sqlserverDeadlockVictim is the error number SQL Server reports to the session it kills

--- a/source-sqlserver-ct/main_test.go
+++ b/source-sqlserver-ct/main_test.go
@@ -65,10 +65,6 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 		return nil, nil
 	}
 
-	// TODO(wgd): Probably scoping this to just flowctl invocations would be cleaner, but this works
-	os.Setenv("SHUTDOWN_AFTER_POLLING", "yes")
-	t.Cleanup(func() { os.Unsetenv("SHUTDOWN_AFTER_POLLING") })
-
 	// Setup: Unique filter ID and full table name
 	var uniqueID = uniqueTableID(t)
 	var baseName = strings.TrimPrefix(t.Name(), "Test") + "_" + uniqueID
@@ -82,6 +78,7 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	require.NoError(t, err)
 	tc.Capture.Logger = t.Log
 	tc.Capture.DiscoveryFilter = regexp.MustCompile(uniqueID)
+	tc.Capture.Env["SHUTDOWN_AFTER_POLLING"] = "yes"
 	tc.DocumentSanitizers = documentSanitizers
 	tc.CheckpointSanitizers = checkpointSanitizers
 

--- a/source-sqlserver-ct/main_test.go
+++ b/source-sqlserver-ct/main_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -13,10 +14,12 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
 	"github.com/estuary/connectors/go/capture/blackbox"
 	"github.com/estuary/connectors/go/capture/sqlserver/tests"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -171,6 +174,51 @@ func (db *sqlserverTestDatabase) QuietExec(t testing.TB, query string) {
 	}
 }
 
+// sqlserverDeadlockVictim is the error number SQL Server reports to the session it kills
+// to break a deadlock. The victim's work is rolled back, so it just tries again.
+const sqlserverDeadlockVictim = 1205
+
+const (
+	maxDeadlockRetries = 10
+	deadlockRetryDelay = 250 * time.Millisecond
+)
+
+// isDeadlockError reports whether err is, or merely reports, SQL Server's deadlock-victim
+// error. The error number alone is not enough, because the stored procedures which
+// manipulate change tracking metadata catch a deadlock hit during their own work and
+// re-raise it under their own error number, quoting the original 1205 in the message.
+func isDeadlockError(err error) bool {
+	var mssqlErr mssqldb.Error
+	if errors.As(err, &mssqlErr) && mssqlErr.Number == sqlserverDeadlockVictim {
+		return true
+	}
+	return strings.Contains(err.Error(), "was deadlocked on lock resources")
+}
+
+// execWithDeadlockRetry executes a control query, retrying if this session is chosen as
+// the victim of a deadlock. Any other failure is fatal to the test.
+//
+// Retrying is safe even for statements which aren't idempotent, such as INSERT, because
+// being chosen as the deadlock victim rolls the statement back in its entirety.
+func (db *sqlserverTestDatabase) execWithDeadlockRetry(t testing.TB, query string) {
+	t.Helper()
+	for attempt := 1; ; attempt++ {
+		var _, err = db.conn.ExecContext(context.Background(), query)
+		if err == nil {
+			return
+		}
+		if !isDeadlockError(err) {
+			t.Fatalf("error executing control query %q: %v", query, err)
+		}
+		if attempt >= maxDeadlockRetries {
+			t.Fatalf("error executing control query %q: still deadlocking after %d attempts: %v", query, attempt, err)
+		}
+		// Back off proportionally to the attempt so that a pile-up of contending tests
+		// spreads out rather than retrying in lockstep.
+		time.Sleep(time.Duration(attempt) * deadlockRetryDelay)
+	}
+}
+
 // QueryRow executes a query and scans results into dest. Does not log to transcript.
 func (db *sqlserverTestDatabase) QueryRow(t testing.TB, query string, dest ...any) {
 	t.Helper()
@@ -188,11 +236,18 @@ func (db *sqlserverTestDatabase) CreateTable(t testing.TB, name, defs string) {
 	db.QuietExec(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName)
 	db.Exec(t, `CREATE TABLE `+tableName+` `+defs)
 
-	// Enable Change Tracking for the table
-	var ctQuery = fmt.Sprintf(`ALTER TABLE %s ENABLE CHANGE_TRACKING`, tableName)
-	db.QuietExec(t, ctQuery)
+	// Enable Change Tracking for the table. Guarded so that it stays idempotent under the
+	// deadlock retry, which can run after an attempt already took effect.
+	var ctQuery = fmt.Sprintf(
+		`IF NOT EXISTS (SELECT 1 FROM sys.change_tracking_tables WHERE object_id = OBJECT_ID('%s')) ALTER TABLE %s ENABLE CHANGE_TRACKING`,
+		tableName, tableName)
+	db.execWithDeadlockRetry(t, ctQuery)
 
-	t.Cleanup(func() { db.QuietExec(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName) })
+	// Dropping a change-tracked table implicitly disables change tracking for it, so this
+	// contends for the same metadata as enabling does.
+	t.Cleanup(func() {
+		db.execWithDeadlockRetry(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName)
+	})
 }
 
 // CreateTableWithoutCT creates a table without enabling Change Tracking, for tests that need manual control.

--- a/source-sqlserver-ct/prerequisites_test.go
+++ b/source-sqlserver-ct/prerequisites_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestPrerequisites(t *testing.T) {
 	t.Run("validateExistingTables", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create tables A and B - both exist and can be validated
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -19,6 +20,7 @@ func TestPrerequisites(t *testing.T) {
 	})
 
 	t.Run("captureMissingTable", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create tables A and B, but drop B after discovery
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)

--- a/source-sqlserver/capture_test.go
+++ b/source-sqlserver/capture_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -48,7 +47,7 @@ func TestCaptureInstanceCleanup(t *testing.T) {
 			tc.Run("Initial Backfill", -1)
 
 			// For the ongoing capture, we need to disable SHUTDOWN_AFTER_POLLING
-			os.Unsetenv("SHUTDOWN_AFTER_POLLING")
+			delete(tc.Capture.Env, "SHUTDOWN_AFTER_POLLING")
 
 			// Launch the ongoing capture in a background goroutine
 			var captureCtx, cancelCapture = context.WithCancel(context.Background())

--- a/source-sqlserver/capture_test.go
+++ b/source-sqlserver/capture_test.go
@@ -31,6 +31,9 @@ func TestCaptureInstanceCleanup(t *testing.T) {
 		{"WithoutDBO", false},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
+			// Serial: this test grants flow_capture the database-wide db_owner role, which
+			// would change what any concurrently-running capture is permitted to do, and
+			// the two cases here deliberately disagree about whether it is granted.
 			var db, tc = blackboxTestSetup(t)
 
 			db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -107,6 +110,8 @@ func TestAlterationAddColumn(t *testing.T) {
 		{"Automatic", false, true},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
+			// Serial: grants flow_capture the database-wide db_owner role, which would
+			// change what any concurrently-running capture is permitted to do.
 			var db, tc = blackboxTestSetup(t)
 
 			// Grant db_owner role required for capture instance automation
@@ -184,6 +189,8 @@ func TestAlterationAddColumn(t *testing.T) {
 }
 
 func TestFilegroupAndRole(t *testing.T) {
+	// Serial: grants flow_capture the database-wide db_owner role, which would change
+	// what any concurrently-running capture is permitted to do.
 	var db, tc = blackboxTestSetup(t)
 
 	// Create table without CDC (connector will create CDC instance with specified config)
@@ -215,6 +222,7 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 		{"Disabled", "no_emit_sourced_schemas"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			var db, tc = blackboxTestSetup(t)
 			db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data VARCHAR(32))`)
 			db.Exec(t, `INSERT INTO <NAME> VALUES (1, 'hello'), (2, 'world')`)
@@ -230,6 +238,7 @@ func TestFeatureFlagEmitSourcedSchemas(t *testing.T) {
 
 func TestSecondaryIndexDiscovery(t *testing.T) {
 	t.Run("pk_and_index", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(k1 INTEGER PRIMARY KEY, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)`)
 		db.Exec(t, `CREATE UNIQUE INDEX UX_<ID>_k23 ON <NAME> (k2, k3)`)
@@ -237,6 +246,7 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("index_only", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)`)
 		db.Exec(t, `CREATE UNIQUE INDEX UX_<ID>_k23 ON <NAME> (k2, k3)`)
@@ -244,6 +254,7 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("nullable_index", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(k1 INTEGER, k2 INTEGER, k3 INTEGER, data TEXT)`)
 		db.Exec(t, `CREATE UNIQUE INDEX UX_<ID>_k23 ON <NAME> (k2, k3)`)
@@ -251,6 +262,7 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("nonunique_index", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)`)
 		db.Exec(t, `CREATE INDEX UX_<ID>_k23 ON <NAME> (k2, k3)`)
@@ -258,6 +270,7 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("nothing", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)`)
 		tc.DiscoverFull("Discover Tables")
@@ -268,6 +281,7 @@ func TestSecondaryIndexDiscovery(t *testing.T) {
 // TestIndexIncludedDiscovery tests discovery when a secondary unique index contains
 // some included non-key columns.
 func TestIndexIncludedDiscovery(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(k1 INTEGER, k2 INTEGER NOT NULL, k3 INTEGER NOT NULL, data TEXT)`)
 	db.Exec(t, `CREATE UNIQUE INDEX UX_<ID>_k23 ON <NAME> (k2, k3) INCLUDE (k1)`)
@@ -278,6 +292,7 @@ func TestIndexIncludedDiscovery(t *testing.T) {
 // TestDiscoverOnlyEnabled tests discovery table filtering when only CDC-enabled tables should be discovered.
 func TestDiscoverOnlyEnabled(t *testing.T) {
 	t.Run("Disabled", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create three tables
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -294,6 +309,7 @@ func TestDiscoverOnlyEnabled(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("Enabled", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create three tables
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -316,6 +332,7 @@ func TestDiscoverOnlyEnabled(t *testing.T) {
 // the collection key shouldn't impact correctness of the capture even if multiple
 // rows have the same collection key value.
 func TestDuplicatedScanKey(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id VARCHAR(8), data VARCHAR(2000))`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES ('AAA', '1'), ('BBB', '2'), ('BBB', '3'), ('CCC', '4')`)
@@ -327,6 +344,7 @@ func TestDuplicatedScanKey(t *testing.T) {
 }
 
 func TestReplicationOnly(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four')`)
@@ -340,6 +358,7 @@ func TestReplicationOnly(t *testing.T) {
 }
 
 func TestKeylessDiscovery(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(a INTEGER, b VARCHAR(2000), c REAL NOT NULL, d VARCHAR(255))`)
 	tc.DiscoverFull("Discover Tables")
@@ -347,6 +366,7 @@ func TestKeylessDiscovery(t *testing.T) {
 }
 
 func TestKeylessCapture(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER, data TEXT)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (1, 'one'), (2, 'two')`)
@@ -361,6 +381,7 @@ func TestKeylessCapture(t *testing.T) {
 // TestCatalogPrimaryKey sets up a table with no primary key in the database
 // and instead specifies one in the catalog configuration.
 func TestCatalogPrimaryKey(t *testing.T) {
+	t.Parallel()
 	var db, tc = blackboxTestSetup(t)
 	db.CreateTable(t, `<NAME>`, `(id INTEGER, name TEXT, value INTEGER)`)
 	db.Exec(t, `INSERT INTO <NAME> VALUES (1, 'alice', 100), (2, 'bob', 200)`)

--- a/source-sqlserver/collation_test.go
+++ b/source-sqlserver/collation_test.go
@@ -44,6 +44,7 @@ func TestColumnCollations(t *testing.T) {
 	} {
 		var subtestName = fmt.Sprintf("%s_%s", tc.ColumnType, tc.CollationName)
 		t.Run(subtestName, func(t *testing.T) {
+			t.Parallel()
 			var db, _ = blackboxTestSetup(t)
 			var ctx = context.Background()
 			db.CreateTable(t, `<NAME>`, fmt.Sprintf(`(id %s(32) COLLATE %s PRIMARY KEY, data TEXT)`, tc.ColumnType, tc.CollationName))

--- a/source-sqlserver/discovery_test.go
+++ b/source-sqlserver/discovery_test.go
@@ -10,12 +10,14 @@ import (
 
 func TestSchemaWhitelist(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		tc.Discover("Discover Tables")
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("IncludeMatching", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{*testSchemaName}))
@@ -23,6 +25,7 @@ func TestSchemaWhitelist(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("IncludeNonmatching", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.include_schemas", []string{"nonexistent_schema"}))
@@ -30,6 +33,7 @@ func TestSchemaWhitelist(t *testing.T) {
 		cupaloy.SnapshotT(t, tc.Transcript.String())
 	})
 	t.Run("Excluded", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
 		require.NoError(t, tc.Capture.EditConfig("discoveryFilters.exclude_schemas", []string{*testSchemaName}))
@@ -40,6 +44,7 @@ func TestSchemaWhitelist(t *testing.T) {
 
 func TestTablePatterns(t *testing.T) {
 	var runSubcase = func(t *testing.T, patterns []string) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		var id = uniqueTableID(t)
 		db.CreateTable(t, fmt.Sprintf("%s.tp_%s_alpha_evt", *testSchemaName, id), `(id INTEGER PRIMARY KEY, data TEXT)`)

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -126,8 +127,17 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 		Database: *dbName,
 	}).ToURI()
 	t.Logf("opening control connection: addr=%q, user=%q", *dbControlAddress, *dbControlUser)
-	conn, err := sql.Open("sqlserver", controlURI)
+	connector, err := mssqldb.NewConnector(controlURI)
 	require.NoError(t, err)
+
+	// Lose deadlocks deliberately. Tests run concurrently, so one test setting up its
+	// tables can deadlock against another test's capture reading that same metadata. The
+	// connector under test does not retry those reads, and should not have to for the sake
+	// of our test harness, whereas this control connection retries cheaply. Volunteering as
+	// the victim keeps the contention on the side which can recover from it.
+	connector.SessionInitSQL = "SET DEADLOCK_PRIORITY LOW"
+
+	var conn = sql.OpenDB(connector)
 	t.Cleanup(func() { conn.Close() })
 
 	// Setup: Create database interface with <NAME> templating
@@ -163,17 +173,13 @@ func (db *sqlserverTestDatabase) Exec(t testing.TB, query string) {
 	if db.transcript != nil {
 		fmt.Fprintf(db.transcript, "sql> %s\n", query)
 	}
-	if _, err := db.conn.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("error executing control query %q: %v", query, err)
-	}
+	db.execWithDeadlockRetry(t, query)
 }
 
 func (db *sqlserverTestDatabase) QuietExec(t testing.TB, query string) {
 	t.Helper()
 	query = db.Expand(query)
-	if _, err := db.conn.ExecContext(context.Background(), query); err != nil {
-		t.Fatalf("error executing control query %q: %v", query, err)
-	}
+	db.execWithDeadlockRetry(t, query)
 }
 
 // sqlserverDeadlockVictim is the error number SQL Server reports to the session it kills
@@ -223,6 +229,13 @@ func (db *sqlserverTestDatabase) execWithDeadlockRetry(t testing.TB, query strin
 	}
 }
 
+// cdcMetadataLock serializes the operations which mutate CDC metadata. SQL Server already
+// serializes these internally, via an exclusive applock held against the 'cdc' principal,
+// so performing them concurrently gains nothing: it only converts the wait into deadlocks
+// and lock starvation which retrying does not reliably clear. Tests still run in parallel,
+// they just queue for this one step.
+var cdcMetadataLock sync.Mutex
+
 // sqlserverCaptureInstanceExists is reported when sp_cdc_enable_table is asked to create a
 // capture instance which already exists. That is the state a partially-failed earlier
 // attempt leaves behind: the capture instance gets created but the table is not marked as
@@ -246,6 +259,9 @@ func isCaptureInstanceExistsError(err error) bool {
 // behind before trying again.
 func (db *sqlserverTestDatabase) enableCDC(t testing.TB, schema, name string) {
 	t.Helper()
+	cdcMetadataLock.Lock()
+	defer cdcMetadataLock.Unlock()
+
 	var enable = fmt.Sprintf(`EXEC sys.sp_cdc_enable_table @source_schema = '%s', @source_name = '%s', @role_name = '%s'`,
 		schema, name, *dbCaptureUser)
 	for attempt := 1; ; attempt++ {
@@ -308,8 +324,10 @@ func (db *sqlserverTestDatabase) CreateTable(t testing.TB, name, defs string) {
 	db.enableCDC(t, schema, shortName)
 
 	// Dropping a CDC-enabled table implicitly disables CDC for it, so this contends for
-	// the same metadata as enabling does.
+	// the same metadata as enabling does and takes the same lock.
 	t.Cleanup(func() {
+		cdcMetadataLock.Lock()
+		defer cdcMetadataLock.Unlock()
 		db.execWithDeadlockRetry(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName)
 	})
 }

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/bradleyjkemp/cupaloy"
 	"github.com/estuary/connectors/go/capture/blackbox"
 	"github.com/estuary/connectors/go/capture/sqlserver/tests"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +176,109 @@ func (db *sqlserverTestDatabase) QuietExec(t testing.TB, query string) {
 	}
 }
 
+// sqlserverDeadlockVictim is the error number SQL Server reports to the session it kills
+// to break a deadlock. The victim's work is rolled back, so it just tries again.
+const sqlserverDeadlockVictim = 1205
+
+const (
+	maxDeadlockRetries = 10
+	deadlockRetryDelay = 250 * time.Millisecond
+)
+
+// isDeadlockError reports whether err is, or merely reports, SQL Server's deadlock-victim
+// error. The error number alone is not enough: sp_cdc_enable_table catches a deadlock hit
+// during its own work and re-raises it as error 22834, quoting the original 1205 only in
+// the message text.
+func isDeadlockError(err error) bool {
+	var mssqlErr mssqldb.Error
+	if errors.As(err, &mssqlErr) && mssqlErr.Number == sqlserverDeadlockVictim {
+		return true
+	}
+	return strings.Contains(err.Error(), "was deadlocked on lock resources")
+}
+
+// execWithDeadlockRetry executes a control query, retrying if this session is chosen as
+// the victim of a deadlock. Any other failure is fatal to the test.
+//
+// Retrying is safe even for statements which aren't idempotent, such as INSERT, because
+// being chosen as the deadlock victim rolls the statement back in its entirety. The
+// exception is a stored procedure which catches the deadlock internally and returns its own
+// error after leaving work behind, which is why enableCDC needs its own retry.
+func (db *sqlserverTestDatabase) execWithDeadlockRetry(t testing.TB, query string) {
+	t.Helper()
+	for attempt := 1; ; attempt++ {
+		var _, err = db.conn.ExecContext(context.Background(), query)
+		if err == nil {
+			return
+		}
+		if !isDeadlockError(err) {
+			t.Fatalf("error executing control query %q: %v", query, err)
+		}
+		if attempt >= maxDeadlockRetries {
+			t.Fatalf("error executing control query %q: still deadlocking after %d attempts: %v", query, attempt, err)
+		}
+		// Back off proportionally to the attempt so that a pile-up of contending tests
+		// spreads out rather than retrying in lockstep.
+		time.Sleep(time.Duration(attempt) * deadlockRetryDelay)
+	}
+}
+
+// sqlserverCaptureInstanceExists is reported when sp_cdc_enable_table is asked to create a
+// capture instance which already exists. That is the state a partially-failed earlier
+// attempt leaves behind: the capture instance gets created but the table is not marked as
+// tracked, so the operation half-happened.
+const sqlserverCaptureInstanceExists = 22926
+
+func isCaptureInstanceExistsError(err error) bool {
+	var mssqlErr mssqldb.Error
+	if errors.As(err, &mssqlErr) && mssqlErr.Number == sqlserverCaptureInstanceExists {
+		return true
+	}
+	return strings.Contains(err.Error(), "already exists in the current database")
+}
+
+// enableCDC turns on CDC for a table. Enabling CDC, and dropping a table which has it
+// enabled, both take locks on the shared CDC metadata tables, so tests doing either
+// concurrently can deadlock.
+//
+// This needs its own retry rather than execWithDeadlockRetry because sp_cdc_enable_table
+// is not idempotent, so each retry has to clear the partial state a failed attempt leaves
+// behind before trying again.
+func (db *sqlserverTestDatabase) enableCDC(t testing.TB, schema, name string) {
+	t.Helper()
+	var enable = fmt.Sprintf(`EXEC sys.sp_cdc_enable_table @source_schema = '%s', @source_name = '%s', @role_name = '%s'`,
+		schema, name, *dbCaptureUser)
+	for attempt := 1; ; attempt++ {
+		var _, err = db.conn.ExecContext(context.Background(), enable)
+		if err == nil {
+			return
+		}
+		if !isDeadlockError(err) && !isCaptureInstanceExistsError(err) {
+			t.Fatalf("error enabling CDC for %s.%s: %v", schema, name, err)
+		}
+		if attempt >= maxDeadlockRetries {
+			t.Fatalf("error enabling CDC for %s.%s: giving up after %d attempts: %v", schema, name, attempt, err)
+		}
+		time.Sleep(time.Duration(attempt) * deadlockRetryDelay)
+		db.dropCaptureInstances(t, schema, name)
+	}
+}
+
+// dropCaptureInstances removes any capture instances for a table, tolerating there being
+// none. This clears the leftovers of a partially-failed sp_cdc_enable_table so that the
+// next attempt starts from a clean slate.
+func (db *sqlserverTestDatabase) dropCaptureInstances(t testing.TB, schema, name string) {
+	t.Helper()
+	var query = fmt.Sprintf(`IF EXISTS (SELECT 1 FROM cdc.change_tables WHERE source_object_id = OBJECT_ID('%s.%s')) `+
+		`EXEC sys.sp_cdc_disable_table @source_schema = '%s', @source_name = '%s', @capture_instance = 'all'`,
+		schema, name, schema, name)
+	if _, err := db.conn.ExecContext(context.Background(), query); err != nil {
+		// Not fatal: the following enable attempt will report the real problem if this
+		// left the table in a state it can't recover from.
+		t.Logf("error clearing capture instances for %s.%s before retry: %v", schema, name, err)
+	}
+}
+
 // QueryRow executes a query and scans results into dest. Does not log to transcript.
 func (db *sqlserverTestDatabase) QueryRow(t testing.TB, query string, dest ...any) {
 	t.Helper()
@@ -200,12 +305,13 @@ func (db *sqlserverTestDatabase) CreateTable(t testing.TB, name, defs string) {
 	db.Exec(t, `CREATE TABLE `+tableName+` `+defs)
 
 	// Enable CDC for the table
-	time.Sleep(1 * time.Second) // Sleep to make deadlocks less likely
-	var cdcQuery = fmt.Sprintf(`EXEC sys.sp_cdc_enable_table @source_schema = '%s', @source_name = '%s', @role_name = '%s'`,
-		schema, shortName, *dbCaptureUser)
-	db.QuietExec(t, cdcQuery)
+	db.enableCDC(t, schema, shortName)
 
-	t.Cleanup(func() { db.QuietExec(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName) })
+	// Dropping a CDC-enabled table implicitly disables CDC for it, so this contends for
+	// the same metadata as enabling does.
+	t.Cleanup(func() {
+		db.execWithDeadlockRetry(t, `IF OBJECT_ID('`+tableName+`', 'U') IS NOT NULL DROP TABLE `+tableName)
+	})
 }
 
 // CreateTableWithoutCDC creates a table without enabling CDC, for tests that need manual control.

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -93,6 +93,15 @@ var checkpointSanitizers = []blackbox.JSONSanitizer{
 	{Matcher: regexp.MustCompile(`"seqval":"[0-9A-Za-z+/=]+"`), Replacement: `"seqval":"REDACTED"`},
 }
 
+// blackboxTestSetup prepares an isolated capture for a test. Isolation comes from the
+// table names and discovery filter both deriving from the test's own name, so tests
+// neither collide on tables nor observe each other's, which is what lets a test declare
+// itself parallel by calling t.Parallel().
+//
+// The minority of tests which alter database-wide state, such as role membership or
+// server configuration, must not overlap with anything else and so omit that call. Go
+// defers every parallel test until the sequential ones have finished, so these get the
+// database to themselves.
 func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.TranscriptCapture) {
 	t.Helper()
 
@@ -355,6 +364,7 @@ func uniqueTableID(t testing.TB, extra ...string) string {
 
 // TestSpec verifies the connector's spec output against a snapshot.
 func TestSpec(t *testing.T) {
+	t.Parallel()
 	var _, tc = blackboxTestSetup(t)
 	tc.Spec("Get Connector Spec")
 	cupaloy.SnapshotT(t, tc.Transcript.String())

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -78,8 +78,99 @@ func runTests(m *testing.M) int {
 			log.WithField("err", err).Error("error building connector for tests")
 			return 1
 		}
+
+		stopScanner, err := startManualCDCScanner()
+		if err != nil {
+			log.WithField("err", err).Error("error taking over CDC log scanning")
+			return 1
+		}
+		defer stopScanner()
 	}
 	return m.Run()
+}
+
+// startManualCDCScanner stops the SQL Agent capture job and drives log scanning from the
+// test harness instead, returning a function which restores the job.
+//
+// Every stream-to-fence waits for a log scan session which completed after the fence
+// attempt began, so how often scans complete is a hard floor on how fast a capture reaches
+// a fence, and the suite pays that floor hundreds of times over. The capture job cannot
+// scan more than once a second, so drive the scans ourselves instead. This is invisible to
+// the connector, which only observes completed entries in sys.dm_cdc_log_scan_sessions and
+// the resulting maximum LSN.
+//
+// Only pays off alongside ${TEST_FENCE_RETRY_INTERVAL}, which blackboxTestSetup sets:
+// frequent scans make a fence available sooner, but the connector's default one second
+// poll still quantizes every fence to a one second boundary.
+func startManualCDCScanner() (func(), error) {
+	var controlURI = (&Config{
+		Address:  *dbControlAddress,
+		User:     *dbControlUser,
+		Password: *dbControlPass,
+		Database: *dbName,
+	}).ToURI()
+	conn, err := sql.Open("sqlserver", controlURI)
+	if err != nil {
+		return nil, fmt.Errorf("opening scanner connection: %w", err)
+	}
+
+	if _, err := conn.ExecContext(context.Background(), `EXEC sys.sp_cdc_stop_job @job_type = 'capture'`); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("stopping capture job: %w", err)
+	}
+
+	// sp_cdc_stop_job only requests the stop, so wait for the job to actually leave the
+	// running state: sp_cdc_scan refuses to run alongside it.
+	const jobRunningQuery = `SELECT TOP 1 CASE WHEN ja.start_execution_date IS NOT NULL AND ja.stop_execution_date IS NULL THEN 1 ELSE 0 END ` +
+		`FROM msdb.dbo.sysjobs j JOIN msdb.dbo.sysjobactivity ja ON ja.job_id = j.job_id ` +
+		`WHERE j.name LIKE '%capture%' ORDER BY ja.session_id DESC`
+	var deadline = time.Now().Add(60 * time.Second)
+	for {
+		var running int
+		if err := conn.QueryRowContext(context.Background(), jobRunningQuery).Scan(&running); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("querying capture job state: %w", err)
+		}
+		if running == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			conn.Close()
+			return nil, fmt.Errorf("capture job still running 60s after being asked to stop")
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	var scannerCtx, cancelScanner = context.WithCancel(context.Background())
+	var scannerDone = make(chan struct{})
+	go func() {
+		defer close(scannerDone)
+		for scannerCtx.Err() == nil {
+			// The transaction limit has to match what msdb.dbo.cdc_jobs advertises, because
+			// the connector reads that value and treats a scan session which hit the limit
+			// as one which may not have caught up.
+			//
+			// Deliberately not tied to scannerCtx: cancelling mid-scan would abort a scan
+			// the connector may already be waiting on, and a scan only takes a moment.
+			if _, err := conn.ExecContext(context.Background(),
+				`EXEC sys.sp_cdc_scan @maxtrans = 500, @maxscans = 1, @continuous = 0`); err != nil && scannerCtx.Err() == nil {
+				log.WithField("err", err).Warn("manual CDC log scan failed")
+			}
+			select {
+			case <-scannerCtx.Done():
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	}()
+
+	return func() {
+		cancelScanner()
+		<-scannerDone
+		if _, err := conn.ExecContext(context.Background(), `EXEC sys.sp_cdc_start_job @job_type = 'capture'`); err != nil {
+			log.WithField("err", err).Warn("error restarting capture job")
+		}
+		conn.Close()
+	}, nil
 }
 
 var documentSanitizers = []blackbox.JSONSanitizer{
@@ -124,6 +215,9 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	tc.Capture.Logger = t.Log
 	tc.Capture.DiscoveryFilter = regexp.MustCompile(uniqueID)
 	tc.Capture.Env["SHUTDOWN_AFTER_POLLING"] = "yes"
+	// Pointless without the manual scanner started in runTests, and vice versa: see the
+	// comment there for why both halves are needed to shorten a fence wait.
+	tc.Capture.Env["TEST_FENCE_RETRY_INTERVAL"] = "100ms"
 	require.NoError(t, tc.Capture.SetLocalCommand(connectorBinary))
 	tc.DocumentSanitizers = documentSanitizers
 	tc.CheckpointSanitizers = checkpointSanitizers

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -68,10 +68,6 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 		return nil, nil
 	}
 
-	// TODO(wgd): Probably scoping this to just flowctl invocations would be cleaner, but this works
-	os.Setenv("SHUTDOWN_AFTER_POLLING", "yes")
-	t.Cleanup(func() { os.Unsetenv("SHUTDOWN_AFTER_POLLING") })
-
 	// Setup: Unique filter ID and full table name
 	var uniqueID = uniqueTableID(t)
 	var baseName = strings.TrimPrefix(t.Name(), "Test") + "_" + uniqueID
@@ -85,6 +81,7 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	require.NoError(t, err)
 	tc.Capture.Logger = t.Log
 	tc.Capture.DiscoveryFilter = regexp.MustCompile(uniqueID)
+	tc.Capture.Env["SHUTDOWN_AFTER_POLLING"] = "yes"
 	tc.DocumentSanitizers = documentSanitizers
 	tc.CheckpointSanitizers = checkpointSanitizers
 

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -46,7 +47,36 @@ func TestMain(m *testing.M) {
 	// Set a 900MiB memory limit, same as we use in production.
 	debug.SetMemoryLimit(900 * 1024 * 1024)
 
-	os.Exit(m.Run())
+	os.Exit(runTests(m))
+}
+
+// connectorBinary is the path to the connector built by runTests, which every capture in
+// this package is pointed at. Empty when tests are skipped for lack of a database.
+var connectorBinary string
+
+// runTests builds the connector once and runs the suite against that binary. Each test
+// performs many flowctl invocations and each one spawns the connector, so building here
+// avoids paying `go run`'s link step hundreds of times over.
+//
+// Split out from TestMain because os.Exit would skip deferred cleanup of the build.
+func runTests(m *testing.M) int {
+	if os.Getenv("TEST_DATABASE") == "yes" {
+		buildDir, err := os.MkdirTemp("", "source-sqlserver-build-*")
+		if err != nil {
+			log.WithField("err", err).Error("error creating build directory")
+			return 1
+		}
+		defer os.RemoveAll(buildDir)
+
+		connectorBinary = buildDir + "/connector"
+		var build = exec.Command("go", "build", "-o", connectorBinary, ".")
+		build.Stderr = os.Stderr
+		if err := build.Run(); err != nil {
+			log.WithField("err", err).Error("error building connector for tests")
+			return 1
+		}
+	}
+	return m.Run()
 }
 
 var documentSanitizers = []blackbox.JSONSanitizer{
@@ -82,6 +112,7 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	tc.Capture.Logger = t.Log
 	tc.Capture.DiscoveryFilter = regexp.MustCompile(uniqueID)
 	tc.Capture.Env["SHUTDOWN_AFTER_POLLING"] = "yes"
+	require.NoError(t, tc.Capture.SetLocalCommand(connectorBinary))
 	tc.DocumentSanitizers = documentSanitizers
 	tc.CheckpointSanitizers = checkpointSanitizers
 

--- a/source-sqlserver/prerequisites_test.go
+++ b/source-sqlserver/prerequisites_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestPrerequisites(t *testing.T) {
 	t.Run("validateExistingTables", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create tables A and B - both exist and can be validated
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
@@ -19,6 +20,7 @@ func TestPrerequisites(t *testing.T) {
 	})
 
 	t.Run("captureMissingTable", func(t *testing.T) {
+		t.Parallel()
 		var db, tc = blackboxTestSetup(t)
 		// Create tables A and B, but drop B after discovery
 		db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -122,6 +123,15 @@ type sqlserverReplicationStream struct {
 	// interval as a reasonable heuristic.
 	establishFenceTimeout time.Duration
 
+	// establishFenceRetryInterval is how long to wait before re-checking whether the CDC
+	// worker has completed a new log scan session, which is what a fence position is
+	// established from. There is no notification when a scan completes, so this is a poll,
+	// and because the first check always fails the interval quantizes every fence to a
+	// multiple of itself. One second is the right default against a CDC worker which scans
+	// no more often than once per second, and tests which drive scanning themselves lower it
+	// via ${TEST_FENCE_RETRY_INTERVAL}.
+	establishFenceRetryInterval time.Duration
+
 	tables struct {
 		sync.RWMutex
 		info map[sqlcapture.StreamID]*tableReplicationInfo
@@ -169,6 +179,19 @@ func (rs *sqlserverReplicationStream) open(ctx context.Context) error {
 	rs.cdcPollingInterval = pollingInterval
 	rs.streamToFenceWatchdogTimeout = max(15*time.Minute, 3*pollingInterval)
 	rs.establishFenceTimeout = max(15*time.Minute, 3*pollingInterval)
+
+	// Test-only override, in the same spirit as ${SHUTDOWN_AFTER_POLLING}: the black-box
+	// tests run the connector as a subprocess, so an in-process test flag can't reach it.
+	// Unset, which is every production capture, this is one second.
+	rs.establishFenceRetryInterval = 1 * time.Second
+	if override := os.Getenv("TEST_FENCE_RETRY_INTERVAL"); override != "" {
+		if parsed, err := time.ParseDuration(override); err != nil {
+			log.WithFields(log.Fields{"value": override, "err": err}).Warn("ignoring unparseable ${TEST_FENCE_RETRY_INTERVAL}")
+		} else {
+			log.WithField("interval", parsed.String()).Info("overriding fence retry interval from ${TEST_FENCE_RETRY_INTERVAL}")
+			rs.establishFenceRetryInterval = parsed
+		}
+	}
 
 	rs.errCh = make(chan error)
 	rs.events = make(chan sqlcapture.DatabaseEvent)
@@ -412,7 +435,7 @@ func (rs *sqlserverReplicationStream) streamToPositionalFence(ctx context.Contex
 	// The behavior of 'establishFenceTimer' is a little bit complicated here. Initially it's
 	// set to the 'fenceAfter' duration so we'll run for at least that long before checking if
 	// we can establish a new fence position. After that initial duration is reached, we reset
-	// it to one second for each retry.
+	// it to 'establishFenceRetryInterval' for each retry.
 	var timedEventsSinceFlush int
 	var latestFlushLSN = rs.fenceLSN
 	var nextFenceLSN LSN
@@ -440,7 +463,7 @@ loop:
 				nextFenceLSN = lsn
 				break loop
 			} else {
-				establishFenceTimer.Reset(1 * time.Second)
+				establishFenceTimer.Reset(rs.establishFenceRetryInterval)
 				continue
 			}
 		case event, ok := <-rs.events:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

Both `source-sqlserver` and `source-sqlserver-ct`'s CI runs take a long time (~15 minutes or more), and I don't really like having to wait that long to deploy changes. This PR speeds that up by making various changes to speed up test execution:
1. Make the test harness safe to run concurrently.
2. Run tests in parallel instead of in series.
3. Stop waiting for things we didn't have to wait for (ex: the test harness does scanning instead of waiting for the SQL Server's CDC worker, setup code now retries on a database deadlock instead of waiting a second & hoping a deadlock doesn't occur).
4. Stop re-doing common work (ex: re-building the same connector binary so many times, caching Go dependencies).

Overall on my local machine, this cut `source-sqlserver`'s test duration from ~1287s -> ~395s, and `source-sqlserver-ct`'s test duration from ~549s -> ~197s.

For more details on specific changes, see the individual commits. There's a lot of them, but I broke them down into small changes so they're hopefully a bit easier to read through.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
