### PR TITLE
materialize-bigquery: report NULL flow_document in load errors

### DIFF
--- a/materialize-bigquery/CHANGELOG.md
+++ b/materialize-bigquery/CHANGELOG.md
@@ -1,5 +1,14 @@
 # materialize-bigquery
 
+## 2026-08-07
+
+### Fixed
+- A load query that reads a NULL `flow_document` now says so, and names the
+  `Exclude Flow Document` option that addresses it. It previously reported
+  `value[1] wrong type int64 expecting string`, giving the type of the binding
+  index rather than of the document, which made it the same message regardless
+  of cause.
+
 ## 2026-07-23
 
 ### Changed

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -33,7 +33,7 @@ type binding struct {
 // its reconstruction yields an explicit null for any root-level column that is
 // NULL, which only matters for collections that reduce the root document rather
 // than replacing it.
-var errNullFlowDocument = errors.New("value[1] is NULL: this row has no flow_document value, " +
+var errNullFlowDocument = errors.New("row has no flow_document value, " +
 	"typically because the binding adopted a table that already held data: see https://go.estuary.dev/matff. " +
 	"The 'Exclude Flow Document' advanced option makes loads reconstruct the document " +
 	"from the table's own columns instead")

--- a/materialize-bigquery/binding.go
+++ b/materialize-bigquery/binding.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
@@ -21,6 +22,22 @@ type binding struct {
 	storeMergeBounds *sql.MergeBoundsBuilder
 }
 
+// errNullFlowDocument is returned when a load query reads a row whose
+// flow_document column is NULL. The column is added as nullable when a binding
+// adopts a table that already held rows, and nothing backfills it for them.
+//
+// A sentinel so this stays distinguishable from a type mismatch without matching
+// on message text. Two caveats not worth putting in front of operators: enabling
+// no_flow_document takes effect on the next transaction of an existing binding
+// (transactor.go selects the load template from the endpoint config alone), and
+// its reconstruction yields an explicit null for any root-level column that is
+// NULL, which only matters for collections that reduce the root document rather
+// than replacing it.
+var errNullFlowDocument = errors.New("value[1] is NULL: this row has no flow_document value, " +
+	"typically because the binding adopted a table that already held data: see https://go.estuary.dev/matff. " +
+	"The 'Exclude Flow Document' advanced option makes loads reconstruct the document " +
+	"from the table's own columns instead")
+
 // bindingDocument is used by the load operation to fetch binding flow_document values
 type bindingDocument struct {
 	Binding  int
@@ -38,8 +55,10 @@ func (bd *bindingDocument) Load(v []bigquery.Value, s bigquery.Schema) error {
 	} else {
 		bd.Binding = int(binding)
 	}
-	if document, ok := v[1].(string); !ok {
-		return fmt.Errorf("value[1] wrong type %T expecting string", v[0])
+	if v[1] == nil {
+		return errNullFlowDocument
+	} else if document, ok := v[1].(string); !ok {
+		return fmt.Errorf("value[1] wrong type %T expecting string", v[1])
 	} else {
 		bd.Document = json.RawMessage(document)
 	}

--- a/materialize-bigquery/binding_test.go
+++ b/materialize-bigquery/binding_test.go
@@ -1,0 +1,72 @@
+package connector
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindingDocumentLoad(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		values      []bigquery.Value
+		wantBinding int
+		wantDoc     string
+		wantErrIs   error
+		wantErr     string
+	}{
+		{
+			name:        "valid",
+			values:      []bigquery.Value{int64(3), `{"id":1}`},
+			wantBinding: 3,
+			wantDoc:     `{"id":1}`,
+		},
+		{
+			name:    "wrong value count",
+			values:  []bigquery.Value{int64(3)},
+			wantErr: "invalid value count: 1",
+		},
+		{
+			name:    "binding wrong type",
+			values:  []bigquery.Value{"3", `{"id":1}`},
+			wantErr: "value[0] wrong type string expecting int",
+		},
+		{
+			name:      "document is NULL",
+			values:    []bigquery.Value{int64(3), nil},
+			wantErrIs: errNullFlowDocument,
+		},
+		{
+			// The reported type must be the document's, not the binding index's.
+			name:    "document wrong type",
+			values:  []bigquery.Value{int64(3), 3.5},
+			wantErr: "value[1] wrong type float64 expecting string",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var bd bindingDocument
+			var err = bd.Load(tt.values, nil)
+
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				return
+			} else if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.NotErrorIs(t, err, errNullFlowDocument)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBinding, bd.Binding)
+			require.Equal(t, tt.wantDoc, string(bd.Document))
+		})
+	}
+}
+
+// The wording is free to change, but a NULL document is expensive to diagnose
+// without these two, so they are worth pinning.
+func TestNullFlowDocumentNamesTheRemedy(t *testing.T) {
+	require.Contains(t, errNullFlowDocument.Error(), "Exclude Flow Document")
+	require.Contains(t, errNullFlowDocument.Error(), "go.estuary.dev/matff")
+}


### PR DESCRIPTION
Closes #5028

## The bug

`bindingDocument.Load` asserts `v[1].(string)` but formatted `v[0]` on failure:

```go
if document, ok := v[1].(string); !ok {
    return fmt.Errorf("value[1] wrong type %T expecting string", v[0])
```

`v[0]` is the binding index, already asserted to be `int64` a few lines above with an early return. So it was always `int64`, and the message was the constant `value[1] wrong type int64 expecting string` whatever the document value actually was.

## Why not just fix the index

The common way to hit this is a NULL `flow_document`: the column is added as nullable when a binding adopts a table that already held rows, nothing backfills it for those rows, and the load query's inner join returns them. Fixing only the index gives `wrong type <nil>`, which is honest but still needs decoding. So NULL gets its own branch, as an `errNullFlowDocument` sentinel naming the cause and the `Exclude Flow Document` option.

## Verification

```
go test ./materialize-bigquery/ -run TestBindingDocumentLoad
```

Two of the five cases fail against `main`: `document is NULL`, and `document wrong type`, which passes a `float64` and so pins the `%T` fix.

Also checked against live BigQuery through the connector's own read path, with the Storage Read API engaged (`IsAccelerated() == true`, which needs `Job.Read` rather than `Query.Read`): a NULL document returns the sentinel, a valid document passes through verbatim, a `float64` reports `float64`.

`go vet` is clean, and cannot catch this class of bug: `%T` accepts any argument, so the printf analyzer sees a well-formed call.

## Two things the message deliberately does not say

Both were in earlier drafts and both are wrong, so flagging them in case they look like omissions:

- **It does not tell you to recreate the binding.** The load template is selected from the endpoint config alone, per transaction (`transactor.go:270-273`), so `Exclude Flow Document` takes effect on an existing binding's next transaction.
- **It does not present a missing value in a required root-level column as a precondition.** Materializing those is enforced by the connector already (`materialize-sql/driver.go:235-238`), and a reconstructed null is discarded by the default LastWriteWins reduction rather than validated (`crates/doc/src/combine/memtable.rs:421-425`, `reduce/strategy.rs:282-284`). It only matters for collections that reduce the root document, so it lives in a code comment rather than in front of operators.

## Out of scope, worth knowing

- **A separate bug in `loadQueryNoFlowDocument`.** It aliases each field by `$col.Field` unquoted (`sqlgen.go:318`) where the rest of the file uses `$col.Identifier`. Confirmed against BigQuery: `AS array` fails with `Unexpected keyword ARRAY`, and the committed snapshot also contains `AS key!binary` and `AS nonAsciiκόσμε`, both syntax errors. Quoting fixes those; it does not fix the second half, which is that a renamed root-level projection reconstructs under the projection name rather than the schema property name. `materialize-mysql` has the same template. Happy to file separately.
- Postgres and Snowflake pass the nil through and the runtime fails with `couldn't parse loaded document as JSON`. `bindingDocument` is the only `ValueLoader` here and `grep "wrong type %T"` hits only this file, so the misprint is not copy-pasted, but the missing NULL diagnostic is effectively repo-wide. A boilerplate-level guard may be the better long-term fix.
- A JSON `null` inside a JSON-typed column is not a SQL NULL and still passes through. Not covered.
- No `VERSION` bump: error text only, and both branches return a non-nil error wrapped identically at `transactor.go`, so no caller control flow changes.
