### PR TITLE
ci: fetch Flow binaries once per run and share them as an artifact

### DIFF
--- a/.github/actions/fetch-flow-artifact/action.yaml
+++ b/.github/actions/fetch-flow-artifact/action.yaml
@@ -1,0 +1,31 @@
+name: Fetch Flow binaries for this run
+description: >-
+  Downloads Flow release binaries once and uploads them as this run's `flow-bin`
+  artifact, for matrix jobs to restore via the restore-flow-binaries action.
+  Beyond sparing GitHub's release endpoint one request per matrix job, this pins
+  every job in a run to identical binaries.
+
+inputs:
+  paths:
+    description: >-
+      Which of the fetched binaries to upload. Callers which only run flowctl
+      upload just that, sparing their matrix jobs the other ~425MB.
+    default: flow-bin/
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Download Flow release binaries
+      shell: bash
+      run: ./fetch-flow.sh
+
+    - name: Upload them as this run's flow-bin artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: flow-bin
+        path: ${{ inputs.paths }}
+        # Only ever consumed by jobs of the run which produced it.
+        retention-days: 1
+        # Stripped release binaries barely compress; skip the CPU cost.
+        compression-level: 0

--- a/.github/actions/restore-flow-binaries/action.yaml
+++ b/.github/actions/restore-flow-binaries/action.yaml
@@ -1,0 +1,21 @@
+name: Restore Flow binaries from this run
+description: >-
+  Restores the `flow-bin` artifact uploaded by this run's fetch-flow-artifact
+  step and adds it to $PATH. Requires an upstream job which produced it.
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Download this run's flow-bin artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: flow-bin
+        path: flow-bin/
+
+    - name: Restore the executable bit and add them to $PATH
+      shell: bash
+      run: |
+        # Artifacts do not preserve file modes.
+        chmod +x flow-bin/*
+        echo "${PWD}/flow-bin" >> $GITHUB_PATH

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -28,12 +28,6 @@ runs:
         TAG=$(echo $GITHUB_SHA | head -c7)
         echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
-    - name: Download latest Flow release binaries and add them to $PATH
-      shell: bash
-      run: |
-        ./fetch-flow.sh
-        echo "${PWD}/flow-bin" >> $GITHUB_PATH
-    
     - name: Login to GitHub package docker registry
       shell: bash
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,14 @@ on:
     branches: [main]
 
 jobs:
+  fetch_flow:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch Flow binaries
+        uses: ./.github/actions/fetch-flow-artifact
+
   build_base_image:
     runs-on: ubuntu-24.04
     steps:
@@ -66,7 +74,7 @@ jobs:
 
   build_connectors:
     runs-on: ubuntu-24.04
-    needs: build_base_image
+    needs: [build_base_image, fetch_flow]
     strategy:
       fail-fast: false
       matrix:
@@ -153,10 +161,8 @@ jobs:
           VARIANTS="${{ matrix.connector }} $(cat ${{ matrix.connector }}/VARIANTS 2>/dev/null || true)"
           echo ::set-output name=variants::${VARIANTS}
 
-      - name: Download latest Flow release binaries and add them to $PATH
-        run: |
-          ./fetch-flow.sh
-          echo "${PWD}/flow-bin" >> $GITHUB_PATH
+      - name: Restore Flow binaries
+        uses: ./.github/actions/restore-flow-binaries
 
       - name: Authenticate with GCloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -147,8 +147,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fetch_flow:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # These tests only ever invoke flowctl, so it's the only binary uploaded.
+      - name: Fetch flowctl
+        uses: ./.github/actions/fetch-flow-artifact
+        with:
+          paths: flow-bin/flowctl
+
   py_connector:
     runs-on: ubuntu-24.04
+    needs: fetch_flow
     strategy:
       fail-fast: false
       matrix:
@@ -427,6 +439,9 @@ jobs:
           docker cp $(docker create --name temp ghcr.io/estuary/network-tunnel:dev sh):/flow-network-tunnel ./network-tunnel/flow-network-tunnel
           docker rm temp
           echo "${PWD}/network-tunnel" >> $GITHUB_PATH
+
+      - name: Restore Flow binaries
+        uses: ./.github/actions/restore-flow-binaries
 
       - name: Common Setup
         id: setup


### PR DESCRIPTION
**Regression?**

No.

**Description:**

In our CI workflows, every matrix job ran `./fetch-flow.sh`, so a push made ~130 requests to GitHub's release endpoint - 67 from `build_connectors` and 65 from `py_connector`. Enough requests land together that GitHub may respond with 503s. `fetch-flow.sh`'s retries mitigate the impact of occasional 503s, but retries don't prevent them.

Following up on @danielnelson's suggestion in https://github.com/estuary/connectors/pull/5054#pullrequestreview-4920177154, this PR adds `fetch-flow-artifact` and `restore-flow-binaries` actions to our workflows so we only fetch binaries once per run & restore them in individual matrix jobs from the uploaded artifact.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
