### PR TITLE
set usage rates for filesource captures

### DIFF
--- a/source-azure-blob-storage/Dockerfile
+++ b/source-azure-blob-storage/Dockerfile
@@ -46,3 +46,4 @@ ENTRYPOINT ["/connector/source-azure-blob-storage"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-dropbox/Dockerfile
+++ b/source-dropbox/Dockerfile
@@ -46,3 +46,4 @@ ENTRYPOINT ["/connector/source-dropbox"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-gcs/Dockerfile
+++ b/source-gcs/Dockerfile
@@ -43,3 +43,4 @@ ENTRYPOINT ["/connector/source-gcs"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-google-drive/Dockerfile
+++ b/source-google-drive/Dockerfile
@@ -42,3 +42,4 @@ USER nonroot:nonroot
 ENTRYPOINT ["/connector/source-google-drive"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
+LABEL dev.estuary.usage-rate=0

--- a/source-http-file/Dockerfile
+++ b/source-http-file/Dockerfile
@@ -43,3 +43,4 @@ ENTRYPOINT ["/connector/source-http-file"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-onedrive/Dockerfile
+++ b/source-onedrive/Dockerfile
@@ -46,3 +46,4 @@ ENTRYPOINT ["/connector/source-onedrive"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-s3/Dockerfile
+++ b/source-s3/Dockerfile
@@ -46,3 +46,4 @@ ENTRYPOINT ["/connector/source-s3"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-sftp/Dockerfile
+++ b/source-sftp/Dockerfile
@@ -44,3 +44,4 @@ ENTRYPOINT ["/connector/source-sftp"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33

--- a/source-sharepoint/Dockerfile
+++ b/source-sharepoint/Dockerfile
@@ -46,3 +46,4 @@ ENTRYPOINT ["/connector/source-sharepoint"]
 
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
+LABEL dev.estuary.usage-rate=0.33


### PR DESCRIPTION
**Description:**

Sets usage rates for filesource captures, in accordance with runtime V2 changes. 

Note that source-google-drive is intentionally usage rate 0.0, vs. the others that are 0.33.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
