### PR TITLE
source-{python}: use `SnapshotResource` and regenerate YAML schema files

### DIFF
--- a/source-ada/source_ada/resources.py
+++ b/source-ada/source_ada/resources.py
@@ -4,7 +4,7 @@ from logging import Logger
 
 from estuary_cdk.flow import CaptureBinding, ValidationError
 from estuary_cdk.capture import Task
-from estuary_cdk.capture.common import BaseDocument, Resource, open_binding
+from estuary_cdk.capture.common import BaseDocument, Resource, SnapshotResource, open_binding
 from estuary_cdk.http import HTTPMixin, TokenSource, HTTPError
 
 from .models import (
@@ -72,16 +72,12 @@ def full_refresh_resources(
         )
 
     resources = [
-        Resource(
+        SnapshotResource(
             name=stream.name,
-            key=["/_meta/row_id"],
-            model=BaseDocument,
             open=functools.partial(open, stream),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=stream.name, interval=timedelta(minutes=15)
             ),
-            schema_inference=True,
         )
         for stream in FULL_REFRESH_RESOURCES
     ]

--- a/source-airtable-native/source_airtable_native/resources.py
+++ b/source-airtable-native/source_airtable_native/resources.py
@@ -99,16 +99,12 @@ def full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
-            model=BaseDocument,
             open=functools.partial(open, snapshot_fn),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=15)
             ),
-            schema_inference=True,
         ) for (name, snapshot_fn) in FULL_REFRESH_RESOURCES
     ]
 
@@ -220,16 +216,12 @@ def full_refresh_table(
 
     name = _resolve_resource_name(base, table)
 
-    return common.Resource(
+    return common.SnapshotResource(
         name=name,
-        key=["/_meta/row_id"],
-        model=BaseDocument,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=name, interval=timedelta(minutes=15)
         ),
-        schema_inference=True,
     )
 
 

--- a/source-braintree-native/acmeCo/add_ons.schema.yaml
+++ b/source-braintree-native/acmeCo/add_ons.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,18 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    anyOf:
-      - type: string
-      - type: "null"
-    title: Id
-required:
-  - id
 title: FullRefreshResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/credit_card_verifications.schema.yaml
+++ b/source-braintree-native/acmeCo/credit_card_verifications.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,10 +20,7 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
@@ -33,9 +29,28 @@ properties:
     format: date-time
     title: Created At
     type: string
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
 required:
-  - id
-  - created_at
-title: CreditCardVerification
+- id
+- created_at
+- updated_at
+title: IncrementalResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/customers.schema.yaml
+++ b/source-braintree-native/acmeCo/customers.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,10 +20,7 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
@@ -33,9 +29,28 @@ properties:
     format: date-time
     title: Created At
     type: string
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
 required:
-  - id
-  - created_at
-title: Customer
+- id
+- created_at
+- updated_at
+title: IncrementalResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/discounts.schema.yaml
+++ b/source-braintree-native/acmeCo/discounts.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,18 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    anyOf:
-      - type: string
-      - type: "null"
-    title: Id
-required:
-  - id
 title: FullRefreshResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/disputes.schema.yaml
+++ b/source-braintree-native/acmeCo/disputes.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,10 +20,7 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
@@ -33,9 +29,28 @@ properties:
     format: date-time
     title: Created At
     type: string
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
 required:
-  - id
-  - created_at
-title: Dispute
+- id
+- created_at
+- updated_at
+title: IncrementalResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/flow.yaml
+++ b/source-braintree-native/acmeCo/flow.yaml
@@ -1,38 +1,37 @@
----
 collections:
   acmeCo/add_ons:
     schema: add_ons.schema.yaml
     key:
-      - /id
+    - /_meta/row_id
   acmeCo/credit_card_verifications:
     schema: credit_card_verifications.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/customers:
     schema: customers.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/discounts:
     schema: discounts.schema.yaml
     key:
-      - /id
+    - /_meta/row_id
   acmeCo/disputes:
     schema: disputes.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/merchant_accounts:
     schema: merchant_accounts.schema.yaml
     key:
-      - /id
+    - /_meta/row_id
   acmeCo/plans:
     schema: plans.schema.yaml
     key:
-      - /id
+    - /_meta/row_id
   acmeCo/subscriptions:
     schema: subscriptions.schema.yaml
     key:
-      - /id
+    - /id
   acmeCo/transactions:
     schema: transactions.schema.yaml
     key:
-      - /id
+    - /id

--- a/source-braintree-native/acmeCo/merchant_accounts.schema.yaml
+++ b/source-braintree-native/acmeCo/merchant_accounts.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,18 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    anyOf:
-      - type: string
-      - type: "null"
-    title: Id
-required:
-  - id
 title: FullRefreshResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/plans.schema.yaml
+++ b/source-braintree-native/acmeCo/plans.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,18 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    anyOf:
-      - type: string
-      - type: "null"
-    title: Id
-required:
-  - id
 title: FullRefreshResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/subscriptions.schema.yaml
+++ b/source-braintree-native/acmeCo/subscriptions.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,10 +20,7 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
@@ -33,9 +29,28 @@ properties:
     format: date-time
     title: Created At
     type: string
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
 required:
-  - id
-  - created_at
-title: Subscription
+- id
+- created_at
+- updated_at
+title: IncrementalResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/acmeCo/transactions.schema.yaml
+++ b/source-braintree-native/acmeCo/transactions.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,10 +20,7 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   id:
     title: Id
@@ -33,9 +29,28 @@ properties:
     format: date-time
     title: Created At
     type: string
+  updated_at:
+    format: date-time
+    title: Updated At
+    type: string
 required:
-  - id
-  - created_at
-title: Transaction
+- id
+- created_at
+- updated_at
+title: IncrementalResource
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-braintree-native/source_braintree_native/resources.py
+++ b/source-braintree-native/source_braintree_native/resources.py
@@ -140,16 +140,13 @@ def non_paginated_full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, path, response_model, _create_gateway(config), braintree_class),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5), concurrency=DEFAULT_SNAPSHOT_CONCURRENCY
             ),
-            schema_inference=True,
         )
         for (name, path, response_model, braintree_class) in NON_PAGINATED_FULL_REFRESH_RESOURCES
     ]
@@ -183,16 +180,13 @@ def paginated_full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, snapshot_fn, _create_gateway(config)),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5), concurrency=DEFAULT_SNAPSHOT_CONCURRENCY
             ),
-            schema_inference=True,
         )
         for (name, snapshot_fn) in PAGINATED_FULL_REFRESH_RESOURCES
     ]

--- a/source-calendly/acmeCo/event_invitees.schema.yaml
+++ b/source-calendly/acmeCo/event_invitees.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: EventInvitee
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/event_types.schema.yaml
+++ b/source-calendly/acmeCo/event_types.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: EventType
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/groups.schema.yaml
+++ b/source-calendly/acmeCo/groups.schema.yaml
@@ -22,16 +22,20 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  uri:
-    title: Uri
-    type: string
-  updated_at:
-    format: date-time
-    title: Updated At
-    type: string
-required:
-- uri
-- updated_at
-title: Group
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/organization_memberships.schema.yaml
+++ b/source-calendly/acmeCo/organization_memberships.schema.yaml
@@ -22,16 +22,20 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  uri:
-    title: Uri
-    type: string
-  updated_at:
-    format: date-time
-    title: Updated At
-    type: string
-required:
-- uri
-- updated_at
-title: OrganizationMembership
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/routing_form_submissions.schema.yaml
+++ b/source-calendly/acmeCo/routing_form_submissions.schema.yaml
@@ -22,16 +22,20 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  uri:
-    title: Uri
-    type: string
-  updated_at:
-    format: date-time
-    title: Updated At
-    type: string
-required:
-- uri
-- updated_at
-title: RoutingFormSubmission
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/routing_forms.schema.yaml
+++ b/source-calendly/acmeCo/routing_forms.schema.yaml
@@ -22,16 +22,20 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  uri:
-    title: Uri
-    type: string
-  updated_at:
-    format: date-time
-    title: Updated At
-    type: string
-required:
-- uri
-- updated_at
-title: RoutingForm
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/acmeCo/scheduled_events.schema.yaml
+++ b/source-calendly/acmeCo/scheduled_events.schema.yaml
@@ -35,3 +35,17 @@ required:
 title: ScheduledEvent
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-calendly/source_calendly/resources.py
+++ b/source-calendly/source_calendly/resources.py
@@ -11,6 +11,7 @@ from estuary_cdk.capture.common import (
     Resource,
     ResourceConfig,
     ResourceState,
+    SnapshotResource,
     open_binding,  # pyright: ignore[reportUnknownVariableType]
 )
 from estuary_cdk.flow import CaptureBinding
@@ -37,6 +38,8 @@ from .models import (
 )
 
 CalendlyResource = Resource[CalendlyEntity, ResourceConfig, ResourceState]
+
+CalendlySnapshotResource = SnapshotResource[CalendlyEntity, ResourceConfig]
 ScheduledEventFetchFn = Callable[
     [str, int, int, HTTPSession, Logger, LogCursor],
     AsyncGenerator[CalendlyEntity | LogCursor, None],
@@ -120,17 +123,13 @@ def _snapshot_resources(http: HTTPMixin, org_uri: str) -> list[CalendlyResource]
         )
 
     return [
-        Resource(
+        CalendlySnapshotResource(
             name=entity_cls.name,
-            key=["/_meta/row_id"],
-            model=entity_cls,
             open=functools.partial(open, entity_cls),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=entity_cls.name,
                 interval=timedelta(minutes=5),
             ),
-            schema_inference=True,
         )
         for entity_cls in SNAPSHOT_STREAMS
     ]

--- a/source-calendly/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-calendly/tests/snapshots/snapshots__discover__stdout.json
@@ -202,22 +202,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "uri": {
-          "title": "Uri",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "Updated At",
-          "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "updated_at"
-      ],
-      "title": "Group",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -285,22 +272,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "uri": {
-          "title": "Uri",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "Updated At",
-          "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "updated_at"
-      ],
-      "title": "OrganizationMembership",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -368,22 +342,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "uri": {
-          "title": "Uri",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "Updated At",
-          "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "updated_at"
-      ],
-      "title": "RoutingFormSubmission",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -451,22 +412,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "uri": {
-          "title": "Uri",
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "title": "Updated At",
-          "type": "string"
         }
       },
-      "required": [
-        "uri",
-        "updated_at"
-      ],
-      "title": "RoutingForm",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {

--- a/source-chargebee-native/source_chargebee_native/resources.py
+++ b/source-chargebee-native/source_chargebee_native/resources.py
@@ -248,14 +248,11 @@ async def full_refresh_resources(
         available_resources.append(name)
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=ChargebeeResource,
             open=functools.partial(open_standalone, name),
-            initial_state=common.ResourceState(),
             initial_config=common.ResourceConfig(name=name, interval=timedelta(hours=1)),
-            schema_inference=True,
         )
         for name in available_resources
     ]
@@ -363,14 +360,11 @@ async def associated_full_refresh_resources(
         available_resources.append((name, association_config))
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=ChargebeeResource,
             open=functools.partial(open_child, association_config),
-            initial_state=common.ResourceState(),
             initial_config=common.ResourceConfig(name=name, interval=timedelta(minutes=2)),
-            schema_inference=True,
         )
         for name, association_config in available_resources
     ]

--- a/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/resources.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Callable
 
 from estuary_cdk.capture.common import (
+    SnapshotResource,
     BaseDocument,
     Resource,
     ResourceState,
@@ -302,10 +303,8 @@ def full_refresh_resource(
             tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=model.name,
-        key=["/_meta/row_id"],
-        model=BaseDocument,
         open=functools.partial(
             open,
             snapshot_fn=functools.partial(
@@ -316,12 +315,10 @@ def full_refresh_resource(
             ),
             use_sourced_schemas=use_sourced_schemas,
         ),
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=model.name,
             interval=timedelta(hours=1),
         ),
-        schema_inference=True,
     )
 
 

--- a/source-front/source_front/resources.py
+++ b/source-front/source_front/resources.py
@@ -72,16 +72,13 @@ def full_refresh_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FrontResource,
             open=functools.partial(open, name),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for (name) in FULL_REFRESH_RESOURCES
     ]

--- a/source-gainsight-nxt/acmeCo/da_picklist.schema.yaml
+++ b/source-gainsight-nxt/acmeCo/da_picklist.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,16 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  Gsid:
-    title: Gsid
-    type: string
-required:
-  - Gsid
-title: DaPicklist
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-gainsight-nxt/source_gainsight_nxt/resources.py
+++ b/source-gainsight-nxt/source_gainsight_nxt/resources.py
@@ -102,16 +102,12 @@ async def full_refresh_resources(
         fields = await fetch_object_fields(http, log, str(config.domain), resource)
 
         resources.append(
-            common.Resource(
+            common.SnapshotResource(
                 name=name,
-                key=["/_meta/row_id"],
-                model=resource,
                 open=functools.partial(open, fields, resource),
-                initial_state=common.ResourceState(),
                 initial_config=common.ResourceConfig(
                     name=name, interval=timedelta(minutes=1)
                 ),
-                schema_inference=True,
             )
         )
 

--- a/source-genesys/source_genesys/resources.py
+++ b/source-genesys/source_genesys/resources.py
@@ -88,16 +88,13 @@ def full_refresh_resources(
 
     for stream in FULL_REFRESH_STREAMS:
         resources.append(
-            common.Resource(
+            common.SnapshotResource(
                 name=stream.name,
-                key=["/_meta/row_id"],
                 model=FullRefreshResource,
                 open=functools.partial(open, stream),
-                initial_state=ResourceState(),
                 initial_config=ResourceConfig(
                     name=stream.name, interval=timedelta(minutes=30)
                 ),
-                schema_inference=True,
             )
         )
 

--- a/source-gong/source_gong/resources.py
+++ b/source-gong/source_gong/resources.py
@@ -89,14 +89,12 @@ async def full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=cls.NAME,
             key=cls.KEY,
             model=cls,
             open=functools.partial(open, cls),
-            initial_state=common.ResourceState(),
             initial_config=ResourceConfigWithSchedule(name=cls.NAME, interval=timedelta(hours=1)),
-            schema_inference=True,
         )
         for cls in FULL_REFRESH_MODELS
     ]

--- a/source-google-sheets-native/source_google_sheets_native/resources.py
+++ b/source-google-sheets-native/source_google_sheets_native/resources.py
@@ -58,14 +58,11 @@ def sheet(http: HTTPSession, spreadsheet_id: str, sheet: Sheet):
             tombstone=Row(_meta=Row.Meta(op="d")),
         )
 
-    return common.Resource(
+    return common.SnapshotResource(
         name=sheet.properties.title,
-        key=["/_meta/row_id"],
         model=Row,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=sheet.properties.title, interval=timedelta(seconds=30)
         ),
-        schema_inference=True,
     )

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -7,7 +7,6 @@ from typing import AsyncGenerator, Iterable
 
 from estuary_cdk.capture import Task
 from estuary_cdk.capture.common import (
-    BaseDocument,
     Resource,
     SnapshotResource,
     open_binding,
@@ -493,16 +492,13 @@ def properties(http: HTTPSession, object_names: Iterable[str]) -> Resource:
             tombstone=Property(_meta=Property.Meta(op="d"), type=""),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=Names.properties,
-        key=["/_meta/row_id"],
         model=Property,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=Names.properties, interval=timedelta(days=1)
         ),
-        schema_inference=True,
     )
 
 
@@ -531,16 +527,13 @@ def deal_pipelines(http: HTTPSession) -> Resource:
             ),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=Names.deal_pipelines,
-        key=["/_meta/row_id"],
         model=DealPipeline,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=Names.deal_pipelines, interval=timedelta(minutes=5)
         ),
-        schema_inference=True,
     )
 
 
@@ -562,14 +555,11 @@ def owners(http: HTTPSession) -> Resource:
             tombstone=Owner(_meta=Owner.Meta(op="d"), createdAt=None, updatedAt=None),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=Names.owners,
-        key=["/_meta/row_id"],
         model=Owner,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(name=Names.owners, interval=timedelta(minutes=5)),
-        schema_inference=True,
     )
 
 
@@ -651,14 +641,11 @@ def forms(http: HTTPSession) -> Resource:
             ),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=Names.forms,
-        key=["/_meta/row_id"],
         model=Form,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(name=Names.forms, interval=timedelta(minutes=5)),
-        schema_inference=True,
     )
 
 

--- a/source-impact-native/acmeCo/ActionInquiries.schema.yaml
+++ b/source-impact-native/acmeCo/ActionInquiries.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,32 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
+  CreationDate:
+    format: date-time
+    title: Creationdate
+    type: string
 required:
-  - Id
+- Id
+- CreationDate
 title: ActionInquiries
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Actions.schema.yaml
+++ b/source-impact-native/acmeCo/Actions.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,32 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
+  CreationDate:
+    format: date-time
+    title: Creationdate
+    type: string
 required:
-  - Id
+- Id
+- CreationDate
 title: Actions
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Ads.schema.yaml
+++ b/source-impact-native/acmeCo/Ads.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
-  Id:
-    title: Id
-    type: string
-required:
-  - Id
 title: Ads
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/BlockRedirectRules.schema.yaml
+++ b/source-impact-native/acmeCo/BlockRedirectRules.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: BlockRedirectRules
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Campaigns.schema.yaml
+++ b/source-impact-native/acmeCo/Campaigns.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
-  Id:
-    title: Id
-    type: string
-required:
-  - Id
 title: Campaigns
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Catalogs.schema.yaml
+++ b/source-impact-native/acmeCo/Catalogs.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
-  Id:
-    title: Id
-    type: string
-required:
-  - Id
 title: Catalogs
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Contracts.schema.yaml
+++ b/source-impact-native/acmeCo/Contracts.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Contracts
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Deals.schema.yaml
+++ b/source-impact-native/acmeCo/Deals.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Deals
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/ExceptionLists.schema.yaml
+++ b/source-impact-native/acmeCo/ExceptionLists.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: ExceptionLists
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Invoices.schema.yaml
+++ b/source-impact-native/acmeCo/Invoices.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Invoices
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Jobs.schema.yaml
+++ b/source-impact-native/acmeCo/Jobs.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Jobs
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/MediaPartnerGroups.schema.yaml
+++ b/source-impact-native/acmeCo/MediaPartnerGroups.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
-  Id:
-    title: Id
-    type: string
-required:
-  - Id
 title: MediaPartnerGroups
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Notes.schema.yaml
+++ b/source-impact-native/acmeCo/Notes.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Notes
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/PhoneNumbers.schema.yaml
+++ b/source-impact-native/acmeCo/PhoneNumbers.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
-  Id:
-    title: Id
-    type: string
-required:
-  - Id
 title: PhoneNumbers
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/PromoCodes.schema.yaml
+++ b/source-impact-native/acmeCo/PromoCodes.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: PromoCodes
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Reports.schema.yaml
+++ b/source-impact-native/acmeCo/Reports.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,11 +21,22 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
 title: Reports
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/Tasks.schema.yaml
+++ b/source-impact-native/acmeCo/Tasks.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: Tasks
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/TrackingValueRequests.schema.yaml
+++ b/source-impact-native/acmeCo/TrackingValueRequests.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: TrackingValueRequests
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/UniqueUrls.schema.yaml
+++ b/source-impact-native/acmeCo/UniqueUrls.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -22,16 +21,27 @@ additionalProperties: true
 properties:
   _meta:
     allOf:
-      - $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    - $ref: '#/$defs/Meta'
     description: Document metadata
   Id:
     title: Id
     type: string
 required:
-  - Id
+- Id
 title: UniqueUrls
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-impact-native/acmeCo/flow.yaml
+++ b/source-impact-native/acmeCo/flow.yaml
@@ -1,78 +1,77 @@
----
 collections:
   acmeCo/ActionInquiries:
     schema: ActionInquiries.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Actions:
     schema: Actions.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Ads:
     schema: Ads.schema.yaml
     key:
-      - /Id
+    - /_meta/row_id
   acmeCo/BlockRedirectRules:
     schema: BlockRedirectRules.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Campaigns:
     schema: Campaigns.schema.yaml
     key:
-      - /Id
+    - /_meta/row_id
   acmeCo/Catalogs:
     schema: Catalogs.schema.yaml
     key:
-      - /Id
+    - /_meta/row_id
   acmeCo/Contracts:
     schema: Contracts.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Deals:
     schema: Deals.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/ExceptionLists:
     schema: ExceptionLists.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Invoices:
     schema: Invoices.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Jobs:
     schema: Jobs.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/MediaPartnerGroups:
     schema: MediaPartnerGroups.schema.yaml
     key:
-      - /Id
+    - /_meta/row_id
   acmeCo/Notes:
     schema: Notes.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/PhoneNumbers:
     schema: PhoneNumbers.schema.yaml
     key:
-      - /Id
+    - /_meta/row_id
   acmeCo/PromoCodes:
     schema: PromoCodes.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/Reports:
     schema: Reports.schema.yaml
     key:
-      - /_meta/row_id
+    - /_meta/row_id
   acmeCo/Tasks:
     schema: Tasks.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/TrackingValueRequests:
     schema: TrackingValueRequests.schema.yaml
     key:
-      - /Id
+    - /Id
   acmeCo/UniqueUrls:
     schema: UniqueUrls.schema.yaml
     key:
-      - /Id
+    - /Id

--- a/source-impact-native/source_impact_native/resources.py
+++ b/source-impact-native/source_impact_native/resources.py
@@ -5,7 +5,7 @@ import functools
 
 from estuary_cdk.flow import CaptureBinding
 from estuary_cdk.capture import Task
-from estuary_cdk.capture.common import Resource, LogCursor, PageCursor, open_binding, ResourceConfig, ResourceState
+from estuary_cdk.capture.common import Resource, SnapshotResource, LogCursor, PageCursor, open_binding, ResourceConfig, ResourceState
 from estuary_cdk.http import HTTPSession, HTTPMixin, TokenSource
 
 from .api import (
@@ -181,14 +181,12 @@ def snapshot_object(
             tombstone=cls(_meta=cls.Meta(op="d")),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=cls.NAME,
         key=[cls.PRIMARY_KEY],
         model=cls,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(name=cls.NAME, interval=timedelta(minutes=5)),
-        schema_inference=True,
     )
 
 def child_object(
@@ -253,12 +251,10 @@ def media_groups_object(
             tombstone=cls(_meta=cls.Meta(op="d")),
         )
 
-    return Resource(
+    return SnapshotResource(
         name=cls.NAME,
         key=[cls.PRIMARY_KEY],
         model=cls,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(name=cls.NAME, interval=timedelta(minutes=5)),
-        schema_inference=True,
     )

--- a/source-incident-io/source_incident_io/resources.py
+++ b/source-incident-io/source_incident_io/resources.py
@@ -80,16 +80,12 @@ def full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=stream.name,
-            key=["/_meta/row_id"],
-            model=BaseDocument,
             open=functools.partial(open, stream),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=stream.name, interval=timedelta(minutes=15)
             ),
-            schema_inference=True,
         ) for stream in FULL_REFRESH_RESOURCES
     ]
 

--- a/source-iterable-native/source_iterable_native/resources.py
+++ b/source-iterable-native/source_iterable_native/resources.py
@@ -4,6 +4,7 @@ from logging import Logger
 
 from estuary_cdk.capture import Task
 from estuary_cdk.capture.common import (
+    SnapshotResource,
     BaseDocument,
     Resource,
     open_binding,
@@ -134,16 +135,12 @@ def full_refresh_resources(
         )
 
     resources = [
-        Resource(
+        SnapshotResource(
             name=stream.name,
-            key=["/_meta/row_id"],
-            model=BaseDocument,
             open=functools.partial(open, stream),
-            initial_state=ResourceState(),
             initial_config=ResourceConfigWithSchedule(
                 name=stream.name, interval=stream.interval
             ),
-            schema_inference=True,
             disable=stream.disable
         )
         for stream in FULL_REFRESH_RESOURCES

--- a/source-iterate/source_iterate/resources.py
+++ b/source-iterate/source_iterate/resources.py
@@ -70,16 +70,13 @@ def full_refresh_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, snapshot_fn),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for (name, snapshot_fn) in FULL_REFRESH_RESOURCES
     ]

--- a/source-jira-native/source_jira_native/resources.py
+++ b/source-jira-native/source_jira_native/resources.py
@@ -316,16 +316,13 @@ def full_refresh_resources(
 
     for stream in FULL_REFRESH_STREAMS:
         resources.append(
-            common.Resource(
+            common.SnapshotResource(
                 name=stream.name,
-                key=["/_meta/row_id"],
                 model=FullRefreshResource,
                 open=functools.partial(open, stream),
-                initial_state=ResourceState(),
                 initial_config=ResourceConfigWithSchedule(
                     name=stream.name, interval=timedelta(minutes=60)
                 ),
-                schema_inference=True,
                 disable=stream.disable,
             )
         )

--- a/source-klaviyo-native/source_klaviyo_native/resources.py
+++ b/source-klaviyo-native/source_klaviyo_native/resources.py
@@ -93,16 +93,12 @@ def full_refresh_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=model.name,
-            key=["/_meta/row_id"],
-            model=common.BaseDocument,
             open=functools.partial(open, model),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=model.name, interval=timedelta(minutes=60)
             ),
-            schema_inference=True,
         )
         for model in FULL_REFRESH_STREAMS
     ]

--- a/source-looker/source_looker/resources.py
+++ b/source-looker/source_looker/resources.py
@@ -121,16 +121,13 @@ def full_refresh_resource(
         )
 
 
-    return common.Resource(
+    return common.SnapshotResource(
         name=stream.name,
-        key=["/_meta/row_id"],
         model=FullRefreshResource,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=stream.name, interval=timedelta(minutes=30)
         ),
-        schema_inference=True,
     )
 
 
@@ -168,16 +165,13 @@ def full_refresh_child_resource(
             tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
         )
 
-    return common.Resource(
+    return common.SnapshotResource(
         name=stream.name,
-        key=["/_meta/row_id"],
         model=FullRefreshResource,
         open=open,
-        initial_state=ResourceState(),
         initial_config=ResourceConfig(
             name=stream.name, interval=timedelta(minutes=30)
         ),
-        schema_inference=True,
     )
 
 

--- a/source-mailchimp-native/acmeCo/automation_emails.schema.yaml
+++ b/source-mailchimp-native/acmeCo/automation_emails.schema.yaml
@@ -1,9 +1,5 @@
 $defs:
   Meta:
-    additionalProperties: true
-    description: |-
-      `extra="allow"` lets context-stamped parent IDs ride in `_meta`;
-      `BaseDocument.Meta` otherwise drops unknown keys.
     properties:
       op:
         default: u
@@ -22,24 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: |-
-  Email in a classic automation workflow. Like its `Automation` parent,
-  the endpoint is feature-gated and empty on the test account, so this shape
-  is docs-based; the required `id` fails loudly if a real payload disagrees.
-
-  The parent `workflow_id` is stamped into `_meta` (we can't live-verify
-  whether the response carries it), and the parent fan-out rejects an empty
-  `workflow_id` rather than build a malformed `automations//emails` path.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-required:
-- id
-title: AutomationEmail
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/automations.schema.yaml
+++ b/source-mailchimp-native/acmeCo/automations.schema.yaml
@@ -18,20 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: |-
-  Classic automation workflow. The endpoint is feature-gated and empty on
-  the test account, so this shape is docs-based; the required `id` fails
-  loudly if a real payload disagrees.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-required:
-- id
-title: Automation
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/email_activity.schema.yaml
+++ b/source-mailchimp-native/acmeCo/email_activity.schema.yaml
@@ -1,16 +1,7 @@
 $defs:
   Meta:
     additionalProperties: true
-    description: |-
-      The recipient-row envelope the flattening dissolves. The response
-      does carry these fields (unlike stamped parent IDs, cf.
-      `ParentIdValidationContext`) — but on the member row, not the event,
-      so from the emitted document's perspective they're provenance.
-
-      `email_id` is the member hash (MD5 of the lowercase email address),
-      stable across campaigns — the stream key leads with `campaign_id` to
-      split same-second same-action events by one member across
-      campaigns.
+    description: The recipient-row envelope the flattening dissolves.
     properties:
       op:
         default: u
@@ -39,14 +30,13 @@ $defs:
     type: object
 additionalProperties: true
 description: |-
-  Flattened activity-event engagement document: the event fields are the
-  body (`action`, `timestamp`, plus `ip`/`url`/`type` riding
-  `extra="allow"`); the recipient-row envelope is stamped into `_meta`.
+  Flattened activity-event engagement document: the raw event plus the
+  member envelope in `_meta` and the stream's identity.
 
   Subclasses `MailchimpChildEntity` rather than
   `MailchimpIncrementalChildEntity`: the email-activity endpoint has no
-  before-style upper-bound param, so it can't ride the generic
-  list-children fetchers; `SINCE_PARAM` is declared directly.
+  before-style upper-bound param, so it can't ride the generic list-children
+  fetchers; `SINCE_PARAM` is declared directly.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
@@ -58,11 +48,20 @@ properties:
     format: date-time
     title: Timestamp
     type: string
+  type:
+    anyOf:
+    - const: hard
+      type: string
+    - const: soft
+      type: string
+    - type: 'null'
+    default: null
+    title: Type
 required:
 - _meta
 - action
 - timestamp
-title: EmailActivity
+title: EmailActivityEvent
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/interest_categories.schema.yaml
+++ b/source-mailchimp-native/acmeCo/interest_categories.schema.yaml
@@ -1,9 +1,5 @@
 $defs:
   Meta:
-    additionalProperties: true
-    description: |-
-      `extra="allow"` lets context-stamped parent IDs ride in `_meta`;
-      `BaseDocument.Meta` otherwise drops unknown keys.
     properties:
       op:
         default: u
@@ -26,16 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-  list_id:
-    title: List Id
-    type: string
-required:
-- id
-- list_id
-title: InterestCategory
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/interests.schema.yaml
+++ b/source-mailchimp-native/acmeCo/interests.schema.yaml
@@ -1,9 +1,5 @@
 $defs:
   Meta:
-    additionalProperties: true
-    description: |-
-      `extra="allow"` lets context-stamped parent IDs ride in `_meta`;
-      `BaseDocument.Meta` otherwise drops unknown keys.
     properties:
       op:
         default: u
@@ -22,25 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: Items carry both parent IDs natively.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-  list_id:
-    title: List Id
-    type: string
-  category_id:
-    title: Category Id
-    type: string
-required:
-- id
-- list_id
-- category_id
-title: Interest
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/lists.schema.yaml
+++ b/source-mailchimp-native/acmeCo/lists.schema.yaml
@@ -22,12 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-required:
-- id
-title: MailchimpList
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/segment_members.schema.yaml
+++ b/source-mailchimp-native/acmeCo/segment_members.schema.yaml
@@ -1,9 +1,5 @@
 $defs:
   Meta:
-    additionalProperties: true
-    description: |-
-      `extra="allow"` lets context-stamped parent IDs ride in `_meta`;
-      `BaseDocument.Meta` otherwise drops unknown keys.
     properties:
       op:
         default: u
@@ -22,23 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: |-
-  Items carry `list_id` natively, so it stays a body field; the parent
-  `segment_id` is absent from the response and stamped into `_meta`.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-  list_id:
-    title: List Id
-    type: string
-required:
-- id
-- list_id
-title: SegmentMember
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-mailchimp-native/acmeCo/tags.schema.yaml
+++ b/source-mailchimp-native/acmeCo/tags.schema.yaml
@@ -1,9 +1,5 @@
 $defs:
   Meta:
-    additionalProperties: true
-    description: |-
-      `extra="allow"` lets context-stamped parent IDs ride in `_meta`;
-      `BaseDocument.Meta` otherwise drops unknown keys.
     properties:
       op:
         default: u
@@ -22,30 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: |-
-  Tag-search items are bare `{id, name}`; the parent `list_id` is stamped
-  into `_meta` (the response omits it). Tags are Mailchimp static segments
-  under the hood — this stream is the `{id, name}` projection of the segments
-  stream's `type: static` subset.
-
-  Pagination rides offset/count, which tag-search honors but does not
-  document; if the provider ever drops it, the walker degrades to a single
-  page of up to 1000 tags (fallback enumeration exists via
-  `GET /lists/{list_id}/segments?type=static`).
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-  name:
-    title: Name
-    type: string
-required:
-- id
-- name
-title: Tag
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-monday/source_monday/resources.py
+++ b/source-monday/source_monday/resources.py
@@ -90,14 +90,11 @@ def full_refresh_resources(log: Logger, http: HTTPMixin, config: EndpointConfig)
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, name, query, snapshot_fn),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(name=name, interval=timedelta(hours=2)),
-            schema_inference=True,
         )
         for name, query, snapshot_fn in FULL_REFRESH_RESOURCES
     ]

--- a/source-pendo/source_pendo/resources.py
+++ b/source-pendo/source_pendo/resources.py
@@ -83,16 +83,13 @@ def full_refresh_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=stream.resource_name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, stream.entity_name),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=stream.resource_name, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for stream in FULL_REFRESH_RESOURCE_TYPES
     ]
@@ -193,16 +190,13 @@ def metadata(
         )
 
     metadata = [
-        common.Resource(
+        common.SnapshotResource(
             name=stream.resource_name,
-            key=["/_meta/row_id"],
             model=Metadata,
             open=functools.partial(open, stream.path),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=stream.resource_name, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for stream in METADATA_TYPES
     ]

--- a/source-posthog/acmeCo/Annotations.schema.yaml
+++ b/source-posthog/acmeCo/Annotations.schema.yaml
@@ -18,16 +18,24 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: PostHog annotation.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-required:
-- id
-title: Annotation
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/Cohorts.schema.yaml
+++ b/source-posthog/acmeCo/Cohorts.schema.yaml
@@ -18,16 +18,24 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: PostHog cohort.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-required:
-- id
-title: Cohort
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/Events.schema.yaml
+++ b/source-posthog/acmeCo/Events.schema.yaml
@@ -41,3 +41,17 @@ required:
 title: Event
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/FeatureFlags.schema.yaml
+++ b/source-posthog/acmeCo/FeatureFlags.schema.yaml
@@ -41,3 +41,17 @@ required:
 title: FeatureFlag
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/Organizations.schema.yaml
+++ b/source-posthog/acmeCo/Organizations.schema.yaml
@@ -18,20 +18,24 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: PostHog organization.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-  name:
-    title: Name
-    type: string
-required:
-- id
-- name
-title: Organization
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/Persons.schema.yaml
+++ b/source-posthog/acmeCo/Persons.schema.yaml
@@ -48,3 +48,17 @@ required:
 title: Person
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/acmeCo/Projects.schema.yaml
+++ b/source-posthog/acmeCo/Projects.schema.yaml
@@ -18,16 +18,24 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: PostHog project.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-required:
-- id
-title: Project
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-posthog/source_posthog/resources.py
+++ b/source-posthog/source_posthog/resources.py
@@ -10,6 +10,7 @@ from estuary_cdk.capture.common import (
     BaseDocument,
     ConnectorState,
     Resource,
+    SnapshotResource,
     open_binding,
 )
 from estuary_cdk.flow import CaptureBinding, ValidationError
@@ -62,6 +63,10 @@ RESOURCE_REQUIRED_SCOPES: dict[str, str] = {
 
 PostHogResource = Resource[
     BasePostHogEntity[str] | BasePostHogEntity[int], ResourceConfig, ResourceState
+]
+
+PostHogSnapshotResource = SnapshotResource[
+    BasePostHogEntity[str] | BasePostHogEntity[int], ResourceConfig
 ]
 
 
@@ -170,17 +175,13 @@ def snapshot_resources(
         )
 
     return [
-        PostHogResource(
+        PostHogSnapshotResource(
             name=model.resource_name,
-            key=["/_meta/row_id"],
-            model=model,
             open=functools.partial(open, model.resource_name),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=model.resource_name,
                 interval=timedelta(minutes=5),
             ),
-            schema_inference=True,
         )
         for model in SNAPSHOT_RESOURCES
     ]

--- a/source-posthog/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-posthog/tests/snapshots/snapshots__discover__stdout.json
@@ -32,21 +32,13 @@
         }
       },
       "additionalProperties": true,
-      "description": "PostHog annotation.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Annotation",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -110,21 +102,13 @@
         }
       },
       "additionalProperties": true,
-      "description": "PostHog cohort.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Cohort",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -370,26 +354,13 @@
         }
       },
       "additionalProperties": true,
-      "description": "PostHog organization.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
         }
       },
-      "required": [
-        "id",
-        "name"
-      ],
-      "title": "Organization",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -557,21 +528,13 @@
         }
       },
       "additionalProperties": true,
-      "description": "PostHog project.",
       "properties": {
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "integer"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Project",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {

--- a/source-qualtrics/acmeCo/survey_questions.schema.yaml
+++ b/source-qualtrics/acmeCo/survey_questions.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,16 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  QuestionID:
-    title: Questionid
-    type: string
-required:
-  - QuestionID
-title: SurveyQuestion
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-qualtrics/acmeCo/survey_responses.schema.yaml
+++ b/source-qualtrics/acmeCo/survey_responses.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -26,16 +25,13 @@ $defs:
         title: Recordeddate
         type: string
     required:
-      - recordedDate
+    - recordedDate
     title: Values
     type: object
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
   responseId:
     title: Responseid
@@ -44,10 +40,24 @@ properties:
     title: Surveyid
     type: string
   values:
-    $ref: "#/$defs/Values"
+    $ref: '#/$defs/Values'
 required:
-  - responseId
-  - values
+- responseId
+- values
 title: SurveyResponse
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-qualtrics/acmeCo/surveys.schema.yaml
+++ b/source-qualtrics/acmeCo/surveys.schema.yaml
@@ -1,19 +1,18 @@
----
 $defs:
   Meta:
     properties:
       op:
         default: u
-        description: "Operation type (c: Create, u: Update, d: Delete)"
+        description: 'Operation type (c: Create, u: Update, d: Delete)'
         enum:
-          - c
-          - u
-          - d
+        - c
+        - u
+        - d
         title: Op
         type: string
       row_id:
         default: -1
-        description: "Row ID of the Document, counting up from zero, or -1 if not known"
+        description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
     title: Meta
@@ -21,16 +20,22 @@ $defs:
 additionalProperties: true
 properties:
   _meta:
-    $ref: "#/$defs/Meta"
-    default:
-      op: u
-      row_id: -1
+    $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: string
-required:
-  - id
-title: Survey
+title: BaseDocument
 type: object
 x-infer-schema: true
+if:
+  required:
+  - _meta
+  properties:
+    _meta:
+      required:
+      - op
+      properties:
+        op:
+          const: d
+then:
+  reduce:
+    strategy: merge
+    delete: true

--- a/source-qualtrics/source_qualtrics/resources.py
+++ b/source-qualtrics/source_qualtrics/resources.py
@@ -102,19 +102,15 @@ def full_refresh_resources(
         )
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=resource.RESOURCE_NAME,
-            key=["/_meta/row_id"],
-            model=resource,
             open=functools.partial(
                 open,
                 fetch_snapshot_fn,
             ),
-            initial_state=common.ResourceState(),
             initial_config=common.ResourceConfig(
                 name=resource.RESOURCE_NAME, interval=timedelta(minutes=15)
             ),
-            schema_inference=True,
         )
         for resource, fetch_snapshot_fn in FULL_REFRESH_RESOURCES
     ]

--- a/source-qualtrics/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-qualtrics/tests/snapshots/snapshots__discover__stdout.json
@@ -36,16 +36,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "QuestionID": {
-          "title": "Questionid",
-          "type": "string"
         }
       },
-      "required": [
-        "QuestionID"
-      ],
-      "title": "SurveyQuestion",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -214,16 +207,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
         }
       },
-      "required": [
-        "id"
-      ],
-      "title": "Survey",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {

--- a/source-ringcentral/source_ringcentral/resources.py
+++ b/source-ringcentral/source_ringcentral/resources.py
@@ -5,6 +5,7 @@ from typing import Type
 
 from estuary_cdk.capture import Task, common
 from estuary_cdk.capture.common import (
+    SnapshotResource,
     Resource,
     ResourceConfig,
     ResourceState,
@@ -69,16 +70,14 @@ def full_refresh_resources(
         )
 
     return [
-        Resource(
+        SnapshotResource(
             name=model.NAME,
             key=[model.KEY],
             model=model,
             open=functools.partial(open, model),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=model.NAME, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for model in FULL_REFRESH_RESOURCES
     ]

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -110,16 +110,13 @@ def full_refresh_resource(
             tombstone=FullRefreshResource(_meta=FullRefreshResource.Meta(op="d"))
         )
 
-    resource = common.Resource(
+    resource = common.SnapshotResource(
         name=name,
-        key=["/_meta/row_id"],
         model=FullRefreshResource,
         open=open,
-        initial_state=ResourceState(),
         initial_config=SalesforceResourceConfigWithSchedule(
             name=name, interval=timedelta(minutes=5)
         ),
-        schema_inference=True,
         disable=not enable
     )
 

--- a/source-sentry/acmeCo/Environments.schema.yaml
+++ b/source-sentry/acmeCo/Environments.schema.yaml
@@ -22,7 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-title: Environment
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-sentry/acmeCo/Projects.schema.yaml
+++ b/source-sentry/acmeCo/Projects.schema.yaml
@@ -22,20 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  access:
-    items:
-      type: string
-    title: Access
-    type: array
-  features:
-    items:
-      type: string
-    title: Features
-    type: array
-required:
-- access
-- features
-title: Project
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-sentry/acmeCo/Releases.schema.yaml
+++ b/source-sentry/acmeCo/Releases.schema.yaml
@@ -22,7 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-title: Release
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-sentry/acmeCo/Teams.schema.yaml
+++ b/source-sentry/acmeCo/Teams.schema.yaml
@@ -22,14 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  access:
-    items:
-      type: string
-    title: Access
-    type: array
-required:
-- access
-title: Team
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-sentry/source_sentry/resources.py
+++ b/source-sentry/source_sentry/resources.py
@@ -155,16 +155,12 @@ async def all_resources(
     explore_cutoff = cutoff - MAX_EXPLORE_FULL_FIDELITY_WINDOW + timedelta(minutes=1)
 
     return [
-        common.Resource(
+        common.SnapshotResource(
             name=resource.resource_name,
-            key=["/_meta/row_id"],
-            model=resource,
             open=functools.partial(open_full_refresh_bindings, resource),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=resource.resource_name, interval=timedelta(minutes=5)
             ),
-            schema_inference=True,
         )
         for resource in FULL_REFRESH_RESOURCES
     ] + [

--- a/source-sentry/tests/snapshots/snapshots__discover__stdout.json
+++ b/source-sentry/tests/snapshots/snapshots__discover__stdout.json
@@ -38,7 +38,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Environment",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -189,27 +189,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "access": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Access",
-          "type": "array"
-        },
-        "features": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Features",
-          "type": "array"
         }
       },
-      "required": [
-        "access",
-        "features"
-      ],
-      "title": "Project",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -279,7 +261,7 @@
           "description": "Document metadata"
         }
       },
-      "title": "Release",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {
@@ -347,19 +329,9 @@
         "_meta": {
           "$ref": "#/$defs/Meta",
           "description": "Document metadata"
-        },
-        "access": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Access",
-          "type": "array"
         }
       },
-      "required": [
-        "access"
-      ],
-      "title": "Team",
+      "title": "BaseDocument",
       "type": "object",
       "x-infer-schema": true,
       "if": {

--- a/source-smartsheet/acmeCo/flow.yaml
+++ b/source-smartsheet/acmeCo/flow.yaml
@@ -2,12 +2,11 @@ collections:
   acmeCo/report_rows:
     schema: report_rows.schema.yaml
     key:
-    - /_meta/report_id
-    - /id
+    - /_meta/row_id
   acmeCo/reports:
     schema: reports.schema.yaml
     key:
-    - /id
+    - /_meta/row_id
   acmeCo/sheet_rows:
     schema: sheet_rows.schema.yaml
     key:

--- a/source-smartsheet/acmeCo/report_rows.schema.yaml
+++ b/source-smartsheet/acmeCo/report_rows.schema.yaml
@@ -15,11 +15,6 @@ $defs:
         description: Row ID of the Document, counting up from zero, or -1 if not known
         title: Row Id
         type: integer
-      report_id:
-        default: -1
-        description: The Smartsheet report this row belongs to
-        title: Report Id
-        type: integer
     title: Meta
     type: object
 additionalProperties: true
@@ -27,12 +22,7 @@ properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-required:
-- id
-title: ReportRow
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-smartsheet/acmeCo/reports.schema.yaml
+++ b/source-smartsheet/acmeCo/reports.schema.yaml
@@ -18,25 +18,11 @@ $defs:
     title: Meta
     type: object
 additionalProperties: true
-description: |-
-  One document per report, mirroring a `GET /reports` list item verbatim:
-  id/name/accessLevel/permalink/isSummaryReport (the passthrough fields ride
-  on `BaseDocument`'s `extra="allow"`). Catalog/metadata only, never row data.
-
-  Unlike `Sheet`, this is *not* refetched from the detail endpoint, so the
-  richer detail-only fields (effectiveAttachmentOptions, totalRowCount,
-  timestamps) are absent by design. The `report_rows` walk also enumerates
-  report ids from this same list, so there's no separate list-summary type.
 properties:
   _meta:
     $ref: '#/$defs/Meta'
     description: Document metadata
-  id:
-    title: Id
-    type: integer
-required:
-- id
-title: Report
+title: BaseDocument
 type: object
 x-infer-schema: true
 if:

--- a/source-smartsheet/acmeCo/sheet_rows.schema.yaml
+++ b/source-smartsheet/acmeCo/sheet_rows.schema.yaml
@@ -30,8 +30,13 @@ properties:
   id:
     title: Id
     type: integer
+  modifiedAt:
+    format: date-time
+    title: Modifiedat
+    type: string
 required:
 - id
+- modifiedAt
 title: SheetRow
 type: object
 x-infer-schema: true

--- a/source-smartsheet/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-smartsheet/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -126,37 +126,36 @@
       "_meta": {
         "op": "c",
         "report_id": 3852843205396356,
-        "row_id": 2,
+        "row_id": 0,
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "accessLevel": "OWNER",
       "cells": [
         {
           "columnId": 4975488054986628,
-          "displayValue": "Retro",
-          "value": "Retro",
+          "displayValue": "Design mockups",
+          "value": "Design mockups",
           "virtualColumnId": 8811664796944260
         },
         {
           "columnId": 2723688241301380,
-          "displayValue": "Complete",
-          "value": "Complete",
+          "displayValue": "In Progress",
+          "value": "In Progress",
           "virtualColumnId": 226678007269252
         },
         {
           "columnId": 7227287868671876,
-          "value": "2026-06-30",
+          "value": "2026-07-15",
           "virtualColumnId": 4730277634639748
         }
       ],
       "createdAt": "2026-07-21T13:51:41Z",
       "dataModifiedAt": "2026-07-21T13:51:41Z",
       "expanded": true,
-      "id": 1103848113047428,
+      "id": 3918597880153988,
       "modifiedAt": "2026-07-21T13:51:41Z",
-      "rowNumber": 3,
-      "sheetId": 858366236821380,
-      "siblingId": 8422197507524484
+      "rowNumber": 1,
+      "sheetId": 858366236821380
     }
   ]
 ]

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -300,16 +300,13 @@ def full_refresh_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, path, response_model),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=60)
             ),
-            schema_inference=True,
         )
         for (name, path, response_model) in FULL_REFRESH_RESOURCES
     ]
@@ -346,16 +343,13 @@ def full_refresh_offset_paginated_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, path, response_model),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=60)
             ),
-            schema_inference=True,
         )
         for (name, path, response_model) in FULL_REFRESH_OFFSET_PAGINATED_RESOURCES
     ]
@@ -392,16 +386,13 @@ def full_refresh_cursor_paginated_resources(
         )
 
     resources = [
-        common.Resource(
+        common.SnapshotResource(
             name=name,
-            key=["/_meta/row_id"],
             model=FullRefreshResource,
             open=functools.partial(open, path, response_model),
-            initial_state=ResourceState(),
             initial_config=ResourceConfig(
                 name=name, interval=timedelta(minutes=60)
             ),
-            schema_inference=True,
         )
         for (name, path, response_model) in FULL_REFRESH_CURSOR_PAGINATED_RESOURCES
     ]


### PR DESCRIPTION
**Regression?**

No.

**Description:**

We've stumbled over the "tombstone doesn't comply with the collection's write schema" pitfall recently, and I'm working on updating the CDK to hopefully prevent that from happening in the future. In order to make those CDK level changes though, all of our connectors need updated to use write schema compliant tombstones. This PR does all that ground work to fix existing connectors' tombstones mostly by simply using the `SnapshotResource` convenience class that ✨ just works ✨ for the majority of full refresh stream use cases.

I also regenerated the discovered YAML schema files we use for capture snapshot tests as well.

Snapshot changes are all expected due to the removal of non-key fields from the snapshot resources' schemas. Most changes are those non-key fields disappearing from the discovery snapshot. In the `source-smartsheet` case, regeneration of the YAML file caused the ordering of documents to be changed due to the removal of the `id` field from the key.

**Notes for reviewers**

This PR doesn't change the key for any collections. It just fixes the possible tombstone triggered JSON schema violations for the remaining CDK based connectors.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
