### PR TITLE
source-mongodb: tolerate any rejection of `$changeStreamSplitLargeEvent`

### DIFF
--- a/source-mongodb/CHANGELOG.md
+++ b/source-mongodb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-17
+
+### Fixed
+
+- Servers that report a recent version but reject the
+  `$changeStreamSplitLargeEvent` pipeline stage, such as Amazon DocumentDB 8, no
+  longer fail the capture at startup. They are now captured without pre-images,
+  matching the existing behavior for MongoDB Atlas deployments that reject the
+  stage.
+
 ## 2026-08-12
 
 ### Added

--- a/source-mongodb/pull.go
+++ b/source-mongodb/pull.go
@@ -649,12 +649,13 @@ func supportsPreImages(ctx context.Context, client *mongo.Client, database strin
 	// pipeline stage.
 	cs, err := client.Database(database).Watch(ctx, mongo.Pipeline{bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}})
 	if err != nil {
+		// Servers reject the stage with varying wording. Treat any command
+		// error naming the stage as meaning the server won't run it, and
+		// capture without pre-images.
 		var commandError mongo.CommandError
-		if errors.As(err, &commandError) {
-			if commandError.Name == "AtlasError" && strings.HasPrefix(commandError.Message, "$changeStreamSplitLargeEvent is not allowed") {
-				ll.WithField("atlasError", err).Info("not requesting pre-images because this MongoDB Atlas instance does not support the $changeStreamSplitLargeEvent stage")
-				return false, nil
-			}
+		if errors.As(err, &commandError) && strings.Contains(commandError.Message, "$changeStreamSplitLargeEvent") {
+			ll.WithField("error", err).Info("not requesting pre-images because this server does not support the $changeStreamSplitLargeEvent stage")
+			return false, nil
 		}
 		return false, fmt.Errorf("opening change stream to test for $changeStreamSplitLargeEvent support: %w", err)
 	}


### PR DESCRIPTION
**Description:**

The pre-image probe only tolerated Atlas's rejection wording. DocumentDB 8 reports version 8.0.0, so it clears the version gate that 5.0 failed, then rejects the stage with different wording and a non-Atlas error name. This PR fixes that by treating any command error naming the stage as unsupported and capture without pre-images instead.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1786989651798389)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
