### PR TITLE
ci: upload `sops` binary alongside `flowctl` in Python connectors' workflow

### DIFF
--- a/.github/actions/fetch-flow-artifact/action.yaml
+++ b/.github/actions/fetch-flow-artifact/action.yaml
@@ -8,8 +8,9 @@ description: >-
 inputs:
   paths:
     description: >-
-      Which of the fetched binaries to upload. Callers which only run flowctl
-      upload just that, sparing their matrix jobs the other ~425MB.
+      Which of the fetched binaries to upload. Narrowing this spares matrix jobs
+      the other ~360MB, but account for what the binaries shell out to and not
+      just what the jobs invoke: flowctl needs sops beside it to decrypt configs.
     default: flow-bin/
 
 runs:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
     paths:
+      # This workflow and the plumbing it runs, so a change to either verifies
+      # itself rather than waiting on an unrelated connector edit to trigger.
+      - ".github/workflows/python.yaml"
+      - ".github/actions/fetch-flow-artifact/**"
+      - ".github/actions/restore-flow-binaries/**"
+      - ".github/actions/setup/**"
+      - ".github/actions/deploy/**"
+      - "fetch-flow.sh"
+
       - "estuary-cdk/**"
       - "source-airtable/**"
       - "source-asana/**"
@@ -74,6 +83,15 @@ on:
   pull_request:
     branches: [main]
     paths:
+      # This workflow and the plumbing it runs, so a change to either verifies
+      # itself rather than waiting on an unrelated connector edit to trigger.
+      - ".github/workflows/python.yaml"
+      - ".github/actions/fetch-flow-artifact/**"
+      - ".github/actions/restore-flow-binaries/**"
+      - ".github/actions/setup/**"
+      - ".github/actions/deploy/**"
+      - "fetch-flow.sh"
+
       - "estuary-cdk/**"
       - "source-airtable/**"
       - "source-asana/**"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -152,11 +152,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # These tests only ever invoke flowctl, so it's the only binary uploaded.
-      - name: Fetch flowctl
+      # These tests only invoke flowctl, but flowctl shells out to sops to
+      # decrypt each test.flow.yaml's encrypted config, so both are uploaded.
+      - name: Fetch flowctl and sops
         uses: ./.github/actions/fetch-flow-artifact
         with:
-          paths: flow-bin/flowctl
+          paths: |
+            flow-bin/flowctl
+            flow-bin/sops
 
   py_connector:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**Regression?**

No.

**Description:**

I broke a number of Python connector's CI jobs after merging https://github.com/estuary/connectors/pull/5055. Those that needed `sops` to decrypt credentials for testing failed with:
```
2026-08-13T12:56:52.903457Z ERROR flowctl::local_specs: scope=file:///home/runner/work/connectors/connectors/source-smartsheet/test.flow.yaml#/captures/acmeCo~1source-smartsheet error=failed to locate sops

Caused by:
    0: failed to locate 'sops' alongside 'flowctl' or on the $PATH
    1: cannot find binary path
```
An example failing job is [here](https://github.com/estuary/connectors/actions/runs/31702348187/job/94454402780).

In that earlier PR, I only uploaded the `flowctl` binary since that's the one connectors directly use, but `flowctl` also uses `sops`. Without `sops` present, attempting to use `flowct` with an encrypted config results in the above error. I should have kept the `sops` binary alongside `flowctl` in the Python connectors' workflow, and this PR remedies that.

Additionally, the Python connectors' workflow has only been kicked off when code changes were made to individual Python connectors, not to the workflow itself. That's made it easy to accidently break the workflow with workflow only changes (like I did in https://github.com/estuary/connectors/pull/5055). I updated the workflow's `paths` filter to include the workflow file itself and the actions it uses, so now workflow only changes will kick off the workflow & it's easier to figure out if those changes broke anything.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
