### PR TITLE
materialize-clickhouse: remove wait for acknowledged

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## 2026-08-06
+
+### Fixed
+- Load waited for the prior transaction's acknowledgment before it could begin
+  staging keys, which could force transactions to be smaller than necessary.
+  Load now only waits for its persistent staging tables to be established, so
+  staging can proceed concurrently with the prior transaction's acknowledgment.
+
 ### Changed
 - Load batches are sent once a full batch is collected, instead of when the
   load binding changes.  On tasks with many active bindings, this should

--- a/materialize-clickhouse/config_test.go
+++ b/materialize-clickhouse/config_test.go
@@ -73,7 +73,7 @@ func TestResolvedAddress(t *testing.T) {
 }
 
 func TestAcknowledge(t *testing.T) {
-	var tr transactor
+	tr := transactor{ensured: make(chan struct{})}
 	state, err := tr.Acknowledge(t.Context(), nil, nil)
 	require.NoError(t, err)
 	require.Nil(t, state)

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -278,14 +278,15 @@ type transactor struct {
 	// than were stored, and an empty stage table means the commit had fully
 	// completed. It is cleared after the first Acknowledge.
 	recovery bool
-	// ensured is set once the first Acknowledge of the session has run the
+	// ensured is closed once ensureTempTables is called to run the
 	// ensure pass: recovering any pending commits and creating / truncating /
 	// re-creating the persistent temp tables for every binding. It is
 	// deliberately independent of the recovery flag, which is only set when
 	// the Open request carried prior connector state -- a brand-new task has
 	// no state but still needs its temp tables ensured before the first
-	// transaction.
-	ensured           bool
+	// transaction.  A channel is used so that Load can wait for it before
+	// reading any Load requests.
+	ensured           chan struct{}
 	state             connectorState
 	runtimeCheckpoint m.RuntimeCheckpoint
 }
@@ -339,6 +340,7 @@ func newTransactor(
 		cfg:               cfg,
 		be:                be,
 		_range:            open.Range,
+		ensured:           make(chan struct{}),
 		state:             make(connectorState, len(bindings)),
 		runtimeCheckpoint: fence.Checkpoint,
 	}
@@ -516,8 +518,8 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 	// Staging keys writes to the persistent load tables, which Acknowledge
 	// establishes via ensureTempTables. RunTransactions runs Acknowledge and
 	// Load in concurrent goroutines, so those tables are only guaranteed to
-	// exist once the acknowledgement has completed.
-	it.WaitForAcknowledged()
+	// exist once ensureTempTables has had a chance to run.
+	<-t.ensured
 
 	// activeBindings tracks the number of keys inserted into each binding's
 	// load table this round, for verification against an authoritative count
@@ -798,7 +800,8 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 	shouldProcess := m.StateKeyFilter(stateKeys)
 	var drained []string
 
-	if !t.ensured {
+	select {
+	default: // ensured channel is not closed
 		// First Acknowledge of the session: recover pending commits and
 		// ensure every binding's persistent temp tables. This always runs
 		// before the first Store (the runtime serializes Acknowledge ahead
@@ -858,8 +861,8 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 				return nil, fmt.Errorf("ensuring temp tables of %s: %w", b.target.Identifier, err)
 			}
 		}
-		t.ensured = true
-	} else {
+		close(t.ensured)
+	case <-t.ensured: // ensured channel is closed
 		for stateKey, si := range t.state {
 			if !shouldProcess(stateKey) {
 				continue

--- a/materialize-clickhouse/driver_clickhouse_test.go
+++ b/materialize-clickhouse/driver_clickhouse_test.go
@@ -369,7 +369,7 @@ func TestDestroy(t *testing.T) {
 	ensureDockerUp(t)
 
 	var cfg = testConfig()
-	var tr = &transactor{}
+	var tr = &transactor{ensured: make(chan struct{})}
 	var err error
 	tr.store.conn, err = clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestAddBinding(t *testing.T) {
 		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
 	})
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -517,7 +517,7 @@ func TestStoreAndLoadDataPath(t *testing.T) {
 	})
 
 	// Build the binding to get rendered SQL.
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -794,7 +794,7 @@ func TestHardDeleteTombstone(t *testing.T) {
 		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
 	})
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -839,7 +839,7 @@ func setupTable(t *testing.T, ctx context.Context, cfg config, dialect sql.Diale
 		_, _ = cleanDB.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
 	})
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -1127,7 +1127,7 @@ func TestMultiBindingStoreAndLoad(t *testing.T) {
 	})
 
 	// Build transactor with 2 bindings.
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -1221,7 +1221,7 @@ func TestMovePartitionMissingTarget(t *testing.T) {
 	_, err = db.ExecContext(ctx, createSQL)
 	require.NoError(t, err)
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.store.conn = storeConn
@@ -1289,6 +1289,7 @@ func newTestTransactor(t *testing.T, ctx context.Context, tableName string) (*tr
 		templates: tpls,
 		cfg:       cfg,
 		_range:    &pf.RangeSpec{},
+		ensured:   make(chan struct{}),
 		state:     make(connectorState),
 	}
 	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
@@ -1384,7 +1385,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.NoError(t, tr.ensureTempTables(ctx, b))
 		stageTestRows(t, ctx, tr, b, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
 
-		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
 		_, err := tr.Acknowledge(ctx, nil, nil)
@@ -1401,7 +1401,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		// StoredRows says 3, but only 1 row remains staged -- as if a prior
 		// process had moved part of the commit before crashing. Recovery must
 		// move the remainder rather than failing the equality check forever.
-		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 3}
 		_, err := tr.Acknowledge(ctx, nil, nil)
@@ -1419,7 +1418,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		// transaction can stage into it.
 		require.NoError(t, tr.store.conn.Exec(ctx, b.store.dropTableSQL))
 
-		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
 		_, err := tr.Acknowledge(ctx, nil, nil)
@@ -1440,7 +1438,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 
 		// No pending state for the binding: the staged row was never
 		// committed and must be discarded, not moved.
-		tr.ensured = false
 		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
@@ -1451,7 +1448,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		tr, b := newTestTransactor(t, ctx, "test_recovery_fresh")
 		_ = tr.store.conn.Exec(ctx, b.store.dropTableSQL)
 
-		tr.ensured = false
 		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, countTable(t, ctx, tr, tr.dialect.Identifier(storeTableName(b.target, 0))))
@@ -1466,7 +1462,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.NoError(t, tr.store.conn.Exec(ctx,
 			fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", stageName, tr.dialect.Identifier("value"))))
 
-		tr.ensured = false
 		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 
@@ -1499,7 +1494,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 
 		// Pending state with rows already moved (StoredRows > 0, empty stage):
 		// this is what drives Acknowledge through the trivial recovery move.
-		tr.ensured = false
 		tr.recovery = true
 		tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
 		_, err := tr.Acknowledge(ctx, nil, nil)
@@ -1531,7 +1525,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		require.NoError(t, tr.UnmarshalState([]byte(oldState)))
 		require.True(t, tr.recovery)
 
-		tr.ensured = false
 		_, err := tr.Acknowledge(ctx, nil, nil)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, countTable(t, ctx, tr, tr.dialect.Identifier("test_recovery_upgrade")))
@@ -1584,7 +1577,6 @@ func TestAcknowledgeRecoveryMatrix(t *testing.T) {
 		stageTestRows(t, ctx, tr, b1, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
 		stageTestRows(t, ctx, tr, b2, []any{"k2", "v2", "c", testTime, `{"id":"k2"}`})
 
-		tr.ensured = false
 		tr.recovery = true
 		tr.state[b1.target.StateKey] = &stateItem{StoredRows: 1}
 		tr.state[b2.target.StateKey] = &stateItem{StoredRows: 1}

--- a/materialize-clickhouse/partition_by_test.go
+++ b/materialize-clickhouse/partition_by_test.go
@@ -333,7 +333,7 @@ func TestPartitionByDataPath(t *testing.T) {
 		_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", dialect.Identifier(tableName)))
 	})
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn
@@ -424,6 +424,7 @@ func TestRecoveryAfterPartitionChangingBackfill(t *testing.T) {
 		templates: tpls,
 		cfg:       cfg,
 		_range:    &pf.RangeSpec{},
+		ensured:   make(chan struct{}),
 		state:     make(connectorState),
 	}
 	storeConn, err := clickhouse.Open(cfg.newClickhouseOptions())
@@ -440,7 +441,6 @@ func TestRecoveryAfterPartitionChangingBackfill(t *testing.T) {
 	// A staged row of the pending pre-backfill commit.
 	stageTestRows(t, ctx, tr, b, []any{"k1", "v1", "c", testTime, `{"id":"k1"}`})
 
-	tr.ensured = false
 	tr.recovery = true
 	tr.state[b.target.StateKey] = &stateItem{StoredRows: 1}
 	_, err = tr.Acknowledge(ctx, nil, nil)
@@ -575,7 +575,7 @@ func TestStoreTablePartitionDrift(t *testing.T) {
 	_, err = db.ExecContext(ctx, staleSQL)
 	require.NoError(t, err)
 
-	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}}
+	var tr = &transactor{dialect: dialect, templates: tpls, cfg: cfg, _range: &pf.RangeSpec{}, ensured: make(chan struct{})}
 	loadConn, err := clickhouse.Open(cfg.newClickhouseOptions())
 	require.NoError(t, err)
 	tr.load.conn = loadConn


### PR DESCRIPTION
**Regression?**

#4944

**Description:**

The `it.WaitForAcknowledged()` does not interact well with transaction sizing, and can cause the transactions to be too small while still waiting before sending Acknowledged.

We still need to wait for temp tables to be setup, so I added a channel we can wait on before the first Load begins.  On the first call, we will wait for `ensureTempTables` to be called but subsequent transactions will proceed with waiting.  This is just staging the ids, no loads will occur until the LoadIterator is exhausted which happens after Acknowledged is written.

**Workflow steps:**

No user changes.

**Documentation links affected:**

None

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
