### PR TITLE
materialize-clickhouse: look up load keys by primary key instead of joining

### DIFF
--- a/materialize-clickhouse/.snapshots/TestSQLGeneration
+++ b/materialize-clickhouse/.snapshots/TestSQLGeneration
@@ -122,10 +122,10 @@ SETTINGS select_sequential_consistency = 1;
 
 SELECT r.flow_document
 	FROM key_value AS r FINAL
-	JOIN flow_temp_load_0_key_value AS l
-		 ON l.key1 = r.key1
-		 AND l.key2 = r.key2
-		 AND l.`key!binary` = r.`key!binary`
+	WHERE (r.key1, r.key2, r.`key!binary`) IN (
+		SELECT key1, key2, `key!binary`
+		FROM flow_temp_load_0_key_value
+	)
 SETTINGS select_sequential_consistency = 1;
 --- End key_value queryLoadTable ---
 
@@ -164,10 +164,10 @@ concat('{',
 	'"stringNumber":', ifNull(toJSONString(toString(r.stringNumber)), 'null')
 , '}') AS flow_document
 	FROM key_value AS r FINAL
-	JOIN flow_temp_load_0_key_value AS l
-		 ON l.key1 = r.key1
-		 AND l.key2 = r.key2
-		 AND l.`key!binary` = r.`key!binary`
+	WHERE (r.key1, r.key2, r.`key!binary`) IN (
+		SELECT key1, key2, `key!binary`
+		FROM flow_temp_load_0_key_value
+	)
 SETTINGS select_sequential_consistency = 1;
 --- End key_value queryLoadTableNoFlowDocument ---
 

--- a/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
+++ b/materialize-clickhouse/.snapshots/TestSQLGenerationQuotedTableNames
@@ -122,10 +122,10 @@ SETTINGS select_sequential_consistency = 1;
 
 SELECT r.flow_document
 	FROM `key_value-@你好-``-"especiál` AS r FINAL
-	JOIN `flow_temp_load_0_key_value-@你好-``-"especiál` AS l
-		 ON l.key1 = r.key1
-		 AND l.key2 = r.key2
-		 AND l.`key!binary` = r.`key!binary`
+	WHERE (r.key1, r.key2, r.`key!binary`) IN (
+		SELECT key1, key2, `key!binary`
+		FROM `flow_temp_load_0_key_value-@你好-``-"especiál`
+	)
 SETTINGS select_sequential_consistency = 1;
 --- End `key_value-@你好-``-"especiál` queryLoadTable ---
 
@@ -164,10 +164,10 @@ concat('{',
 	'"stringNumber":', ifNull(toJSONString(toString(r.stringNumber)), 'null')
 , '}') AS flow_document
 	FROM `key_value-@你好-``-"especiál` AS r FINAL
-	JOIN `flow_temp_load_0_key_value-@你好-``-"especiál` AS l
-		 ON l.key1 = r.key1
-		 AND l.key2 = r.key2
-		 AND l.`key!binary` = r.`key!binary`
+	WHERE (r.key1, r.key2, r.`key!binary`) IN (
+		SELECT key1, key2, `key!binary`
+		FROM `flow_temp_load_0_key_value-@你好-``-"especiál`
+	)
 SETTINGS select_sequential_consistency = 1;
 --- End `key_value-@你好-``-"especiál` queryLoadTableNoFlowDocument ---
 

--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-10
+
+### Fixed
+- The load query joined the target table against the staging table of keys,
+  which read every row of the target -- including the whole `flow_document`
+  column -- for each transaction. On a large binding this could exceed the
+  ClickHouse driver's read deadline, failing the query and restarting the
+  transaction without it ever committing. The load query now restricts the
+  target to the staged keys directly, so ClickHouse resolves them through the
+  table's primary key index and reads only the rows being loaded.
+
 ## 2026-08-06
 
 ### Fixed

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -496,7 +496,7 @@ func (t *transactor) addBinding(_ context.Context, target sql.Table) error {
 const (
 	// ClickHouse recommends inserting batches of 100,000 rows.
 	// https://clickhouse.com/docs/optimize/bulk-inserts
-	// Load phase: insert keys to temporary tables for subsequent join on the target table.
+	// Load phase: insert keys to temporary tables for a subsequent lookup against the target table.
 	// Store phase: insert documents to stage tables for subsequent move to the target table.
 	maxBatchSize = 100_000
 
@@ -523,7 +523,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 	// activeBindings tracks the number of keys inserted into each binding's
 	// load table this round, for verification against an authoritative count
-	// before the join.
+	// before the load query runs.
 	activeBindings := make(map[int]int64, len(t.bindings))
 	batch := make([]batchItem, 0, maxBatchSize)
 	batchBytes := 0
@@ -581,7 +581,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 			b := t.bindings[i]
 			// Free resources on the ClickHouse server. Truncate rather than
 			// drop: the load table's identity must stay stable so that key
-			// inserts and the join query resolve the same table from any
+			// inserts and the load query resolve the same table from any
 			// replica of a clustered deployment.
 			//
 			// A failure leaves this round's keys in the table, so it is
@@ -632,7 +632,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 
 	// Hard check: an authoritative count of each load table must account for
 	// every key inserted this round. A shortfall means the keys are not
-	// visible to the replica that will serve the join -- running it anyway
+	// visible to the replica that will serve the load query -- running it anyway
 	// would silently treat existing documents as absent, storing unreduced
 	// documents over them.
 	for i, inserted := range activeBindings {
@@ -648,7 +648,7 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(int, json.RawMessage) 
 		}
 	}
 
-	// Keys are now ready to be JOIN'd between the temporary and target tables.
+	// Keys are now staged and ready for the target table to be queried for them.
 	loadBinding := func(i int, b *binding) error {
 		// Documents already delivered via loaded() cannot be recalled, so the
 		// query may only be retried while nothing has been emitted: re-running

--- a/materialize-clickhouse/sqlgen.go
+++ b/materialize-clickhouse/sqlgen.go
@@ -458,17 +458,17 @@ SETTINGS mutations_sync = 1;
 
 -- Load tables stage the keys of documents the connector needs to look up during a
 -- transaction's load phase. The connector inserts keys into the staging load table,
--- then joins the target table (using FINAL for deduplication) against the staging
--- table to retrieve the current version of documents for those keys.
+-- then selects from the target table (using FINAL for deduplication) restricted to
+-- those keys, to retrieve the current version of their documents.
 --
 -- Load tables use the MergeTree engine so that large key sets are spilled to disk
 -- rather than held entirely in memory, avoiding server memory limit issues.
 --
 -- Like store tables, load tables are PERSISTENT: created once (IF NOT EXISTS) at
 -- session start and truncated -- never re-created -- between load rounds, keeping
--- the name->UUID mapping stable so that key inserts and the join query resolve the
--- same object from any replica of a clustered deployment. The join query and the
--- pre-join key-count check run with select_sequential_consistency = 1 so they
+-- the name->UUID mapping stable so that key inserts and the load query resolve the
+-- same object from any replica of a clustered deployment. The load query and the
+-- key-count check preceding it run with select_sequential_consistency = 1 so they
 -- observe both the keys just inserted and target-table rows committed by prior
 -- transactions' partition moves. Load tables hold nothing durable (only the current
 -- round's lookup keys), so they are safe to truncate at any time. Like store
@@ -521,6 +521,26 @@ INSERT INTO {{ template "loadTableName" . }} (
 {{ end }}
 
 {{/*
+Restricting the target to the staged keys with a tuple IN, rather than joining
+against the load table, is what keeps the load query affordable on a large
+target. The key tuple is exactly the target's ORDER BY (see createTargetTable),
+so ClickHouse resolves the set through the primary key index and reads only the
+mark ranges that can contain those keys. Joining instead makes the load table
+the build side and streams every row of the target -- including the whole
+flow_document column -- through the hash probe, at a cost that scales with the
+size of the table rather than with the number of keys being loaded.
+
+Keys are never null in a Flow collection, so the NULL-unsafe semantics of IN
+(transform_null_in = 0) cannot exclude a key that the target actually holds.
+*/}}
+{{ define "loadKeyPredicate" -}}
+({{ range $ind, $key := $.Keys }}{{ if $ind }}, {{ end }}r.{{ $key.Identifier }}{{ end }}) IN (
+		SELECT {{ range $ind, $key := $.Keys }}{{ if $ind }}, {{ end }}{{ $key.Identifier }}{{ end }}
+		FROM {{ template "loadTableName" . }}
+	)
+{{- end }}
+
+{{/*
 The load queries (queryLoadTable and queryLoadTableNoFlowDocument) each carry
 SETTINGS select_sequential_consistency = 1 so that a query observes both the
 just-inserted keys and target-table rows committed by prior transactions'
@@ -530,11 +550,7 @@ partition moves, from any replica.
 {{ if $.Document -}}
 SELECT r.{{$.Document.Identifier}}
 	FROM {{$.Identifier}} AS r FINAL
-	JOIN {{ template "loadTableName" . }} AS l
-	{{- range $ind, $key := $.Keys }}
-		{{ if $ind }} AND {{ else }} ON {{ end -}}
-		l.{{$key.Identifier}} = r.{{$key.Identifier}}
-	{{- end }}
+	WHERE {{ template "loadKeyPredicate" . }}
 SETTINGS select_sequential_consistency = 1;
 {{ end -}}
 {{ end }}
@@ -575,11 +591,7 @@ concat('{',
 {{- end }}
 , '}') AS flow_document
 	FROM {{$.Identifier}} AS r FINAL
-	JOIN {{ template "loadTableName" . }} AS l
-	{{- range $ind, $key := $.Keys }}
-		{{ if $ind }} AND {{ else }} ON {{ end -}}
-		l.{{$key.Identifier}} = r.{{$key.Identifier}}
-	{{- end }}
+	WHERE {{ template "loadKeyPredicate" . }}
 SETTINGS select_sequential_consistency = 1;
 {{ else -}}
 SELECT ''::String LIMIT 0


### PR DESCRIPTION
Closes #5036 

**Description:**

The load query joined the target table against the staging table of keys, which gave ClickHouse nothing to prune on: the staging table becomes the build side and every row of the target — `flow_document` included — streams through the hash probe. Cost scales with table size rather than with the number of keys being loaded.

It now restricts the target to the staged keys with a tuple `IN`. The key tuple is exactly the target's `ORDER BY`, so ClickHouse resolves the set through the primary key index and reads only the relevant mark ranges.

Before, as the connector issued it (`<database>`, `<table>` and `<key1..4>` standing in for a real binding's names, and `0` for its range key):

```sql
SELECT r.flow_document
	FROM <table> AS r FINAL
	JOIN flow_temp_load_0_<table> AS l
		 ON l.<key1> = r.<key1>
		 AND l.<key2> = r.<key2>
		 AND l.<key3> = r.<key3>
		 AND l.<key4> = r.<key4>
SETTINGS select_sequential_consistency = 1;
```

After:

```sql
SELECT r.flow_document
	FROM <table> AS r FINAL
	WHERE (r.<key1>, r.<key2>, r.<key3>, r.<key4>) IN (
		SELECT <key1>, <key2>, <key3>, <key4>
		FROM flow_temp_load_0_<table>
	)
SETTINGS select_sequential_consistency = 1;
```

Measured on a customer's 4.5B-row / 88 GiB table by running exactly this pair (both `FORMAT Null`, so the server does the work but nothing crosses the wire) against the same 7.0M staged keys:

| | JOIN | tuple IN |
|---|---|---|
| duration | 269s | 4.8s |
| rows read | 4.51B | 14.1M |
| bytes read | 1.36 TiB | 2.40 GiB |
| CPU | 1488s | 8.2s |

Cost per key is flat (2.02 rows read per staged key at both 5.8M and 7.0M keys), so it doesn't regress as the table grows.

The immediate symptom was a crash loop: the query exceeded `clickhouse-go`'s default 300s `ReadTimeout` — which is a deadline over the whole result stream, not an idle timeout — so the transaction restarted without ever committing. 69 transactions were killed this way in a week across three bindings on that task.

Incidentally stricter than the join: `IN` returns one row per target row, so it can't emit a duplicate key the way a join can if the staging table ever held one.

**Workflow steps:**

No changes.

**Documentation links affected:**

None — no config or user-facing surface changes.

**Notes for reviewers:**

- Both load templates (`queryLoadTable` and the `no_flow_document` variant) share the new `loadKeyPredicate`.
- Single-key bindings render `(r.key) IN (…)`. ClickHouse parses single-element parens as grouping, not a 1-tuple (`toTypeName((1))` is `UInt8`), so this is equivalent to a bare `IN` and prunes identically. Verified against a 26.2.1 server. Note no snapshot fixture covers a single-key binding — both use three keys — so that equivalence rests on parse semantics rather than a test.
- Not addressed here: `ReadTimeout` is left unset, so it stays at the SDK's 300s. That's a hard cap on any streamed query and will bite the next large binding regardless of this fix. Worth a follow-up.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.

