### PR TITLE
source-twilio: stop filtering re-fetched Messages records against the…

### DIFF
--- a/source-twilio/CHANGELOG.md
+++ b/source-twilio/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 2026-08-14
+
+### Fixed
+- The Messages stream no longer filters re-fetched records against the
+  `date_sent` cursor before emitting them. Previously, records returned by
+  the lookback window with both `date_sent` and `date_updated` older than
+  the persisted cursor were silently dropped, so in-place updates (e.g.
+  `price` populated shortly after a message is sent) never reached the
+  collection and messages missed on first read were never captured.
+- Messages with a null `date_sent` (queued or failed messages) no longer
+  cause the stream to fail; they are emitted as-is and do not advance the
+  cursor.
+
+### Changed
+- The Messages stream emits records as they are paged from the API instead
+  of buffering and sorting an entire date slice in memory. The cursor
+  advances only after a slice is read to completion, so checkpoints taken
+  mid-slice cannot skip past unprocessed records.

--- a/source-twilio/source_twilio/streams.py
+++ b/source-twilio/source_twilio/streams.py
@@ -626,18 +626,33 @@ class Messages(IncrementalTwilioStreamWithLookbackWindow, TwilioNestedStream):
         # date_sent and date_updated older than the max date_sent observed in the previous sweep, and
         # filtering on the cursor silently discards exactly the updates the lookback window exists to
         # capture. Re-emitting previously seen documents is safe since collections reduce on the key.
+        #
+        # The API returns messages in reverse chronological order, and IncrementalTwilioStream
+        # checkpoints intra-slice every `state_checkpoint_interval` records. The cursor therefore
+        # must not advance while records are still streaming: the first record seen carries the
+        # newest date_sent in the slice, and an intra-slice checkpoint taken after it would persist
+        # a cursor beyond the older records still being processed, permanently skipping them if the
+        # connector crashes or restarts mid-slice. Instead, track the max date_sent locally and only
+        # advance the cursor once the slice has been read to completion. Checkpoints taken mid-slice
+        # carry the prior cursor, so a restart re-reads the slice from the beginning, which is safe
+        # (at-least-once) since collections reduce on the key.
+        max_cursor_value = None
         for record in super(IncrementalTwilioStream, self).read_records(sync_mode, cursor_field, stream_slice, stream_state):
             # A message that has not been sent yet (or failed to send) can have a null date_sent.
-            # Normalize timestamps when present, yield the record regardless, and only advance the
-            # cursor from non-null date_sent values so a single anomalous record can't fail the
-            # entire sweep (this connector only checkpoints after reading every stream).
+            # Normalize timestamps when present, yield the record regardless, and only consider
+            # non-null date_sent values for cursor advancement so a single anomalous record can't
+            # fail the entire sweep.
             if record.get(self.cursor_field):
                 record[self.cursor_field] = pendulum.parse(record[self.cursor_field], strict=False).to_iso8601_string()
-                if self._cursor_value is None or record[self.cursor_field] > self._cursor_value:
-                    self._cursor_value = record[self.cursor_field]
+                if max_cursor_value is None or record[self.cursor_field] > max_cursor_value:
+                    max_cursor_value = record[self.cursor_field]
             if record.get("date_updated"):
                 record["date_updated"] = pendulum.parse(record["date_updated"], strict=False).to_iso8601_string()
             yield record
+
+        # The slice was read to completion; it is now safe to advance the cursor.
+        if max_cursor_value is not None and (self._cursor_value is None or max_cursor_value > self._cursor_value):
+            self._cursor_value = max_cursor_value
 
 
 class MessageMedia(IncrementalTwilioStream, TwilioNestedStream):

--- a/source-twilio/source_twilio/streams.py
+++ b/source-twilio/source_twilio/streams.py
@@ -616,24 +616,28 @@ class Messages(IncrementalTwilioStreamWithLookbackWindow, TwilioNestedStream):
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
-        unsorted_records = []
-        initial_cursor = self.state.get(self.cursor_field, self._start_date)
-
-        # Skip the IncrementalTwilioStream's read_records method since it filters only based on date_sent instead of 
-        # both date_sent and date_updated.
+        # Skip the IncrementalTwilioStream's read_records method since it filters records based on the
+        # cursor before yielding them.
+        #
+        # Every record returned within the requested DateSent window is yielded unconditionally. The
+        # Twilio API cannot filter on date_updated, so the lookback window re-reads a trailing DateSent
+        # range to pick up in-place updates (e.g. price being populated shortly after a message is sent).
+        # Records must NOT be filtered against the cursor here: a re-fetched record typically has both
+        # date_sent and date_updated older than the max date_sent observed in the previous sweep, and
+        # filtering on the cursor silently discards exactly the updates the lookback window exists to
+        # capture. Re-emitting previously seen documents is safe since collections reduce on the key.
         for record in super(IncrementalTwilioStream, self).read_records(sync_mode, cursor_field, stream_slice, stream_state):
-            record[self.cursor_field] = pendulum.parse(record[self.cursor_field], strict=False).to_iso8601_string()
-            record["date_updated"] = pendulum.parse(record["date_updated"], strict=False).to_iso8601_string()
-            unsorted_records.append(record)
-        sorted_records = sorted(unsorted_records, key=lambda x: x[self.cursor_field])
-        for record in sorted_records:
-            # If this is a new record, yield it and update the cursor.
-            if record[self.cursor_field] >= initial_cursor:
-                self._cursor_value = record[self.cursor_field]
-                yield record
-            # Otherwise if it's an update to a record we've seen before, yield it.
-            elif record["date_updated"] >= initial_cursor:
-                yield record
+            # A message that has not been sent yet (or failed to send) can have a null date_sent.
+            # Normalize timestamps when present, yield the record regardless, and only advance the
+            # cursor from non-null date_sent values so a single anomalous record can't fail the
+            # entire sweep (this connector only checkpoints after reading every stream).
+            if record.get(self.cursor_field):
+                record[self.cursor_field] = pendulum.parse(record[self.cursor_field], strict=False).to_iso8601_string()
+                if self._cursor_value is None or record[self.cursor_field] > self._cursor_value:
+                    self._cursor_value = record[self.cursor_field]
+            if record.get("date_updated"):
+                record["date_updated"] = pendulum.parse(record["date_updated"], strict=False).to_iso8601_string()
+            yield record
 
 
 class MessageMedia(IncrementalTwilioStream, TwilioNestedStream):


### PR DESCRIPTION
… date_sent cursor

The Messages stream's lookback window re-reads a trailing DateSent range to capture in-place updates, since the Twilio API cannot filter on date_updated. However, read_records then filtered records against the persisted cursor (max date_sent from the prior sweep) before yielding: records with both date_sent and date_updated older than that cursor were silently dropped. A re-fetched record typically satisfies exactly that condition, so the updates the lookback window exists to capture (e.g. price populated shortly after send) never reached the collection, and any message missed on first read was dropped permanently on every re-fetch.

Observed in production as ~25% of incrementally-captured messages retaining price: null, plus a smaller set of messages absent entirely.

Changes:
- Yield every record returned within the queried DateSent window. Re-emitting previously seen documents is safe since collections reduce on the key.
- Track the cursor as a running max against the persisted state instead of buffering and sorting the whole slice, so records stream as they are paged.
- Tolerate null date_sent (queued/failed messages): yield the record without advancing the cursor rather than crashing the sweep, which only checkpoints after every stream completes.

**Regression?**

(Is this pull-request fixing a regression introduced by an earlier pull-request? If so please link the earlier pull-request, otherwise remove this section)

**Description:**

(Describe the high level scope of new or changed features)

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
