### PR TITLE
source-*-batch: fail fast when INSERTs fail during tests

### DIFF
--- a/source-db2-batch/capture_test.go
+++ b/source-db2-batch/capture_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy"
 	st "github.com/estuary/connectors/source-boilerplate/testing"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSimpleCapture exercises the simplest use-case of a capture first doing an initial
@@ -66,24 +66,39 @@ func TestAsyncCapture(t *testing.T) {
 	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
 
 	t.Run("Capture", func(t *testing.T) {
-		// Spawn a worker thread which will insert 50 rows of data in parallel with the capture.
-		var insertsDone atomic.Bool
+		// Spawn a worker thread which will insert 50 rows of data in parallel with the
+		// capture. It reports its outcome over a channel.
+		var insertResult = make(chan error, 1)
 		go func() {
 			for i := 0; i < 250; i++ {
 				time.Sleep(100 * time.Millisecond)
-				executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES (?, ?)", tableName), i, fmt.Sprintf("Value for row %d", i))
+				var query = fmt.Sprintf("INSERT INTO %s VALUES (?, ?)", tableName)
+				if _, err := control.Exec(query, i, fmt.Sprintf("Value for row %d", i)); err != nil {
+					insertResult <- fmt.Errorf("inserting row %d: %w", i, err)
+					return
+				}
 				log.WithField("i", i).Debug("inserted row")
 			}
 			time.Sleep(1 * time.Second)
-			insertsDone.Store(true)
+			insertResult <- nil
 		}()
 
 		// Run the capture over and over for 5 seconds each time until all inserts have finished, then verify results.
-		for !insertsDone.Load() {
+		var insertErr error
+		var insertsDone bool
+		for !insertsDone {
 			var captureCtx, cancelCapture = context.WithCancel(ctx)
 			time.AfterFunc(5*time.Second, cancelCapture)
 			cs.Capture(captureCtx, t, nil)
+
+			select {
+			case insertErr = <-insertResult:
+				insertsDone = true
+			default:
+			}
 		}
+		// Fail fast if the inserting goroutine reports an error.
+		require.NoError(t, insertErr)
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }

--- a/source-oracle-batch/main_test.go
+++ b/source-oracle-batch/main_test.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -74,21 +73,28 @@ func TestBasicCapture(t *testing.T) {
 	t.Run("Discovery", func(t *testing.T) { snapshotBindings(t, cs.Bindings) })
 
 	t.Run("Capture", func(t *testing.T) {
-		// Spawn a worker thread which will insert 50 rows of data in parallel with the capture.
-		var insertsDone atomic.Bool
+		// Spawn a worker thread which will insert 50 rows of data in parallel with the
+		// capture. It reports its outcome over a channel.
+		var insertResult = make(chan error, 1)
 		go func() {
 			for i := 0; i < 250; i++ {
 				time.Sleep(100 * time.Millisecond)
-				executeControlQuery(ctx, t, control, fmt.Sprintf("INSERT INTO %s VALUES (:1, :2)", tableName), i, fmt.Sprintf("Value for row %d", i))
+				var query = fmt.Sprintf("INSERT INTO %s VALUES (:1, :2)", tableName)
+				if _, err := control.ExecContext(ctx, query, i, fmt.Sprintf("Value for row %d", i)); err != nil {
+					insertResult <- fmt.Errorf("inserting row %d: %w", i, err)
+					return
+				}
 				log.WithField("i", i).Debug("inserted row")
 			}
 			time.Sleep(1 * time.Second)
-			insertsDone.Store(true)
+			insertResult <- nil
 		}()
 
 		var ids = make(map[string]bool)
 		// Run the capture over and over for 5 seconds each time until all inserts have finished, then verify results.
-		for !insertsDone.Load() {
+		var insertErr error
+		var insertsDone bool
+		for !insertsDone {
 			var captureCtx, cancelCapture = context.WithCancel(ctx)
 			time.AfterFunc(5*time.Second, cancelCapture)
 			cs.Capture(captureCtx, t, func(data json.RawMessage) {
@@ -99,7 +105,15 @@ func TestBasicCapture(t *testing.T) {
 					ids[d.Id] = true
 				}
 			})
+
+			select {
+			case insertErr = <-insertResult:
+				insertsDone = true
+			default:
+			}
 		}
+		// Fail fast if the inserting goroutine reports an error.
+		require.NoError(t, insertErr)
 
 		require.Equal(t, 250, len(ids))
 		cupaloy.SnapshotT(t, cs.Summary())

--- a/source-postgres-batch/main_test.go
+++ b/source-postgres-batch/main_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -253,24 +252,39 @@ func TestAsyncCapture(t *testing.T) {
 	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
 
 	t.Run("Capture", func(t *testing.T) {
-		// Spawn a worker thread which will insert 50 rows of data in parallel with the capture.
-		var insertsDone atomic.Bool
+		// Spawn a worker thread which will insert 50 rows of data in parallel with the
+		// capture. It reports its outcome over a channel.
+		var insertResult = make(chan error, 1)
 		go func() {
 			for i := 0; i < 250; i++ {
 				time.Sleep(100 * time.Millisecond)
-				executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName), i, fmt.Sprintf("Value for row %d", i))
+				var query = fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName)
+				if _, err := control.Exec(query, i, fmt.Sprintf("Value for row %d", i)); err != nil {
+					insertResult <- fmt.Errorf("inserting row %d: %w", i, err)
+					return
+				}
 				log.WithField("i", i).Debug("inserted row")
 			}
 			time.Sleep(1 * time.Second)
-			insertsDone.Store(true)
+			insertResult <- nil
 		}()
 
 		// Run the capture over and over for 5 seconds each time until all inserts have finished, then verify results.
-		for !insertsDone.Load() {
+		var insertErr error
+		var insertsDone bool
+		for !insertsDone {
 			var captureCtx, cancelCapture = context.WithCancel(ctx)
 			time.AfterFunc(5*time.Second, cancelCapture)
 			cs.Capture(captureCtx, t, nil)
+
+			select {
+			case insertErr = <-insertResult:
+				insertsDone = true
+			default:
+			}
 		}
+		// Fail fast if the inserting goroutine reports an error.
+		require.NoError(t, insertErr)
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }

--- a/source-redshift-batch/main_test.go
+++ b/source-redshift-batch/main_test.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -293,24 +292,39 @@ func TestBasicCapture(t *testing.T) {
 	cs.Bindings[0].ResourceConfigJson = resourceConfigBytes
 
 	t.Run("Capture", func(t *testing.T) {
-		// Spawn a worker thread which will insert 50 rows of data in parallel with the capture.
-		var insertsDone atomic.Bool
+		// Spawn a worker thread which will insert 50 rows of data in parallel with the
+		// capture. It reports its outcome over a channel.
+		var insertResult = make(chan error, 1)
 		go func() {
 			for i := 0; i < 50; i++ {
 				time.Sleep(500 * time.Millisecond)
-				executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName), i, fmt.Sprintf("Value for row %d", i))
+				var query = fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableName)
+				if _, err := control.Exec(query, i, fmt.Sprintf("Value for row %d", i)); err != nil {
+					insertResult <- fmt.Errorf("inserting row %d: %w", i, err)
+					return
+				}
 				log.WithField("i", i).Debug("inserted row")
 			}
 			time.Sleep(10 * time.Second)
-			insertsDone.Store(true)
+			insertResult <- nil
 		}()
 
 		// Run the capture over and over for 5 seconds each time until all inserts have finished, then verify results.
-		for !insertsDone.Load() {
+		var insertErr error
+		var insertsDone bool
+		for !insertsDone {
 			var captureCtx, cancelCapture = context.WithCancel(ctx)
 			time.AfterFunc(5*time.Second, cancelCapture)
 			cs.Capture(captureCtx, t, nil)
+
+			select {
+			case insertErr = <-insertResult:
+				insertsDone = true
+			default:
+			}
 		}
+		// Fail fast if the inserting goroutine reports an error.
+		require.NoError(t, insertErr)
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }

--- a/source-redshift-batch/run_tests.sh
+++ b/source-redshift-batch/run_tests.sh
@@ -4,4 +4,4 @@ CONNECTOR=$(basename "$DIR")
 
 export TEST_DATABASE="${TEST_DATABASE:-yes}"
 
-cd $DIR/.. && go test -short -failfast -timeout=0 -v ./$CONNECTOR/... "$@"
+cd $DIR/.. && go test -short -failfast -timeout=1h -v ./$CONNECTOR/... "$@"

--- a/source-sqlserver-batch/main_test.go
+++ b/source-sqlserver-batch/main_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -260,24 +259,39 @@ func TestAsyncCapture(t *testing.T) {
 	t.Run("Discovery", func(t *testing.T) { cupaloy.SnapshotT(t, summarizeBindings(t, cs.Bindings)) })
 
 	t.Run("Capture", func(t *testing.T) {
-		// Spawn a worker thread which will insert 50 rows of data in parallel with the capture.
-		var insertsDone atomic.Bool
+		// Spawn a worker thread which will insert 50 rows of data in parallel with the
+		// capture. It reports its outcome over a channel.
+		var insertResult = make(chan error, 1)
 		go func() {
 			for i := 0; i < 250; i++ {
 				time.Sleep(100 * time.Millisecond)
-				executeControlQuery(t, control, fmt.Sprintf("INSERT INTO %s VALUES (@p1, @p2)", tableName), i, fmt.Sprintf("Value for row %d", i))
+				var query = fmt.Sprintf("INSERT INTO %s VALUES (@p1, @p2)", tableName)
+				if _, err := control.Exec(query, i, fmt.Sprintf("Value for row %d", i)); err != nil {
+					insertResult <- fmt.Errorf("inserting row %d: %w", i, err)
+					return
+				}
 				log.WithField("i", i).Debug("inserted row")
 			}
 			time.Sleep(1 * time.Second)
-			insertsDone.Store(true)
+			insertResult <- nil
 		}()
 
 		// Run the capture over and over for 5 seconds each time until all inserts have finished, then verify results.
-		for !insertsDone.Load() {
+		var insertErr error
+		var insertsDone bool
+		for !insertsDone {
 			var captureCtx, cancelCapture = context.WithCancel(ctx)
 			time.AfterFunc(5*time.Second, cancelCapture)
 			cs.Capture(captureCtx, t, nil)
+
+			select {
+			case insertErr = <-insertResult:
+				insertsDone = true
+			default:
+			}
 		}
+		// Fail fast if the inserting goroutine reports an error.
+		require.NoError(t, insertErr)
 		cupaloy.SnapshotT(t, cs.Summary())
 	})
 }


### PR DESCRIPTION
**Regression?**

No.

**Description:**

A [CI job](https://github.com/estuary/connectors/actions/runs/31748444778/job/94608596049) for `source-redshift-batch` ran for 6 hours before GitHub's default job timeout cancelled it. The job normally takes 7–9 minutes.

For the spinning job, the last 18,121 log lines repeat the same three lines about once per second:
```
  driver.go:474: executing query ( query="SELECT * FROM "public"."basiccapture_884124" WHERE ..." )
  main_test.go:312: capture terminated with error: ... relation "public.basiccapture_884124" does not exist (SQLSTATE 42P01)
  main_test.go:312: running test capture with checkpoint: {...}
```

The `source-redshift-batch` CI job gets stuck for hours like this because:
1. Two CI jobs shared one table. `uniqueTableID` derives the table name from `t.Name()` alone, so every run on every branch uses `public.basiccapture_884124` on the shared cloud Redshift cluster. Run `31748444363` started its `source-redshift-batch` job 4 seconds after ours and used the same table: it ran `DROP`+`CREATE` at 22:08:13 (our next insert failed at 22:08:14 with
`could not open relation with OID 25980427`), then its cleanup dropped the table at 22:09:06 (our spin began at 22:09:09).
2. `require` was called from a worker goroutine. The inserter calls `executeControlQuery` → `require.NoError` → `t.FailNow()` → `runtime.Goexit()`. Per the [`testing` docs](https://pkg.go.dev/testing#B.FailNow), `FailNow` from a non-test goroutine terminates only that goroutine and does not stop the test. The one failed insert killed the inserter before it reached `insertsDone.Store(true)`, so the flag could never be set.

This PR fixes that by having the worker goroutine report its outcome over a channel instead of asserting directly. The test goroutine reads the channel and calls `require.NoError`, so `FailNow` runs where it can actually abort the subtest & let it fail fast rather than wait 6 hours for GitHub to abort the job.

The other batch connectors (`source-postgres-batch`, `source-sqlserver-batch`, `source-oracle-batch`) were also calling `require` in a worker goroutine, so I fixed those as well for symmetry even though they don't run tests against a shared database instance.

**Checklist:**

- [ ] If this change is user-visible, the affected connector's `CHANGELOG.md` and documentation have been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)). The `Docs / CHANGELOG check` CI job reviews this automatically; apply the `docs-check-skip` label to dismiss a false positive.
