### PR TITLE
source-mongodb: add `skipBackfills` option

### DIFF
--- a/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/amazon-documentdb.md
@@ -81,6 +81,7 @@ Amazon DocumentDB source connector.
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
 | `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
+| `/advanced/skipBackfills` | Skip Backfills | Not applicable to Amazon DocumentDB. This option only affects bindings using the **Change Stream Incremental** capture mode, which DocumentDB does not support. | string |  |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/azure-cosmosdb.md
@@ -93,6 +93,7 @@ Azure Cosmos DB source connector.
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
 | `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
+| `/advanced/skipBackfills` | Skip Backfills | Comma-separated list of collections which should not be backfilled. Each one should be formatted as `database_name:collection`. Use `*:*` to skip the backfill of every change stream collection. Only applies to bindings using the **Change Stream Incremental** capture mode. | string |  |
 
 #### Bindings
 

--- a/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
+++ b/docs/reference/Connectors/capture-connectors/MongoDB/mongodb.md
@@ -109,6 +109,7 @@ MongoDB source connector.
 | `/advanced/disablePreImages` | Disable Pre-Images | Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections. | boolean |  |
 | `/advanced/exclusiveCollectionFilter` | Change Stream Exclusive Collection Filter | Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled: the filter is evaluated against every oplog event with one clause per enabled binding, so with many bindings it can slow reads enough for change stream lag to grow; prefer `excludeCollections` in that case. | boolean |  |
 | `/advanced/excludeCollections` | Exclude Collections | Comma-separated list of collections to exclude from database change streams. Each one should be formatted as `database_name:collection`. Cannot be set if `exclusiveCollectionFilter` is enabled. | string |  |
+| `/advanced/skipBackfills` | Skip Backfills | Comma-separated list of collections which should not be backfilled. Each one should be formatted as `database_name:collection`. Use `*:*` to skip the backfill of every change stream collection. Only applies to bindings using the **Change Stream Incremental** capture mode. | string |  |
 
 #### Bindings
 

--- a/source-mongodb/.snapshots/TestCaptureSkipBackfills
+++ b/source-mongodb/.snapshots/TestCaptureSkipBackfills
@@ -1,0 +1,26 @@
+# ================================
+# Collection "acmeCo/test/backfilledCollection": 10 Documents
+# ================================
+{"_id":"pk val 0","_meta":{"op":"c","snapshot":true,"source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 0"}}
+{"_id":"pk val 1","_meta":{"op":"c","snapshot":true,"source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 1"}}
+{"_id":"pk val 2","_meta":{"op":"c","snapshot":true,"source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 2"}}
+{"_id":"pk val 3","_meta":{"op":"c","snapshot":true,"source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 3"}}
+{"_id":"pk val 4","_meta":{"op":"c","snapshot":true,"source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 4"}}
+{"_id":"pk val 5","_meta":{"op":"c","source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 5"}}
+{"_id":"pk val 6","_meta":{"op":"c","source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 6"}}
+{"_id":"pk val 7","_meta":{"op":"c","source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 7"}}
+{"_id":"pk val 8","_meta":{"op":"c","source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 8"}}
+{"_id":"pk val 9","_meta":{"op":"c","source":{"collection":"backfilledCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 9"}}
+# ================================
+# Collection "acmeCo/test/skippedCollection": 5 Documents
+# ================================
+{"_id":"pk val 5","_meta":{"op":"c","source":{"collection":"skippedCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 5"}}
+{"_id":"pk val 6","_meta":{"op":"c","source":{"collection":"skippedCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 6"}}
+{"_id":"pk val 7","_meta":{"op":"c","source":{"collection":"skippedCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 7"}}
+{"_id":"pk val 8","_meta":{"op":"c","source":{"collection":"skippedCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 8"}}
+{"_id":"pk val 9","_meta":{"op":"c","source":{"collection":"skippedCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 9"}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"testDb%2FbackfilledCollection":{"backfill":{"backfilled_docs":5,"done":true,"last_id":{"Type":2,"Value":"CQAAAHBrIHZhbCA0AA=="},"last_poll_start":"<LAST_POLLED_TS>"}},"testDb%2FskippedCollection":{"backfill":{"done":true}}},"databaseResumeTokens":{"testDb":"<TOKEN>"}}
+

--- a/source-mongodb/.snapshots/TestCaptureSkipBackfillsMidBackfill
+++ b/source-mongodb/.snapshots/TestCaptureSkipBackfillsMidBackfill
@@ -1,0 +1,13 @@
+# ================================
+# Collection "acmeCo/test/largeCollection": 5 Documents
+# ================================
+{"_id":"pk val 10","_meta":{"op":"c","source":{"collection":"largeCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 10"}}
+{"_id":"pk val 11","_meta":{"op":"c","source":{"collection":"largeCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 11"}}
+{"_id":"pk val 12","_meta":{"op":"c","source":{"collection":"largeCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 12"}}
+{"_id":"pk val 13","_meta":{"op":"c","source":{"collection":"largeCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 13"}}
+{"_id":"pk val 14","_meta":{"op":"c","source":{"collection":"largeCollection","db":"testDb"}},"onlyColumn":{"array":["a","b","c"],"date-max":"9999-12-31T23:59:59.999Z","date-min":"0000-01-01T00:00:00.000Z","date-normal":"2023-11-07T16:57:00.000Z","float":1.23,"int":1,"str":"onlyColumn val 14"}}
+# ================================
+# Final State Checkpoint
+# ================================
+{"bindingStateV1":{"testDb%2FlargeCollection":{"backfill":{"backfilled_docs":5,"done":true}}},"databaseResumeTokens":{"testDb":"<TOKEN>"}}
+

--- a/source-mongodb/.snapshots/TestSpec
+++ b/source-mongodb/.snapshots/TestSpec
@@ -100,6 +100,11 @@
             "type": "string",
             "title": "Exclude Collections",
             "description": "Comma-separated list of collections to exclude from database change streams. Each one should be formatted as 'database_name:collection'. Cannot be set if exclusiveCollectionFilter is enabled."
+          },
+          "skipBackfills": {
+            "type": "string",
+            "title": "Skip Backfills",
+            "description": "Comma-separated list of collections which should not be backfilled. Each one should be formatted as 'database_name:collection'. Use '*:*' to skip the backfill of every change stream collection."
           }
         },
         "additionalProperties": false,

--- a/source-mongodb/CHANGELOG.md
+++ b/source-mongodb/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## 2026-08-12
+
+### Added
+
+- New `skipBackfills` advanced option: a comma-separated list of collections,
+  whose backfill is skipped so that only their change events are captured.
+
 ## 2026-08-05
 
 ### Fixed
+
 - Captures now report an `unsupported collection type` error at startup when a
   captured database contains a collection of a type the connector does not
   recognize, instead of silently treating it as a standard collection.

--- a/source-mongodb/config_test.go
+++ b/source-mongodb/config_test.go
@@ -10,6 +10,230 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestShouldBackfill(t *testing.T) {
+	type expect struct {
+		database   string
+		collection string
+		want       bool
+	}
+
+	for _, tt := range []struct {
+		name          string
+		skipBackfills string
+		expect        []expect
+	}{
+		{
+			name:          "unset backfills everything",
+			skipBackfills: "",
+			expect: []expect{
+				{"db", "one", true},
+				{"db", "two", true},
+			},
+		},
+		{
+			name:          "wildcard skips everything",
+			skipBackfills: "*:*",
+			expect: []expect{
+				{"db", "one", false},
+				{"otherDb", "two", false},
+			},
+		},
+		{
+			name:          "single collection",
+			skipBackfills: "db:one",
+			expect: []expect{
+				{"db", "one", false},
+				{"db", "two", true},
+				{"otherDb", "one", true},
+			},
+		},
+		{
+			name:          "comma-separated list",
+			skipBackfills: "db:one,otherDb:two",
+			expect: []expect{
+				{"db", "one", false},
+				{"otherDb", "two", false},
+				{"db", "two", true},
+			},
+		},
+		{
+			// Dots are ordinary characters here, unlike in MongoDB's own
+			// 'database.collection' namespace notation.
+			name:          "collection names containing dots",
+			skipBackfills: "db:system.views",
+			expect: []expect{
+				{"db", "system.views", false},
+				{"db", "system", true},
+			},
+		},
+		{
+			// The namespace is compared as one string and never parsed, so a
+			// name containing the ':' separator still matches.
+			name:          "names containing the separator",
+			skipBackfills: "db:logs:2024",
+			expect: []expect{
+				{"db", "logs:2024", false},
+				{"db", "logs", true},
+			},
+		},
+		{
+			// Known limitation of the ':' separator: because a database name may
+			// contain a ':' too, two distinct collections can format to the same
+			// configuration string and are therefore indistinguishable here. Both
+			// are skipped by the single entry below. This requires a ':' in a
+			// database name, which is legal but pathological.
+			name:          "ambiguous names collide",
+			skipBackfills: "pro:beDb:orders",
+			expect: []expect{
+				{"pro:beDb", "orders", false},
+				{"pro", "beDb:orders", false},
+			},
+		},
+		{
+			name:          "matching is case-sensitive",
+			skipBackfills: "db:Users",
+			expect: []expect{
+				{"db", "Users", false},
+				{"db", "users", true},
+				{"DB", "Users", true},
+			},
+		},
+		{
+			// No character within an element is special, so a wildcard matches
+			// only a collection genuinely named that way.
+			name:          "wildcards are literal",
+			skipBackfills: "db:*,other:logs*",
+			expect: []expect{
+				{"db", "*", false},
+				{"other", "logs*", false},
+				{"db", "one", true},
+				{"other", "logs", true},
+				{"other", "logs2024", true},
+			},
+		},
+		{
+			name:          "wildcard within a list matches nothing",
+			skipBackfills: "db:one,*:*",
+			expect: []expect{
+				{"db", "one", false},
+				{"db", "two", true},
+			},
+		},
+		{
+			name:          "whitespace around list elements is ignored",
+			skipBackfills: "db:one, otherDb:two ,\tdb:three",
+			expect: []expect{
+				{"db", "one", false},
+				{"otherDb", "two", false},
+				{"db", "three", false},
+				{"db", "two", true},
+			},
+		},
+		{
+			name:          "whitespace around the wildcard is ignored",
+			skipBackfills: " *:*\n",
+			expect: []expect{
+				{"db", "one", false},
+				{"otherDb", "two", false},
+			},
+		},
+		{
+			name:          "whitespace within an element is preserved",
+			skipBackfills: "db: one",
+			expect: []expect{
+				{"db", " one", false},
+				{"db", "one", true},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config{Advanced: advancedConfig{SkipBackfills: tt.skipBackfills}}
+			for _, e := range tt.expect {
+				require.Equalf(t, e.want, cfg.shouldBackfill(e.database, e.collection),
+					"database %q collection %q", e.database, e.collection)
+			}
+		})
+	}
+}
+
+func TestValidateSkipBackfills(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		skipBackfills string
+		wantErr       string
+	}{
+		{name: "unset", skipBackfills: ""},
+		{name: "wildcard", skipBackfills: "*:*"},
+		{name: "single collection", skipBackfills: "db:one"},
+		{name: "list", skipBackfills: "db:one,otherDb:two"},
+		{
+			// Accepted, though it matches only a collection genuinely named '*'.
+			name:          "per-database wildcard is not special",
+			skipBackfills: "db:*",
+		},
+		{
+			// A ':' in a name is accepted: the value is never parsed, only
+			// compared, so there is no ambiguity to reject.
+			name:          "names containing the separator",
+			skipBackfills: "pro:beDb:orders",
+		},
+		{
+			name:          "missing separator",
+			skipBackfills: "one",
+			wantErr:       `collection "one" must be formatted as "database_name:collection"`,
+		},
+		{
+			name:          "missing separator within a list",
+			skipBackfills: "db:one,two",
+			wantErr:       `collection "two" must be formatted as "database_name:collection"`,
+		},
+		{
+			// The wildcard is only meaningful as the entire value, so within a
+			// list it is just another element which needs a separator.
+			name:          "bare wildcard",
+			skipBackfills: "*",
+			wantErr:       `collection "*" must be formatted as "database_name:collection"`,
+		},
+		{
+			name:          "whitespace around list elements",
+			skipBackfills: "db:one, otherDb:two",
+		},
+		{
+			name:          "whitespace around the wildcard",
+			skipBackfills: " *:*\n",
+		},
+		{
+			// A value of only whitespace carries no namespaces and is treated
+			// as unset rather than as one malformed entry.
+			name:          "whitespace-only value",
+			skipBackfills: "   ",
+		},
+		{
+			// The offending element is reported trimmed, so the message names
+			// the collection the user typed rather than " two".
+			name:          "missing separator after whitespace",
+			skipBackfills: "db:one, two",
+			wantErr:       `collection "two" must be formatted as "database_name:collection"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config{
+				Address:  "mongodb://localhost:27017",
+				User:     "user",
+				Password: "password",
+				Advanced: advancedConfig{SkipBackfills: tt.skipBackfills},
+			}
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSpec(t *testing.T) {
 	driver := driver{}
 	response, err := driver.Spec(context.Background(), &pc.Request_Spec{})

--- a/source-mongodb/main.go
+++ b/source-mongodb/main.go
@@ -131,6 +131,40 @@ type advancedConfig struct {
 	DisablePreImages          bool   `json:"disablePreImages,omitempty" jsonschema:"title=Disable Pre-Images,description=Disable requesting pre-images even if the MongoDB deployment supports them and they are enabled for collections." jsonschema_extras:"nonsensitive=true"`
 	ExclusiveCollectionFilter bool   `json:"exclusiveCollectionFilter,omitempty" jsonschema:"title=Change Stream Exclusive Collection Filter,description=Add a MongoDB pipeline filter to database change streams to exclusively match events having enabled capture bindings. Should only be used if a small number of bindings are enabled." jsonschema_extras:"nonsensitive=true"`
 	ExcludeCollections        string `json:"excludeCollections,omitempty" jsonschema:"title=Exclude Collections,description=Comma-separated list of collections to exclude from database change streams. Each one should be formatted as 'database_name:collection'. Cannot be set if exclusiveCollectionFilter is enabled."`
+	SkipBackfills             string `json:"skipBackfills,omitempty" jsonschema:"title=Skip Backfills,description=Comma-separated list of collections which should not be backfilled. Each one should be formatted as 'database_name:collection'. Use '*:*' to skip the backfill of every change stream collection."`
+}
+
+const skipAllBackfills = "*:*"
+
+func (c *config) skipsAllBackfills() bool {
+	return strings.TrimSpace(c.Advanced.SkipBackfills) == skipAllBackfills
+}
+
+func (c *config) skipBackfillsNamespaces() []string {
+	namespaces := strings.Split(c.Advanced.SkipBackfills, ",")
+	for idx, ns := range namespaces {
+		namespaces[idx] = strings.TrimSpace(ns)
+	}
+	return namespaces
+}
+
+func (c *config) shouldBackfill(database, collection string) bool {
+	if c.skipsAllBackfills() {
+		return false
+	}
+
+	var namespace = database + ":" + collection
+
+	// NOTE: MongoDB database and collection names are case-sensitive
+	//
+	// The whole namespace is compared as a single string, so a database or
+	// collection name which itself contains a ':' is matched correctly
+	// without needing to be parsed.
+	if slices.Contains(c.skipBackfillsNamespaces(), namespace) {
+		return false
+	}
+
+	return true
 }
 
 func parseExcludeCollections(excludeCollections string) (map[string][]string, error) {
@@ -191,6 +225,14 @@ func (c *config) Validate() error {
 
 	if _, err := parseExcludeCollections(c.Advanced.ExcludeCollections); err != nil {
 		return err
+	}
+
+	if strings.TrimSpace(c.Advanced.SkipBackfills) != "" && !c.skipsAllBackfills() {
+		for _, ns := range c.skipBackfillsNamespaces() {
+			if !strings.Contains(ns, ":") {
+				return fmt.Errorf("invalid 'skipBackfills' configuration: collection %q must be formatted as \"database_name:collection\"", ns)
+			}
+		}
 	}
 
 	return nil
@@ -500,6 +542,15 @@ func (d *driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 			return nil, fmt.Errorf("binding %q is configured with mode '%s', but the server does not support change streams", resourcePath, res.getMode())
 		} else if res.getMode() == captureModeChangeStream && !collectionType.canChangeStream() {
 			return nil, fmt.Errorf("binding %q is configured with mode '%s', but the collection type '%s' does not support change streams", resourcePath, res.getMode(), collectionType)
+		}
+
+		if !cfg.skipsAllBackfills() &&
+			res.getMode() != captureModeChangeStream &&
+			!cfg.shouldBackfill(res.Database, res.Collection) {
+			return nil, fmt.Errorf(
+				"binding %q is named by the 'skipBackfills' advanced option, which only applies to bindings with mode '%s', and this binding has mode '%s': disable the binding instead of skipping its backfill",
+				resourcePath, captureModeChangeStream, res.getMode(),
+			)
 		}
 
 		bindings = append(bindings, &pc.Response_Validated_Binding{

--- a/source-mongodb/main_test.go
+++ b/source-mongodb/main_test.go
@@ -138,10 +138,10 @@ func TestCaptureMixedIdTypeBackfillResumption(t *testing.T) {
 		oid, err := primitive.ObjectIDFromHex(fmt.Sprintf("%024x", idx))
 		require.NoError(t, err)
 		for _, id := range []any{
-			idx,                                         // number
-			fmt.Sprintf("str-%04d", idx),                // string
+			idx,                          // number
+			fmt.Sprintf("str-%04d", idx), // string
 			primitive.Binary{Subtype: 0x04, Data: uuid}, // binData (UUID)
-			oid,                                         // objectId
+			oid, // objectId
 		} {
 			_, err := col.InsertOne(ctx, bson.M{"_id": id, "value": idx})
 			require.NoError(t, err)
@@ -469,6 +469,110 @@ func TestCaptureExclusiveCollectionFilter(t *testing.T) {
 	addTestTableData(ctx, t, client, database2, col3, 5, 5, binaryPkVals, "firstColumn", "secondColumn", "thirdColumn")
 
 	// Read change stream documents.
+	advanceCapture(ctx, t, cs)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}
+
+// A collection named by the `skipBackfills` advanced option must capture only
+// its change events, while its unnamed siblings are backfilled as usual.
+func TestCaptureSkipBackfills(t *testing.T) {
+	database := "testDb"
+	skippedCol := "skippedCollection"
+	backfilledCol := "backfilledCollection"
+
+	ctx := context.Background()
+	client, cfg := testClient(t)
+
+	cleanup := func() {
+		require.NoError(t, client.Database(database).Drop(ctx))
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	cfg.Advanced.SkipBackfills = database + ":" + skippedCol
+
+	// Pre-existing data
+	addTestTableData(ctx, t, client, database, skippedCol, 5, 0, stringPkVals, "onlyColumn")
+	addTestTableData(ctx, t, client, database, backfilledCol, 5, 0, stringPkVals, "onlyColumn")
+
+	cs := &st.CaptureSpec{
+		Driver:       &driver{},
+		EndpointSpec: &cfg,
+		Checkpoint:   []byte("{}"),
+		Validator:    &st.SortedCaptureValidator{NormalizeJSON: true},
+		Sanitizers:   commonSanitizers(),
+		Bindings: []*flow.CaptureSpec_Binding{
+			makeBinding(t, database, skippedCol, captureModeChangeStream, ""),
+			makeBinding(t, database, backfilledCol, captureModeChangeStream, ""),
+		},
+	}
+
+	advanceCapture(ctx, t, cs)
+
+	// Both collections capture their change events from here on.
+	addTestTableData(ctx, t, client, database, skippedCol, 5, 5, stringPkVals, "onlyColumn")
+	addTestTableData(ctx, t, client, database, backfilledCol, 5, 5, stringPkVals, "onlyColumn")
+
+	advanceCapture(ctx, t, cs)
+
+	cupaloy.SnapshotT(t, cs.Summary())
+}
+
+// A backfill which is already partway through must be abandoned when the
+// collection is added to `skipBackfills` and the capture restarted.
+func TestCaptureSkipBackfillsMidBackfill(t *testing.T) {
+	database := "testDb"
+	collection := "largeCollection"
+
+	ctx := context.Background()
+	client, cfg := testClient(t)
+
+	cleanup := func() {
+		require.NoError(t, client.Database(database).Drop(ctx))
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	addTestTableData(ctx, t, client, database, collection, 10, 0, stringPkVals, "onlyColumn")
+
+	binding := makeBinding(t, database, collection, captureModeChangeStream, "")
+	sk := boilerplate.StateKey(binding.StateKey)
+
+	// Start from a checkpoint representing a backfill which is halfway through.
+	resumeState := captureState{
+		Resources: map[boilerplate.StateKey]resourceState{
+			sk: {Backfill: backfillState{
+				Done:            makePtr(false),
+				LastCursorValue: rawValue(t, stringPkVals(4)),
+				BackfilledDocs:  5,
+			}},
+		},
+	}
+	checkpoint, err := json.Marshal(resumeState)
+	require.NoError(t, err)
+
+	// Skip the rest of the backfill
+	cfg.Advanced.SkipBackfills = database + ":" + collection
+
+	cs := &st.CaptureSpec{
+		Driver:       &driver{},
+		EndpointSpec: &cfg,
+		Checkpoint:   checkpoint,
+		Validator:    &st.SortedCaptureValidator{NormalizeJSON: true},
+		Sanitizers:   commonSanitizers(),
+		Bindings:     []*flow.CaptureSpec_Binding{binding},
+	}
+
+	advanceCapture(ctx, t, cs)
+
+	var state captureState
+	require.NoError(t, json.Unmarshal(cs.Checkpoint, &state))
+	require.True(t, state.Resources[sk].Backfill.done())
+	require.Nil(t, state.Resources[sk].Backfill.LastCursorValue)
+
+	// Change events are still captured
+	addTestTableData(ctx, t, client, database, collection, 5, 10, stringPkVals, "onlyColumn")
 	advanceCapture(ctx, t, cs)
 
 	cupaloy.SnapshotT(t, cs.Summary())

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -167,6 +167,8 @@ func (d *driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) err
 		return fmt.Errorf("updating resource states: %w", err)
 	}
 
+	skipConfiguredBackfills(&prevState, changeStreamBindings, &cfg)
+
 	var c = capture{
 		client:                      client,
 		output:                      stream,
@@ -393,6 +395,44 @@ func updateResourceStates(prevState captureState, allBindings []bindingInfo) (ca
 	}
 
 	return newState, nil
+}
+
+func skipConfiguredBackfills(state *captureState, changeStreamBindings []bindingInfo, cfg *config) {
+	if cfg.Advanced.SkipBackfills == "" {
+		return
+	}
+
+	// Batch mode bindings are deliberately left alone: their backfill is the only
+	// way they capture anything, so marking one complete would capture nothing at
+	// all, and it would also leave `LastPollStart` unset for the polling loop.
+	// driver.Validate rejects a config which names a batch binding explicitly.
+	for _, b := range changeStreamBindings {
+		if cfg.shouldBackfill(b.resource.Database, b.resource.Collection) {
+			continue
+		}
+
+		resState := state.Resources[b.stateKey]
+		if resState.Backfill.done() {
+			continue
+		}
+
+		fields := log.Fields{
+			"database":       b.resource.Database,
+			"collection":     b.resource.Collection,
+			"backfilledDocs": resState.Backfill.BackfilledDocs,
+		}
+		if resState.Backfill.LastCursorValue != nil {
+			log.WithFields(fields).WithField(
+				"lastCursorValue", resState.Backfill.LastCursorValue,
+			).Warn("abandoning in-progress backfill for collection: documents after the last cursor position will not be captured")
+		} else {
+			log.WithFields(fields).Info("skipping backfill for collection")
+		}
+
+		resState.Backfill.Done = makePtr(true)
+		resState.Backfill.LastCursorValue = nil
+		state.Resources[b.stateKey] = resState
+	}
 }
 
 func (s *captureState) isChangeStreamBackfillComplete(changeStreamBindings []bindingInfo) bool {

--- a/source-mongodb/pull_test.go
+++ b/source-mongodb/pull_test.go
@@ -8,6 +8,87 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+func TestSkipConfiguredBackfills(t *testing.T) {
+	// sk1 has never been backfilled, sk2 is partway through, and sk3 is finished.
+	initialState := func() captureState {
+		return captureState{
+			Resources: map[boilerplate.StateKey]resourceState{
+				"sk2": {Backfill: backfillState{Done: makePtr(false), LastCursorValue: &bson.RawValue{Value: []byte("second")}, BackfilledDocs: 100}},
+				"sk3": {Backfill: backfillState{Done: makePtr(true), LastCursorValue: &bson.RawValue{Value: []byte("third")}, BackfilledDocs: 300}},
+			},
+			DatabaseResumeTokens: map[string]bson.Raw{"db": bson.Raw("dbToken")},
+		}
+	}
+
+	changeStreamBindings := []bindingInfo{
+		{index: 0, stateKey: "sk1", resource: resource{Database: "db", Collection: "one"}},
+		{index: 1, stateKey: "sk2", resource: resource{Database: "db", Collection: "two"}},
+		{index: 2, stateKey: "sk3", resource: resource{Database: "db", Collection: "three"}},
+	}
+
+	t.Run("unset leaves state untouched", func(t *testing.T) {
+		state := initialState()
+		skipConfiguredBackfills(&state, changeStreamBindings, &config{})
+		require.Equal(t, initialState(), state)
+	})
+
+	t.Run("a never-started backfill is marked done", func(t *testing.T) {
+		state := initialState()
+		cfg := &config{Advanced: advancedConfig{SkipBackfills: "db:one"}}
+		skipConfiguredBackfills(&state, changeStreamBindings, cfg)
+
+		want := initialState()
+		want.Resources["sk1"] = resourceState{Backfill: backfillState{Done: makePtr(true)}}
+		require.Equal(t, want, state)
+	})
+
+	t.Run("an in-progress backfill is terminated and its resume position discarded", func(t *testing.T) {
+		state := initialState()
+		cfg := &config{Advanced: advancedConfig{SkipBackfills: "db:two"}}
+		skipConfiguredBackfills(&state, changeStreamBindings, cfg)
+
+		want := initialState()
+		// BackfilledDocs is retained as a record of what was already emitted.
+		want.Resources["sk2"] = resourceState{Backfill: backfillState{Done: makePtr(true), BackfilledDocs: 100}}
+		require.Equal(t, want, state)
+	})
+
+	t.Run("a completed backfill keeps its resume position", func(t *testing.T) {
+		state := initialState()
+		cfg := &config{Advanced: advancedConfig{SkipBackfills: "db:three"}}
+		skipConfiguredBackfills(&state, changeStreamBindings, cfg)
+		require.Equal(t, initialState(), state)
+	})
+
+	t.Run("the wildcard skips every binding", func(t *testing.T) {
+		state := initialState()
+		cfg := &config{Advanced: advancedConfig{SkipBackfills: skipAllBackfills}}
+		skipConfiguredBackfills(&state, changeStreamBindings, cfg)
+
+		want := initialState()
+		want.Resources["sk1"] = resourceState{Backfill: backfillState{Done: makePtr(true)}}
+		want.Resources["sk2"] = resourceState{Backfill: backfillState{Done: makePtr(true), BackfilledDocs: 100}}
+		require.Equal(t, want, state)
+		require.True(t, state.isChangeStreamBackfillComplete(changeStreamBindings))
+	})
+
+	t.Run("batch bindings are never skipped", func(t *testing.T) {
+		state := captureState{
+			Resources: map[boilerplate.StateKey]resourceState{
+				"sk4": {Backfill: backfillState{Done: makePtr(false), LastCursorValue: &bson.RawValue{Value: []byte("fourth")}}},
+			},
+		}
+		cfg := &config{Advanced: advancedConfig{SkipBackfills: skipAllBackfills}}
+		skipConfiguredBackfills(&state, nil, cfg)
+
+		require.Equal(t, captureState{
+			Resources: map[boilerplate.StateKey]resourceState{
+				"sk4": {Backfill: backfillState{Done: makePtr(false), LastCursorValue: &bson.RawValue{Value: []byte("fourth")}}},
+			},
+		}, state)
+	})
+}
+
 func TestUpdateResourceStates(t *testing.T) {
 	prevState := captureState{
 		Resources: map[boilerplate.StateKey]resourceState{


### PR DESCRIPTION
**Regression?**

(Is this pull-request fixing a regression introduced by an earlier pull-request? If so please link the earlier pull-request, otherwise remove this section)

**Description:**

Adds the skipBackfills option present in other database connectors.

Colons are used as database/collection delimiters despite being valid characters to follow the standard established with `/advanced/excludeCollections`. `*:*` is used as a magic value to specify that all backfills should be skipped.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
