### PR TITLE
docs: source-google-search-console site_urls format

### DIFF
--- a/docs/reference/Connectors/capture-connectors/google-search-console.md
+++ b/docs/reference/Connectors/capture-connectors/google-search-console.md
@@ -87,7 +87,7 @@ so many of these properties aren't required.
 | **`/credentials/email`** | Admin Email | The email of your [Google Workspace administrator](https://support.google.com/a/answer/182076?hl=en). This is likely the account used during setup.  |
 | `/custom_reports` | Custom Reports (Optional) | A JSON array describing the [custom reports](#custom-reports) you want to sync from Google Search Console.  | string |  |
 | `/end_date` | End Date | UTC date in the format 2017-01-25. Any data after this date will not be replicated. Must be greater or equal to the start date field. | string |  |
-| **`/site_urls`** | Website URL | The [URLs of the website properties](https://support.google.com/webmasters/answer/34592?hl=en) attached to your GSC account: <ul><li>domain:example.com</li><li> https:<span></span>//example.com/</li></ul>  This connector supports both URL-prefix and domain property URLs.  | array | Required |
+| **`/site_urls`** | Website URL | The [URLs of the website properties](https://support.google.com/webmasters/answer/34592?hl=en) attached to your GSC account. Use `sc-domain:example.com` for a Domain property, or `https://example.com/` for a URL-prefix property.  | array | Required |
 | **`/start_date`** | Start Date | UTC date in the format 2017-01-25. Any data before this date will not be replicated. | string | Required |
 
 #### Bindings
@@ -112,7 +112,8 @@ captures:
               auth_type: Service
               service_account_info: <secret>
               email: admin@yourdomain.com
-            site_urls: https://yourdomain.com
+            site_urls:
+              - https://yourdomain.com/
             start_date: 2022-03-01
 
       bindings:


### PR DESCRIPTION
**Description:**

Docs-only fix to the Google Search Console connector reference page.

The `site_urls` description gave `domain:example.com` as the Domain property example. The Search Console API does not accept that value. Domain properties are `sc-domain:example.com`, URL-prefix properties are the full URL including scheme and trailing slash, `https://example.com/`. Per the [searchanalytics.query reference](https://developers.google.com/webmaster-tools/v1/searchanalytics/query):

> The URL of the property as defined in Search Console. Examples: `http://www.example.com/` (for a URL-prefix property) or `sc-domain:example.com` (for a Domain property)

The connector's published spec already carries the correct examples:

```json
"examples": ["https://example1.com/", "sc-domain:example2.com"]
```

So the docs page contradicted the field hint rendered in the dashboard. A user working from the page tried `domain:<their-domain>` and the capture failed; `sc-domain:<their-domain>` worked.

Also corrects the sample spec, which passed `site_urls` as a scalar for a field typed `array`.

**Workflow steps:**

No behavior change. Users configuring a Domain property now get the format the API accepts.

**Documentation links affected:**

https://docs.estuary.dev/reference/Connectors/capture-connectors/google-search-console/#endpoint

**Notes for reviewers:**

Scoped to the existing property-table row and the sample. No new section, no CHANGELOG entry, since no connector code changed.
