### PR TITLE
source-{Rust}: log when no bindings are enabled

### DIFF
--- a/source-http-ingest/src/server.rs
+++ b/source-http-ingest/src/server.rs
@@ -112,6 +112,7 @@ pub async fn run_server(
         router = router.layer(cors);
     }
 
+    let num_bindings = bindings.len();
     let handler = Handler::try_new(stdin, stdout, endpoint_config, bindings)?;
     let router = router.with_state(Arc::new(handler));
 
@@ -119,7 +120,19 @@ pub async fn run_server(
     let listener = tokio::net::TcpListener::bind(address)
         .await
         .context("listening on port")?;
-    tracing::info!(eventType = "connectorStatus", "listening for connections");
+
+    if num_bindings == 0 {
+        tracing::info!(
+            eventType = "connectorStatus",
+            "listening for connections, no bindings are enabled"
+        );
+    } else {
+        tracing::info!(
+            eventType = "connectorStatus",
+            bindings = num_bindings,
+            "listening for connections"
+        );
+    }
     axum::serve(listener, router.into_make_service())
         .await
         .context("running server")?;

--- a/source-kafka/src/lib.rs
+++ b/source-kafka/src/lib.rs
@@ -94,7 +94,19 @@ pub async fn run_connector(
                 &mut stdout,
             )?;
 
-            tracing::info!(eventType = "connectorStatus", "Starting capture");
+            let num_bindings = req.capture.as_ref().map_or(0, |spec| spec.bindings.len());
+            if num_bindings == 0 {
+                tracing::info!(
+                    eventType = "connectorStatus",
+                    "Starting capture, no bindings are enabled"
+                );
+            } else {
+                tracing::info!(
+                    eventType = "connectorStatus",
+                    bindings = num_bindings,
+                    "Starting capture"
+                );
+            }
 
             let eof = tokio::spawn(async move {
                 let mut line_string = String::new();


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR finishes out the "log when no bindings are enabled" effort for the remaining capture connectors that weren't covered by https://github.com/estuary/connectors/pull/5024, https://github.com/estuary/connectors/pull/5008, or https://github.com/estuary/connectors/pull/5004. The remaining stragglers are our Rust connectors, which don't have a common framework, so the logging is modified directly in the connectors' code.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
