### PR TITLE
build: add revision label to docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,6 +296,7 @@ jobs:
             docker build --build-arg BASE_CONNECTOR=ghcr.io/estuary/${{ matrix.connector }}:local \
                          --build-arg DOCS_URL=https://go.estuary.dev/${VARIANT} \
                          --tag ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }} \
+                         --label org.opencontainers.image.revision=$GITHUB_SHA \
                          --file connector-variant.Dockerfile .;
             docker image push ghcr.io/estuary/${VARIANT}:${{ steps.prep.outputs.tag }};
           done


### PR DESCRIPTION
**Description:**

It is kind of hard to trace an image id from the logs back to the source revision, expecially on `:delayed` tags.  In the logs you might find a message like this, but I don't know a way to get back to the git revision short of digging through the GitHub actions:
```json
{
  "fields": {
    "image": "ghcr.io/estuary/materialize-hubspot:v1",
    "image_inspection": {
      "id": "d8394b36150c56cd7498f9a376729041bb96279b91690253a6f12cb9dc7edf3b",
      "image_created_at": "2026-08-10T21:41:02.523635916Z",
      "network_ports": [],
      "runtime_protocol": "materialize",
      "usage_rate": 1.0,
      "usage_rate_source": "default for capture and materialize protocol"
    }
  },
  "level": "info",
  "message": "started connector container",
  "ts": "2026-08-11T13:56:23.962901131Z"
}
```

With this change a label is added to the docker image which you can look up with:

```
$ docker buildx imagetools inspect ghcr.io/estuary/materialize-s3-iceberg:delayed --format '{{json .Image.Config.Labels}}'
{
  "FLOW_RUNTIME_PROTOCOL": "materialize",
  "org.opencontainers.image.revision": "13e6993ea51f07b00066dfc08e852176e665808a"
}
```

The label name is taked from https://specs.opencontainers.org/image-spec/annotations/.

**Documentation links affected:**

None

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
