### PR TITLE
source-google-ads: read geo_target_constant once per sync

### DIFF
--- a/source-google-ads/CHANGELOG.md
+++ b/source-google-ads/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-10
+
+### Fixed
+- The `geo_target_constant` stream is now read once per sync instead of once per configured customer ID.
+
 ## 2026-07-22
 
 ### Changed

--- a/source-google-ads/source_google_ads/streams.py
+++ b/source-google-ads/source_google_ads/streams.py
@@ -598,3 +598,17 @@ class GeoTargetConstant(GoogleAdsStream):
     """
 
     primary_key = ["geo_target_constant.id"]
+
+    def stream_slices(
+        self, stream_state: Mapping[str, Any] = None, **kwargs
+    ) -> Iterable[Optional[Mapping[str, any]]]:
+        """
+        geo_target_constant is a global table rather than per-customer data. Slicing per customer
+        the way GoogleAdsStream does re-reads the entire table once per configured customer. That
+        ends up emitting a lot of duplicate data, so instead of that, a single slice is emitted
+        and the table is read from whichever customer comes first.
+        """
+        if not self.customers:
+            return
+
+        yield {"customer_id": self.customers[0].id}

--- a/source-google-ads/tests/test_streams.py
+++ b/source-google-ads/tests/test_streams.py
@@ -7,13 +7,15 @@ from unittest.mock import Mock
 
 import pytest
 from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.utils.slice_logger import DebugSliceLogger
 from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.v25.errors.types.errors import ErrorCode, GoogleAdsError, GoogleAdsFailure
 from google.ads.googleads.v25.errors.types.request_error import RequestErrorEnum
 from google.api_core.exceptions import DataLoss, InternalServerError, ResourceExhausted, TooManyRequests
 from grpc import RpcError
 from source_google_ads.google_ads import GoogleAds
-from source_google_ads.streams import ClickView, cyclic_sieve
+from source_google_ads.models import Customer
+from source_google_ads.streams import ClickView, GeoTargetConstant, cyclic_sieve
 
 from .common import MockGoogleAdsClient as MockGoogleAdsClient
 
@@ -219,6 +221,53 @@ def test_retry_transient_errors(mocker, config, customers, error_cls):
         records = list(stream.read_records(sync_mode=SyncMode.incremental, cursor_field=["segments.date"], stream_slice=stream_slice))
     assert mocked_search.call_count == 5
     assert records == []
+
+
+class MockGoogleAdsGeoTargetConstants(MockGoogleAds):
+    """Serves the geo_target_constant table, recording which customers it was asked for."""
+
+    def __init__(self, credentials):
+        super().__init__(credentials=credentials)
+        self.requested_customer_ids = []
+
+    def send_request(self, query: str, customer_id: str):
+        self.requested_customer_ids.append(customer_id)
+        return iter([[{"geo_target_constant.id": 1000002}, {"geo_target_constant.id": 1000003}]])
+
+
+def read_geo_target_constants(stream):
+    return list(
+        stream.read_full_refresh(
+            cursor_field=None,
+            logger=logging.getLogger("test"),
+            slice_logger=DebugSliceLogger(),
+        )
+    )
+
+
+def test_geo_target_constant_reads_the_table_once_for_all_customers(mock_ads_client, config):
+    """
+    geo_target_constant is a global table, so it must be read once no matter how many customers are
+    configured - reading it per customer means re-reading ~270k identical rows for each one.
+    """
+    customers = [Customer(id=str(customer_id)) for customer_id in range(1, 12)]
+    google_api = MockGoogleAdsGeoTargetConstants(credentials=config["credentials"])
+    stream = GeoTargetConstant(google_api, customers=customers)
+    stream.get_query = Mock(return_value="query")
+
+    records = read_geo_target_constants(stream)
+
+    assert google_api.requested_customer_ids == ["1"]
+    assert records == [{"geo_target_constant.id": 1000002}, {"geo_target_constant.id": 1000003}]
+
+
+def test_geo_target_constant_without_customers(mock_ads_client, config):
+    google_api = MockGoogleAdsGeoTargetConstants(credentials=config["credentials"])
+    stream = GeoTargetConstant(google_api, customers=[])
+    stream.get_query = Mock(return_value="query")
+
+    assert read_geo_target_constants(stream) == []
+    assert google_api.requested_customer_ids == []
 
 
 def test_cyclic_sieve(caplog):


### PR DESCRIPTION
**Regression?**

No.

**Description:**

`geo_target_constant` is a global table with no customer dimension, but it was sliced per customer like every other full refresh stream. A capture with N customer IDs re-read the same ~270k rows N times every sync, at N times the API quota and collection volume. Emit a single slice instead so `geo_target_constant` is only read a single time per sync.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
