### PR TITLE
ci: Test Go connector helper packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,6 +212,27 @@ jobs:
         run: |
           bash source-mongodb/docker-compose-init.sh
 
+      # Run the tests of every in-repo helper package which this connector
+      # transitively depends on. This list is computed on the fly so that we
+      # don't have to keep an explicit list up-to-date. Likewise instead of
+      # having an explicit `contains()` clause governing Go connectors we'll
+      # just identify them as connectors whose subdirectory contains Go files.
+      - name: Test Go helper packages for ${{ matrix.connector }}
+        if: hashFiles(format('{0}/*.go', matrix.connector)) != ''
+        env:
+          GIT_LFS_SKIP_SMUDGE: 1 # See 'Database Tests' step comment
+        run: |
+          set -euo pipefail
+          DEPS=$(go list -deps -test \
+            -f '{{if and (not .ForTest) .Module (eq .Module.Path "github.com/estuary/connectors")}}{{.ImportPath}}{{end}}' \
+            './${{ matrix.connector }}/...')
+          PKGS=$(echo "$DEPS" \
+            | grep -v '\.test$' \
+            | grep -Ev '^github.com/estuary/connectors/${{ matrix.connector }}(/|$)' \
+            | sort -u || true)
+          [ -n "$PKGS" ] || exit 0
+          go test -short -count=1 $PKGS
+
       # Go connector tests which aren't run as part of Dockerfile builds. Most Go connectors
       # run their tests as part of the Docker build, but running the tests outside of there
       # makes GCP credentials plumbing for encrypted configs significantly simpler.

--- a/sqlcapture/discovery.go
+++ b/sqlcapture/discovery.go
@@ -306,14 +306,6 @@ func generateCollectionSchema(db Database, table *DiscoveryInfo, fullWriteSchema
 	return documentSchema, keyPointers, isFallback, nil
 }
 
-// Per the flow JSON schema: Collection names are paths of Unicode letters, numbers, '-', '_', or
-// '.'. Each path component is separated by a slash '/', and a name may not begin or end in a '/'.
-
-// There is also a requirement for gazette journals that they must be a "clean" path. As a
-// simplification to ensure that recommended collection names meet this requirement we will replace
-// any occurences of '/' with '_' as well.
-var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)
-
 var LowercaseRecommendedNames = true
 
 func recommendedCatalogName(schema, table string) string {
@@ -321,9 +313,20 @@ func recommendedCatalogName(schema, table string) string {
 		schema = strings.ToLower(schema)
 		table = strings.ToLower(table)
 	}
-	var sanitizedSchema = catalogNameSanitizerRe.ReplaceAllString(schema, "_")
-	var sanitizedTable = catalogNameSanitizerRe.ReplaceAllString(table, "_")
-	return sanitizedSchema + "/" + sanitizedTable
+	return sanitizeCatalogNameComponent(schema) + "/" + sanitizeCatalogNameComponent(table)
+}
+
+var catalogNameSanitizerRe = regexp.MustCompile(`(?i)[^a-z0-9\-_.]`)
+
+// sanitizeCatalogNameComponent replaces characters which are invalid in collection
+// names with underscores, and rewrites the path elements '.' and '..' so that the
+// resulting slash-joined name is always a clean path.
+func sanitizeCatalogNameComponent(name string) string {
+	name = catalogNameSanitizerRe.ReplaceAllString(name, "_")
+	if name == "." || name == ".." {
+		return strings.ReplaceAll(name, ".", "_")
+	}
+	return name
 }
 
 // primaryKeyToCollectionKey converts a database primary key column name into a Flow collection key

--- a/sqlcapture/discovery_test.go
+++ b/sqlcapture/discovery_test.go
@@ -16,52 +16,52 @@ func TestRecommendedCatalogName(t *testing.T) {
 		{
 			schema: "something",
 			table:  "typical",
-			want:   "something_typical",
+			want:   "something/typical",
 		},
 		{
 			schema: "Capital",
 			table:  "LetterS",
-			want:   "capital_letters",
+			want:   "capital/letters",
 		},
 		{
 			schema: "for$bidden",
 			table:  "char%s",
-			want:   "for_bidden_char_s",
+			want:   "for_bidden/char_s",
 		},
 		{
 			schema: "schema",
 			table:  "/table",
-			want:   "schema__table",
+			want:   "schema/_table",
 		},
 		{
 			schema: "path-like",
 			table:  "/../this",
-			want:   "path-like__.._this",
+			want:   "path-like/_.._this",
 		},
 		{
 			schema: "@",
 			table:  "!",
-			want:   "___",
+			want:   "_/_",
 		},
 		{
 			schema: ".",
 			table:  "/",
-			want:   ".__",
+			want:   "_/_",
 		},
 		{
-			schema: ".",
-			table:  "", // This should not be possible, but even if it were it would not be a problem as a collection name.
-			want:   "._",
+			schema: "..",
+			table:  "table",
+			want:   "__/table",
 		},
 		{
 			schema: "/",
 			table:  "./",
-			want:   "__._",
+			want:   "_/._",
 		},
 		{
 			schema: "multiple////",
 			table:  "slashes",
-			want:   "multiple_____slashes",
+			want:   "multiple____/slashes",
 		},
 	}
 


### PR DESCRIPTION
**Description:**

We have a bunch of helper packages which various connectors depend on, and in theory those helper packages have tests, but in practice those tests weren't getting run in CI. See for example the `sqlcapture` test case bitrot also fixed in this PR.

It looks like at present all of the other tests were still passing, but to avoid future breakage not getting noticed it seems like it would be a good idea for connector CI testing to include the unit tests for the various helper packages they rely on.

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
