### PR TITLE
source-zuora: emit sourced schemas plus other misc. fixes

### DIFF
--- a/source-zuora/CHANGELOG.md
+++ b/source-zuora/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-13
+
+### Added
+- `AchNocEventLog` is now captured incrementally. It is the only object whose change
+  timestamp is `UpdatedOn` rather than `UpdatedDate`, so it previously matched no cursor
+  and was re-exported in full on every poll.
+
+  The binding's key changes from `/_meta/row_id` to `/Id`, and a data flow reset for the binding is required as a result of the key change.
+
 ## 2026-08-04
 
 ### Added

--- a/source-zuora/CHANGELOG.md
+++ b/source-zuora/CHANGELOG.md
@@ -8,6 +8,13 @@
   and was re-exported in full on every poll.
 
   The binding's key changes from `/_meta/row_id` to `/Id`, and a data flow reset for the binding is required as a result of the key change.
+- Every binding now emits a source-defined schema built from Zuora's own field types, so
+  columns are created in destinations even when a column has only ever held `null`.
+
+  Two field types now have their values coerced to match what the schema declares. Booleans
+  become real booleans rather than the strings `"true"`/`"false"`, and datetimes are
+  normalized to RFC3339 — AQuA renders them with an ISO 8601 basic offset (`+0000`) that
+  RFC3339 rejects.
 
 ## 2026-08-04
 

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -128,15 +128,16 @@ def _parse_catalog(response_bytes: bytes) -> DescribeCatalog:
     return DescribeCatalog(objects=objects)
 
 
-async def fetch_object_fields(
+async def fetch_object_metadata(
     base_url: str,
     http: HTTPSession,
     log: Logger,
     object_name: str,
-) -> list[str]:
-    """Return every field name to select when exporting a Zuora object. This includes
-    its own exportable fields plus the `<RelatedObject>.Id` joins that carry its foreign
-    keys.
+) -> DescribeObject:
+    """Describe a Zuora object.
+
+    The caller takes the field names to select when exporting it: its own exportable
+    fields plus the `<RelatedObject>.Id` joins that carry its foreign keys.
     """
     url = f"{base_url}/v1/describe/{object_name}"
     described = _parse_describe_object(
@@ -166,7 +167,7 @@ async def fetch_object_fields(
             },
         },
     )
-    return described.query_field_names
+    return described
 
 
 def _parse_describe_object(response_bytes: bytes) -> DescribeObject:

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -13,9 +13,10 @@ from .models import (
     DescribeCatalog,
     DescribeField,
     DescribeObject,
-    ValidationContext,
     ZuoraDocument,
+    ValidationContext,
     ZuoraRow,
+    ZuoraType,
 )
 from .shared import VERSION_HEADERS
 
@@ -137,8 +138,10 @@ async def fetch_object_metadata(
 ) -> DescribeObject:
     """Describe a Zuora object.
 
-    The caller takes the field names to select when exporting it: its own exportable
-    fields plus the `<RelatedObject>.Id` joins that carry its foreign keys.
+    The caller takes two things from the result: the field names to select when
+    exporting it (its own exportable fields plus the `<RelatedObject>.Id` joins that
+    carry its foreign keys), and each field's declared type, which becomes the binding's
+    sourced schema.
     """
     url = f"{base_url}/v1/describe/{object_name}"
     described = _parse_describe_object(
@@ -223,6 +226,7 @@ class _WindowEnd:
 async def _export_window(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     model: type[ZuoraDocument],
     manager: ExportManager,
     window_start: datetime,
@@ -240,7 +244,7 @@ async def _export_window(
     window still overflowing, raises ExportTooLargeError naming the object and
     window rather than the opaque Zuora file id.
     """
-    context = ValidationContext(object_name=object_name)
+    context = ValidationContext(object_name=object_name, field_types=field_types)
     max_cursor: datetime | None = None
     # count drives intermediate checkpoints and resets at each one; total is the
     # window's whole-lifetime document count, kept separately for the summary log.
@@ -302,6 +306,7 @@ async def _export_window(
 async def fetch_changes(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     model: type[ZuoraDocument],
     manager: ExportManager,
     log: Logger,
@@ -315,7 +320,7 @@ async def fetch_changes(
     window_end = min(log_cursor + MAX_EXPORT_WINDOW, now)
 
     async for item in _export_window(
-        object_name, fields, model, manager, log_cursor, window_end, log
+        object_name, fields, field_types, model, manager, log_cursor, window_end, log
     ):
         if not isinstance(item, _WindowEnd):
             yield item  # a document or an intermediate datetime checkpoint
@@ -345,6 +350,7 @@ async def fetch_changes(
 async def fetch_page(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     model: type[ZuoraDocument],
     manager: ExportManager,
     start_date: datetime,
@@ -356,7 +362,7 @@ async def fetch_page(
     if page is not None:
         assert isinstance(page, str)
 
-    context = ValidationContext(object_name=object_name)
+    context = ValidationContext(object_name=object_name, field_types=field_types)
     resume_id: str | None = page
     limit = BACKFILL_PAGE_SIZE
     docs_since_checkpoint = 0
@@ -420,20 +426,22 @@ async def fetch_page(
 async def fetch_snapshot(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     manager: ExportManager,
     log: Logger,
 ) -> AsyncGenerator[ZuoraRow, None]:
     """Full table export for objects with no usable incremental cursor field.
 
-    Snapshot objects have no cursor, so they use ZuoraRow (empty cells -> None, all
-    fields inferred) rather than an incremental ZuoraDocument subclass.
+    Snapshot objects have no cursor, so they use ZuoraRow (empty cells -> None,
+    typed cells converted, all fields inferred) rather than an incremental
+    ZuoraDocument subclass.
 
     Note: without a time cursor there's no window to bisect, so a snapshot that
     exceeds Zuora's export size limit raises ExportTooLargeError and fails the
     binding. If that happens for a real object, we should paginate the export
     with Export ZOQL's LIMIT/OFFSET (first-N plus skip rows) to complete it in chunks.
     """
-    context = ValidationContext(object_name=object_name)
+    context = ValidationContext(object_name=object_name, field_types=field_types)
     query = build_query(object_name, fields)
     async for row in manager.export_rows(query, ZuoraRow, context):
         yield row

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -6,7 +6,6 @@ from typing import AsyncGenerator
 
 from estuary_cdk.capture.common import LogCursor, PageCursor
 from estuary_cdk.http import HTTPSession
-from estuary_cdk.incremental_csv_processor import BaseCSVRow
 
 from .export_manager import ExportManager, ExportTooLargeError
 from .models import (
@@ -14,7 +13,9 @@ from .models import (
     DescribeCatalog,
     DescribeField,
     DescribeObject,
+    ValidationContext,
     ZuoraDocument,
+    ZuoraRow,
 )
 from .shared import VERSION_HEADERS
 
@@ -239,6 +240,7 @@ async def _export_window(
     window still overflowing, raises ExportTooLargeError naming the object and
     window rather than the opaque Zuora file id.
     """
+    context = ValidationContext(object_name=object_name)
     max_cursor: datetime | None = None
     # count drives intermediate checkpoints and resets at each one; total is the
     # window's whole-lifetime document count, kept separately for the summary log.
@@ -250,8 +252,7 @@ async def _export_window(
             after=window_start, before=window_end,
         )
         try:
-            async for row in manager.export_rows(query, object_name):
-                doc = model.model_validate(row)
+            async for doc in manager.export_rows(query, model, context):
                 cursor = doc.get_cursor()
                 if (
                     max_cursor is not None
@@ -355,6 +356,7 @@ async def fetch_page(
     if page is not None:
         assert isinstance(page, str)
 
+    context = ValidationContext(object_name=object_name)
     resume_id: str | None = page
     limit = BACKFILL_PAGE_SIZE
     docs_since_checkpoint = 0
@@ -371,8 +373,7 @@ async def fetch_page(
         )
         count = 0
         try:
-            async for row in manager.export_rows(query, object_name):
-                doc = model.model_validate(row)
+            async for doc in manager.export_rows(query, model, context):
                 if resume_id is not None and doc.Id <= resume_id:
                     # `Id >` resume is only correct if ORDER BY Id is a stable
                     # total order. Fail loudly if a tenant violates that.
@@ -421,17 +422,18 @@ async def fetch_snapshot(
     fields: list[str],
     manager: ExportManager,
     log: Logger,
-) -> AsyncGenerator[BaseCSVRow, None]:
+) -> AsyncGenerator[ZuoraRow, None]:
     """Full table export for objects with no usable incremental cursor field.
 
-    Snapshot objects have no cursor, so they use BaseCSVRow (empty cells -> None,
-    all fields inferred) rather than an incremental ZuoraDocument subclass.
+    Snapshot objects have no cursor, so they use ZuoraRow (empty cells -> None, all
+    fields inferred) rather than an incremental ZuoraDocument subclass.
 
     Note: without a time cursor there's no window to bisect, so a snapshot that
     exceeds Zuora's export size limit raises ExportTooLargeError and fails the
     binding. If that happens for a real object, we should paginate the export
     with Export ZOQL's LIMIT/OFFSET (first-N plus skip rows) to complete it in chunks.
     """
+    context = ValidationContext(object_name=object_name)
     query = build_query(object_name, fields)
-    async for row in manager.export_rows(query, object_name):
-        yield BaseCSVRow.model_validate(row)
+    async for row in manager.export_rows(query, ZuoraRow, context):
+        yield row

--- a/source-zuora/source_zuora/api.py
+++ b/source-zuora/source_zuora/api.py
@@ -181,10 +181,12 @@ def _parse_describe_object(response_bytes: bytes) -> DescribeObject:
         if field_name_el is None or not field_name_el.text:
             continue
         selectable_el = field_el.find("selectable")
+        type_el = field_el.find("type")
         fields.append(
             DescribeField(
                 name=field_name_el.text,
                 selectable=selectable_el is not None and selectable_el.text == "true",
+                type=type_el.text if type_el is not None else None,
                 contexts=[
                     c.text for c in field_el.findall("./contexts/context") if c.text
                 ],

--- a/source-zuora/source_zuora/export_manager.py
+++ b/source-zuora/source_zuora/export_manager.py
@@ -1,12 +1,16 @@
 import asyncio
 from logging import Logger
-from typing import AsyncGenerator
+from typing import AsyncGenerator, TypeVar
 
 from estuary_cdk.http import HTTPError, HTTPSession
 from estuary_cdk.incremental_csv_processor import IncrementalCSVProcessor
 
-from .models import AquaJobResponse, AquaJobStatus
+from .models import AquaJobResponse, AquaJobStatus, ValidationContext, ZuoraRow
 from .shared import VERSION_HEADERS
+
+# The manager streams whichever row model the caller asks for, so callers keep the
+# precise type they passed in rather than a ZuoraRow they have to narrow.
+RowT = TypeVar("RowT", bound=ZuoraRow)
 
 # AQuA request schema version. With partner/project omitted the job runs in
 # stateless mode regardless, so this only selects the response semantics.
@@ -82,21 +86,6 @@ class ExportTooLargeError(Exception):
     """
 
 
-def _column_to_field(column: str, object_name: str) -> str:
-    """Map an export CSV column header to the field name documents carry.
-
-    With useQueryLabels every header is "<Object>.<Field>", for both the exported
-    object's own columns and any joined related object's. An own column drops the
-    prefix so it matches its describe name ("Account.Id" of an Account export ->
-    "Id"), while a joined column keeps it as a flattened name ("Account.Id" of an
-    Invoice export -> "AccountId").
-    """
-    prefix, _, field = column.partition(".")
-    if not field:
-        return column
-    return field if prefix == object_name else f"{prefix}{field}"
-
-
 class ExportManager:
     """Runs Zuora AQuA (Aggregate Query API) export jobs in stateless mode.
 
@@ -120,18 +109,14 @@ class ExportManager:
     async def export_rows(
         self,
         query: str,
-        object_name: str,
-    ) -> AsyncGenerator[dict, None]:
-        """Run `query` and stream its rows, keyed by field name.
-
-        object_name is the object `query` selects FROM. It's needed to tell an
-        own column apart from a joined one when naming fields (see
-        _column_to_field).
-        """
+        model: type[RowT],
+        context: ValidationContext,
+    ) -> AsyncGenerator[RowT, None]:
+        """Run `query` and stream its rows as validated `model` instances."""
         # Each segment file is a self-contained CSV with its own header row, so
         # streaming them back-to-back through per-file processors is seamless.
         for file_id in await self._run_job(query):
-            async for row in self._fetch_results(file_id, object_name):
+            async for row in self._fetch_results(file_id, model, context):
                 yield row
 
     async def _run_job(self, query: str) -> list[str]:
@@ -260,8 +245,9 @@ class ExportManager:
     async def _fetch_results(
         self,
         file_id: str,
-        object_name: str,
-    ) -> AsyncGenerator[dict, None]:
+        model: type[RowT],
+        context: ValidationContext,
+    ) -> AsyncGenerator[RowT, None]:
         url = f"{self.base_url}/v1/files/{file_id}"
         try:
             _resp_headers, body_factory = await self.http.request_stream(
@@ -275,5 +261,7 @@ class ExportManager:
             raise
         # Keyed by header name, never by position. Zuora does not return columns
         # in the order the query selected them.
-        async for row in IncrementalCSVProcessor(body_factory()):
-            yield {_column_to_field(k, object_name): v for k, v in row.items()}
+        async for row in IncrementalCSVProcessor(
+            body_factory(), model, validation_context=context
+        ):
+            yield row

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -110,6 +111,16 @@ assert ZUORA_TYPE_SCHEMAS.keys() == set(ZuoraType), (
     f"every ZuoraType needs a schema; missing {set(ZuoraType) - ZUORA_TYPE_SCHEMAS.keys()}"
 )
 
+# Types whose values the connector rewrites before emitting them in
+# order to align with the emitted sourced schemas. Every member
+# here needs a branch in ZuoraRow.transform_cells.
+CONVERTED_TYPES: frozenset[ZuoraType] = frozenset(
+    {
+        ZuoraType.BOOLEAN,
+        ZuoraType.DATETIME,
+    }
+)
+
 
 def sourced_schema(field_types: dict[str, ZuoraType]) -> dict[str, object]:
     """Build a SourcedSchema value from an object's field name -> Zuora type map."""
@@ -123,14 +134,57 @@ def sourced_schema(field_types: dict[str, ZuoraType]) -> dict[str, object]:
     }
 
 
+_BOOLEAN_TOKENS: dict[str, bool] = {"true": True, "false": False}
+
+
+# Already-compliant: a colon-separated offset, or Z.
+_RFC3339_DATETIME = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+# What AQuA actually emits. Almost RFC3339 compliant, but the offset's colon is missing.
+_BASIC_OFFSET_DATETIME = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?)([+-]\d{2})(\d{2})$"
+)
+
+
+def normalize_datetime(field_name: str, value: str) -> str:
+    """Rewrite an export's datetime cell as RFC3339.
+
+    AQuA renders datetimes with an ISO 8601 basic offset -- `+0000`, no colon -- which
+    RFC3339 rejects. Inserting the colon is the whole transformation. Values that
+    already comply pass through, so this is idempotent.
+    """
+    if _RFC3339_DATETIME.match(value):
+        return value
+    basic = _BASIC_OFFSET_DATETIME.match(value)
+    if basic is None:
+        raise ValueError(
+            f"{field_name}: expected an RFC3339-convertible datetime, got {value!r}. "
+            f"Zuora's describe types this field as datetime. Reach out to Estuary "
+            f"support to update this connector to convert this datetime format to "
+            f"be RFC3339 compliant."
+        )
+    stamp, offset_hours, offset_minutes = basic.groups()
+    return f"{stamp}{offset_hours}:{offset_minutes}"
+
+
+def parse_boolean(field_name: str, value: str) -> bool:
+    """Convert an export's boolean cell to a real bool."""
+    parsed = _BOOLEAN_TOKENS.get(value.strip().lower())
+    if parsed is None:
+        raise ValueError(
+            f"{field_name}: expected a boolean, got {value!r}. Zuora's describe types "
+            f"this field as boolean. Reach out to Estuary support for help resolving "
+            f"this error."
+        )
+    return parsed
+
+
 @dataclass(frozen=True)
 class ValidationContext:
-    """What a row needs to know about its object in order to validate.
-
-    Passed as the pydantic validation context. A model rather than a bare dict so the
-    validator reads a typed attribute instead of a string key it could misspell.
-    """
+    """What a row needs to know about its object in order to validate."""
     object_name: str
+    field_types: dict[str, ZuoraType]
 
 
 def _column_to_field(column: str, object_name: str) -> str:
@@ -151,26 +205,56 @@ def _column_to_field(column: str, object_name: str) -> str:
 class ZuoraRow(BaseCSVRow):
     """Every exported row, incremental or snapshot.
 
-    Renames each export column to the name documents carry.
+    Renames each export column to the name documents carry, and rewrites the cells whose
+    declared type the raw CSV text does not satisfy: a boolean column holds "true", and a
+    datetime column holds an offset RFC3339 rejects.
     """
 
     @model_validator(mode="before")
     @classmethod
     def transform_cells(cls, data: Any, info: ValidationInfo) -> Any:
         if not isinstance(info.context, ValidationContext):
-            # Without it the columns keep their "<Object>." prefixes and the document
-            # would have no Id. Fail rather than emit a mangled row.
+            # Every caller has the object's types to hand, and a row validated without
+            # them would keep its raw cells and contradict the schema the binding
+            # declares. Fail rather than convert nothing.
             raise RuntimeError(
                 f"Implementation error: {cls.__name__} must be validated with a "
-                f"ValidationContext, got {info.context!r}, so its columns would not "
-                f"be renamed."
+                f"ValidationContext, got {info.context!r}, so its cells would not "
+                f"be converted."
             )
         if not isinstance(data, dict):
             return data
-        return {
+
+        # Rename first: field_types is keyed by the name the document carries, not the
+        # header the export sent.
+        converted = {
             _column_to_field(column, info.context.object_name): value
             for column, value in data.items()
         }
+        field_types = info.context.field_types
+        for name, zuora_type in field_types.items():
+            if zuora_type not in CONVERTED_TYPES:
+                continue
+            value = converted.get(name)
+            # This validator runs ahead of BaseCSVRow's null handling -- pydantic runs a
+            # subclass's before-validator first -- so a raw export cell is still "" here.
+            # None turns up only when re-validating a document that has already been
+            # through it. Neither has anything to convert.
+            if value is None or value == "":
+                continue
+            if not isinstance(value, str):
+                continue  # already converted, e.g. a re-validated document
+            if zuora_type == ZuoraType.BOOLEAN:
+                converted[name] = parse_boolean(name, value)
+            elif zuora_type == ZuoraType.DATETIME:
+                converted[name] = normalize_datetime(name, value)
+            else:
+                raise RuntimeError(
+                    f"Implementation error: '{zuora_type}' is in CONVERTED_TYPES but "
+                    f"has no converter, so {name} would be declared as a type its "
+                    f"value does not satisfy."
+                )
+        return converted
 
 
 class ZuoraDocument(ZuoraRow):
@@ -340,8 +424,6 @@ class DescribeObject(BaseModel, extra="allow"):
         for related in self.joinable_object_names:
             types[f"{related}Id"] = ZuoraType.TEXT
         return types
-
-
 
 
 class CatalogObject(BaseModel, extra="allow"):

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -70,6 +70,17 @@ class UpdatedDateDocument(ZuoraDocument):
         return self.UpdatedDate
 
 
+class UpdatedOnDocument(ZuoraDocument):
+    """AchNocEventLog names its timestamps UpdatedOn/CreatedOn rather than
+    UpdatedDate/CreatedDate, and exports no UpdatedDate at all.
+    """
+    CURSOR_FIELD: ClassVar[str] = "UpdatedOn"
+    UpdatedOn: AwareDatetime
+
+    def get_cursor(self) -> AwareDatetime:
+        return self.UpdatedOn
+
+
 class TransactionDateDocument(ZuoraDocument):
     """Append-only transaction logs (PaymentTransactionLog,
     PaymentMethodTransactionLog, ...) have no UpdatedDate. Their only date field

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -1,8 +1,9 @@
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from pydantic import AwareDatetime, BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, Field, ValidationInfo, model_validator
 
 from estuary_cdk.capture.common import (
     ResourceState,
@@ -122,7 +123,57 @@ def sourced_schema(field_types: dict[str, ZuoraType]) -> dict[str, object]:
     }
 
 
-class ZuoraDocument(BaseCSVRow):
+@dataclass(frozen=True)
+class ValidationContext:
+    """What a row needs to know about its object in order to validate.
+
+    Passed as the pydantic validation context. A model rather than a bare dict so the
+    validator reads a typed attribute instead of a string key it could misspell.
+    """
+    object_name: str
+
+
+def _column_to_field(column: str, object_name: str) -> str:
+    """Map an export CSV column header to the field name documents carry.
+
+    With useQueryLabels every header is "<Object>.<Field>", for both the exported
+    object's own columns and any joined related object's. An own column drops the
+    prefix so it matches its describe name ("Account.Id" of an Account export ->
+    "Id"), while a joined column keeps it as a flattened name ("Account.Id" of an
+    Invoice export -> "AccountId").
+    """
+    prefix, _, field = column.partition(".")
+    if not field:
+        return column
+    return field if prefix == object_name else f"{prefix}{field}"
+
+
+class ZuoraRow(BaseCSVRow):
+    """Every exported row, incremental or snapshot.
+
+    Renames each export column to the name documents carry.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def transform_cells(cls, data: Any, info: ValidationInfo) -> Any:
+        if not isinstance(info.context, ValidationContext):
+            # Without it the columns keep their "<Object>." prefixes and the document
+            # would have no Id. Fail rather than emit a mangled row.
+            raise RuntimeError(
+                f"Implementation error: {cls.__name__} must be validated with a "
+                f"ValidationContext, got {info.context!r}, so its columns would not "
+                f"be renamed."
+            )
+        if not isinstance(data, dict):
+            return data
+        return {
+            _column_to_field(column, info.context.object_name): value
+            for column, value in data.items()
+        }
+
+
+class ZuoraDocument(ZuoraRow):
     """Base for objects captured incrementally off a single date cursor.
     """
     CURSOR_FIELD: ClassVar[str]
@@ -274,7 +325,7 @@ class DescribeObject(BaseModel, extra="allow"):
     def query_field_types(self) -> dict[str, ZuoraType]:
         """Zuora's declared type for every column an export selects, keyed by the name
         the *document* carries rather than the name the query selects: a joined
-        `<Related>.Id` arrives as `<Related>Id` (see export_manager._column_to_field).
+        `<Related>.Id` arrives as `<Related>Id` (see _column_to_field).
 
         This is where raw describe strings become ZuoraType, so nothing downstream has
         to cope with an unrecognized one. Joined columns are always Zuora ids, hence

--- a/source-zuora/source_zuora/models.py
+++ b/source-zuora/source_zuora/models.py
@@ -52,6 +52,76 @@ class EndpointConfig(BaseModel):
 ConnectorState = GenericConnectorState[ResourceState]
 
 
+class UnknownZuoraTypeError(Exception):
+    """Zuora described a field with a type this connector does not recognize.
+
+    Raised rather than degrading the field to an untyped string: a string declaration
+    would claim the connector knows the field's shape when it does not, and would strip
+    whatever format inference had established for that column. Discovery fails instead,
+    naming the field, so the type can be classified deliberately.
+    """
+
+
+class ZuoraType(StrEnum):
+    """A field's declared type, as `<type>` in a GET /v1/describe/{object} response."""
+    TEXT = "text"
+    PICKLIST = "picklist"
+    LONGTEXT = "longtext"
+    ZOQL = "ZOQL"
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    DECIMAL = "decimal"
+    NUMBER = "number"
+    DATE = "date"
+    DATETIME = "datetime"
+    TIMESTAMP = "timestamp"
+
+    @classmethod
+    def parse(cls, raw: str | None, field_name: str) -> "ZuoraType":
+        """Classify a describe `<type>`, or fail naming the field it came from."""
+        try:
+            return cls(raw)
+        except ValueError:
+            raise UnknownZuoraTypeError(
+                f"{field_name}: Zuora declared the type {raw!r}, which this connector "
+                f"does not recognize. It must be added to ZuoraType and "
+                f"ZUORA_TYPE_SCHEMAS before this object can be captured."
+            ) from None
+
+
+# Zuora's declared type -> the JSON schema a SourcedSchema declares for that field.
+ZUORA_TYPE_SCHEMAS: dict[ZuoraType, dict[str, str]] = {
+    ZuoraType.TEXT: {"type": "string"},
+    ZuoraType.PICKLIST: {"type": "string"},
+    ZuoraType.LONGTEXT: {"type": "string"},
+    ZuoraType.ZOQL: {"type": "string"},
+    ZuoraType.BOOLEAN: {"type": "boolean"},
+    ZuoraType.INTEGER: {"type": "string", "format": "integer"},
+    ZuoraType.DECIMAL: {"type": "string", "format": "number"},
+    ZuoraType.NUMBER: {"type": "string", "format": "number"},
+    ZuoraType.DATE: {"type": "string", "format": "date"},
+    ZuoraType.DATETIME: {"type": "string", "format": "date-time"},
+    ZuoraType.TIMESTAMP: {"type": "string"},
+}
+
+# Make sure that every ZuoraType has an entry in ZUORA_TYPE_SCHEMAS.
+assert ZUORA_TYPE_SCHEMAS.keys() == set(ZuoraType), (
+    f"every ZuoraType needs a schema; missing {set(ZuoraType) - ZUORA_TYPE_SCHEMAS.keys()}"
+)
+
+
+def sourced_schema(field_types: dict[str, ZuoraType]) -> dict[str, object]:
+    """Build a SourcedSchema value from an object's field name -> Zuora type map."""
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            name: ZUORA_TYPE_SCHEMAS[zuora_type]
+            for name, zuora_type in field_types.items()
+        },
+    }
+
+
 class ZuoraDocument(BaseCSVRow):
     """Base for objects captured incrementally off a single date cursor.
     """
@@ -138,6 +208,9 @@ class DescribeField(BaseModel, extra="allow"):
     name: str
     selectable: bool = False
     contexts: list[str] = Field(default_factory=list)
+    # Zuora's declared type, e.g. text/decimal/datetime/boolean. Absent in
+    # hand-written test fixtures, so optional.
+    type: str | None = None
 
     @property
     def is_exportable(self) -> bool:
@@ -196,6 +269,28 @@ class DescribeObject(BaseModel, extra="allow"):
         return self.exportable_field_names + [
             f"{name}.Id" for name in self.joinable_object_names
         ]
+
+    @property
+    def query_field_types(self) -> dict[str, ZuoraType]:
+        """Zuora's declared type for every column an export selects, keyed by the name
+        the *document* carries rather than the name the query selects: a joined
+        `<Related>.Id` arrives as `<Related>Id` (see export_manager._column_to_field).
+
+        This is where raw describe strings become ZuoraType, so nothing downstream has
+        to cope with an unrecognized one. Joined columns are always Zuora ids, hence
+        text; describe says nothing about them because they are relationships rather
+        than fields.
+        """
+        types = {
+            f.name: ZuoraType.parse(f.type, f.name)
+            for f in self.fields
+            if f.is_exportable
+        }
+        for related in self.joinable_object_names:
+            types[f"{related}Id"] = ZuoraType.TEXT
+        return types
+
+
 
 
 class CatalogObject(BaseModel, extra="allow"):

--- a/source-zuora/source_zuora/resources.py
+++ b/source-zuora/source_zuora/resources.py
@@ -24,6 +24,7 @@ from .models import (
     EndpointConfig,
     TransactionDateDocument,
     UpdatedDateDocument,
+    UpdatedOnDocument,
     ZuoraDocument,
 )
 
@@ -31,6 +32,7 @@ from .models import (
 DOCUMENT_MODELS: list[type[ZuoraDocument]] = [
     UpdatedDateDocument,
     TransactionDateDocument,
+    UpdatedOnDocument,
 ]
 
 

--- a/source-zuora/source_zuora/resources.py
+++ b/source-zuora/source_zuora/resources.py
@@ -15,7 +15,7 @@ from .api import (
     LAG,
     discover_object_names,
     fetch_changes,
-    fetch_object_fields,
+    fetch_object_metadata,
     fetch_page,
     fetch_snapshot,
 )
@@ -80,16 +80,16 @@ async def _describe_object(
 ) -> DescribedObject | None:
     async with _DISCOVER_SEM:
         try:
-            fields = await fetch_object_fields(base_url, http, log, object_name)
+            described = await fetch_object_metadata(base_url, http, log, object_name)
         except Exception as err:
             detail = {"http_code": err.code} if isinstance(err, HTTPError) else {"error": str(err)}
             log.warning("Skipping object: describe failed", {"object": object_name, **detail})
             return None
 
-    if not fields:
+    if not described.query_field_names:
         log.warning("Skipping object: no selectable fields", {"object": object_name})
         return None
-    return DescribedObject(name=object_name, fields=fields)
+    return DescribedObject(name=object_name, fields=described.query_field_names)
 
 
 def _incremental_resource(

--- a/source-zuora/source_zuora/resources.py
+++ b/source-zuora/source_zuora/resources.py
@@ -9,8 +9,6 @@ from estuary_cdk.capture.common import CaptureBinding, ResourceConfig, ResourceS
 from estuary_cdk.flow import OAuth2TokenFlowSpec, ValidationError
 from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
 
-from estuary_cdk.incremental_csv_processor import BaseCSVRow
-
 from .api import (
     LAG,
     discover_object_names,
@@ -26,6 +24,8 @@ from .models import (
     UpdatedDateDocument,
     UpdatedOnDocument,
     ZuoraDocument,
+    ZuoraRow,
+    ZuoraType,
 )
 
 
@@ -51,9 +51,11 @@ def _attach_token_source(http: HTTPMixin, config: EndpointConfig) -> None:
 
 @dataclass(frozen=True)
 class DescribedObject:
-    """A queryable Zuora object and its exportable field names."""
+    """A queryable Zuora object, the field names its export selects, and the Zuora
+    type of each column those fields produce."""
     name: str
     fields: list[str]
+    field_types: dict[str, ZuoraType]
 
 
 async def validate_credentials(
@@ -89,12 +91,17 @@ async def _describe_object(
     if not described.query_field_names:
         log.warning("Skipping object: no selectable fields", {"object": object_name})
         return None
-    return DescribedObject(name=object_name, fields=described.query_field_names)
+    return DescribedObject(
+        name=object_name,
+        fields=described.query_field_names,
+        field_types=described.query_field_types,
+    )
 
 
 def _incremental_resource(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     model: type[ZuoraDocument],
     manager: ExportManager,
     start_date: datetime,
@@ -116,6 +123,7 @@ def _incremental_resource(
                 fetch_changes,
                 object_name,
                 fields,
+                field_types,
                 model,
                 manager,
             ),
@@ -123,6 +131,7 @@ def _incremental_resource(
                 fetch_page,
                 object_name,
                 fields,
+                field_types,
                 model,
                 manager,
                 start_date,
@@ -146,6 +155,7 @@ def _incremental_resource(
 def _snapshot_resource(
     object_name: str,
     fields: list[str],
+    field_types: dict[str, ZuoraType],
     manager: ExportManager,
 ) -> common.SnapshotResource:
     def open(
@@ -164,13 +174,14 @@ def _snapshot_resource(
                 fetch_snapshot,
                 object_name,
                 fields,
+                field_types,
                 manager,
             ),
         )
 
     return common.SnapshotResource(
         name=object_name,
-        model=BaseCSVRow,
+        model=ZuoraRow,
         open=open,
         initial_config=ResourceConfig(name=object_name, interval=timedelta(hours=4)),
     )
@@ -201,11 +212,21 @@ async def _build_resources(
         if model is not None:
             resources.append(
                 _incremental_resource(
-                    described.name, described.fields, model, manager, config.start_date, cutoff
+                    described.name,
+                    described.fields,
+                    described.field_types,
+                    model,
+                    manager,
+                    config.start_date,
+                    cutoff,
                 )
             )
         else:
-            resources.append(_snapshot_resource(described.name, described.fields, manager))
+            resources.append(
+                _snapshot_resource(
+                    described.name, described.fields, described.field_types, manager
+                )
+            )
 
     return resources
 

--- a/source-zuora/source_zuora/resources.py
+++ b/source-zuora/source_zuora/resources.py
@@ -19,6 +19,7 @@ from .api import (
 )
 from .export_manager import ExportManager
 from .models import (
+    ConnectorState,
     EndpointConfig,
     TransactionDateDocument,
     UpdatedDateDocument,
@@ -26,6 +27,7 @@ from .models import (
     ZuoraDocument,
     ZuoraRow,
     ZuoraType,
+    sourced_schema,
 )
 
 
@@ -107,13 +109,16 @@ def _incremental_resource(
     start_date: datetime,
     cutoff: datetime,
 ) -> common.Resource:
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
         task: Task,
         all_bindings,
     ) -> None:
+        task.sourced_schema(binding_index, sourced_schema(field_types))
+        await task.checkpoint(state=ConnectorState())
+
         common.open_binding(
             binding,
             binding_index,
@@ -158,13 +163,16 @@ def _snapshot_resource(
     field_types: dict[str, ZuoraType],
     manager: ExportManager,
 ) -> common.SnapshotResource:
-    def open(
+    async def open(
         binding: CaptureBinding[ResourceConfig],
         binding_index: int,
         state: ResourceState,
         task: Task,
         all_bindings,
     ) -> None:
+        task.sourced_schema(binding_index, sourced_schema(field_types))
+        await task.checkpoint(state=ConnectorState())
+
         common.open_binding(
             binding,
             binding_index,
@@ -250,6 +258,3 @@ async def enabled_resources(
     _attach_token_source(http, config)
     object_names = [binding.resourceConfig.name for binding in bindings]
     return await _build_resources(log, http, config, object_names)
-
-
-

--- a/source-zuora/tests/test_capture.py
+++ b/source-zuora/tests/test_capture.py
@@ -65,7 +65,7 @@ class FakeManager:
         self.too_large_over_rows = too_large_over_rows
         self.queries: list[str] = []
 
-    async def export_rows(self, query: str, object_name: str):
+    async def export_rows(self, query: str, model, context):
         self.queries.append(query)
         lo = re.search(rf"{self.cursor_field} >= '([^']+)'", query)
         hi = re.search(rf"{self.cursor_field} < '([^']+)'", query)
@@ -102,7 +102,11 @@ class FakeManager:
 
         out_fmt = "%Y-%m-%dT%H:%M:%S.%fZ" if self.emit_millis else _FMT
         for rid, dt in matching:
-            yield {"Id": rid, self.cursor_field: dt.astimezone(UTC).strftime(out_fmt)}
+            # Like the real manager, hand the row to the model with the caller's context.
+            yield model.model_validate(
+                {"Id": rid, self.cursor_field: dt.astimezone(UTC).strftime(out_fmt)},
+                context=context,
+            )
 
 
 async def _collect(agen) -> list:
@@ -415,9 +419,12 @@ async def test_fetch_page_id_engine_ordering_violation_raises():
     # `Id >` resume is only dupe-free if ORDER BY Id is a stable total order;
     # out-of-order rows must kill the backfill rather than risk skipped records.
     class UnorderedManager:
-        async def export_rows(self, query, object_name):
-            yield {"Id": "aa02", "UpdatedDate": "2020-01-02T00:00:00Z"}
-            yield {"Id": "aa01", "UpdatedDate": "2020-01-01T00:00:00Z"}
+        async def export_rows(self, query, model, context):
+            for row in (
+                {"Id": "aa02", "UpdatedDate": "2020-01-02T00:00:00Z"},
+                {"Id": "aa01", "UpdatedDate": "2020-01-01T00:00:00Z"},
+            ):
+                yield model.model_validate(row, context=context)
 
     start = datetime(2020, 1, 1, tzinfo=UTC)
     with pytest.raises(RuntimeError, match="ordering violation"):
@@ -495,7 +502,7 @@ async def test_fetch_snapshot_too_large_propagates():
     # A snapshot has no time cursor, so it can't be bisected — a too-large export
     # surfaces loudly rather than being silently truncated.
     class TooBig:
-        async def export_rows(self, query, object_name):
+        async def export_rows(self, query, model, context):
             raise ExportTooLargeError("too big")
             yield  # unreachable; makes this an async generator
 

--- a/source-zuora/tests/test_capture.py
+++ b/source-zuora/tests/test_capture.py
@@ -200,10 +200,18 @@ def test_build_id_page_query_resume_adds_strict_id_bound():
 # --- fetch_changes -------------------------------------------------------------
 
 
-async def _run_changes(manager, cursor, model=UpdatedDateDocument, object_name="Account"):
+async def _run_changes(
+    manager, cursor, model=UpdatedDateDocument, object_name="Account", field_types=None
+):
     return await _collect(
         api.fetch_changes(
-            object_name, ["Id", model.CURSOR_FIELD], model, manager, _LOG, cursor
+            object_name,
+            ["Id", model.CURSOR_FIELD],
+            field_types or {},
+            model,
+            manager,
+            _LOG,
+            cursor,
         )
     )
 
@@ -329,10 +337,20 @@ async def test_fetch_changes_transaction_date_cursor():
 # --- fetch_page ----------------------------------------------------------------
 
 
-async def _run_page(manager, start_date, page, cutoff, model=UpdatedDateDocument):
+async def _run_page(
+    manager, start_date, page, cutoff, model=UpdatedDateDocument, field_types=None
+):
     return await _collect(
         api.fetch_page(
-            "Account", ["Id", model.CURSOR_FIELD], model, manager, start_date, _LOG, page, cutoff
+            "Account",
+            ["Id", model.CURSOR_FIELD],
+            field_types or {},
+            model,
+            manager,
+            start_date,
+            _LOG,
+            page,
+            cutoff,
         )
     )
 
@@ -492,7 +510,7 @@ async def test_fetch_changes_bisects_too_large_window():
 @pytest.mark.asyncio
 async def test_fetch_snapshot_full_table_no_bounds():
     manager = FakeManager([("1", datetime(2020, 1, 1, tzinfo=UTC))])
-    out = await _collect(api.fetch_snapshot("Product", ["Id", "Name"], manager, _LOG))  # type: ignore[arg-type]
+    out = await _collect(api.fetch_snapshot("Product", ["Id", "Name"], {}, manager, _LOG))  # type: ignore[arg-type]
     assert all(isinstance(d, BaseCSVRow) for d in out)
     assert "WHERE" not in manager.queries[0]  # full table, unbounded
 
@@ -507,4 +525,4 @@ async def test_fetch_snapshot_too_large_propagates():
             yield  # unreachable; makes this an async generator
 
     with pytest.raises(ExportTooLargeError):
-        await _collect(api.fetch_snapshot("Product", ["Id"], TooBig(), _LOG))  # type: ignore[arg-type]
+        await _collect(api.fetch_snapshot("Product", ["Id"], {}, TooBig(), _LOG))  # type: ignore[arg-type]

--- a/source-zuora/tests/test_describe.py
+++ b/source-zuora/tests/test_describe.py
@@ -199,8 +199,10 @@ class _FakeHTTP:
 @pytest.mark.asyncio
 async def test_describe_object_returns_exportable_and_joined_field_names():
     http = _FakeHTTP(_DESCRIBE_XML)
-    fields = await api.fetch_object_fields("https://rest.zuora.com", http, _LOG, "Account")
-    assert fields == ["Id", "UpdatedDate", "Contact.Id"]
+    described = await api.fetch_object_metadata(
+        "https://rest.zuora.com", http, _LOG, "Account"
+    )
+    assert described.query_field_names == ["Id", "UpdatedDate", "Contact.Id"]
     assert http.urls == ["https://rest.zuora.com/v1/describe/Account"]
 
 
@@ -209,7 +211,7 @@ async def test_describe_requests_pin_api_version_header():
     from source_zuora.shared import ZUORA_API_VERSION
 
     http = _FakeHTTP(_DESCRIBE_XML)
-    await api.fetch_object_fields("https://rest.zuora.com", http, _LOG, "Account")
+    await api.fetch_object_metadata("https://rest.zuora.com", http, _LOG, "Account")
     assert http.headers[0].get("Zuora-Version") == ZUORA_API_VERSION
 
 

--- a/source-zuora/tests/test_export_manager.py
+++ b/source-zuora/tests/test_export_manager.py
@@ -22,7 +22,7 @@ _BASE = "https://rest.zuora.com"
 
 
 def _ctx(object_name: str) -> ValidationContext:
-    return ValidationContext(object_name=object_name)
+    return ValidationContext(object_name=object_name, field_types={})
 
 
 @pytest.fixture(autouse=True)

--- a/source-zuora/tests/test_export_manager.py
+++ b/source-zuora/tests/test_export_manager.py
@@ -14,11 +14,15 @@ from estuary_cdk.http import HTTPError
 
 from source_zuora import export_manager as em
 from source_zuora.export_manager import ExportError, ExportManager, ExportTooLargeError
-from source_zuora.models import AquaJobStatus
+from source_zuora.models import AquaJobStatus, ValidationContext, ZuoraRow
 from source_zuora.shared import ZUORA_API_VERSION
 
 _LOG = logging.getLogger(__name__)
 _BASE = "https://rest.zuora.com"
+
+
+def _ctx(object_name: str) -> ValidationContext:
+    return ValidationContext(object_name=object_name)
 
 
 @pytest.fixture(autouse=True)
@@ -195,10 +199,10 @@ async def test_poll_times_out(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_results_strips_object_prefix():
+async def test_fetch_results_yields_validated_documents_with_own_prefix_stripped():
     http = FakeHTTP(downloads={"file1": b"Account.Id,Account.Name\n1,Acme\n"})
-    rows = [r async for r in _mgr(http)._fetch_results("file1", "Account")]
-    assert rows == [{"Id": "1", "Name": "Acme"}]
+    rows = [r async for r in _mgr(http)._fetch_results("file1", ZuoraRow, _ctx("Account"))]
+    assert [r.model_dump(exclude={"meta_"}) for r in rows] == [{"Id": "1", "Name": "Acme"}]
 
 
 @pytest.mark.asyncio
@@ -212,8 +216,8 @@ async def test_fetch_results_flattens_joined_columns_without_shadowing_id():
             b"inv1,INV-1,acc1,con1\n"
         }
     )
-    rows = [r async for r in _mgr(http)._fetch_results("file1", "Invoice")]
-    assert rows == [
+    rows = [r async for r in _mgr(http)._fetch_results("file1", ZuoraRow, _ctx("Invoice"))]
+    assert [r.model_dump(exclude={"meta_"}) for r in rows] == [
         {
             "Id": "inv1",
             "InvoiceNumber": "INV-1",
@@ -221,32 +225,6 @@ async def test_fetch_results_flattens_joined_columns_without_shadowing_id():
             "BillToContactId": "con1",
         }
     ]
-
-
-# --- _column_to_field ----------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "column, object_name, expected",
-    [
-        # Own columns drop the prefix so they match their describe names.
-        ("Invoice.Id", "Invoice", "Id"),
-        ("Invoice.AccountId", "Invoice", "AccountId"),
-        # Joined columns keep the related object as a flattened name.
-        ("Account.Id", "Invoice", "AccountId"),
-        ("AccountReceivableAccountingCode.Id", "InvoiceItem",
-         "AccountReceivableAccountingCodeId"),
-        # An object whose name is a prefix of another's must not be confused for
-        # it: an InvoiceItem export's own columns say "InvoiceItem.", while
-        # "Invoice." is the join.
-        ("InvoiceItem.Id", "InvoiceItem", "Id"),
-        ("Invoice.Id", "InvoiceItem", "InvoiceId"),
-        # A header without a prefix is passed through rather than mangled.
-        ("Id", "Account", "Id"),
-    ],
-)
-def test_column_to_field(column, object_name, expected):
-    assert em._column_to_field(column, object_name) == expected
 
 
 # A too-large 403 carries the max-object-size XML marker in its body, which the
@@ -263,7 +241,7 @@ _TOO_LARGE_403 = HTTPError(
 async def test_fetch_results_403_with_marker_raises_too_large():
     http = FakeHTTP(downloads={"file1": _TOO_LARGE_403})
     with pytest.raises(ExportTooLargeError):
-        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
+        [r async for r in _mgr(http)._fetch_results("file1", ZuoraRow, _ctx("Account"))]
 
 
 @pytest.mark.asyncio
@@ -281,7 +259,7 @@ async def test_fetch_results_403_without_marker_propagates():
         }
     )
     with pytest.raises(HTTPError) as exc:
-        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
+        [r async for r in _mgr(http)._fetch_results("file1", ZuoraRow, _ctx("Account"))]
     assert not isinstance(exc.value, ExportTooLargeError)
 
 
@@ -289,7 +267,7 @@ async def test_fetch_results_403_without_marker_propagates():
 async def test_fetch_results_other_http_error_propagates():
     http = FakeHTTP(downloads={"file1": HTTPError("server error", 500)})
     with pytest.raises(HTTPError):
-        [r async for r in _mgr(http)._fetch_results("file1", "Account")]
+        [r async for r in _mgr(http)._fetch_results("file1", ZuoraRow, _ctx("Account"))]
 
 
 # --- export_rows (end to end) --------------------------------------------------
@@ -302,8 +280,8 @@ async def test_export_rows_submit_poll_stream():
         polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
         downloads={"file1": b"Account.Id\n7\n"},
     )
-    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
-    assert rows == [{"Id": "7"}]
+    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", ZuoraRow, _ctx("Account"))]
+    assert [r.Id for r in rows] == ["7"]
 
 
 @pytest.mark.asyncio
@@ -320,8 +298,8 @@ async def test_export_rows_concatenates_segments_in_order():
             "s2": b"Account.Id\n3\n",
         },
     )
-    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
-    assert rows == [{"Id": "1"}, {"Id": "2"}, {"Id": "3"}]
+    rows = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", ZuoraRow, _ctx("Account"))]
+    assert [r.Id for r in rows] == ["1", "2", "3"]
     assert http.downloaded_file_ids == ["s1", "s2"]
 
 
@@ -332,7 +310,7 @@ async def test_export_rows_pins_api_version_header():
         polls=[b'{"id": "job1", "status": "completed", "batches": [{"fileId": "file1"}]}'],
         downloads={"file1": b"Account.Id\n7\n"},
     )
-    _ = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", "Account")]
+    _ = [r async for r in _mgr(http).export_rows("SELECT Id FROM Account", ZuoraRow, _ctx("Account"))]
     # submit + poll (request) and download (request_stream) all carry the pin
     assert http.request_headers  # submit + poll happened
     assert all(

--- a/source-zuora/tests/test_resources.py
+++ b/source-zuora/tests/test_resources.py
@@ -12,7 +12,6 @@ import pytest
 from estuary_cdk.capture import common
 from estuary_cdk.flow import ValidationError
 from estuary_cdk.http import HTTPError
-from estuary_cdk.incremental_csv_processor import BaseCSVRow
 
 from source_zuora import resources
 from source_zuora.models import (
@@ -22,6 +21,8 @@ from source_zuora.models import (
     TransactionDateDocument,
     UpdatedDateDocument,
     UpdatedOnDocument,
+    ZuoraRow,
+    ZuoraType,
 )
 
 _LOG = logging.getLogger(__name__)
@@ -46,7 +47,9 @@ def _described(name: str, field_names: list[str]) -> DescribeObject:
     return DescribeObject(
         name=name,
         fields=[
-            DescribeField(name=field, selectable=True, contexts=["soap", "export"])
+            DescribeField(
+                name=field, selectable=True, contexts=["soap", "export"], type="text"
+            )
             for field in field_names
         ],
     )
@@ -66,6 +69,8 @@ async def test_describe_one_success_returns_described_object():
         )
     assert result is not None
     assert result.name == "Account" and result.fields == ["Id", "UpdatedDate"]
+    # Each column's declared type comes along, for the binding's sourced schema.
+    assert result.field_types == {"Id": ZuoraType.TEXT, "UpdatedDate": ZuoraType.TEXT}
 
 
 @pytest.mark.asyncio
@@ -108,7 +113,13 @@ def test_incremental_resource_shape_and_boundary_ownership():
     start = datetime(2020, 1, 1, tzinfo=UTC)
     cutoff = datetime(2024, 1, 1, tzinfo=UTC)
     r = resources._incremental_resource(
-        "Account", ["Id", "UpdatedDate"], UpdatedDateDocument, object(), start, cutoff
+        "Account",
+        ["Id", "UpdatedDate"],
+        {"Id": ZuoraType.TEXT, "UpdatedDate": ZuoraType.DATETIME},
+        UpdatedDateDocument,
+        object(),
+        start,
+        cutoff,
     )
     assert r.key == ["/Id"]
     assert r.model is UpdatedDateDocument
@@ -121,10 +132,14 @@ def test_incremental_resource_shape_and_boundary_ownership():
 
 
 def test_snapshot_resource_shape():
-    r = resources._snapshot_resource("Product", ["Id", "Name"], object())
+    r = resources._snapshot_resource(
+        "Product", ["Id", "Name"], {"Id": ZuoraType.TEXT, "Name": ZuoraType.TEXT}, object()
+    )
     assert isinstance(r, common.SnapshotResource)
     assert r.key == ["/_meta/row_id"]
-    assert r.model is BaseCSVRow
+    # ZuoraRow rather than BaseCSVRow: snapshots declare no fields either, but their
+    # boolean and datetime cells still need converting.
+    assert r.model is ZuoraRow
     assert r.schema_inference is True
 
 

--- a/source-zuora/tests/test_resources.py
+++ b/source-zuora/tests/test_resources.py
@@ -16,6 +16,8 @@ from estuary_cdk.incremental_csv_processor import BaseCSVRow
 
 from source_zuora import resources
 from source_zuora.models import (
+    DescribeField,
+    DescribeObject,
     EndpointConfig,
     TransactionDateDocument,
     UpdatedDateDocument,
@@ -39,15 +41,26 @@ def _binding(name: str) -> SimpleNamespace:
     return SimpleNamespace(resourceConfig=SimpleNamespace(name=name))
 
 
+def _described(name: str, field_names: list[str]) -> DescribeObject:
+    """A describe response where every named field is exportable."""
+    return DescribeObject(
+        name=name,
+        fields=[
+            DescribeField(name=field, selectable=True, contexts=["soap", "export"])
+            for field in field_names
+        ],
+    )
+
+
 # --- _describe_one -------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_describe_one_success_returns_described_object():
     async def fake(base_url, http, log, name):
-        return ["Id", "UpdatedDate"]
+        return _described(name, ["Id", "UpdatedDate"])
 
-    with patch("source_zuora.resources.fetch_object_fields", fake):
+    with patch("source_zuora.resources.fetch_object_metadata", fake):
         result = await resources._describe_object(
             "Account", "u", AsyncMock(), _LOG
         )
@@ -60,7 +73,7 @@ async def test_describe_one_http_error_is_skipped():
     async def fake(base_url, http, log, name):
         raise HTTPError("nope", 500)
 
-    with patch("source_zuora.resources.fetch_object_fields", fake):
+    with patch("source_zuora.resources.fetch_object_metadata", fake):
         assert await resources._describe_object(
             "Account", "u", AsyncMock(), _LOG
         ) is None
@@ -71,7 +84,7 @@ async def test_describe_one_generic_error_is_skipped():
     async def fake(base_url, http, log, name):
         raise ValueError("bad xml")
 
-    with patch("source_zuora.resources.fetch_object_fields", fake):
+    with patch("source_zuora.resources.fetch_object_metadata", fake):
         assert await resources._describe_object(
             "Account", "u", AsyncMock(), _LOG
         ) is None
@@ -80,9 +93,9 @@ async def test_describe_one_generic_error_is_skipped():
 @pytest.mark.asyncio
 async def test_describe_one_no_exportable_fields_is_skipped():
     async def fake(base_url, http, log, name):
-        return []
+        return _described(name, [])
 
-    with patch("source_zuora.resources.fetch_object_fields", fake):
+    with patch("source_zuora.resources.fetch_object_metadata", fake):
         assert await resources._describe_object(
             "Account", "u", AsyncMock(), _LOG
         ) is None
@@ -122,12 +135,12 @@ def test_snapshot_resource_shape():
 async def test_all_resources_enumerates_catalog_and_dispatches_by_updated_date():
     async def fake_describe(base_url, http, log, name):
         # Account is incremental (has UpdatedDate); Product is a snapshot.
-        return ["Id", "UpdatedDate"] if name == "Account" else ["Id"]
+        return _described(name, ["Id", "UpdatedDate"] if name == "Account" else ["Id"])
 
     async def fake_catalog(base_url, http, log):
         return ["Account", "Product"]
 
-    with patch("source_zuora.resources.fetch_object_fields", fake_describe), patch(
+    with patch("source_zuora.resources.fetch_object_metadata", fake_describe), patch(
         "source_zuora.resources.discover_object_names", fake_catalog
     ), patch.object(resources, "_attach_token_source"):
         res = await resources.all_resources(_LOG, AsyncMock(), _config())
@@ -153,12 +166,12 @@ async def test_all_resources_classifies_by_cursor_field_priority():
     }
 
     async def fake_describe(base_url, http, log, name):
-        return fields_by_object[name]
+        return _described(name, fields_by_object[name])
 
     async def fake_catalog(base_url, http, log):
         return list(fields_by_object)
 
-    with patch("source_zuora.resources.fetch_object_fields", fake_describe), patch(
+    with patch("source_zuora.resources.fetch_object_metadata", fake_describe), patch(
         "source_zuora.resources.discover_object_names", fake_catalog
     ), patch.object(resources, "_attach_token_source"):
         res = await resources.all_resources(_LOG, AsyncMock(), _config())
@@ -179,13 +192,13 @@ async def test_enabled_resources_describes_only_bound_objects():
 
     async def fake_describe(base_url, http, log, name):
         described.append(name)
-        return ["Id", "UpdatedDate"]
+        return _described(name, ["Id", "UpdatedDate"])
 
     async def fake_catalog(base_url, http, log):
         catalog_calls["n"] += 1
         return ["A", "B", "C"]
 
-    with patch("source_zuora.resources.fetch_object_fields", fake_describe), patch(
+    with patch("source_zuora.resources.fetch_object_metadata", fake_describe), patch(
         "source_zuora.resources.discover_object_names", fake_catalog
     ), patch.object(resources, "_attach_token_source"):
         await resources.enabled_resources(

--- a/source-zuora/tests/test_resources.py
+++ b/source-zuora/tests/test_resources.py
@@ -138,9 +138,81 @@ def test_snapshot_resource_shape():
     assert isinstance(r, common.SnapshotResource)
     assert r.key == ["/_meta/row_id"]
     # ZuoraRow rather than BaseCSVRow: snapshots declare no fields either, but their
-    # boolean and datetime cells still need converting.
+    # boolean and datetime cells still need converting to match the sourced schema.
     assert r.model is ZuoraRow
     assert r.schema_inference is True
+
+
+# --- open() emits the sourced schema -------------------------------------------
+
+
+class _FakeTask:
+    def __init__(self):
+        self.schemas: list[tuple[int, dict]] = []
+        self.checkpoints = 0
+
+    def sourced_schema(self, binding_index: int, schema: dict) -> None:
+        self.schemas.append((binding_index, schema))
+
+    async def checkpoint(self, state, merge_patch: bool = True) -> None:
+        self.checkpoints += 1
+
+
+@pytest.mark.asyncio
+async def test_incremental_open_emits_a_sourced_schema_and_flushes_it():
+    types = {"Id": ZuoraType.TEXT, "UpdatedDate": ZuoraType.DATETIME, "AutoPay": ZuoraType.BOOLEAN}
+    r = resources._incremental_resource(
+        "Account",
+        list(types),
+        types,
+        UpdatedDateDocument,
+        object(),
+        datetime(2020, 1, 1, tzinfo=UTC),
+        datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    task = _FakeTask()
+    with patch.object(resources.common, "open_binding") as open_binding:
+        await r.open(SimpleNamespace(), 7, SimpleNamespace(), task, [])
+
+    assert len(task.schemas) == 1
+    index, schema = task.schemas[0]
+    assert index == 7
+    properties = schema["properties"]
+    assert properties["AutoPay"] == {"type": "boolean"}
+    assert properties["UpdatedDate"] == {"type": "string", "format": "date-time"}
+    # A binding with no new data would never checkpoint on its own, so the schema has
+    # to be flushed here or it is never emitted.
+    assert task.checkpoints == 1
+    assert open_binding.called
+
+
+@pytest.mark.asyncio
+async def test_open_passes_the_type_map_to_both_fetch_paths():
+    types = {"Id": ZuoraType.TEXT, "UpdatedDate": ZuoraType.DATETIME}
+    r = resources._incremental_resource(
+        "Account", list(types), types, UpdatedDateDocument, object(),
+        datetime(2020, 1, 1, tzinfo=UTC), datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    with patch.object(resources.common, "open_binding") as open_binding:
+        await r.open(SimpleNamespace(), 0, SimpleNamespace(), _FakeTask(), [])
+
+    kwargs = open_binding.call_args.kwargs
+    # Without the type map reaching the fetch functions, documents would keep their raw
+    # cells and contradict the schema just declared.
+    assert types in kwargs["fetch_changes"].args
+    assert types in kwargs["fetch_page"].args
+
+
+@pytest.mark.asyncio
+async def test_snapshot_open_emits_a_sourced_schema_too():
+    types = {"Id": ZuoraType.TEXT, "CreatedOn": ZuoraType.DATETIME}
+    r = resources._snapshot_resource("EmailHistory", list(types), types, object())
+    task = _FakeTask()
+    with patch.object(resources.common, "open_binding") as open_binding:
+        await r.open(SimpleNamespace(), 3, SimpleNamespace(), task, [])
+
+    assert [i for i, _ in task.schemas] == [3]
+    assert types in open_binding.call_args.kwargs["fetch_snapshot"].args
 
 
 # --- all_resources / enabled_resources dispatch --------------------------------

--- a/source-zuora/tests/test_resources.py
+++ b/source-zuora/tests/test_resources.py
@@ -19,6 +19,7 @@ from source_zuora.models import (
     EndpointConfig,
     TransactionDateDocument,
     UpdatedDateDocument,
+    UpdatedOnDocument,
 )
 
 _LOG = logging.getLogger(__name__)
@@ -145,6 +146,10 @@ async def test_all_resources_classifies_by_cursor_field_priority():
         "PaymentTransactionLog": ["Id", "TransactionDate"],
         "Product": ["Id", "Name"],
         "Invoice": ["Id", "UpdatedDate", "TransactionDate"],
+        # AchNocEventLog spells its timestamps UpdatedOn/CreatedOn. Its
+        # PaymentMethodUpdatedDate must not be mistaken for a cursor: matching is by
+        # exact field name, not by suffix.
+        "AchNocEventLog": ["Id", "UpdatedOn", "CreatedOn", "PaymentMethodUpdatedDate"],
     }
 
     async def fake_describe(base_url, http, log, name):
@@ -162,6 +167,9 @@ async def test_all_resources_classifies_by_cursor_field_priority():
     assert by_name["PaymentTransactionLog"].model is TransactionDateDocument
     assert by_name["Product"].key == ["/_meta/row_id"]  # snapshot
     assert by_name["Invoice"].model is UpdatedDateDocument  # UpdatedDate wins
+    # Incremental on UpdatedOn, keyed on /Id -- not a full-table snapshot.
+    assert by_name["AchNocEventLog"].model is UpdatedOnDocument
+    assert by_name["AchNocEventLog"].key == ["/Id"]
 
 
 @pytest.mark.asyncio

--- a/source-zuora/tests/test_sourced_schemas.py
+++ b/source-zuora/tests/test_sourced_schemas.py
@@ -7,8 +7,11 @@ from source_zuora.models import (
     DescribeField,
     DescribeObject,
     sourced_schema,
+    ValidationContext,
+    ZuoraRow,
     ZuoraType,
     UnknownZuoraTypeError,
+    _column_to_field,
 )
 
 
@@ -133,3 +136,32 @@ def test_a_field_with_no_declared_type_fails_the_object():
     )
     with pytest.raises(UnknownZuoraTypeError, match="Id"):
         described.query_field_types
+
+
+@pytest.mark.parametrize(
+    "column, object_name, expected",
+    [
+        # Own columns drop the prefix so they match their describe names.
+        ("Invoice.Id", "Invoice", "Id"),
+        ("Invoice.AccountId", "Invoice", "AccountId"),
+        # Joined columns keep the related object as a flattened name.
+        ("Account.Id", "Invoice", "AccountId"),
+        ("AccountReceivableAccountingCode.Id", "InvoiceItem",
+         "AccountReceivableAccountingCodeId"),
+        # An object whose name is a prefix of another's must not be confused for
+        # it: an InvoiceItem export's own columns say "InvoiceItem.", while
+        # "Invoice." is the join.
+        ("InvoiceItem.Id", "InvoiceItem", "Id"),
+        ("Invoice.Id", "InvoiceItem", "InvoiceId"),
+        # A header without a prefix is passed through rather than mangled.
+        ("Id", "Account", "Id"),
+    ],
+)
+def test_column_to_field(column, object_name, expected):
+    assert _column_to_field(column, object_name) == expected
+
+
+def test_renaming_is_idempotent_so_revalidation_is_safe():
+    # A document's own field names carry no prefix, so a second pass leaves them be.
+    assert _column_to_field("AccountId", "Invoice") == "AccountId"
+    assert _column_to_field("Id", "Invoice") == "Id"

--- a/source-zuora/tests/test_sourced_schemas.py
+++ b/source-zuora/tests/test_sourced_schemas.py
@@ -1,13 +1,23 @@
 """Tests for the describe-type -> JSON-schema mapping used to build SourcedSchemas."""
 
+import re
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+
 import pytest
 
+from estuary_cdk.capture.task import with_sourced_schema_defaults
+
 from source_zuora.models import (
+    CONVERTED_TYPES,
     ZUORA_TYPE_SCHEMAS,
     DescribeField,
     DescribeObject,
+    normalize_datetime,
+    parse_boolean,
     sourced_schema,
     ValidationContext,
+    UpdatedDateDocument,
     ZuoraRow,
     ZuoraType,
     UnknownZuoraTypeError,
@@ -41,6 +51,18 @@ def test_parse_rejects_a_type_it_does_not_recognize(raw):
         ZuoraType.parse(raw, "Balance")
 
 
+def test_every_converted_type_has_a_converter_branch():
+    # convert_typed_cells raises if these disagree, which would only surface on a
+    # tenant that has such a field. Pin it here instead.
+    row = {"f": "unconvertible"}
+    for zuora_type in CONVERTED_TYPES:
+        with pytest.raises(Exception) as caught:
+            ZuoraRow.model_validate(row, context=ValidationContext(object_name="Thing", field_types={"f": zuora_type}))
+        assert "no converter" not in str(caught.value), (
+            f"{zuora_type} is in CONVERTED_TYPES but convert_typed_cells has no branch"
+        )
+
+
 def test_numerics_are_formatted_strings_not_json_numbers():
     # A JSON number would lose precision on Zuora's money decimals; materialize-sql
     # turns a format-annotated string into a numeric column anyway.
@@ -63,6 +85,65 @@ def test_dates_are_format_annotated():
     }
 
 
+def test_types_needing_value_conversion_are_declared_as_such():
+    # Declaring a format the raw cell does not satisfy is worse than declaring none, so
+    # these two must never be annotated without their converter being applied.
+    assert CONVERTED_TYPES == {ZuoraType.BOOLEAN, ZuoraType.DATETIME}
+
+
+# How AQuA renders a datetime: an ISO 8601 basic offset, which RFC3339 rejects for
+# want of a colon.
+ZUORA_DATETIME = "2026-08-11T13:08:57+0000"
+
+
+def test_normalize_datetime_fixes_the_shape_zuora_actually_emits():
+    assert normalize_datetime("CreatedDate", ZUORA_DATETIME) == "2026-08-11T13:08:57+00:00"
+
+
+def test_normalize_datetime_is_idempotent_and_passes_compliant_values_through():
+    once = normalize_datetime("CreatedDate", ZUORA_DATETIME)
+    assert normalize_datetime("CreatedDate", once) == once
+    for compliant in (
+        "2026-08-11T13:08:57Z",
+        "2026-08-11T13:08:57+00:00",
+        "2026-08-11T13:08:57.123456+00:00",
+    ):
+        assert normalize_datetime("CreatedDate", compliant) == compliant
+
+
+def test_normalize_datetime_preserves_a_non_utc_offset():
+    # dateTimeUtc pins the offset to UTC today; preserving it costs nothing and avoids
+    # silently relabelling a local time as UTC if that ever changes.
+    assert (
+        normalize_datetime("CreatedDate", "2026-08-11T13:08:57-0530")
+        == "2026-08-11T13:08:57-05:30"
+    )
+
+
+def test_normalize_datetime_accepts_fractional_seconds():
+    assert (
+        normalize_datetime("CreatedDate", "2026-08-11T13:08:57.500+0000")
+        == "2026-08-11T13:08:57.500+00:00"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "2026-08-11 13:08:57+0000",  # space separator, no T
+        "2026-08-11T13:08:57",  # no offset at all
+        "2026-08-11",  # a date, not a datetime
+        "",
+        "not a date",
+    ],
+)
+def test_normalize_datetime_rejects_shapes_we_have_not_seen(raw: str):
+    # A value we cannot make compliant must fail here rather than reach a destination
+    # that would reject it more confusingly.
+    with pytest.raises(ValueError, match="CreatedDate"):
+        normalize_datetime("CreatedDate", raw)
+
+
 def test_no_declaration_mentions_null():
     assert not any(
         "null" in schema["type"] for schema in ZUORA_TYPE_SCHEMAS.values()
@@ -81,6 +162,18 @@ def test_sourced_schema_is_closed():
     schema = sourced_schema({"Id": ZuoraType.TEXT, "Balance": ZuoraType.DECIMAL})
     assert schema["type"] == "object"
     assert schema["additionalProperties"] is False
+
+
+def test_meta_and_required_are_filled_in_by_the_cdk():
+    # The connector deliberately does not hand-roll these; assert on what the runtime
+    # actually receives, so this keeps holding if the CDK's defaults change.
+    complete = with_sourced_schema_defaults(
+        sourced_schema({"Id": ZuoraType.TEXT, "Balance": ZuoraType.DECIMAL})
+    )
+    properties = complete["properties"]
+    assert "_meta" in properties
+    assert set(complete["required"]) == {"Id", "Balance", "_meta"}
+    assert complete["additionalProperties"] is False
 
 
 def test_sourced_schema_types_each_field_from_its_zuora_type():
@@ -139,6 +232,50 @@ def test_a_field_with_no_declared_type_fails_the_object():
 
 
 @pytest.mark.parametrize(
+    "raw, expected",
+    [("true", True), ("false", False), ("TRUE", True), ("False", False), (" true ", True)],
+)
+def test_parse_boolean_accepts_zuoras_spellings(raw: str, expected: bool):
+    assert parse_boolean("AutoPay", raw) is expected
+
+
+@pytest.mark.parametrize("raw", ["1", "0", "yes", "no", "", "maybe", "t"])
+def test_parse_boolean_rejects_everything_else_loudly(raw: str):
+    # Silently accepting a wider vocabulary would hide a field that is not really a
+    # boolean; the failure is how we find out.
+    with pytest.raises(ValueError, match="AutoPay"):
+        parse_boolean("AutoPay", raw)
+
+
+# --- cell conversion -----------------------------------------------------------
+#
+# A declared type the document does not satisfy is worse than no declaration, so these
+# pin the two conversions the sourced schema depends on.
+
+ACCOUNT_TYPES = {
+    "Id": ZuoraType.TEXT,
+    "AutoPay": ZuoraType.BOOLEAN,
+    "CreatedDate": ZuoraType.DATETIME,
+    "UpdatedDate": ZuoraType.DATETIME,
+    "Balance": ZuoraType.DECIMAL,
+    "Status": ZuoraType.PICKLIST,
+}
+
+
+def _row(**overrides: str | None) -> dict[str, str | None]:
+    row: dict[str, str | None] = {
+        "Id": "8a2880fb96384b0a019643313fe536fb",
+        "AutoPay": "true",
+        "CreatedDate": "2026-08-11T13:08:57+0000",
+        "UpdatedDate": "2026-08-11T13:08:57+0000",
+        "Balance": "1234.56",
+        "Status": "Active",
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.parametrize(
     "column, object_name, expected",
     [
         # Own columns drop the prefix so they match their describe names.
@@ -161,7 +298,187 @@ def test_column_to_field(column, object_name, expected):
     assert _column_to_field(column, object_name) == expected
 
 
+def test_the_validator_renames_columns_before_converting():
+    # field_types is keyed by the document's names, so the rename has to come first or
+    # nothing would match and no cell would convert.
+    doc = ZuoraRow.model_validate(
+        {"Invoice.Id": "inv1", "Account.Id": "acc1", "Invoice.Posted": "true"},
+        context=ValidationContext(
+            object_name="Invoice",
+            field_types={
+                "Id": ZuoraType.TEXT,
+                "AccountId": ZuoraType.TEXT,
+                "Posted": ZuoraType.BOOLEAN,
+            },
+        ),
+    )
+    assert doc.Id == "inv1"
+    assert doc.AccountId == "acc1"
+    assert doc.Posted is True
+
+
 def test_renaming_is_idempotent_so_revalidation_is_safe():
     # A document's own field names carry no prefix, so a second pass leaves them be.
     assert _column_to_field("AccountId", "Invoice") == "AccountId"
     assert _column_to_field("Id", "Invoice") == "Id"
+
+
+def test_boolean_cells_become_real_booleans():
+    doc = ZuoraRow.model_validate(_row(), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES))
+    assert doc.AutoPay is True
+    assert ZuoraRow.model_validate(
+        _row(AutoPay="false"), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+    ).AutoPay is False
+
+
+def test_datetime_cells_become_rfc3339():
+    doc = ZuoraRow.model_validate(_row(), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES))
+    assert doc.CreatedDate == "2026-08-11T13:08:57+00:00"
+
+
+def test_untyped_cells_are_left_exactly_as_they_arrived():
+    # Numerics stay strings on purpose: the schema annotates them with format: number,
+    # which materializes as numeric without risking a float round-trip.
+    doc = ZuoraRow.model_validate(_row(), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES))
+    assert doc.Balance == "1234.56"
+    assert doc.Status == "Active"
+    assert doc.Id == "8a2880fb96384b0a019643313fe536fb"
+
+
+def test_empty_cells_stay_null_rather_than_converting():
+    doc = ZuoraRow.model_validate(
+        _row(AutoPay="", CreatedDate=""), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+    )
+    assert doc.AutoPay is None
+    assert doc.CreatedDate is None
+
+
+@pytest.mark.parametrize(
+    "context",
+    [None, {"object_name": "Account", "field_types": ACCOUNT_TYPES}],
+    ids=["absent", "bare dict"],
+)
+def test_validating_without_a_validation_context_is_an_error(context):
+    # Silently skipping conversion would emit cells that contradict the schema the
+    # binding declares, so anything but a ValidationContext fails loudly -- including
+    # the bare dict this used to accept.
+    with pytest.raises(Exception, match="ValidationContext"):
+        ZuoraRow.model_validate(_row(), context=context)
+
+
+def test_an_unexpected_boolean_token_fails_the_row():
+    with pytest.raises(Exception, match="AutoPay"):
+        ZuoraRow.model_validate(
+            _row(AutoPay="Y"), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+        )
+
+
+def test_the_cursor_field_still_parses_after_normalization():
+    # UpdatedDate is both converted here and declared AwareDatetime on the model, so
+    # this is the one field where the two have to agree.
+    doc = UpdatedDateDocument.model_validate(
+        _row(), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+    )
+    assert doc.get_cursor() == datetime(2026, 8, 11, 13, 8, 57, tzinfo=UTC)
+
+
+def test_validating_an_already_converted_document_is_a_no_op():
+    # Re-validation must not try to parse a real bool as a string.
+    once = ZuoraRow.model_validate(_row(), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES))
+    twice = ZuoraRow.model_validate(
+        once.model_dump(by_alias=True), context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+    )
+    assert twice.AutoPay is True
+    assert twice.CreatedDate == "2026-08-11T13:08:57+00:00"
+
+
+# --- the closing of the loop ---------------------------------------------------
+#
+# The whole point of the converters is that a document satisfies the schema declared
+# for it. If those two disagree, the mismatch surfaces at materialization time in a
+# destination, which is the worst place to find it.
+#
+# Scope note: these validate against the connector's own declaration, not the
+# CDK-completed one, and exclude _meta. A SourcedSchema is a widening hint the runtime
+# unions into the inferred schema, not a validator of connector output -- its _meta
+# block requires the `uuid` the runtime adds afterwards, and bounds `row_id` to values
+# a connector deliberately violates with -1 for "not known".
+
+
+class DeclarationViolation(AssertionError):
+    """A value does not satisfy the schema declared for its column."""
+
+
+def _check_declared_columns(doc: ZuoraRow, field_types: dict[str, ZuoraType]) -> None:
+    """Assert every column's value satisfies the schema declared for it.
+
+    Hand-rolled rather than handed to jsonschema, because jsonschema does not enforce
+    `format` unless a checker is installed for it -- and it ships no `date-time` checker
+    at all, which is precisely the declaration most worth checking here.
+    """
+    document = doc.model_dump(by_alias=True, mode="json")
+    document.pop("_meta", None)
+    for name, zuora_type in field_types.items():
+        declared = ZUORA_TYPE_SCHEMAS[zuora_type]
+        value = document[name]
+        if declared["type"] == "boolean":
+            if not isinstance(value, bool):
+                raise DeclarationViolation(f"{name}: declared boolean, got {value!r}")
+            continue
+        if not isinstance(value, str):
+            raise DeclarationViolation(f"{name}: declared string, got {value!r}")
+        match declared.get("format"):
+            case "date-time":
+                if not re.fullmatch(
+                    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})",
+                    value,
+                ):
+                    raise DeclarationViolation(f"{name}: not RFC3339: {value!r}")
+            case "date":
+                if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+                    raise DeclarationViolation(f"{name}: not a date: {value!r}")
+            case "integer":
+                if not re.fullmatch(r"-?\d+", value):
+                    raise DeclarationViolation(f"{name}: not an integer: {value!r}")
+            case "number":
+                try:
+                    Decimal(value)
+                except InvalidOperation:
+                    raise DeclarationViolation(f"{name}: not a number: {value!r}")
+
+
+def test_a_converted_document_satisfies_every_column_it_declares():
+    _check_declared_columns(
+        ZuoraRow.model_validate(
+            _row(),
+            context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES),
+        ),
+        ACCOUNT_TYPES,
+    )
+
+
+def test_an_all_null_row_is_not_expected_to_satisfy_the_declaration():
+    # Deliberate: the declaration does not mention null, so an all-null row violates it.
+    # That is not a contradiction -- the runtime unions this schema into the inferred
+    # one, which picks null up from the documents. A schema a document must satisfy is
+    # the wrong mental model for a sourced schema.
+    empty = {name: "" for name in ACCOUNT_TYPES}
+    doc = ZuoraRow.model_validate(
+        empty, context=ValidationContext(object_name="Account", field_types=ACCOUNT_TYPES)
+    )
+    with pytest.raises(DeclarationViolation):
+        _check_declared_columns(doc, ACCOUNT_TYPES)
+
+
+def test_the_raw_export_row_would_not():
+    # Why the converters are mandatory rather than cosmetic: straight off the wire the
+    # row holds "true" where the schema declares a boolean, and an offset RFC3339
+    # rejects where it declares date-time.
+    raw = ZuoraRow.model_construct(**_row())
+    with pytest.raises(DeclarationViolation, match="AutoPay"):
+        _check_declared_columns(raw, ACCOUNT_TYPES)
+    # And the datetime specifically -- the half jsonschema never checked.
+    with pytest.raises(DeclarationViolation, match="not RFC3339"):
+        _check_declared_columns(
+            raw, {"CreatedDate": ZuoraType.DATETIME}
+        )

--- a/source-zuora/tests/test_sourced_schemas.py
+++ b/source-zuora/tests/test_sourced_schemas.py
@@ -1,0 +1,135 @@
+"""Tests for the describe-type -> JSON-schema mapping used to build SourcedSchemas."""
+
+import pytest
+
+from source_zuora.models import (
+    ZUORA_TYPE_SCHEMAS,
+    DescribeField,
+    DescribeObject,
+    sourced_schema,
+    ZuoraType,
+    UnknownZuoraTypeError,
+)
+
+
+EXPORT = ["soap", "export"]
+
+
+def test_every_type_zuora_declares_is_a_known_member():
+    declared = {
+        "text", "decimal", "datetime", "picklist", "date",
+        "boolean", "integer", "ZOQL", "longtext", "number", "timestamp",
+    }
+    assert {ZuoraType.parse(t, "f") for t in declared} == set(ZuoraType)
+
+
+def test_every_member_has_a_schema():
+    # Also asserted at import; restated here so the failure names this contract.
+    assert ZUORA_TYPE_SCHEMAS.keys() == set(ZuoraType)
+
+
+@pytest.mark.parametrize(
+    "raw", ["someTypeZuoraAddedLater", None, ""], ids=["unknown", "absent", "empty"]
+)
+def test_parse_rejects_a_type_it_does_not_recognize(raw):
+    # Degrading to an untyped string would claim we know the field's shape when we do
+    # not, and would strip whatever format inference had established for the column.
+    with pytest.raises(UnknownZuoraTypeError, match="Balance"):
+        ZuoraType.parse(raw, "Balance")
+
+
+def test_numerics_are_formatted_strings_not_json_numbers():
+    # A JSON number would lose precision on Zuora's money decimals; materialize-sql
+    # turns a format-annotated string into a numeric column anyway.
+    for zuora_type in (ZuoraType.DECIMAL, ZuoraType.NUMBER):
+        assert ZUORA_TYPE_SCHEMAS[zuora_type] == {"type": "string", "format": "number"}
+    assert ZUORA_TYPE_SCHEMAS[ZuoraType.INTEGER] == {"type": "string", "format": "integer"}
+
+
+def test_booleans_are_declared_as_real_booleans():
+    # The one type with no string-format equivalent, hence the one that needs its
+    # values converted.
+    assert ZUORA_TYPE_SCHEMAS[ZuoraType.BOOLEAN] == {"type": "boolean"}
+
+
+def test_dates_are_format_annotated():
+    assert ZUORA_TYPE_SCHEMAS[ZuoraType.DATE] == {"type": "string", "format": "date"}
+    assert ZUORA_TYPE_SCHEMAS[ZuoraType.DATETIME] == {
+        "type": "string",
+        "format": "date-time",
+    }
+
+
+def test_no_declaration_mentions_null():
+    assert not any(
+        "null" in schema["type"] for schema in ZUORA_TYPE_SCHEMAS.values()
+    )
+
+
+def test_an_unrecognized_type_names_the_field_and_what_to_do():
+    with pytest.raises(UnknownZuoraTypeError) as caught:
+        ZuoraType.parse("geolocation", "ShipToAddress")
+    message = str(caught.value)
+    assert "ShipToAddress" in message and "geolocation" in message
+    assert "ZUORA_TYPE_SCHEMAS" in message
+
+
+def test_sourced_schema_is_closed():
+    schema = sourced_schema({"Id": ZuoraType.TEXT, "Balance": ZuoraType.DECIMAL})
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+
+
+def test_sourced_schema_types_each_field_from_its_zuora_type():
+    schema = sourced_schema({"AutoPay": ZuoraType.BOOLEAN, "Name": ZuoraType.TEXT, "Mrr": ZuoraType.DECIMAL})
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert properties["AutoPay"] == {"type": "boolean"}
+    assert properties["Name"] == {"type": "string"}
+    assert properties["Mrr"] == {"type": "string", "format": "number"}
+
+
+def test_query_field_types_keys_joined_columns_by_their_document_name():
+    # A joined Contact.Id selection arrives in the document as ContactId, and describe
+    # says nothing about its type because it is a relationship, not a field.
+    described = DescribeObject(
+        name="Invoice",
+        fields=[
+            DescribeField(name="Id", selectable=True, contexts=EXPORT, type="text"),
+            DescribeField(name="Amount", selectable=True, contexts=EXPORT, type="decimal"),
+            DescribeField(name="Skipped", selectable=False, contexts=["soap"], type="text"),
+        ],
+        related_object_names=["Account"],
+    )
+    assert described.query_field_types == {
+        "Id": ZuoraType.TEXT,
+        "Amount": ZuoraType.DECIMAL,
+        "AccountId": ZuoraType.TEXT,
+    }
+
+
+def test_query_field_types_covers_exactly_the_selected_columns():
+    described = DescribeObject(
+        name="Invoice",
+        fields=[
+            DescribeField(name="Id", selectable=True, contexts=EXPORT, type="text"),
+            DescribeField(name="Amount", selectable=True, contexts=EXPORT, type="decimal"),
+        ],
+        related_object_names=["Account"],
+    )
+    # query_field_names selects "Account.Id"; the document carries "AccountId".
+    selected = {
+        (name.split(".")[0] + "Id") if "." in name else name
+        for name in described.query_field_names
+    }
+    assert selected == described.query_field_types.keys()
+
+
+def test_a_field_with_no_declared_type_fails_the_object():
+    # Discovery fails rather than the object silently losing a column's type.
+    described = DescribeObject(
+        name="Thing",
+        fields=[DescribeField(name="Id", selectable=True, contexts=EXPORT)],
+    )
+    with pytest.raises(UnknownZuoraTypeError, match="Id"):
+        described.query_field_types


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR's scope includes:
- Changing `AchNocEventLog` to be captured incrementally based on the `UpdatedOn` field instead of fully refreshing it every sweep.
- Converting fields that Zuora's metadata states are booleans and datetimes into actual boolean values and RFC3339 compliant datetime strings.
- Emitting sourced schema messages based off the metadata provided by Zuora.

There are a number of backwards incompatible changes in this PR, but there's only a single capture currently & we've been working with them to improve the connector, so I plan to communicate these changes to them before rolling them out instead of gating anything behind a feature flag.

Best reviewed commit-by-commit.

**Checklist:**

- [x] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
