### PR TITLE
docs: use :::deprecated on amazon-sqs and zendesk-support

### DIFF
--- a/docs/reference/Connectors/capture-connectors/amazon-sqs.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-sqs.md
@@ -6,7 +6,7 @@ description: Capture Amazon SQS messages into Estuary, using AWS IAM secret and 
 
 This connector captures data from Amazon Simple Queue Service (SQS) into Estuary collections.
 
-:::warning
+:::deprecated
 This connector is deprecated. For the best experience, we recommend using our native [Amazon SQS connector](./amazon-sqs-native.md) instead.
 :::
 

--- a/docs/reference/Connectors/capture-connectors/zendesk-support.md
+++ b/docs/reference/Connectors/capture-connectors/zendesk-support.md
@@ -2,6 +2,10 @@
 
 This connector captures data from Zendesk into Estuary collections.
 
+:::deprecated
+This connector is deprecated. For the best experience, we recommend using our native [Zendesk Support connector](./zendesk-support-native.md) instead.
+:::
+
 ## Supported data resources
 
 The following data resources are supported through the Zendesk API:


### PR DESCRIPTION
Companion to estuary/flow#3362. Two connector pages here document deprecated connectors but did not carry the `:::deprecated` admonition.

| Page | Before | After |
|---|---|---|
| `amazon-sqs.md` | `:::warning` | `:::deprecated` |
| `zendesk-support.md` | no admonition at all, despite the `(Deprecated)` title | `:::deprecated` added |

## Why

`theme-admonition-deprecated` is the CSS class the Kapa exclusion rule matches on. That rule is live and verified, so pages using the wrong admonition type stay in the search index. These pages are served after cutover via the submodule aggregation into estuary/docs, so they need the same fix as the flow side.

## Already handled, not in this PR

- `mailchimp.md` is fixed in #5070, which adds both the `(Deprecated)` title suffix and the `:::deprecated` block.
- `shopify.md` was already correct here. Its wording is the one flow#3362 adopts.

## Verification

The two files are now byte-identical to their counterparts in flow#3362 (matching blob hashes `270742c69` and `bfb295287`). The flow-side build compiled with no broken-link errors under `onBrokenLinks: 'throw'`, and all four pages render `theme-admonition-deprecated`. This matters for `zendesk-support.md`, which gains a link to `zendesk-support-native.md` that did not previously exist on the page.

Pages carrying `:::deprecated` under `docs/` goes from 17 to 19, reaching 20 once #5070 lands.
