### PR TITLE
materialize-s3-iceberg: document variant column value typing

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/amazon-s3-iceberg.md
@@ -153,9 +153,19 @@ Variant preserves the semi-structured shape of the data natively, so query engin
 nested paths without parsing JSON text. Collection key fields keep their string mapping, and the
 per-field `castToString` option still forces a JSON string column. String-encoded numbers — a
 field typed as both `string` and `integer` or `number` with a matching `format` annotation — also
-keep their numeric column, since their values are already pinned to a single type. Make sure your
-query engine supports reading format v3 variant columns (for example Spark 4.0, Snowflake, or
-DuckDB 1.5.3 and later) before enabling this option.
+keep their numeric column, since their values are already pinned to a single type.
+
+Within a variant column, a string is stored using the type implied by its format annotation,
+matching how the same value is typed as a column of its own: `{format: date-time}` becomes a
+variant timestamp (nanosecond precision when `nanosecond_timestamps` is also enabled),
+`{format: date}` a variant date, and a base64-encoded string variant binary. Formats with no
+variant equivalent — `uuid`, `time`, and `duration` — are stored as strings, as they are in a
+column of their own, and a value that fails to parse as its annotated type is stored as a string.
+Only top-level fields carry format annotations, so values nested inside an object, an array, or the
+root document are stored as strings.
+
+Make sure your query engine supports reading format v3 variant columns (for example Spark 4.0,
+Snowflake, or DuckDB 1.5.3 and later) before enabling this option.
 
 ## Table Maintenance
 

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,21 +1,6 @@
 # Changelog
 
-## 2026-07-23
-
-### Changed
-- Schema changes now first commit any transaction that was staged but not yet
-  fully applied to the tables they affect, instead of leaving it to be applied
-  afterwards. This prevents failures where staged data built against the
-  previous table schema could no longer be applied after a column was added,
-  made nullable, or had its type migrated.
-
-### Fixed
-- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
-  a binding no longer risks losing the rows of a transaction that was committed
-  but not yet fully applied to the destination: the pending transaction is now
-  applied before the backfill takes effect.
-
-## 2026-07-22
+## 2026-08-17
 
 ### Added
 - New advanced option `variant_columns` materializes object, array, and
@@ -44,6 +29,21 @@
   null for converted columns unless the binding is explicitly backfilled;
   prior snapshots remain readable in full via time travel. Key fields and
   `castToString` fields are untouched.
+
+## 2026-07-23
+
+### Changed
+- Schema changes now first commit any transaction that was staged but not yet
+  fully applied to the tables they affect, instead of leaving it to be applied
+  afterwards. This prevents failures where staged data built against the
+  previous table schema could no longer be applied after a column was added,
+  made nullable, or had its type migrated.
+
+### Fixed
+- With the `retain_existing_data_on_backfill` feature flag enabled, backfilling
+  a binding no longer risks losing the rows of a transaction that was committed
+  but not yet fully applied to the destination: the pending transaction is now
+  applied before the backfill takes effect.
 
 ## 2026-07-20
 

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,20 +1,5 @@
 # Changelog
 
-## 2026-08-17
-
-### Changed
-- With `variant_columns` enabled, a string stored in a variant column now uses
-  the type implied by its format annotation instead of always being stored as
-  a variant string, matching how the same value is typed as a column of its
-  own: `{format: date-time}` becomes a variant timestamp (nanosecond precision
-  when `nanosecond_timestamps` is also enabled), `{format: date}` a variant
-  date, and `{contentEncoding: base64}` variant binary. Formats with no variant
-  equivalent — `uuid`, `time`, and `duration` — are stored as strings, as they
-  are in a column of their own, and a value that fails to parse as its
-  annotated type is stored as a string. Only top-level fields carry format
-  annotations, so values nested inside an object, an array, or the root
-  document are stored as strings.
-
 ## 2026-07-23
 
 ### Changed
@@ -42,6 +27,16 @@
   annotation) keep their numeric column. Reading variant
   columns requires an Iceberg v3-capable query engine (for example Spark 4.0,
   Snowflake, or DuckDB 1.5.3 and later).
+- Strings in a variant column are stored with the type implied by their format
+  annotation, matching how the same value is typed as a column of its own:
+  `{format: date-time}` is stored as a variant timestamp (nanosecond precision
+  when `nanosecond_timestamps` is also enabled), `{format: date}` as a variant
+  date, and `{contentEncoding: base64}` as variant binary. Formats with no
+  variant equivalent — `uuid`, `time`, and `duration` — are stored as strings,
+  as they are in a column of their own, and a value that fails to parse as its
+  annotated type is stored as a string. Only top-level fields carry format
+  annotations, so values nested inside an object, an array, or the root
+  document are stored as strings.
 - Enabling `variant_columns` on an existing materialization converts its
   tables in place: each table upgrades to Iceberg format v3 and every affected
   column is re-created under the same name as a variant column (Iceberg has no

--- a/materialize-s3-iceberg/CHANGELOG.md
+++ b/materialize-s3-iceberg/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-08-17
+
+### Changed
+- With `variant_columns` enabled, a string stored in a variant column now uses
+  the type implied by its format annotation instead of always being stored as
+  a variant string, matching how the same value is typed as a column of its
+  own: `{format: date-time}` becomes a variant timestamp (nanosecond precision
+  when `nanosecond_timestamps` is also enabled), `{format: date}` a variant
+  date, and `{contentEncoding: base64}` variant binary. Formats with no variant
+  equivalent — `uuid`, `time`, and `duration` — are stored as strings, as they
+  are in a column of their own, and a value that fails to parse as its
+  annotated type is stored as a string. Only top-level fields carry format
+  annotations, so values nested inside an object, an array, or the root
+  document are stored as strings.
+
 ## 2026-07-23
 
 ### Changed


### PR DESCRIPTION
**Description:**

#4887 added the `variant_columns` option, which stores object, array, and multi-type fields as Iceberg `variant` columns instead of JSON strings. That PR also settled how the values *inside* a variant column are typed, but the docs never mentioned it.

A variant can hold a typed value, not just text. So when a field carries a format annotation, we store a real timestamp, date, or binary inside the variant rather than a string — the same type the value would get if it were a column of its own. This PR documents that in the connector's changelog and docs page. No code changes.

**Workflow steps:**

Using the option doesn't change. The docs now tell you:

- `{format: date-time}` becomes a variant timestamp (nanosecond precision if `nanosecond_timestamps` is on), `{format: date}` a variant date, and a base64 string variant binary
- `uuid`, `time`, and `duration` stay strings, since a variant has no matching type — they're strings as standalone columns too
- a value that fails to parse is stored as a string rather than failing the materialization
- only top-level fields carry format annotations, so anything nested inside an object, an array, or the root document stays a string

**Notes for reviewers:**

- I wrote a new dated changelog entry instead of extending #4887's. Both shipped in the same release, so no user ever saw the old behavior — happy to fold it in if you'd prefer one entry.
- This connector's docs live in this repo, which the docs site pulls in as a submodule. An older copy of this page still sits in `estuary/flow`, but it stopped being the source in July, so I left it alone.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: n/a
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: this is the docs PR
