### PR TITLE
source-shopify-native: add `markets` stream & capture inactive `locations`

### DIFF
--- a/docs/reference/Connectors/capture-connectors/shopify-native.md
+++ b/docs/reference/Connectors/capture-connectors/shopify-native.md
@@ -22,6 +22,7 @@ The following data resources are supported through the Shopify API:
    * Inventory Levels
 * [Locations](https://shopify.dev/docs/api/admin-graphql/2026-01/queries/locations?example=Retrieve+a+list+of+locations)
    * Location Metafields
+* [Markets](https://shopify.dev/docs/api/admin-graphql/latest/queries/markets)
 * [Orders](https://shopify.dev/docs/api/admin-graphql/2026-01/queries/orders?example=Retrieve+a+list+of+orders)
    * Order Agreements
    * Order Metafields
@@ -73,6 +74,7 @@ When authenticating with an access token or client credentials, ensure the follo
 * `read_locations`
 * `read_marketing_events`
 * `read_marketplace_fulfillment_orders`
+* `read_markets`
 * `read_merchant_managed_fulfillment_orders`
 * `read_orders`
   * If you want to read orders older than 60 days, extend the `read_orders` scope with `read_all_orders`

--- a/source-shopify-native/CHANGELOG.md
+++ b/source-shopify-native/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 2026-08-08
+
+### Added
+- New `markets` stream capturing each Shopify Market, with that market's
+  market catalogs embedded as a `catalogs` list. Requires the `read_markets`
+  access scope. The stream is skipped for stores that don't grant it.
+
+### Changed
+- `locations` and `location_metafields` now include deactivated locations.
+  Existing captures pick up a deactivated location once its `updatedAt`
+  advances. Locations deactivated before this release require a backfill of
+  those bindings to appear.

--- a/source-shopify-native/acmeCo/abandoned_checkouts.schema.yaml
+++ b/source-shopify-native/acmeCo/abandoned_checkouts.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/custom_collection_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/custom_collection_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/custom_collections.schema.yaml
+++ b/source-shopify-native/acmeCo/custom_collections.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/customer_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/customer_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/customers.schema.yaml
+++ b/source-shopify-native/acmeCo/customers.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/disputes.schema.yaml
+++ b/source-shopify-native/acmeCo/disputes.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -59,6 +59,11 @@ collections:
     key:
     - /_meta/store
     - /id
+  acmeCo/markets:
+    schema: markets.schema.yaml
+    key:
+    - /_meta/store
+    - /_meta/row_id
   acmeCo/order_agreements:
     schema: order_agreements.schema.yaml
     key:

--- a/source-shopify-native/acmeCo/flow.yaml
+++ b/source-shopify-native/acmeCo/flow.yaml
@@ -2,104 +2,130 @@ collections:
   acmeCo/abandoned_checkouts:
     schema: abandoned_checkouts.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/custom_collection_metafields:
     schema: custom_collection_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/custom_collections:
     schema: custom_collections.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/customer_metafields:
     schema: customer_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/customers:
     schema: customers.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/disputes:
     schema: disputes.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/fulfillment_orders:
     schema: fulfillment_orders.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/fulfillments:
     schema: fulfillments.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/inventory_items:
     schema: inventory_items.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/inventory_levels:
     schema: inventory_levels.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/location_metafields:
     schema: location_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/locations:
     schema: locations.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_agreements:
     schema: order_agreements.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_metafields:
     schema: order_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_refunds:
     schema: order_refunds.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_returns:
     schema: order_returns.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_risks:
     schema: order_risks.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/order_transactions:
     schema: order_transactions.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/orders:
     schema: orders.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/product_media:
     schema: product_media.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/product_metafields:
     schema: product_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/product_variant_metafields:
     schema: product_variant_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/product_variants:
     schema: product_variants.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/products:
     schema: products.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/smart_collection_metafields:
     schema: smart_collection_metafields.schema.yaml
     key:
+    - /_meta/store
     - /id
   acmeCo/smart_collections:
     schema: smart_collections.schema.yaml
     key:
+    - /_meta/store
     - /id

--- a/source-shopify-native/acmeCo/fulfillment_orders.schema.yaml
+++ b/source-shopify-native/acmeCo/fulfillment_orders.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/fulfillments.schema.yaml
+++ b/source-shopify-native/acmeCo/fulfillments.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/inventory_items.schema.yaml
+++ b/source-shopify-native/acmeCo/inventory_items.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/inventory_levels.schema.yaml
+++ b/source-shopify-native/acmeCo/inventory_levels.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/location_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/location_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/locations.schema.yaml
+++ b/source-shopify-native/acmeCo/locations.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/markets.schema.yaml
+++ b/source-shopify-native/acmeCo/markets.schema.yaml
@@ -1,0 +1,46 @@
+$defs:
+  Meta:
+    properties:
+      op:
+        default: u
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
+        enum:
+        - c
+        - u
+        - d
+        title: Op
+        type: string
+      row_id:
+        default: -1
+        description: Row ID of the Document, counting up from zero, or -1 if not known
+        title: Row Id
+        type: integer
+      store:
+        default: ''
+        description: The Shopify store this document belongs to
+        title: Store
+        type: string
+    title: Meta
+    type: object
+additionalProperties: true
+properties:
+  _meta:
+    $ref: '#/$defs/Meta'
+    description: Document metadata
+title: ShopifyDocument
+type: object
+x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_agreements.schema.yaml
+++ b/source-shopify-native/acmeCo/order_agreements.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/order_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_refunds.schema.yaml
+++ b/source-shopify-native/acmeCo/order_refunds.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_returns.schema.yaml
+++ b/source-shopify-native/acmeCo/order_returns.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_risks.schema.yaml
+++ b/source-shopify-native/acmeCo/order_risks.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/order_transactions.schema.yaml
+++ b/source-shopify-native/acmeCo/order_transactions.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/orders.schema.yaml
+++ b/source-shopify-native/acmeCo/orders.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/product_media.schema.yaml
+++ b/source-shopify-native/acmeCo/product_media.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/product_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/product_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/product_variant_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/product_variant_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/product_variants.schema.yaml
+++ b/source-shopify-native/acmeCo/product_variants.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/products.schema.yaml
+++ b/source-shopify-native/acmeCo/products.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/smart_collection_metafields.schema.yaml
+++ b/source-shopify-native/acmeCo/smart_collection_metafields.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/acmeCo/smart_collections.schema.yaml
+++ b/source-shopify-native/acmeCo/smart_collections.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ShopifyGraphQLResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-shopify-native/config.yaml
+++ b/source-shopify-native/config.yaml
@@ -1,17 +1,23 @@
 stores:
     - store: estuary-alex-testing
       credentials:
-        credentials_title: Private App Credentials
-        access_token_sops: ENC[AES256_GCM,data:U4H9/+mC+YbmCzSeQOs77ikDHAFAl8flLkohlfLvIG4oR6O444s=,iv:RpboQbPOJnctlQeH2EEnns+xtBydFpD6TecqLiilFD4=,tag:zWOk5wMGZObyaLemX0bZ7w==,type:str]
+        credentials_title: Client Credentials
+        client_id_sops: ENC[AES256_GCM,data:iUmz7PRVpxjjVEw52GKxdJE4LuGK1fUvmyrFB02VFpk=,iv:Po49niFbYgBRcirzU+hOcx8b2sQuwPqJ9GL6hWULoec=,tag:bCrBOWegJHpJ8cZCy3lTrA==,type:str]
+        client_secret_sops: ENC[AES256_GCM,data:abPOlCVuar7MgiO2zkgl9+qGm60I+4NXRRgvAdskVqAaD70yGw4=,iv:tY8zHAscEVARDeQKAbxLYsaMm0ipeaS2gES/ljxSM5U=,tag:5vPcq7SmzUSbcXoeW3r3XA==,type:str]
 start_date: "2025-01-10T00:00:00Z"
 advanced:
     window_size: P50000D
 sops:
+    kms: []
     gcp_kms:
         - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
           created_at: "2026-02-10T14:31:14Z"
           enc: CiQAdmEdwsIlJneQ2fXL155ChSwlJWjSsbXJPov0rLvZ67BYKaISSQDNZIk6KsWXDUNAXjyc2C/5rNbt67SyOZRv+8m0bkmtWcHAkq7Qe2CdsqquG2FG5Mc0XPVvt7wmhb1N51XpxaGykrD79QbhWR4=
-    lastmodified: "2026-02-10T14:31:14Z"
-    mac: ENC[AES256_GCM,data:/pYcG5z75ME8I68UVj1whiJAHRTp/VOAoAa0elRQiPJCP93LvAFeNhekN4T23pdyiscL88prwVNjzS8dMvAPSTSxF0T/H2di7BYqDawAEKV4C42cup74wB1Gxl8QeUpTwmYIlOSq/13kuSF+mEruPrTvvnSddiwkYrGyUciEPJo=,iv:R2u0T3Nrsqbuin5HE9xkk9mlOXCOJEo6NVmvuftv2o0=,tag:IeX6GSZ+hF7n36fEilmFfw==,type:str]
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-08-08T00:02:45Z"
+    mac: ENC[AES256_GCM,data:koJ4s+nDo1y1P6ydz/IkXEgLQk0XsYZ5qp4GD083up6RrRI/s8lVAxkWc6zkgk1bXyzhdFzVHRvco28fWhguj+uAuGZM3EAkRAaWjpSf9L+RQ5ptIKe15aw/btyE24mwG0pyUjbJjzWKzYXhoduto7shWyZTMiFaiHHL0gzN67w=,iv:78G1MJIMM/5dZ+y45RHelnY5/FVLoaTsR+qxqkOLcr8=,tag:cGu1u+eV0DY+469HPTccxA==,type:str]
+    pgp: []
     encrypted_suffix: _sops
     version: 3.10.2

--- a/source-shopify-native/source_shopify_native/graphql/README.md
+++ b/source-shopify-native/source_shopify_native/graphql/README.md
@@ -25,4 +25,6 @@ Bulk operations reject a connection nested inside a list, so a `Refund`'s `refun
 
 The resolver flattens each connection into a plain list under the field name, stripping all `edges`/`pageInfo`/cursor metadata, and mutates the parent documents in place.
 
+Bulk rejection isn't the only reason to reach for this. A stream that is already on the non-bulk path for other reasons uses the same declaration to keep a connection from truncating - `markets` runs non-bulk because `Market` has no date cursor, and declares its `catalogs` connection so large markets drain rather than stopping at the inline page.
+
 Each `NestedConnection` declares a `parent_path` locating the parent object(s) carrying it, so a connection anywhere in the document can be resolved. For example, `["refunds"]` is each object in the `refunds` list, `[]` is the document node itself, and a multi-step path descends fields, fanning out over any list it meets. Two rules follow from the `node(id:)` drain: every parent must be a `Node` with an `id` and connections resolve in declaration order - resolving one flattens it to a list, so a connection nested inside another must be declared after the connection it sits within.

--- a/source-shopify-native/source_shopify_native/graphql/__init__.py
+++ b/source-shopify-native/source_shopify_native/graphql/__init__.py
@@ -11,6 +11,7 @@ from .inventory.inventory_items import InventoryItems
 from .inventory.inventory_levels import InventoryLevels
 from .locations.locations import Locations
 from .locations.metafields import LocationMetafields
+from .markets import Markets
 from .products.products import Products
 from .products.variants import ProductVariants
 from .products.media import ProductMedia
@@ -44,6 +45,7 @@ __all__ = [
     "InventoryLevels",
     "Locations",
     "LocationMetafields",
+    "Markets",
     "Products",
     "ProductVariants",
     "ProductMedia",

--- a/source-shopify-native/source_shopify_native/graphql/locations/locations.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/locations.py
@@ -59,6 +59,10 @@ class Locations(ShopifyGraphQLResource):
             first=first,
             after=after,
             capabilities=capabilities,
+            # Both active and inactive locations are returned with `includeInactive: true`,
+            # and marking a location as inactive updates its updatedAt field, so fetching
+            # both in the same query works out fine.
+            extra_root_args="includeInactive: true",
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
+++ b/source-shopify-native/source_shopify_native/graphql/locations/metafields.py
@@ -26,6 +26,10 @@ class LocationMetafields(MetafieldsResource):
             first=first,
             after=after,
             capabilities=capabilities,
+            # Both active and inactive locations are returned with `includeInactive: true`,
+            # and marking a location as inactive updates its updatedAt field, so fetching
+            # both in the same query works out fine.
+            extra_root_args="includeInactive: true",
         )
 
     @staticmethod

--- a/source-shopify-native/source_shopify_native/graphql/markets.py
+++ b/source-shopify-native/source_shopify_native/graphql/markets.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+from logging import Logger
+from typing import AsyncGenerator
+
+from ..models import NestedConnection, ShopifyGraphQLResource, StoreCapabilities
+
+# Selection for each MarketCatalog under a Market. `markets` is deliberately left out: it points
+# back at the Market carrying this catalog, and each catalog's own `markets` connection would
+# multiply the query cost for data the parent document already holds.
+_MARKET_CATALOG_SELECTION = """
+id
+title
+status
+publication {
+    id
+}
+operations {
+    id
+    processedRowCount
+    rowCount {
+        count
+        exceedsMax
+    }
+    status
+}
+"""
+
+
+class Markets(ShopifyGraphQLResource):
+    """Markets of a Shopify store, each carrying its market catalogs inline.
+
+    Market has no `createdAt`/`updatedAt` and the `markets` connection cannot filter or
+    sort by date, so there is no usable incremental cursor and the full set is re-fetched
+    each snapshot.
+
+    MarketCatalog has no query root of its own that the connector captures, so catalogs are
+    embedded in their Market rather than referenced by id.
+
+    Two connections are deliberately left out of the field set for now:
+    - `webPresences`, which would need a second inline connection and force `OUTER_PAGE_SIZE`
+      down to stay under Shopify's per-query cost ceiling.
+    - `conditions.regionsCondition.regions`, because `RegionsCondition` is not a `Node`. The
+      nested resolver drains overflow with `node(id:)` re-queries, so a market with more regions
+      than the inline page would have no id to page from.
+    """
+
+    NAME = "markets"
+    QUERY_ROOT = "markets"
+    SHOULD_USE_BULK_QUERIES = False
+    QUALIFYING_SCOPES = {"read_markets"}
+    QUERY = """
+    id
+    name
+    handle
+    status
+    type
+    catalogsCount {
+        count
+        precision
+    }
+    currencySettings {
+        baseCurrency {
+            currencyCode
+            currencyName
+            enabled
+            manualRate
+            rateUpdatedAt
+        }
+        localCurrencies
+        roundingEnabled
+    }
+    priceInclusions {
+        inclusiveDutiesPricingStrategy
+        inclusiveTaxPricingStrategy
+    }
+    conditions {
+        conditionTypes
+    }
+    # {{ catalogs }}
+    """
+    NESTED_CONNECTIONS = [
+        NestedConnection(
+            parent_path=[],
+            parent_typename="Market",
+            field_name="catalogs",
+            node_selection=_MARKET_CATALOG_SELECTION,
+            page_size=5,
+            overflow_page_size=100,
+        ),
+    ]
+    # 25 markets x (~5 object points + 5 catalogs x ~4) lands near 625, leaving headroom under
+    # Shopify's 1000 point per-query ceiling. MAX_COST_EXCEEDED is fatal, so the margin is
+    # deliberate.
+    OUTER_PAGE_SIZE = 25
+
+    @staticmethod
+    def build_query(
+        start: datetime,
+        end: datetime,
+        first: int | None = None,
+        after: str | None = None,
+        capabilities: StoreCapabilities | None = None,
+    ) -> str:
+        # An unfiltered, cursor-paginated query: Market has no updated_at and the markets
+        # connection cannot filter or sort by date, so `start`/`end` are unused.
+        return f"""
+        {{
+            markets(
+                {f"first: {first}" if first else ""}
+                {f'after: "{after}"' if after else ""}
+            ) {{
+                edges {{
+                    node {{
+                        {Markets._resolve_nested_connections(Markets.QUERY)}
+                    }}
+                }}
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+            }}
+        }}
+        """
+
+    @staticmethod
+    async def process_result(
+        log: Logger, lines: AsyncGenerator[bytes, None]
+    ) -> AsyncGenerator[dict, None]:
+        async for record in Markets._process_result(
+            log, lines, "gid://shopify/Market/"
+        ):
+            yield record

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -45,6 +45,7 @@ scopes = [
     "read_orders",  # Orders, AbandonedCheckouts, Fulfillments, Transactions, Refunds, Risks
     "read_locations",  # Locations
     "read_inventory",  # InventoryItems, InventoryLevels, Locations
+    "read_markets",  # Markets
     "read_customers",  # Customers
     "read_own_subscription_contracts",  # SubscriptionContracts
     "read_users", # StaffMembers

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -695,6 +695,9 @@ class ShopifyGraphQLResource(BaseDocument):
         includeCreatedAt: bool = True,
         includeUpdatedAt: bool = True,
         capabilities: "StoreCapabilities | None" = None,
+        # Raw GraphQL spliced verbatim into the query root's argument list, for arguments
+        # that only one connection accepts (ex: `includeInactive` on `locations`).
+        extra_root_args: str = "",
     ) -> str:
         lower_bound = dt_to_str(start)
         upper_bound = dt_to_str(end)
@@ -721,6 +724,7 @@ class ShopifyGraphQLResource(BaseDocument):
                 {sort_key_clause}
                 {f"first: {first}" if first else ""}
                 {f'after: "{after}"' if after else ""}
+                {extra_root_args}
             ) {{
                 edges {{
                     node {{

--- a/source-shopify-native/source_shopify_native/models.py
+++ b/source-shopify-native/source_shopify_native/models.py
@@ -517,7 +517,51 @@ class NestedConnection:
         )
 
 
-class ShopifyGraphQLResource(BaseDocument):
+# BaseDocument plus the store discriminator that every Shopify collection keys on.
+#
+# Both incremental (`/_meta/store`, `/id`) and snapshot (`/_meta/store`, `/_meta/row_id`)
+# bindings put the store in their key, so the field has to be present in the schema the
+# connector discovers - Flow rejects a key pointing at a location its schema doesn't know.
+# The CDK's BaseDocument.Meta only carries op/row_id.
+#
+# Snapshot bindings use this model directly and leave every other field to schema inference.
+# ShopifyGraphQLResource extends it for the typed, query-backed streams.
+class ShopifyDocument(BaseDocument):
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    class Meta(BaseDocument.Meta):
+        model_config = ConfigDict(validate_assignment=True)
+
+        store: str = Field(
+            default="",
+            description="The Shopify store this document belongs to",
+        )
+
+    meta_: Meta = Field(  # type: ignore[override]
+        default_factory=lambda: ShopifyDocument.Meta(op="u"),
+        alias="_meta",
+        description="Document metadata",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_store_from_context(cls, data: Any, info: ValidationInfo) -> Any:
+        """Inject store name from validation context into document metadata.
+
+        Uses mode="before" so the store is set on the raw dict before Pydantic constructs
+        the model. Combined with validate_assignment=True on Meta, this ensures the store
+        field is tracked in model_fields_set and survives model_dump(exclude_unset=True).
+        """
+        if not isinstance(data, dict):
+            return data
+        if info.context and isinstance(info.context, StoreValidationContext):
+            meta = data.get("_meta") or {}
+            meta["store"] = info.context.store
+            data["_meta"] = meta
+        return data
+
+
+class ShopifyGraphQLResource(ShopifyDocument):
     QUERY: ClassVar[str] = ""
     QUERY_ROOT: ClassVar[str] = ""
     FRAGMENTS: ClassVar[list[str]] = []
@@ -540,8 +584,6 @@ class ShopifyGraphQLResource(BaseDocument):
     # Outer-connection page size override. Streams that inline nested connections lower this to keep
     # the per-query cost comfortably under Shopify's ceiling (with headroom for more connections).
     OUTER_PAGE_SIZE: ClassVar[int | None] = None
-
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
@@ -567,37 +609,6 @@ class ShopifyGraphQLResource(BaseDocument):
                     f"another connection's node_selection). Embed the placeholder verbatim where the "
                     f"connection belongs."
                 )
-
-    class Meta(BaseDocument.Meta):
-        model_config = ConfigDict(validate_assignment=True)
-
-        store: str = Field(
-            default="",
-            description="The Shopify store this document belongs to",
-        )
-
-    meta_: Meta = Field(  # type: ignore[override]
-        default_factory=lambda: ShopifyGraphQLResource.Meta(op="u"),
-        alias="_meta",
-        description="Document metadata",
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _inject_store_from_context(cls, data: Any, info: ValidationInfo) -> Any:
-        """Inject store name from validation context into document metadata.
-
-        Uses mode="before" so the store is set on the raw dict before Pydantic constructs
-        the model. Combined with validate_assignment=True on Meta, this ensures the store
-        field is tracked in model_fields_set and survives model_dump(exclude_unset=True).
-        """
-        if not isinstance(data, dict):
-            return data
-        if info.context and isinstance(info.context, StoreValidationContext):
-            meta = data.get("_meta") or {}
-            meta["store"] = info.context.store
-            data["_meta"] = meta
-        return data
 
     id: str
 

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -42,6 +42,7 @@ from .models import (
     PlanName,
     ShopDetails,
     ShopifyClientCredentials,
+    ShopifyDocument,
     ShopifyGraphQLResource,
     StoreCapabilities,
     StoreConfig,
@@ -702,7 +703,7 @@ async def all_resources(
                 data_model = create_response_data_model(model)
 
                 fetch_snapshot_fns: dict[str, functools.partial] = {}
-                tombstones: dict[str, ShopifyGraphQLResource] = {}
+                tombstones: dict[str, ShopifyDocument] = {}
                 for store_id in stores_with_access:
                     ctx = store_contexts[store_id]
                     if model.SHOULD_USE_BULK_QUERIES:
@@ -726,9 +727,8 @@ async def all_resources(
                     # The tombstone must carry the /_meta/store discriminator so
                     # deletes target the correct [store, row_id] key. The CDK only
                     # fills in op/row_id.
-                    tombstones[store_id] = ShopifyGraphQLResource(
-                        id="",
-                        _meta=ShopifyGraphQLResource.Meta(op="d", store=store_id),
+                    tombstones[store_id] = ShopifyDocument(
+                        _meta=ShopifyDocument.Meta(op="d", store=store_id),
                     )
 
                 open_binding(
@@ -746,6 +746,9 @@ async def all_resources(
             SnapshotResource(
                 name=model.NAME,
                 key=snapshot_key,
+                # ShopifyDocument's discovered schema include /_meta/store, which is
+                # a necessary key component that the CDK's BaseDocument couldn't know about.
+                model=ShopifyDocument,
                 open=create_snapshot_open_fn(model, stores_with_access),
                 initial_config=ResourceConfigWithSchedule(
                     name=model.NAME,

--- a/source-shopify-native/source_shopify_native/resources.py
+++ b/source-shopify-native/source_shopify_native/resources.py
@@ -173,6 +173,7 @@ PII_RESOURCES: set[type[ShopifyGraphQLResource]] = {
 
 FULL_REFRESH_RESOURCES: list[type[ShopifyGraphQLResource]] = [
     gql.StaffMembers,
+    gql.Markets,
 ]
 
 

--- a/source-shopify-native/test.flow.yaml
+++ b/source-shopify-native/test.flow.yaml
@@ -13,106 +13,132 @@ captures:
     - resource:
         name: abandoned_checkouts
         interval: PT5M
+        schedule: ''
       target: acmeCo/abandoned_checkouts
     - resource:
         name: customers
         interval: PT5M
+        schedule: ''
       target: acmeCo/customers
       disable: true
     - resource:
         name: customer_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/customer_metafields
       disable: true
     - resource:
         name: products
         interval: PT5M
+        schedule: ''
       target: acmeCo/products
     - resource:
         name: product_media
         interval: PT5M
+        schedule: ''
       target: acmeCo/product_media
     - resource:
         name: product_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/product_metafields
     - resource:
         name: product_variants
         interval: PT5M
+        schedule: ''
       target: acmeCo/product_variants
     - resource:
         name: product_variant_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/product_variant_metafields
     - resource:
         name: fulfillment_orders
         interval: PT5M
+        schedule: ''
       target: acmeCo/fulfillment_orders
     - resource:
         name: fulfillments
         interval: PT5M
+        schedule: ''
       target: acmeCo/fulfillments
     - resource:
         name: orders
         interval: PT5M
+        schedule: ''
       target: acmeCo/orders
     - resource:
         name: order_agreements
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_agreements
     - resource:
         name: order_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_metafields
     - resource:
         name: order_transactions
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_transactions
     - resource:
         name: order_refunds
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_refunds
     - resource:
         name: order_returns
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_returns
     - resource:
         name: order_risks
         interval: PT5M
+        schedule: ''
       target: acmeCo/order_risks
     - resource:
         name: inventory_items
         interval: PT5M
+        schedule: ''
       target: acmeCo/inventory_items
     - resource:
         name: inventory_levels
         interval: PT5M
+        schedule: ''
       target: acmeCo/inventory_levels
     - resource:
         name: custom_collections
         interval: PT5M
+        schedule: ''
       target: acmeCo/custom_collections
     - resource:
         name: smart_collections
         interval: PT5M
+        schedule: ''
       target: acmeCo/smart_collections
     - resource:
         name: custom_collection_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/custom_collection_metafields
     - resource:
         name: smart_collection_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/smart_collection_metafields
     - resource:
         name: locations
         interval: PT5M
+        schedule: ''
       target: acmeCo/locations
     - resource:
         name: location_metafields
         interval: PT5M
+        schedule: ''
       target: acmeCo/location_metafields
     - resource:
         name: disputes
         interval: PT5M
+        schedule: 55 23 * * *
       target: acmeCo/disputes

--- a/source-shopify-native/test.flow.yaml
+++ b/source-shopify-native/test.flow.yaml
@@ -142,3 +142,7 @@ captures:
         interval: PT5M
         schedule: 55 23 * * *
       target: acmeCo/disputes
+    - resource:
+        name: markets
+        interval: PT15M
+      target: acmeCo/markets

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -6733,5 +6733,43 @@
       "metafields": [],
       "updatedAt": "redacted"
     }
+  ],
+  [
+    "acmeCo/markets",
+    {
+      "_meta": {
+        "op": "c",
+        "row_id": 0,
+        "store": "estuary-alex-testing",
+        "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+      },
+      "catalogs": [],
+      "catalogsCount": {
+        "count": 0,
+        "precision": "EXACT"
+      },
+      "conditions": {
+        "conditionTypes": [
+          "REGION"
+        ]
+      },
+      "currencySettings": {
+        "baseCurrency": {
+          "currencyCode": "USD",
+          "currencyName": "US Dollar",
+          "enabled": true,
+          "manualRate": null,
+          "rateUpdatedAt": null
+        },
+        "localCurrencies": false,
+        "roundingEnabled": true
+      },
+      "handle": "international",
+      "id": "gid://shopify/Market/45947256877",
+      "name": "International",
+      "priceInclusions": null,
+      "status": "ACTIVE",
+      "type": "REGION"
+    }
   ]
 ]

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -6576,14 +6576,6 @@
             "name": "Point of Sale"
           },
           "publishDate": "2025-01-14T15:09:43Z"
-        },
-        {
-          "__parentId": "gid://shopify/Collection/295442513965",
-          "publication": {
-            "id": "gid://shopify/Publication/204831391789",
-            "name": "Microsoft Copilot"
-          },
-          "publishDate": "2026-06-26T04:37:46Z"
         }
       ],
       "sortOrder": "BEST_SELLING",
@@ -6658,14 +6650,6 @@
             "name": "Online Store"
           },
           "publishDate": "2025-01-14T15:10:14Z"
-        },
-        {
-          "__parentId": "gid://shopify/Collection/295442612269",
-          "publication": {
-            "id": "gid://shopify/Publication/204831391789",
-            "name": "Microsoft Copilot"
-          },
-          "publishDate": "2026-06-26T04:37:46Z"
         }
       ],
       "sortOrder": "BEST_SELLING",

--- a/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -2208,5 +2208,82 @@
       "/_meta/store",
       "/id"
     ]
+  },
+  {
+    "recommendedName": "markets",
+    "resourceConfig": {
+      "name": "markets",
+      "interval": "PT15M"
+    },
+    "documentSchema": {
+      "$defs": {
+        "Meta": {
+          "properties": {
+            "op": {
+              "default": "u",
+              "description": "Operation type (c: Create, u: Update, d: Delete)",
+              "enum": [
+                "c",
+                "u",
+                "d"
+              ],
+              "title": "Op",
+              "type": "string"
+            },
+            "row_id": {
+              "default": -1,
+              "description": "Row ID of the Document, counting up from zero, or -1 if not known",
+              "title": "Row Id",
+              "type": "integer"
+            },
+            "store": {
+              "default": "",
+              "description": "The Shopify store this document belongs to",
+              "title": "Store",
+              "type": "string"
+            }
+          },
+          "title": "Meta",
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/Meta",
+          "description": "Document metadata"
+        }
+      },
+      "title": "ShopifyDocument",
+      "type": "object",
+      "x-infer-schema": true,
+      "if": {
+        "required": [
+          "_meta"
+        ],
+        "properties": {
+          "_meta": {
+            "required": [
+              "op"
+            ],
+            "properties": {
+              "op": {
+                "const": "d"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "reduce": {
+          "strategy": "merge",
+          "delete": true
+        }
+      }
+    },
+    "key": [
+      "/_meta/store",
+      "/_meta/row_id"
+    ]
   }
 ]


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes:
### Cleanup
- Updating various test files due to either Shopify side API changes or previously merged changes where the PR author (usually me) forgot to run `flowctl raw discover` when making changes that affected discovered bindings.
- Using client credentials authentication for snapshot testing to make it easier to add and remove scopes without needing to regenerate credentials.

### Features
- Capturing inactive `locations` with an additional root argument `includeInactive: true`.
- Adding a `markets` stream.

### Bug fixes
- Fixing a bug where the discovered schemas for snapshot streams (only `staff_members` and `markets` right now) omitted the `/_meta/store` field despite declaring it as a key.

Snapshot changes are expected due to the addition of the new `markets` stream.

Best reviewed commit-by-commit.

Closes https://github.com/estuary/connectors/issues/4822 and https://github.com/estuary/connectors/issues/4746.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
