### PR TITLE
source-smartsheet: key snapshot resources off /_meta/row_id

### DIFF
--- a/source-smartsheet/CHANGELOG.md
+++ b/source-smartsheet/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
+## 2026-08-13
+
+### Fixed
+
+- The `reports` and `report_rows` captures no longer fail when the number of reports
+  or report rows decreases. Previously the deletion record written for a removed row
+  was rejected, failing the entire capture pass and discarding that pass's valid
+  documents along with it.
+
+### Changed
+
+- The `reports` and `report_rows` collections are now keyed on `/_meta/row_id`, and are
+  discovered with a minimal write schema instead of declaring a required `id`.
+
 ## 2026-07-22
 
 ### Added
+
 - Initial release of the Smartsheet capture connector.

--- a/source-smartsheet/source_smartsheet/resources.py
+++ b/source-smartsheet/source_smartsheet/resources.py
@@ -11,7 +11,6 @@ from estuary_cdk.capture.common import (
     SnapshotResource,
     open_binding,  # pyright: ignore[reportUnknownVariableType]
 )
-from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.flow import CaptureBinding, ValidationError
 from estuary_cdk.http import HTTPError, HTTPMixin, TokenSource
 
@@ -224,19 +223,15 @@ async def reports(http: HTTPMixin, config: EndpointConfig) -> SmartsheetResource
             state,
             task,
             fetch_snapshot=functools.partial(snapshot_reports, http, config.region),
-            tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
         )
 
     return SnapshotResource(
         name=Report.resource_name,
-        key=["/id"],
-        model=Report,
         open=open,  # pyright: ignore[reportUnknownArgumentType]
         initial_config=common.ResourceConfig(
             name=Report.resource_name,
             interval=REPORTS_INTERVAL,
         ),
-        schema_inference=True,
     )
 
 
@@ -254,19 +249,15 @@ async def report_rows(http: HTTPMixin, config: EndpointConfig) -> SmartsheetReso
             state,
             task,
             fetch_snapshot=functools.partial(snapshot_report_rows, http, config.region),
-            tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
         )
 
     return SnapshotResource(
         name=ReportRow.resource_name,
-        key=["/_meta/report_id", "/id"],
-        model=ReportRow,
         open=open,  # pyright: ignore[reportUnknownArgumentType]
         initial_config=common.ResourceConfig(
             name=ReportRow.resource_name,
             interval=REPORTS_INTERVAL,
         ),
-        schema_inference=True,
     )
 
 

--- a/source-smartsheet/tests/snapshots/snapshots__discover__capture.stdout.json
+++ b/source-smartsheet/tests/snapshots/snapshots__discover__capture.stdout.json
@@ -216,21 +216,13 @@
         }
       },
       "additionalProperties": true,
-      "description": "One document per report, mirroring a `GET /reports` list item.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Report",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -258,7 +250,7 @@
       }
     },
     "key": [
-      "/id"
+      "/_meta/row_id"
     ]
   },
   {
@@ -287,12 +279,6 @@
               "description": "Row ID of the Document, counting up from zero, or -1 if not known",
               "title": "Row Id",
               "type": "integer"
-            },
-            "report_id": {
-              "default": -1,
-              "description": "The Smartsheet report this row belongs to",
-              "title": "Report Id",
-              "type": "integer"
             }
           },
           "title": "Meta",
@@ -304,16 +290,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "ReportRow",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -341,8 +320,7 @@
       }
     },
     "key": [
-      "/_meta/report_id",
-      "/id"
+      "/_meta/row_id"
     ]
   }
 ]


### PR DESCRIPTION
**Regression?**

(Is this pull-request fixing a regression introduced by an earlier pull-request? If so please link the earlier pull-request, otherwise remove this section)

**Description:**

The `Report` and `ReportRow` models were being used as our write schemas, causing document tombstones to fail validation due to the fact they were missing `id` primary keys. These streams now use `BaseDocument` as their model instead.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [X] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
