### PR TITLE
sqlcapture: Support linked_collections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.0.5
 	github.com/duckdb/duckdb-go/v2 v2.10502.0
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
-	github.com/estuary/flow v0.6.10
+	github.com/estuary/flow v0.6.13
 	github.com/estuary/vitess v0.15.10
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-mysql-org/go-mysql v0.0.0-20250907131429-558ed11751bc
@@ -81,7 +81,7 @@ require (
 	github.com/tidwall/gjson v1.17.3
 	github.com/tidwall/sjson v1.2.5
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee
+	go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64
 	go.mongodb.org/mongo-driver v1.17.7
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/estuary/flow v0.6.10 h1:Z+zM5Qct0aR5EQAhfHmi4bR3jZPDpNwK0R5KPlZz/Wc=
-github.com/estuary/flow v0.6.10/go.mod h1:jdQeVWS9sw520EU2u9UPYryE5iEo1Gu9Ju99LXJ8r7Y=
+github.com/estuary/flow v0.6.13 h1:TLqACCjW04JCRhbaynx77lqtrt9MStsoLNxYPFgz1vw=
+github.com/estuary/flow v0.6.13/go.mod h1:TRYgc5HrpCCuNu9K3LnL0Of8/3+BLe3Ad5JSpY47EHE=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e h1:stJOXFppEkEksGtqpJjIIfufID+RUkrkMCFKgu4Vfaw=
 github.com/estuary/go-mysql v0.0.0-20250918155720-90d473fd1a3e/go.mod h1:FQxw17uRbFvMZFK+dPtIPufbU46nBdrGaxOw0ac9MFs=
 github.com/estuary/vitess v0.15.10 h1:oXJgcG0HGZWuwjdvSp4pIFIAXtKLaR9Fl9VBynSszFA=
@@ -1079,8 +1079,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.6.5 h1:Duz9fAzIZFhYWgRjp/FgNq2gO1jId9Yae/rLn3Rr
 go.etcd.io/etcd/client/pkg/v3 v3.6.5/go.mod h1:8Wx3eGRPiy0qOFMZT/hfvdos+DjEaPxdIDiCDUv/FQk=
 go.etcd.io/etcd/client/v3 v3.6.5 h1:yRwZNFBx/35VKHTcLDeO7XVLbCBFbPi+XV4OC3QJf2U=
 go.etcd.io/etcd/client/v3 v3.6.5/go.mod h1:ZqwG/7TAFZ0BJ0jXRPoJjKQJtbFo/9NIY8uoFFKcCyo=
-go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee h1:yceN2m1184/i4YSN4tlfMSdpnV+xnePgnUf4KFa00oE=
-go.gazette.dev/core v0.103.1-0.20260505142537-ce718ada37ee/go.mod h1:4qMw9JDecqIx6EijHy6ndbueTYeglm6LW4qKxEUOZ8M=
+go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64 h1:YX2MhHISLxvz1xoS+YQntf4FMZ24Q02+97nmTHImrYI=
+go.gazette.dev/core v0.103.1-0.20260722193110-e54beb5c6e64/go.mod h1:fbzVmqkkTxqOnpcvdXuSWJ28XoMMm08ovNaATv1Zuas=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
 go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=

--- a/go/capture/blackbox/capture.go
+++ b/go/capture/blackbox/capture.go
@@ -458,6 +458,42 @@ func (c *Capture) EditBinding(index int, path string, val any) error {
 	return nil
 }
 
+// EditCapture modifies a property of the first capture in the catalog.
+// The path is relative to the capture, e.g. "shards.flags.indirect-specs".
+func (c *Capture) EditCapture(path string, val any) error {
+	var captureName = gjson.GetBytes(c.Catalog, "captures.@keys.0").String()
+	var fullPath = fmt.Sprintf("captures.%s.%s", captureName, path)
+	var result, err = sjson.SetBytes(c.Catalog, fullPath, val)
+	if err != nil {
+		return err
+	}
+	c.Catalog = result
+	return nil
+}
+
+// BindingTarget returns the target collection name of the indexed binding of
+// the first capture in the catalog.
+func (c *Capture) BindingTarget(index int) string {
+	var captureName = gjson.GetBytes(c.Catalog, "captures.@keys.0").String()
+	var fullPath = fmt.Sprintf("captures.%s.bindings.%d.target", captureName, index)
+	return gjson.GetBytes(c.Catalog, fullPath).String()
+}
+
+// DeleteCollection removes collections whose names contain the filter substring.
+func (c *Capture) DeleteCollection(filter string) error {
+	for _, name := range gjson.GetBytes(c.Catalog, "collections.@keys").Array() {
+		if !strings.Contains(name.String(), filter) {
+			continue
+		}
+		var result, err = sjson.DeleteBytes(c.Catalog, "collections."+name.String())
+		if err != nil {
+			return err
+		}
+		c.Catalog = result
+	}
+	return nil
+}
+
 // EditCheckpoint modifies a property of the checkpoint state.
 // The path is specified in sjson dot notation, e.g. "bindingStateV1.test%2Ffoobar.scanned"
 func (c *Capture) EditCheckpoint(path string, val any) error {

--- a/source-postgres/.snapshots/TestLinkedCollections
+++ b/source-postgres/.snapshots/TestLinkedCollections
@@ -1,0 +1,192 @@
+sql> CREATE TABLE test.linkedcollections_294068_a (id INTEGER PRIMARY KEY, data TEXT)
+sql> CREATE TABLE test.linkedcollections_294068_b (id INTEGER PRIMARY KEY, data TEXT)
+sql> INSERT INTO test.linkedcollections_294068_a VALUES (1, 'one'), (2, 'two')
+sql> INSERT INTO test.linkedcollections_294068_b VALUES (3, 'three'), (4, 'four')
+=== Discover: Discover Tables ===
+acmeCo/test_capture/test/linkedcollections_294068_a
+acmeCo/test_capture/test/linkedcollections_294068_b
+=== Run: Initial Backfill ===
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "linkedcollections_294068_a"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "one",
+    "id": 1
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "linkedcollections_294068_a"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "two",
+    "id": 2
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "linkedcollections_294068_b"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "three",
+    "id": 3
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "snapshot": true,
+        "table": "linkedcollections_294068_b"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "four",
+    "id": 4
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "test%2Flinkedcollections_294068_a": {
+      "backfilled": 2,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    },
+    "test%2Flinkedcollections_294068_b": {
+      "backfilled": 2,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+sql> INSERT INTO test.linkedcollections_294068_a VALUES (5, 'five'), (6, 'six')
+sql> INSERT INTO test.linkedcollections_294068_b VALUES (7, 'seven'), (8, 'eight')
+=== Run: Replication ===
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "table": "linkedcollections_294068_a",
+        "ts_ms": "REDACTED",
+        "txid": "REDACTED"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "five",
+    "id": 5
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "table": "linkedcollections_294068_a",
+        "ts_ms": "REDACTED",
+        "txid": "REDACTED"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "six",
+    "id": 6
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "table": "linkedcollections_294068_b",
+        "ts_ms": "REDACTED",
+        "txid": "REDACTED"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "seven",
+    "id": 7
+  }
+]
+[
+  "acmeCo/test_capture/test/linkedcollections_294068_a",
+  {
+    "_meta": {
+      "op": "c",
+      "source": {
+        "loc": "REDACTED",
+        "schema": "test",
+        "table": "linkedcollections_294068_b",
+        "ts_ms": "REDACTED",
+        "txid": "REDACTED"
+      },
+      "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
+    },
+    "data": "eight",
+    "id": 8
+  }
+]
+--- Final Checkpoint ---
+{
+  "bindingStateV1": {
+    "test%2Flinkedcollections_294068_a": {
+      "backfilled": 2,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    },
+    "test%2Flinkedcollections_294068_b": {
+      "backfilled": 2,
+      "key_columns": [
+        "id"
+      ],
+      "mode": "Active"
+    }
+  },
+  "cursor": "REDACTED"
+}
+

--- a/source-postgres/capture_test.go
+++ b/source-postgres/capture_test.go
@@ -879,3 +879,38 @@ func TestBackfillPriority(t *testing.T) {
 	tc.Run("Backfill 3 (Low Priority)", transactionCountBaseline+1)  // Run until everything else is backfilled
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
+
+// TestLinkedCollections exercises the indirect "linked collections" form of the
+// capture protocol, in which every binding leaves its collection unset and
+// instead references an entry of the spec's linked_collections table by index.
+// Two tables with identical shapes are captured into a single shared output
+// collection, which is the fan-in pattern this protocol feature exists for.
+func TestLinkedCollections(t *testing.T) {
+	var db, tc = blackboxTestSetup(t)
+	db.CreateTable(t, `<NAME>_a`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+	db.CreateTable(t, `<NAME>_b`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+	db.Exec(t, `INSERT INTO <NAME>_a VALUES (1, 'one'), (2, 'two')`)
+	db.Exec(t, `INSERT INTO <NAME>_b VALUES (3, 'three'), (4, 'four')`)
+	tc.Discover("Discover Tables")
+
+	// Repoint the second binding at the first binding's collection so both
+	// tables feed into it, drop the now-unused second collection, and set the
+	// indirect-specs flag so the built spec and its Validate / Open requests
+	// carry the shared collection in a linked_collections table.
+	var unused = tc.Capture.BindingTarget(1)
+	require.NoError(t, tc.Capture.EditBinding(1, "target", tc.Capture.BindingTarget(0)))
+	require.NoError(t, tc.Capture.DeleteCollection(unused))
+	require.NoError(t, tc.Capture.EditCapture("shards.flags.indirect-specs", "true"))
+
+	// Since both tables feed the same collection the transcript can't group
+	// their documents by collection name, so give the first table a higher
+	// backfill priority to make the document ordering deterministic.
+	require.NoError(t, tc.Capture.EditBinding(0, "resource.priority", 10))
+
+	tc.Run("Initial Backfill", transactionCountBaseline+2)
+
+	db.Exec(t, `INSERT INTO <NAME>_a VALUES (5, 'five'), (6, 'six')`)
+	db.Exec(t, `INSERT INTO <NAME>_b VALUES (7, 'seven'), (8, 'eight')`)
+	tc.Run("Replication", transactionCountBaseline)
+	cupaloy.SnapshotT(t, tc.Transcript.String())
+}

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -245,7 +245,7 @@ func (d *Driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 
 		// When performing a keyed backfill, it's an error for the collection key to be the fallback key. It has to be one or more top-level properties.
 		if (res.Mode == BackfillModeAutomatic || res.Mode == BackfillModeNormal || res.Mode == BackfillModePrecise) && len(res.PrimaryKey) == 0 {
-			if slices.Equal(binding.Collection.Key, db.FallbackCollectionKey()) {
+			if slices.Equal(req.BindingCollection(binding).Key, db.FallbackCollectionKey()) {
 				var err = fmt.Errorf("output collection for stream %q has the fallback key, which can't be used for a backfill", streamID)
 				log.WithError(err).Debug("prerequisite error")
 				errs = append(errs, err)
@@ -380,13 +380,14 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		}
 		res.SetDefaults()
 		var streamID = JoinStreamID(res.Namespace, res.Stream)
+		var collection = open.Capture.BindingCollection(binding)
 
 		tables = append(tables, TableID{Schema: res.Namespace, Table: res.Stream})
 
 		// TODO: Remove the whole 'Enable TxIDs' thing and instead include them unconditionally
 		// at some point in the future once automatic schema updates are a thing and the
 		// number of captures which would be broken by the change is acceptably small.
-		for _, projection := range binding.Collection.Projections {
+		for _, projection := range collection.Projections {
 			if projection.Ptr == "/_meta/source/txid" {
 				db.RequestTxIDs(res.Namespace, res.Stream)
 			}
@@ -397,7 +398,7 @@ func (d *Driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 			StreamID:      streamID,
 			StateKey:      boilerplate.StateKey(binding.StateKey),
 			Resource:      res,
-			CollectionKey: binding.Collection.Key,
+			CollectionKey: collection.Key,
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Connector support for the `linked_collections` mechanism added to the runtime in https://github.com/estuary/flow/pull/3303. We don't actually refer to collection specs in very many places so really all we need to do is a Flow version bump and using new accessors in a couple of places.

Also adds a test in `source-postgres` which exercises the feature and demonstrates that it produces the expected results into a single collection, although strictly speaking the test doesn't show that the `linked_collections` field is actually used and I had to verify that bit myself out-of-band, but if you assume that the `shards.flags.indirect-specs = true` setting does what it's supposed to the test still has a little value.

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
