### PR TITLE
estuary-cdk: add validation around `SnapshotResource`s and tombstones

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -782,6 +782,26 @@ def open(
     return (response.Opened(explicitAcknowledgements=requires_explicit_acks), _run)
 
 
+def _assert_tombstone_covers_key(tombstone: BaseDocument, key: list[str]) -> None:
+    """Assert every collection-key field other than the CDK-managed
+    /_meta/row_id is set on the tombstone.
+
+    A tombstone is sparse by design, but the CDK only fills in /_meta/row_id, so
+    every other key field has to be pre-set by the caller."""
+    dump = tombstone.model_dump(by_alias=True, exclude_unset=True)
+    for key_pointer in key:
+        if key_pointer == "/_meta/row_id":
+            continue
+        node: Any = dump
+        for field in key_pointer.strip("/").split("/"):
+            assert isinstance(node, dict) and field in node, (
+                f"A snapshot tombstone must have every collection key field "
+                f"other than /_meta/row_id pre-set, but {key_pointer} is unset. "
+                f"Key: {key}, tombstone: {dump}"
+            )
+            node = node[field]
+
+
 def _tombstone_discriminator_values(
     tombstone: BaseDocument, key: list[str]
 ) -> tuple[object, ...]:
@@ -789,7 +809,7 @@ def _tombstone_discriminator_values(
     /_meta/row_id, in key order. These are what must differ between snapshot
     subtasks: two subtasks sharing them would emit tombstones into the same
     (discriminator, row_id) keyspace."""
-    dump = tombstone.model_dump(by_alias=True)
+    dump = tombstone.model_dump(by_alias=True, exclude_unset=True)
     values: list[object] = []
     for key_pointer in key:
         # row_id is assigned per-pass by the CDK and is identical across
@@ -798,7 +818,6 @@ def _tombstone_discriminator_values(
             continue
         node: Any = dump
         for field in key_pointer.strip("/").split("/"):
-            # A KeyError here means the tombstone is missing a key field.
             node = node[field]
         values.append(node)
     return tuple(values)
@@ -931,6 +950,20 @@ def open_binding(
             )
 
     if fetch_snapshot:
+        key = binding.collection.key
+
+        if tombstone is None:
+            # Default tombstone for snapshot bindings so callers don't need to
+            # provide one. The cast satisfies the _BaseDocument TypeVar since
+            # BaseDocument is its bound.
+            tombstone = cast(
+                _BaseDocument, BaseDocument(_meta=BaseDocument.Meta(op="d"))
+            )
+
+        for snapshot_tombstone in (
+            tombstone.values() if isinstance(tombstone, dict) else [tombstone]
+        ):
+            _assert_tombstone_covers_key(snapshot_tombstone, key)
 
         async def snapshot_closure(
             task: Task,
@@ -950,8 +983,7 @@ def open_binding(
             )
 
         if isinstance(fetch_snapshot, dict):
-            key = binding.collection.key
-            assert "/_meta/row_id" in key and len(key) > 1, (
+            assert len(key) > 1, (
                 f"A fetch_snapshot subtask requires a compound collection "
                 f"key containing /_meta/row_id plus a subtask discriminator. "
                 f"Got: {key}"
@@ -997,13 +1029,6 @@ def open_binding(
                     ),
                 )
         else:
-            if tombstone is None:
-                # Default tombstone for snapshot bindings so callers don't need to
-                # provide one. The cast satisfies the _BaseDocument TypeVar since
-                # BaseDocument is its bound.
-                tombstone = cast(
-                    _BaseDocument, BaseDocument(_meta=BaseDocument.Meta(op="d"))
-                )
             assert not isinstance(tombstone, dict)
             assert not isinstance(resource_state.snapshot, dict)
 

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -602,6 +602,17 @@ def resolve_bindings(
         if not found:
             errors.append(f"{resource_term} '{'.'.join(path)}' was not found.")
 
+    for binding, resource in resolved:
+        if isinstance(resource, SnapshotResource) and (
+            "/_meta/row_id" not in binding.collection.key
+        ):
+            errors.append(
+                f"Collection '{binding.collection.name}' is bound to snapshot "
+                f"{resource_term.lower()} '{'.'.join(binding.resourceConfig.path())}' "
+                f"and so must be keyed on /_meta/row_id, but its key is "
+                f"{binding.collection.key}."
+            )
+
     if errors:
         raise ValidationError(errors)
 

--- a/estuary-cdk/estuary_cdk/capture/common.py
+++ b/estuary-cdk/estuary_cdk/capture/common.py
@@ -483,6 +483,12 @@ class SnapshotResource(Resource[_BaseDocument, _BaseResourceConfig, ResourceStat
     model: type[BaseDocument] | Resource.FixedSchema = BaseDocument
     schema_inference: bool = True
 
+    def __post_init__(self):
+        assert "/_meta/row_id" in self.key, (
+            f"A SnapshotResource must be keyed on /_meta/row_id, which is how "
+            f"the CDK addresses the document a deletion removes. Got: {self.key}"
+        )
+
 
 def discovered(
     resources: list["Resource[_BaseDocument, _BaseResourceConfig, _BaseResourceState]"],

--- a/estuary-cdk/tests/test_snapshot_subtasks.py
+++ b/estuary-cdk/tests/test_snapshot_subtasks.py
@@ -273,19 +273,6 @@ class TestOpenBindingSnapshotDict:
                 tombstone={"A": _doc("A", "")},
             )
 
-    def test_requires_row_id_in_key(self):
-        output = io.BytesIO()
-        task = _task(output, Task.Stopping())
-        with pytest.raises(AssertionError, match="compound collection key"):
-            open_binding(
-                _binding(["/_meta/store", "/id"]),
-                0,
-                self._state(),
-                task,
-                fetch_snapshot={"A": self._noop},
-                tombstone={"A": _doc("A", "")},
-            )
-
     def test_requires_matching_tombstone_dict(self):
         output = io.BytesIO()
         task = _task(output, Task.Stopping())
@@ -391,3 +378,73 @@ class TestResolveBindingsSnapshotKey:
         )
         resolved = resolve_bindings([_binding(["/id"], name="issues")], [resource])
         assert len(resolved) == 1
+
+
+class TestOpenBindingSnapshotSingle:
+    """A single (non-dict) fetch_snapshot is subject to the same key/tombstone
+    rules as a subtask. These went unchecked until a snapshot binding keyed on
+    `/id` shipped and only failed once its source count first shrank."""
+
+    async def _noop(self, log: logging.Logger) -> AsyncGenerator[StoreDoc, None]:
+        if False:
+            yield  # pragma: no cover
+
+    def test_accepts_row_id_key_with_default_tombstone(self):
+        task = _task(io.BytesIO(), Task.Stopping())
+        task.spawn_child = MagicMock()  # type: ignore[method-assign]
+
+        # The canonical shape: keyed solely on row_id, so the CDK's own default
+        # tombstone suffices and no caller-supplied fields are needed.
+        open_binding(
+            _binding(["/_meta/row_id"]),
+            0,
+            ResourceState(),
+            task,
+            fetch_snapshot=self._noop,
+        )
+
+        assert task.spawn_child.call_count == 1
+        assert task.spawn_child.call_args.args[0] == "staff_members.snapshot"
+
+    def test_accepts_compound_key_when_tombstone_carries_discriminator(self):
+        task = _task(io.BytesIO(), Task.Stopping())
+        task.spawn_child = MagicMock()  # type: ignore[method-assign]
+
+        open_binding(
+            _binding(COMPOUND_KEY),
+            0,
+            ResourceState(),
+            task,
+            fetch_snapshot=self._noop,
+            tombstone=_doc("A", ""),
+        )
+
+        assert task.spawn_child.call_count == 1
+
+    def test_rejects_tombstone_missing_a_key_field(self):
+        # row_id is in the key, but the CDK cannot populate `store`, so this
+        # tombstone would delete whatever sits at store="" instead.
+        with pytest.raises(AssertionError, match="/_meta/store is unset"):
+            open_binding(
+                _binding(COMPOUND_KEY),
+                0,
+                ResourceState(),
+                _task(io.BytesIO(), Task.Stopping()),
+                fetch_snapshot=self._noop,
+                tombstone=BaseDocument(_meta=BaseDocument.Meta(op="d")),
+            )
+
+    def test_rejects_tombstone_relying_on_a_default_for_a_key_field(self):
+        # StoreDoc.Meta declares `store` with a default, so it resolves on the
+        # model -- but documents serialize with exclude_unset, so a value the
+        # caller never set is absent from the captured document and would key
+        # the deletion to the default instead.
+        with pytest.raises(AssertionError, match="/_meta/store is unset"):
+            open_binding(
+                _binding(COMPOUND_KEY),
+                0,
+                ResourceState(),
+                _task(io.BytesIO(), Task.Stopping()),
+                fetch_snapshot=self._noop,
+                tombstone=StoreDoc(id="", _meta=StoreDoc.Meta(op="d")),
+            )

--- a/estuary-cdk/tests/test_snapshot_subtasks.py
+++ b/estuary-cdk/tests/test_snapshot_subtasks.py
@@ -10,16 +10,18 @@ import pytest
 from pydantic import Field
 
 from estuary_cdk.capture.common import (
+    Resource,
     ResourceConfig,
     ResourceState,
     SnapshotResource,
     _binding_snapshot_task,  # pyright: ignore[reportPrivateUsage]
     open_binding,
+    resolve_bindings,
 )
 from estuary_cdk.capture.document import BaseDocument
 from estuary_cdk.capture.task import Task
 from estuary_cdk.capture.transactor import Transactor
-from estuary_cdk.flow import CaptureBinding, CollectionSpec
+from estuary_cdk.flow import CaptureBinding, CollectionSpec, ValidationError
 
 COMPOUND_KEY = ["/_meta/store", "/_meta/row_id"]
 
@@ -343,3 +345,49 @@ class TestSnapshotResourceKey:
     def test_rejects_compound_key_without_row_id(self):
         with pytest.raises(AssertionError, match="must be keyed on /_meta/row_id"):
             _ = self._resource(key=["/_meta/store", "/id"])
+
+
+class TestResolveBindingsSnapshotKey:
+    """The collection's key belongs to the user, so a mismatch is reported as a
+    ValidationError during Validate -- failing the publish -- rather than
+    asserted once a task is already running."""
+
+    def _resource(self, name: str = "staff_members") -> SnapshotResource:
+        return SnapshotResource(
+            name=name,
+            open=lambda *args: None,
+            initial_config=ResourceConfig(name=name, interval=timedelta()),
+        )
+
+    def test_accepts_row_id_key(self):
+        resolved = resolve_bindings([_binding(["/_meta/row_id"])], [self._resource()])
+        assert len(resolved) == 1
+
+    def test_accepts_compound_key_containing_row_id(self):
+        resolved = resolve_bindings([_binding(COMPOUND_KEY)], [self._resource()])
+        assert len(resolved) == 1
+
+    def test_rejects_key_without_row_id(self):
+        with pytest.raises(ValidationError) as excinfo:
+            _ = resolve_bindings([_binding(["/id"])], [self._resource()])
+
+        (error,) = excinfo.value.errors
+        assert "c/staff_members" in error
+        assert "must be keyed on /_meta/row_id" in error
+        assert "['/id']" in error
+
+    def test_ignores_non_snapshot_resources(self):
+        # A snapshot binding declared as a plain Resource is invisible here --
+        # only its `open` callback knows it passes fetch_snapshot -- so Validate
+        # must not reject it.
+        resource = Resource(
+            name="issues",
+            key=["/id"],
+            model=BaseDocument,
+            open=lambda *args: None,
+            initial_state=ResourceState(),
+            initial_config=ResourceConfig(name="issues", interval=timedelta()),
+            schema_inference=True,
+        )
+        resolved = resolve_bindings([_binding(["/id"], name="issues")], [resource])
+        assert len(resolved) == 1

--- a/estuary-cdk/tests/test_snapshot_subtasks.py
+++ b/estuary-cdk/tests/test_snapshot_subtasks.py
@@ -12,6 +12,7 @@ from pydantic import Field
 from estuary_cdk.capture.common import (
     ResourceConfig,
     ResourceState,
+    SnapshotResource,
     _binding_snapshot_task,  # pyright: ignore[reportPrivateUsage]
     open_binding,
 )
@@ -310,3 +311,35 @@ class TestOpenBindingSnapshotDict:
                 # keyspaces would overlap and clobber each other.
                 tombstone={"A": _doc("A", ""), "B": _doc("A", "")},
             )
+
+
+class TestSnapshotResourceKey:
+    """SnapshotResource's key is an invariant of the type, not of a particular
+    binding, so it is enforced at construction. That covers every path which
+    builds resources -- Discover, Validate and Open -- and validates only what
+    the connector itself declares."""
+
+    def _resource(self, **overrides) -> SnapshotResource:
+        return SnapshotResource(
+            name="staff_members",
+            open=lambda *args: None,
+            initial_config=ResourceConfig(name="staff_members", interval=timedelta()),
+            **overrides,
+        )
+
+    def test_defaults_to_row_id(self):
+        assert self._resource().key == ["/_meta/row_id"]
+
+    def test_accepts_compound_key_containing_row_id(self):
+        # A snapshot may key on a subtask discriminator as well, as long as
+        # row_id is still there to address the removed row.
+        assert self._resource(key=COMPOUND_KEY).key == COMPOUND_KEY
+
+    def test_rejects_key_without_row_id(self):
+        # The issue #5051 shape, caught before any collection exists.
+        with pytest.raises(AssertionError, match="must be keyed on /_meta/row_id"):
+            _ = self._resource(key=["/id"])
+
+    def test_rejects_compound_key_without_row_id(self):
+        with pytest.raises(AssertionError, match="must be keyed on /_meta/row_id"):
+            _ = self._resource(key=["/_meta/store", "/id"])


### PR DESCRIPTION
**Regression?**

No.

**Description:**

This PR adds additional validation around tombstones and snapshot resources to the CDK to catch common mistakes. These new validations include:
- `SnapshotResource.__post_init__` assert its own key includes `/_meta/row_id`.
- `resolve_bindings` reports a snapshot binding's collection key that doesn't contain `/_meta/row_id` as a `ValidationError`.
- `open_binding` asserts the tombstone carries every key field the CDK does not fill itself.

Closes #5051.

**Notes for reviewers:**

I'd like to also validate that tombstones satisfy the schema generated by a resource's `model`, but that's currently tricky / touches a lot of code since resources currently don't know what the tombstones are. I plan to add that validation in a future PR to keep this stack's scope to a reasonable level.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>