### PR TITLE
source-smartsheet: log Content-Encoding headers on error paths

### DIFF
--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -662,18 +662,21 @@ class HTTPMixin(Mixin, HTTPSession):
                             {
                                 "status_code": resp.status,
                                 "content_type": resp.content_type,
+                                "content_encoding": resp.headers.getall(
+                                    "Content-Encoding", []
+                                ),
                                 "body": format_error_body(body),
                             },
                         )
                     else:
                         raise HTTPError(
-                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
+                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nContent-Encoding: {resp.headers.getall('Content-Encoding', [])}\nResponse:\n{format_error_body(body)}",
                             resp.status,
                         )
                 elif resp.status >= 400 and resp.status < 500:
                     body = await resp.read()
                     raise HTTPError(
-                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
+                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nContent-Encoding: {resp.headers.getall('Content-Encoding', [])}\nResponse:\n{format_error_body(body)}",
                         resp.status,
                     )
                 else:


### PR DESCRIPTION
**Regression?**

(Is this pull-request fixing a regression introduced by an earlier pull-request? If so please link the earlier pull-request, otherwise remove this section)

**Description:**

The previous logging PR logged the `Content-Type` header, when `Content-Encoding` is more relevant to the current troubleshooting effort. This header should help us understand whether Smartsheet is not reporting response encodings, double-compressing bodies, or something else.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Documentation links affected:**

(list any [documentation links](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing) that you created, or existing ones that you've identified as needing updates, along with a brief description)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
