### PR TITLE
ci: retry transient failures when fetching Flow binaries

### DIFF
--- a/fetch-flow.sh
+++ b/fetch-flow.sh
@@ -9,12 +9,16 @@ mkdir -p flow-bin &&
 rm -f flow-bin/* &&
 cd flow-bin &&
 
-# Get the older package for etcd and gazette.
-curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/estuary/flow/releases/download/dev/flow-x86-linux.tar.gz" | tar -zx &&
+# Get the older package for etcd and gazette. Downloaded to a file rather than
+# piped into tar: GitHub's release endpoint returns transient 503s under load,
+# and `--retry` restarts the transfer, which would corrupt an in-progress extract.
+curl -L --proto '=https' --tlsv1.2 -sSf --retry 5 "https://github.com/estuary/flow/releases/download/dev/flow-x86-linux.tar.gz" -o flow-x86-linux.tar.gz &&
+tar -zxf flow-x86-linux.tar.gz &&
+rm flow-x86-linux.tar.gz &&
 
 # Overwrite some of the binaries with the latest release.
-curl -L -sSf "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flowctl-linux-x86_64" -o flowctl &&
-curl -L -sSf "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flowctl-go-linux-x86_64" -o flowctl-go &&
-curl -L -sSf "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flow-parser-linux-x86_64" -o flow-parser &&
-curl -L -sSf "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flow-connector-init-linux-x86_64" -o flow-connector-init &&
+curl -L -sSf --retry 5 "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flowctl-linux-x86_64" -o flowctl &&
+curl -L -sSf --retry 5 "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flowctl-go-linux-x86_64" -o flowctl-go &&
+curl -L -sSf --retry 5 "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flow-parser-linux-x86_64" -o flow-parser &&
+curl -L -sSf --retry 5 "https://github.com/estuary/flow/releases/download/${FLOW_RELEASE}/flow-connector-init-linux-x86_64" -o flow-connector-init &&
 chmod +x flowctl flowctl-go flow-parser flow-connector-init


### PR DESCRIPTION
**Regression?**

No

**Description:**

GitHub's release download endpoint returns 503 under concurrent load. A recent connectors CI run lost 10 of 67 jobs to it, each rejected ~100ms into the step before any bytes transferred -- the shape of edge throttling rather than an outage, with 67 jobs pulling the same 243MB asset within seconds of each other.

This commit adds `--retry 5` to all five downloads, which covers 503 along with 429, the other 5xx codes, and timeouts.

The legacy package download also has to stop piping into tar. `--retry` restarts the transfer from the beginning, so retrying mid-stream would feed tar a second copy of the header and corrupt the extract rather than recover from it. Download it to a file first, then extract. The file lands in `flow-bin/`, which this script already wipes on entry and which is gitignored, so a failed run leaves nothing behind.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
