### PR TITLE
estuary-cdk: don't crash when an HTTP error body isn't UTF-8

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -82,6 +82,17 @@ class HTTPError(RuntimeError):
         self.message = message
 
 
+def format_error_body(body: bytes) -> str:
+    """
+    Decode a response body for an error message or log field.
+
+    Error bodies aren't guaranteed to be UTF-8, and raising here would destroy
+    the error being reported, so undecodable bytes are escaped rather than
+    dropped or replaced.
+    """
+    return body.decode("utf-8", errors="backslashreplace")
+
+
 class HTTPSession(abc.ABC):
     """
     HTTPSession is an abstract base class for an HTTP client implementation.
@@ -650,18 +661,19 @@ class HTTPMixin(Mixin, HTTPSession):
                             "server internal error (will retry)",
                             {
                                 "status_code": resp.status,
-                                "body": body.decode("utf-8"),
+                                "content_type": resp.content_type,
+                                "body": format_error_body(body),
                             },
                         )
                     else:
                         raise HTTPError(
-                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nResponse:\n{body.decode('utf-8')}",
+                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
                             resp.status,
                         )
                 elif resp.status >= 400 and resp.status < 500:
                     body = await resp.read()
                     raise HTTPError(
-                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nResponse:\n{body.decode('utf-8')}",
+                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
                         resp.status,
                     )
                 else:


### PR DESCRIPTION
**Regression?**

No.

**Description:**

The 4xx and 5xx paths in `estuary-cdk/estuary_cdk/http.py` decoded bodies with a strict `body.decode("utf-8")` inside the argument to `HTTPError`, so a non-UTF-8 body raised `UnicodeDecodeError` before the exception existed. The status never reached the logs, and `except HTTPError` handling was bypassed. The same decode sits in the 5xx "will retry" log line, so a retryable 503 with a binary body killed the task instead of backing off.

This PR fixes that by escaping undecodable bytes rather than raising on them, and errors report `Content-Type` so a body that arrived compressed without saying so is identifiable.

Fixes #5050.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
