### PR TITLE
source-facebook-marketing-native: split insight jobs by field when ad level jobs fail

### DIFF
--- a/source-facebook-marketing-native/CHANGELOG.md
+++ b/source-facebook-marketing-native/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2026-08-19
+
+### Fixed
+- Ads Insights jobs that Facebook refuses to run are now retried with
+  progressively smaller sets of fields. Previously a single ad the API could not
+  report on would fail the entire capture, and since the day's cursor only
+  advances once every ad succeeds, each restart retried the same day
+  indefinitely.
+
+### Changed
+- When Facebook will not return a particular field for an ad on a given day, that
+  field is now omitted from the record rather than the record being lost. The
+  omission is reported in the connector logs.

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
@@ -86,14 +86,23 @@ class FacebookInsightsJobManager:
         Examples:
             - "ACCOUNT job [depth=0]"
             - "campaigns job (2 entities) [depth=1, from ACCOUNT]"
-            - "adsets job (1 entities) [depth=2, from campaigns]"
+            - "adsets job (1 entities, ids=[123]) [depth=2, from campaigns]"
+
+        Small jobs name their entities, since those are the ones that fail
+        unsplittably and a bare count doesn't say which entity to go look at.
         """
         if job.scope == JobScope.ACCOUNT:
             return f"ACCOUNT job [depth={job.depth}]"
 
         count = len(job.entity_ids) if job.entity_ids else 0
+        ids_info = (
+            f", ids={job.entity_ids}" if job.entity_ids and count <= 3 else ""
+        )
         parent_info = f", from {job.parent_scope.value}" if job.parent_scope else ""
-        return f"{job.scope.value} job ({count} entities) [depth={job.depth}{parent_info}]"
+        return (
+            f"{job.scope.value} job ({count} entities{ids_info}) "
+            f"[depth={job.depth}{parent_info}]"
+        )
 
     def _build_filter(self, job: InsightsJob) -> InsightsFilter | None:
         """Build InsightsFilter from job scope and entity IDs."""
@@ -145,6 +154,7 @@ class FacebookInsightsJobManager:
                     action_breakdowns=model.action_breakdowns,
                     action_attribution_windows=model.action_attribution_windows,
                     filtering=filtering,
+                    job_desc=job_desc,
                 )
 
                 await self._wait_for_completion(log, job_id, job_desc)
@@ -205,6 +215,7 @@ class FacebookInsightsJobManager:
         action_breakdowns: list[ActionBreakdown] | None = None,
         action_attribution_windows: list[AttributionWindow] | None = None,
         filtering: InsightsFilter | None = None,
+        job_desc: str | None = None,
     ) -> str:
         url = f"{self._base_url}/act_{account_id}/insights"
 
@@ -235,7 +246,12 @@ class FacebookInsightsJobManager:
         if response.error:
             raise FacebookAPIError(error=response.error)
 
-        log.info(f"Submitted async insights job: {response.report_run_id}")
+        # Name the job alongside its id: with MAX_CONCURRENT_JOBS in flight,
+        # a bare id can't be tied back to the scope that produced it.
+        log.info(
+            f"Submitted async insights job for {job_desc or 'job'}: "
+            f"{response.report_run_id}"
+        )
         return response.report_run_id
 
     async def _check_job_status(
@@ -672,19 +688,40 @@ class FacebookInsightsJobManager:
                     return
 
                 elif status.async_status == AsyncJobStatus.JOB_FAILED:
-                    parts = [f"{desc}: job failed at {status.async_percent_completion}% (job_id={job_id})"]
+                    # No "%" in this message: it becomes the FacebookError message,
+                    # which is interpolated into log calls that carry structured
+                    # fields, where logging would read it as a format placeholder.
+                    parts = [
+                        f"{desc}: job failed at {status.async_percent_completion} percent "
+                        f"(job_id={job_id})"
+                    ]
+                    if status.error_code is not None:
+                        code_desc = f"code={status.error_code}"
+                        if status.error_subcode is not None:
+                            code_desc += f", subcode={status.error_subcode}"
+                        parts.append(code_desc)
+                    if status.error_message:
+                        parts.append(status.error_message)
                     if status.error_user_title:
                         parts.append(f"reason: {status.error_user_title}")
                     if status.error_user_msg:
                         parts.append(status.error_user_msg)
                     error_msg = " — ".join(parts)
-                    log.error(error_msg)
+                    log.error(
+                        error_msg,
+                        extra={
+                            "job_id": job_id,
+                            "error_code": status.error_code,
+                            "error_subcode": status.error_subcode,
+                            "async_percent_completion": status.async_percent_completion,
+                        },
+                    )
 
                     raise FacebookAPIError(
                         error=FacebookError(
                             message=error_msg,
                             type=InternalJobErrorType.JOB_FAILURE,
-                            code=status.error_code or 100,
+                            code=status.error_code if status.error_code is not None else 100,
                             error_subcode=status.error_subcode,
                         )
                     )

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/manager.py
@@ -24,6 +24,7 @@ from .types import (
     AsyncJobStatusResponse,
     AsyncJobSubmissionResponse,
     FacebookPaginatedInsightsResponse,
+    FieldSplitPart,
     FilterField,
     InsightRecord,
     InsightsFilter,
@@ -41,6 +42,11 @@ from .metrics import JobMetrics
 
 # Job retry configuration - each split job gets a fresh retry budget
 MAX_RETRIES: int = 3
+
+# Retries for a single-field job before the field is declared unfetchable.
+# Only the leaf retries: an internal node failing just means "split further",
+# which is cheap and self-correcting, while dropping a field is irreversible.
+MAX_FIELD_LEAF_RETRIES: int = 2
 
 # Per-account concurrency limit for actually-executing jobs (via semaphore)
 # Facebook rate limits are per ad account
@@ -128,13 +134,14 @@ class FacebookInsightsJobManager:
         account_id: str,
         time_range: TimeRange,
         result_queue: asyncio.Queue[InsightRecord],
+        metrics: JobMetrics,
     ) -> JobOutcome:
         """
         Execute a single insights job with retry logic.
 
         Returns JobSuccess if records were streamed to the queue, or JobSplit
-        if the job was split into child jobs. Raises CannotSplitFurtherError
-        if a single-ad job fails and cannot be split further.
+        if the job was split into child jobs. A job that cannot be split by
+        entity falls back to splitting its field set.
         """
         job_desc = self._describe_job(job)
         last_error: Exception | None = None
@@ -173,13 +180,19 @@ class FacebookInsightsJobManager:
                     raise
                 if isinstance(converted, DataLimitExceededError):
                     log.info(f"{job_desc} hit data limits, splitting immediately")
-                    return await self._split_or_raise(log, job, account_id, time_range, job_desc)
+                    return await self._split_or_degrade(
+                        log, job, model, account_id, time_range, job_desc,
+                        result_queue, metrics, converted,
+                    )
                 last_error = converted
                 log.warning(f"{job_desc} failed (attempt {attempt}/{MAX_RETRIES}): {converted}")
 
-            except DataLimitExceededError:
+            except DataLimitExceededError as e:
                 log.info(f"{job_desc} hit data limits, splitting immediately")
-                return await self._split_or_raise(log, job, account_id, time_range, job_desc)
+                return await self._split_or_degrade(
+                    log, job, model, account_id, time_range, job_desc,
+                    result_queue, metrics, e,
+                )
 
             except FacebookAPIError as e:
                 last_error = e
@@ -187,22 +200,318 @@ class FacebookInsightsJobManager:
 
         # All retries exhausted
         log.warning(f"{job_desc} failed after {MAX_RETRIES} attempts: {last_error}")
-        return await self._split_or_raise(log, job, account_id, time_range, job_desc, last_error)
+        return await self._split_or_degrade(
+            log, job, model, account_id, time_range, job_desc,
+            result_queue, metrics, last_error,
+        )
 
-    async def _split_or_raise(
+    async def _split_or_degrade(
         self,
         log: Logger,
         job: InsightsJob,
+        model: type[FacebookInsightsResource],
         account_id: str,
         time_range: TimeRange,
         job_desc: str,
+        result_queue: asyncio.Queue[InsightRecord],
+        metrics: JobMetrics,
         error: Exception | None = None,
-    ) -> JobSplit:
-        """Split a job into children or raise CannotSplitFurtherError if atomic."""
+    ) -> JobOutcome:
+        """
+        Split a job into children, or split it by field if it is already atomic.
+
+        A single-ad job cannot be narrowed any further by entity, but the failure
+        may live inside one field rather than in the breadth of the request - a
+        single ad whose `actions` array explodes across the action breakdowns
+        will fail no matter how few ads are asked for. Splitting the field set
+        recovers everything except the offending field.
+        """
         if not job.can_split():
-            raise CannotSplitFurtherError(f"{job_desc} cannot be split: {error}")
+            return await self._execute_field_split(
+                log, job, model, account_id, time_range, job_desc,
+                result_queue, metrics, error,
+            )
         children = await self._split_job(log, job, account_id, time_range)
         return JobSplit(children=children)
+
+    def _join_key(self, model: type[FacebookInsightsResource]) -> list[str]:
+        """
+        Every column that identifies a row, used to re-join field-split parts.
+
+        This is the model's full primary key, which is not the same thing as
+        the key columns that have to be requested: a breakdown stream is keyed
+        on its breakdown columns, and those arrive because `breakdowns` is set,
+        not because they were asked for as fields. Joining on the requestable
+        subset alone would collapse every breakdown row of an entity-day into
+        one record.
+
+        Which columns Facebook returns unasked is not knowable from the model:
+        breakdown columns come from `breakdowns`, `date_start` and `date_stop`
+        from the unconditional `time_increment=1`, and `account_id` is stamped
+        on by `_fetch_results`. Custom insights models rely on that - they key
+        on `/date_start` without listing it in `fields`. `_verify_join_key`
+        checks the returned rows instead of trying to predict them.
+        """
+        pointers = [key.lstrip("/") for key in model.primary_keys]
+        assert all("/" not in p for p in pointers), (
+            f"{model.name} has a nested primary key; the field-split join key "
+            f"assumes top-level pointers: {model.primary_keys}"
+        )
+        return pointers
+
+    def _requested_key_fields(
+        self, model: type[FacebookInsightsResource]
+    ) -> list[str]:
+        """
+        The key columns that are requestable fields, so ride along in every part.
+
+        Breakdown columns are deliberately excluded: Facebook rejects them as
+        fields, and every part gets them anyway from the unchanged `breakdowns`
+        parameter.
+        """
+        return [p for p in self._join_key(model) if p in model.fields]
+
+    def _verify_join_key(
+        self,
+        records: list[InsightRecord],
+        join_key: list[str],
+        fields: list[str],
+        job_desc: str,
+    ) -> None:
+        """
+        Refuse a chunk whose rows do not all carry the whole join key.
+
+        A key column missing from a row makes that row indistinguishable from
+        every other row missing it, so merging would silently collapse unrelated
+        rows and still report success. Nothing downstream catches it either:
+        custom insights models make their breakdown columns optional, so the
+        collapsed record validates cleanly. Fail the day and leave the cursor
+        where it is instead.
+        """
+        missing: set[str] = set()
+        for record in records:
+            missing.update(key for key in join_key if key not in record)
+
+        if missing:
+            raise CannotSplitFurtherError(
+                f"{job_desc}: Facebook returned rows without the key "
+                f"column(s) {sorted(missing)} while {len(fields)} fields were "
+                f"requested, so the field-split parts cannot be re-joined"
+            )
+
+    async def _run_with_fields(
+        self,
+        log: Logger,
+        job: InsightsJob,
+        model: type[FacebookInsightsResource],
+        account_id: str,
+        time_range: TimeRange,
+        fields: list[str],
+        job_desc: str,
+    ) -> list[InsightRecord]:
+        """Run one field subset to completion, returning its verified rows."""
+        job_id = await self._submit_job(
+            log=log,
+            account_id=account_id,
+            level=model.level,
+            fields=fields,
+            time_range=time_range,
+            breakdowns=model.breakdowns,
+            action_breakdowns=model.action_breakdowns,
+            action_attribution_windows=model.action_attribution_windows,
+            filtering=self._build_filter(job),
+            job_desc=job_desc,
+        )
+
+        await self._wait_for_completion(log, job_id, job_desc)
+
+        records = [
+            record
+            async for record in self._fetch_results(
+                log, job_id, account_id, model.level
+            )
+        ]
+
+        # Checked per chunk rather than on the merged output: this fails before
+        # the remaining chunks are run, and before a bad key can collapse rows
+        # into a record that no longer shows what went wrong.
+        self._verify_join_key(records, self._join_key(model), fields, job_desc)
+
+        return records
+
+    async def _bisect_fields(
+        self,
+        log: Logger,
+        job: InsightsJob,
+        model: type[FacebookInsightsResource],
+        account_id: str,
+        time_range: TimeRange,
+        job_desc: str,
+        fields: list[str],
+        pk_fields: list[str],
+        unfetched: list[str],
+        depth: int,
+    ) -> list[FieldSplitPart]:
+        """
+        Halve the field set until each part succeeds, dropping what never succeeds.
+
+        Primary keys ride along in both halves so the parts can be re-joined.
+        Returns one part per successful chunk; fields that fail even alone are
+        appended to `unfetched` and contribute no part at all.
+        """
+        part_desc = f"{job_desc} fields[{len(fields)}] d={depth}"
+        non_pk = [f for f in fields if f not in pk_fields]
+        last_error: Exception | None = None
+
+        attempts = MAX_FIELD_LEAF_RETRIES if len(non_pk) <= 1 else 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return [
+                    FieldSplitPart(
+                        fields=fields,
+                        records=await self._run_with_fields(
+                            log, job, model, account_id, time_range, fields, part_desc
+                        ),
+                    )
+                ]
+            except HTTPError as e:
+                # Only Facebook's own rejections mean "this request is too big".
+                # A transport failure must propagate, or a network blip would be
+                # silently recorded as a field Facebook cannot report on.
+                converted = try_parse_facebook_api_error(e)
+                if converted is None:
+                    raise
+                last_error = converted
+            except (FacebookAPIError, DataLimitExceededError) as e:
+                last_error = e
+
+            if attempt < attempts:
+                log.warning(
+                    f"{part_desc} failed (attempt {attempt}/{attempts}), retrying",
+                    extra={"fields": fields, "depth": depth},
+                )
+
+        if not non_pk:
+            raise CannotSplitFurtherError(
+                f"{job_desc} cannot be reduced below its primary keys "
+                f"({pk_fields}): {last_error}"
+            )
+
+        if len(non_pk) == 1:
+            dropped = str(non_pk[0])
+            log.warning(
+                f"{job_desc}: Facebook cannot report on field '{dropped}' for "
+                f"this entity; dropping it.",
+                extra={
+                    "unfetched_field": dropped,
+                    "entity_ids": job.entity_ids,
+                    "since": time_range["since"],
+                    "until": time_range["until"],
+                },
+            )
+            unfetched.append(dropped)
+            return []
+
+        mid = len(non_pk) // 2
+        halves = (pk_fields + non_pk[:mid], pk_fields + non_pk[mid:])
+        log.info(
+            f"Field split {part_desc}: {len(non_pk)} fields -> "
+            f"{mid} + {len(non_pk) - mid}"
+        )
+
+        results: list[FieldSplitPart] = []
+        for half in halves:
+            results.extend(
+                await self._bisect_fields(
+                    log, job, model, account_id, time_range, job_desc,
+                    half, pk_fields, unfetched, depth + 1,
+                )
+            )
+        return results
+
+    def _merge_by_primary_key(
+        self, parts: list[FieldSplitPart], pk_fields: list[str]
+    ) -> list[InsightRecord]:
+        """
+        Re-join field-split parts into whole records, keyed on the primary key.
+
+        `pk_fields` must be the model's whole key (see `_join_key`), not just
+        the part of it that was requested as fields.
+        """
+        merged: dict[tuple, InsightRecord] = {}
+
+        for part in parts:
+            for record in part.records:
+                key = tuple(record.get(f) for f in pk_fields)
+                merged.setdefault(key, {}).update(record)
+
+        return list(merged.values())
+
+    async def _execute_field_split(
+        self,
+        log: Logger,
+        job: InsightsJob,
+        model: type[FacebookInsightsResource],
+        account_id: str,
+        time_range: TimeRange,
+        job_desc: str,
+        result_queue: asyncio.Queue[InsightRecord],
+        metrics: JobMetrics,
+        error: Exception | None = None,
+    ) -> JobOutcome:
+        """
+        Recover an atomic job by splitting its field set instead of its entities.
+
+        Losing some fields is the point of this fallback, but losing every one of
+        them is not degradation - it means Facebook will not report on this
+        entity at all, which no amount of splitting explains. Raise rather than
+        let the cursor advance past data we never obtained.
+        """
+        pk_fields = self._requested_key_fields(model)
+        splittable = [f for f in model.fields if f not in pk_fields]
+        unfetched: list[str] = []
+
+        log.info(
+            f"{job_desc} cannot be split by entity; splitting its "
+            f"{len(model.fields)} fields instead. Triggered by: {error}"
+        )
+
+        parts = await self._bisect_fields(
+            log, job, model, account_id, time_range, job_desc,
+            list(model.fields), pk_fields, unfetched, depth=0,
+        )
+
+        # A chunk that succeeded with no rows while a sibling returned rows
+        # yielded no values for its fields, which is the same loss as a field
+        # Facebook refused - only reached by a different route, and otherwise
+        # invisible, since the records simply come out without those columns.
+        # Gated on a sibling having rows: an entity with no activity in the
+        # window empties every chunk, and that is not degradation.
+        if any(part.records for part in parts):
+            for part in parts:
+                if not part.records:
+                    unfetched.extend(f for f in part.fields if f not in pk_fields)
+
+        if len(unfetched) == len(splittable):
+            raise CannotSplitFurtherError(
+                f"{job_desc}: Facebook would not report on any of its "
+                f"{len(splittable)} fields, even one at a time. Last error: {error}"
+            )
+
+        records = self._merge_by_primary_key(parts, self._join_key(model))
+        for record in records:
+            await result_queue.put(record)
+
+        if unfetched:
+            metrics.track_degraded(unfetched)
+
+        log.info(
+            f"Completed {job_desc} by field splitting: {len(records)} records "
+            f"from {len(parts)} parts, "
+            f"{len(model.fields) - len(unfetched)}/{len(model.fields)} fields",
+            extra={"unfetched_fields": unfetched},
+        )
+        return JobSuccess(records_count=len(records))
 
     async def _submit_job(
         self,
@@ -566,7 +875,7 @@ class FacebookInsightsJobManager:
             """Wrapper to acquire semaphore before execution."""
             async with self._semaphore:
                 return await self._execute_job(
-                    log, job, model, account_id, time_range, result_queue
+                    log, job, model, account_id, time_range, result_queue, metrics
                 )
 
         try:
@@ -662,6 +971,21 @@ class FacebookInsightsJobManager:
                 f"max_depth={metrics.max_depth}"
             )
             log.info(f"Final tree breakdown: {metrics.tree_progress_summary()}")
+
+            if metrics.degraded:
+                # Records carry no marker, so this line is the only record that
+                # documents for this window are missing data they should have had.
+                log.warning(
+                    f"Incomplete data for {time_range['since']} to "
+                    f"{time_range['until']}: {metrics.degradation_summary()}",
+                    extra={
+                        "account_id": account_id,
+                        "degraded_jobs": metrics.degraded,
+                        "unfetched_fields": sorted(metrics.unfetched_fields),
+                        "since": time_range["since"],
+                        "until": time_range["until"],
+                    },
+                )
 
     async def _wait_for_completion(
         self,

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/metrics.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/metrics.py
@@ -35,6 +35,12 @@ class JobMetrics:
     records: int = 0
     max_depth: int = 0
 
+    # Jobs that could only be completed by dropping fields Facebook refused to
+    # report on. Nothing marks the resulting records, so these counters are the
+    # only signal that a document is missing data it should have had.
+    degraded: int = 0
+    unfetched_fields: set[str] = field(default_factory=set)
+
     submitted_by_scope: dict[JobScope, int] = field(default_factory=_scope_counter)
     completed_by_scope: dict[JobScope, int] = field(default_factory=_scope_counter)
     pending_by_scope: dict[JobScope, int] = field(default_factory=_scope_counter)
@@ -56,6 +62,19 @@ class JobMetrics:
         """Track a job split (remove from pending, don't count as completed)."""
         self.split += 1
         self.pending_by_scope[job.scope] -= 1
+
+    def track_degraded(self, unfetched: list[str]) -> None:
+        """Track a job completed only by dropping fields Facebook refused."""
+        self.degraded += 1
+        self.unfetched_fields.update(unfetched)
+
+    def degradation_summary(self) -> str:
+        """Human-readable summary of data dropped during this fetch."""
+        if not self.degraded:
+            return "none"
+
+        fields = ", ".join(sorted(self.unfetched_fields))
+        return f"{self.degraded} jobs degraded, fields dropped: {fields}"
 
     def tree_progress_summary(self) -> str:
         """Generate tree progress summary string."""

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
@@ -150,6 +150,20 @@ class InsightsJob:
 
 
 @dataclass
+class FieldSplitPart:
+    """
+    One chunk of a field-split job: what it asked for and what came back.
+
+    The requested fields have to travel with the rows, because an empty chunk
+    is only interpretable next to its field set - without it there is no way to
+    say which fields a chunk that returned nothing failed to produce.
+    """
+
+    fields: list[str]
+    records: list[InsightRecord]
+
+
+@dataclass
 class JobOutcome:
     """Base class for job execution outcomes."""
 

--- a/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/insights/types.py
@@ -187,6 +187,7 @@ class AsyncJobStatusResponse(BaseModel):
     async_percent_completion: int
     error: FacebookError | None = None
     error_code: int | None = None
+    error_message: str | None = None
     error_subcode: int | None = None
     error_user_title: str | None = None
     error_user_msg: str | None = None

--- a/source-facebook-marketing-native/tests/conftest.py
+++ b/source-facebook-marketing-native/tests/conftest.py
@@ -65,11 +65,18 @@ def job_manager(
 
 @pytest.fixture
 def mock_model() -> MagicMock:
-    """Create mock insights model with minimal required attributes."""
+    """Create mock insights model with minimal required attributes.
+
+    `fields` carries the primary key columns because field splitting requests
+    them in every part so the parts can be re-joined.
+    """
     model = MagicMock()
+    model.name = "ads_insights"
     model.level = ApiLevel.AD
-    model.fields = ["impressions", "clicks"]
-    model.breakdowns = None
+    model.fields = ["account_id", "ad_id", "date_start", "impressions", "clicks"]
+    model.primary_keys = ["/account_id", "/ad_id", "/date_start"]
+    # A real model's `breakdowns` ClassVar defaults to [], never None.
+    model.breakdowns = []
     model.action_breakdowns = None
     model.action_attribution_windows = None
     return model

--- a/source-facebook-marketing-native/tests/factories/responses.py
+++ b/source-facebook-marketing-native/tests/factories/responses.py
@@ -22,6 +22,11 @@ def create_job_status_response(
     job_id: str,
     status: str = "Job Completed",
     percent: int = 100,
+    error_code: int | None = None,
+    error_subcode: int | None = None,
+    error_message: str | None = None,
+    error_user_title: str | None = None,
+    error_user_msg: str | None = None,
 ) -> dict[str, Any]:
     """Create mock job status response.
 
@@ -29,15 +34,32 @@ def create_job_status_response(
         job_id: The job ID
         status: Job status string (e.g., "Job Completed", "Job Running", "Job Failed")
         percent: Completion percentage (0-100)
+        error_code: Facebook error code, returned on failed report runs
+        error_subcode: Facebook error subcode, which decides the retry/split remedy
+        error_message: Facebook's internal error message
+        error_user_title: Short reason shown in Ads Manager
+        error_user_msg: Long-form reason shown in Ads Manager
 
     Returns:
         {"id": job_id, "async_status": status, "async_percent_completion": percent}
+        plus any error fields provided.
     """
-    return {
+    response: dict[str, Any] = {
         "id": job_id,
         "async_status": status,
         "async_percent_completion": percent,
     }
+
+    optional_fields = {
+        "error_code": error_code,
+        "error_subcode": error_subcode,
+        "error_message": error_message,
+        "error_user_title": error_user_title,
+        "error_user_msg": error_user_msg,
+    }
+    response.update({k: v for k, v in optional_fields.items() if v is not None})
+
+    return response
 
 
 def create_insights_response(

--- a/source-facebook-marketing-native/tests/integration/test_job_manager.py
+++ b/source-facebook-marketing-native/tests/integration/test_job_manager.py
@@ -7,11 +7,19 @@ handling using a MockHTTPSession that simulates Facebook's API behavior.
 
 import asyncio
 import json
+import logging
 import pytest
 
 from source_facebook_marketing_native.insights import FacebookInsightsJobManager
 from source_facebook_marketing_native.insights.errors import CannotSplitFurtherError
-from source_facebook_marketing_native.insights.manager import MAX_RETRIES
+from source_facebook_marketing_native.models import (
+    AdsInsights,
+    AdsInsightsAgeAndGender,
+)
+from source_facebook_marketing_native.insights.manager import (
+    MAX_FIELD_LEAF_RETRIES,
+    MAX_RETRIES,
+)
 
 from tests.factories import (
     MockHTTPSession,
@@ -352,6 +360,8 @@ class TestJobSplitting:
         mock_http.add_handler(r"/act_[^/]+/insights$", handle_discovery, method="GET")
         mock_http.add_handler(r"/job_", handle_status, method="GET")
 
+        # Every job fails, so the single ad ends up with no fetchable field and
+        # the capture stops rather than advancing past it.
         with pytest.raises(CannotSplitFurtherError):
             async for _ in job_manager.fetch_insights(
                 mock_log, mock_model, "act_123", time_range
@@ -359,7 +369,8 @@ class TestJobSplitting:
                 pass
 
         # Verify we descended through the full hierarchy
-        # Note: ad.id level doesn't call discovery - it raises CannotSplitFurtherError directly
+        # Note: ad.id level doesn't call discovery - a single ad is split by
+        # field set instead.
         assert "account" in discovery_calls, "Should discover campaigns at account level"
         assert "campaign.id" in discovery_calls, "Should discover adsets for campaign"
         assert "adset.id" in discovery_calls, "Should discover ads for adset"
@@ -374,10 +385,15 @@ class TestAtomicFailure:
     """Test behavior when splitting is no longer possible."""
 
     @pytest.mark.asyncio
-    async def test_single_ad_failure_raises_exception(
+    async def test_entity_unfetchable_at_any_granularity_fails_the_capture(
         self, job_manager, mock_http, mock_log, mock_model, time_range, mock_sleep
     ):
-        """Single ad job that fails raises CannotSplitFurtherError."""
+        """An entity that yields no field at all must stop the capture.
+
+        Dropping some fields is expected. Facebook refusing every field of a
+        single entity is not something splitting explains, so the cursor must
+        not advance past data we never obtained.
+        """
 
         def handle_submit(request):
             return create_job_submission_response("job_1")
@@ -400,6 +416,8 @@ class TestAtomicFailure:
         mock_http.add_handler(r"/act_[^/]+/insights$", handle_discovery, method="GET")
         mock_http.add_handler(r"/job_", handle_status, method="GET")
 
+        # Every request fails, so every field is dropped and nothing is left to
+        # emit. That is a broken entity, not degradation.
         with pytest.raises(CannotSplitFurtherError):
             async for _ in job_manager.fetch_insights(
                 mock_log, mock_model, "act_123", time_range
@@ -432,6 +450,418 @@ class TestAtomicFailure:
             results.append(record)
 
         assert len(results) == 0
+
+
+# =============================================================================
+# TestFieldSplitting - Recovering Atomic Jobs By Splitting Their Field Set
+# =============================================================================
+
+
+class TestFieldSplitting:
+    """A single ad that fails is retried with progressively fewer fields."""
+
+    @staticmethod
+    def _descend_to_single_ad(request):
+        """Discovery responses that walk account -> campaign -> adset -> ad."""
+        params = request.get("params", {})
+        if params and "filtering" in params:
+            filtering = json.loads(params["filtering"])
+            field = filtering[0]["field"]
+            if field == "campaign.id":
+                return create_discovery_response(["single_adset"], "adset_id")
+            elif field == "adset.id":
+                return create_discovery_response(["single_ad"], "ad_id")
+        return create_discovery_response(["single_campaign"], "campaign_id")
+
+    def _wire(
+        self,
+        mock_http,
+        failing_fields: set[str],
+        submits: dict,
+        segments: list[dict[str, str]] | None = None,
+    ):
+        """Fail any job requesting one of `failing_fields`; succeed otherwise.
+
+        Rows carry the primary key columns so merged records can be checked.
+        `segments` stands in for Facebook's breakdown columns: each entry
+        becomes one more row per job, carrying its own metric values, the way
+        a breakdown stream returns one row per age/gender combination.
+        """
+
+        def handle_submit(request):
+            params = request.get("params", {})
+            requested = set(params.get("fields", "").split(","))
+            submits["count"] += 1
+            submits.setdefault("field_sets", []).append(requested)
+            job_id = f"job_{submits['count']}"
+            submits[job_id] = requested
+            return create_job_submission_response(job_id)
+
+        def handle_status(request):
+            job_id = request["url"].split("/")[-1]
+            if submits.get(job_id, set()) & failing_fields:
+                return create_job_status_response(
+                    job_id, "Job Failed", percent=0,
+                    error_code=2, error_subcode=1504044,
+                )
+            return create_job_status_response(job_id, "Job Completed")
+
+        def handle_results(request):
+            job_id = request["url"].split("/")[-2]
+            requested = submits.get(job_id, set())
+            metrics = sorted(requested - {"account_id", "ad_id", "date_start"})
+            rows = []
+            for index, segment in enumerate(segments or [{}]):
+                row = {"ad_id": "single_ad", "date_start": "2024-01-01", **segment}
+                for name in metrics:
+                    row[name] = f"{name}_value_{index}"
+                rows.append(row)
+            return create_insights_response(rows)
+
+        mock_http.add_handler(r"/act_[^/]+/insights$", handle_submit, method="POST")
+        mock_http.add_handler(
+            r"/act_[^/]+/insights$", self._descend_to_single_ad, method="GET"
+        )
+        mock_http.add_handler(r"job_\d+$", handle_status, method="GET")
+        mock_http.add_handler(r"job_\d+/insights", handle_results, method="GET")
+
+    @pytest.mark.asyncio
+    async def test_recovers_every_field_that_can_be_fetched(
+        self, job_manager, mock_http, mock_log, mock_model, time_range, mock_sleep
+    ):
+        """Only the offending field is lost; the rest are merged into one record.
+
+        This is the whole point of field splitting: a single ad whose `actions`
+        array explodes should cost that one field, not the entire ad-day.
+        """
+        submits = {"count": 0}
+        self._wire(mock_http, failing_fields={"impressions"}, submits=submits)
+
+        results = []
+        async for record in job_manager.fetch_insights(
+            mock_log, mock_model, "act_123", time_range
+        ):
+            results.append(record)
+
+        assert len(results) == 1, "parts must re-join into a single record"
+        record = results[0]
+        assert record["clicks"] == "clicks_value_0", "fetchable field survives"
+        assert "impressions" not in record, "unfetchable field is dropped"
+        # Primary keys ride along in every part, so they are always present.
+        assert record["ad_id"] == "single_ad"
+        assert record["date_start"] == "2024-01-01"
+        assert record["account_id"] == "act_123"
+
+    @pytest.mark.asyncio
+    async def test_leaf_retries_before_declaring_a_field_unfetchable(
+        self, job_manager, mock_http, mock_log, mock_model, time_range, mock_sleep
+    ):
+        """Dropping a field is irreversible, so the leaf gets a second chance."""
+        submits = {"count": 0}
+        self._wire(mock_http, failing_fields={"impressions"}, submits=submits)
+
+        async for _ in job_manager.fetch_insights(
+            mock_log, mock_model, "act_123", time_range
+        ):
+            pass
+
+        single_field_attempts = [
+            fields
+            for fields in submits["field_sets"]
+            if fields - {"account_id", "ad_id", "date_start"} == {"impressions"}
+        ]
+        assert len(single_field_attempts) == MAX_FIELD_LEAF_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_reproduces_measured_behaviour_for_the_real_model(
+        self, job_manager, mock_http, mock_log, time_range, mock_sleep
+    ):
+        """Pin the algorithm to what was measured against the live API.
+
+        Probing ad 6947535033445 (account 174802123, 2026-01-11) with the real
+        AdsInsights field set recovered 47 of 48 fields, with `actions` alone
+        irreducibly unfetchable.
+        """
+        submits = {"count": 0}
+        self._wire(mock_http, failing_fields={"actions"}, submits=submits)
+
+        results = []
+        async for record in job_manager.fetch_insights(
+            mock_log, AdsInsights, "act_123", time_range
+        ):
+            results.append(record)
+
+        assert len(results) == 1
+        record = results[0]
+
+        assert "actions" not in record, "the one unfetchable field is dropped"
+        recovered = {f for f in AdsInsights.fields if f in record}
+        assert len(recovered) == len(AdsInsights.fields) - 1
+        assert set(AdsInsights.fields) - recovered == {"actions"}
+
+    @pytest.mark.asyncio
+    async def test_breakdown_rows_survive_field_splitting(
+        self, job_manager, mock_http, mock_log, time_range, mock_sleep
+    ):
+        """A breakdown stream keeps one record per segment, not one per ad-day.
+
+        Parts are joined on the model's whole primary key, which for
+        ads_insights_age_and_gender includes the `age` and `gender` breakdown
+        columns. Those never appear in `fields` - Facebook rejects them there,
+        and returns them because `breakdowns` is set - so joining on only the
+        requestable keys would collapse every segment of an ad-day into one
+        record and let the cursor advance past the rest.
+        """
+        segments = [
+            {"age": "25-34", "gender": "male"},
+            {"age": "25-34", "gender": "female"},
+            {"age": "35-44", "gender": "male"},
+        ]
+        submits = {"count": 0}
+        self._wire(
+            mock_http,
+            failing_fields={"actions"},
+            submits=submits,
+            segments=segments,
+        )
+
+        results = []
+        async for record in job_manager.fetch_insights(
+            mock_log, AdsInsightsAgeAndGender, "act_123", time_range
+        ):
+            results.append(record)
+
+        assert len(results) == len(segments), "every segment must survive the join"
+        by_segment = {(r["age"], r["gender"]): r for r in results}
+        assert set(by_segment) == {(s["age"], s["gender"]) for s in segments}
+
+        # Each segment keeps its own values rather than another segment's, and
+        # loses only the field Facebook refused.
+        for index, segment in enumerate(segments):
+            record = by_segment[(segment["age"], segment["gender"])]
+            assert record["impressions"] == f"impressions_value_{index}"
+            assert record["clicks"] == f"clicks_value_{index}"
+            assert "actions" not in record
+
+        # The breakdown columns must never be requested as fields.
+        for field_set in submits["field_sets"]:
+            assert not field_set & {"age", "gender"}
+
+    @pytest.mark.asyncio
+    async def test_rows_missing_a_key_column_fail_rather_than_collapse(
+        self, job_manager, mock_http, mock_log, time_range, mock_sleep
+    ):
+        """Facebook omitting a key column must fail the day, not merge blindly.
+
+        Rows that do not carry `gender` cannot be told apart, so merging them
+        would collapse unrelated segments into one record and report success.
+        A custom insights model would not even reject the result downstream,
+        because its breakdown columns are optional.
+        """
+        submits = {"count": 0}
+        self._wire(
+            mock_http,
+            # Forces the descent to a single ad and then the field split, which
+            # is the only path that merges parts and so the only one that joins.
+            failing_fields={"actions"},
+            submits=submits,
+            # The second segment's rows come back without `gender`.
+            segments=[{"age": "25-34", "gender": "male"}, {"age": "35-44"}],
+        )
+
+        with pytest.raises(CannotSplitFurtherError, match=r"\['gender'\]"):
+            async for _ in job_manager.fetch_insights(
+                mock_log, AdsInsightsAgeAndGender, "act_123", time_range
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_chunk_that_returns_no_rows_is_reported_as_degraded(
+        self,
+        job_manager,
+        mock_http,
+        mock_log,
+        mock_model,
+        time_range,
+        mock_sleep,
+        caplog,
+    ):
+        """A chunk that succeeds with no rows still lost its fields.
+
+        The bisect only recurses on failure, so a chunk that comes back empty is
+        terminal: its fields are simply absent from the merged records. That is
+        the same loss as a field Facebook refused to report on, and has to be
+        counted the same way - otherwise the capture claims complete data for
+        the window while quietly missing columns.
+        """
+        submits = {"count": 0}
+
+        def handle_submit(request):
+            params = request.get("params", {})
+            submits["count"] += 1
+            job_id = f"job_{submits['count']}"
+            submits[job_id] = set(params.get("fields", "").split(","))
+            return create_job_submission_response(job_id)
+
+        def handle_status(request):
+            job_id = request["url"].split("/")[-1]
+            # Only the full field set fails, forcing the split into halves.
+            if len(submits.get(job_id, set())) == len(mock_model.fields):
+                return create_job_status_response(
+                    job_id, "Job Failed", percent=0,
+                    error_code=2, error_subcode=1504044,
+                )
+            return create_job_status_response(job_id, "Job Completed")
+
+        def handle_results(request):
+            job_id = request["url"].split("/")[-2]
+            requested = submits.get(job_id, set())
+            # The clicks half succeeds but returns nothing at all.
+            if "clicks" in requested:
+                return create_insights_response([])
+            return create_insights_response(
+                [{"ad_id": "single_ad", "date_start": "2024-01-01", "impressions": 100}]
+            )
+
+        mock_http.add_handler(r"/act_[^/]+/insights$", handle_submit, method="POST")
+        mock_http.add_handler(
+            r"/act_[^/]+/insights$", self._descend_to_single_ad, method="GET"
+        )
+        mock_http.add_handler(r"job_\d+$", handle_status, method="GET")
+        mock_http.add_handler(r"job_\d+/insights", handle_results, method="GET")
+
+        with caplog.at_level(logging.WARNING):
+            results = []
+            async for record in job_manager.fetch_insights(
+                mock_log, mock_model, "act_123", time_range
+            ):
+                results.append(record)
+
+        # The fetchable half is still delivered; only `clicks` is missing.
+        assert len(results) == 1
+        assert results[0]["impressions"] == 100
+        assert "clicks" not in results[0]
+
+        degraded = [
+            record
+            for record in caplog.records
+            if record.getMessage().startswith("Incomplete data")
+        ]
+        assert len(degraded) == 1, "the loss must be reported once for the window"
+        assert degraded[0].unfetched_fields == ["clicks"]
+
+    @pytest.mark.asyncio
+    async def test_entity_with_no_activity_is_not_treated_as_broken(
+        self,
+        job_manager,
+        mock_http,
+        mock_log,
+        mock_model,
+        time_range,
+        mock_sleep,
+        caplog,
+    ):
+        """Zero records is legitimate when every field was fetchable.
+
+        The failure condition is "no field could be fetched", not "no records
+        came back" - an ad that simply had no activity in the window returns
+        nothing, and must not be mistaken for one Facebook refuses to report on.
+        """
+        submits = {"count": 0}
+
+        def handle_submit(request):
+            params = request.get("params", {})
+            submits["count"] += 1
+            job_id = f"job_{submits['count']}"
+            submits[job_id] = set(params.get("fields", "").split(","))
+            return create_job_submission_response(job_id)
+
+        def handle_status(request):
+            job_id = request["url"].split("/")[-1]
+            # Only the full field set fails, forcing a split; halves succeed.
+            if len(submits.get(job_id, set())) == len(mock_model.fields):
+                return create_job_status_response(
+                    job_id, "Job Failed", percent=0,
+                    error_code=2, error_subcode=1504044,
+                )
+            return create_job_status_response(job_id, "Job Completed")
+
+        def handle_results(request):
+            return create_insights_response([])
+
+        mock_http.add_handler(r"/act_[^/]+/insights$", handle_submit, method="POST")
+        mock_http.add_handler(
+            r"/act_[^/]+/insights$", self._descend_to_single_ad, method="GET"
+        )
+        mock_http.add_handler(r"job_\d+$", handle_status, method="GET")
+        mock_http.add_handler(r"job_\d+/insights", handle_results, method="GET")
+
+        with caplog.at_level(logging.WARNING):
+            results = []
+            async for record in job_manager.fetch_insights(
+                mock_log, mock_model, "act_123", time_range
+            ):
+                results.append(record)
+
+        assert results == []
+
+        # Every chunk was empty, so there is no asymmetry to report: the ad had
+        # no activity, which is not the same as data we failed to obtain.
+        assert not [
+            record
+            for record in caplog.records
+            if record.getMessage().startswith("Incomplete data")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_all_fields_fetchable_after_split_loses_nothing(
+        self, job_manager, mock_http, mock_log, mock_model, time_range, mock_sleep
+    ):
+        """When only the full field set is too large, no data is lost at all."""
+        submits = {"count": 0}
+        # Fails only when both metrics are requested together.
+        original_add = mock_http.add_handler
+
+        def handle_submit(request):
+            params = request.get("params", {})
+            requested = set(params.get("fields", "").split(","))
+            submits["count"] += 1
+            job_id = f"job_{submits['count']}"
+            submits[job_id] = requested
+            return create_job_submission_response(job_id)
+
+        def handle_status(request):
+            job_id = request["url"].split("/")[-1]
+            requested = submits.get(job_id, set())
+            if {"impressions", "clicks"} <= requested:
+                return create_job_status_response(
+                    job_id, "Job Failed", percent=0,
+                    error_code=2, error_subcode=1504044,
+                )
+            return create_job_status_response(job_id, "Job Completed")
+
+        def handle_results(request):
+            job_id = request["url"].split("/")[-2]
+            requested = submits.get(job_id, set())
+            row = {"ad_id": "single_ad", "date_start": "2024-01-01"}
+            for name in requested - {"account_id", "ad_id", "date_start"}:
+                row[name] = f"{name}_value"
+            return create_insights_response([row])
+
+        original_add(r"/act_[^/]+/insights$", handle_submit, method="POST")
+        original_add(r"/act_[^/]+/insights$", self._descend_to_single_ad, method="GET")
+        original_add(r"job_\d+$", handle_status, method="GET")
+        original_add(r"job_\d+/insights", handle_results, method="GET")
+
+        results = []
+        async for record in job_manager.fetch_insights(
+            mock_log, mock_model, "act_123", time_range
+        ):
+            results.append(record)
+
+        assert len(results) == 1
+        assert results[0]["impressions"] == "impressions_value"
+        assert results[0]["clicks"] == "clicks_value"
 
 
 # =============================================================================

--- a/source-facebook-marketing-native/tests/unit/test_job_manager.py
+++ b/source-facebook-marketing-native/tests/unit/test_job_manager.py
@@ -13,7 +13,20 @@ from estuary_cdk.http import HTTPError
 
 from source_facebook_marketing_native.client import FacebookAPIError
 from source_facebook_marketing_native.insights import FacebookInsightsJobManager
+from source_facebook_marketing_native.insights.errors import CannotSplitFurtherError
+from source_facebook_marketing_native.models import (
+    AdsInsights,
+    AdsInsightsActionType,
+    AdsInsightsAgeAndGender,
+    AdsInsightsComscoreMarket,
+    AdsInsightsCountry,
+    AdsInsightsPlatformAndDevice,
+    AdsInsightsRegion,
+    InsightsConfig,
+    build_custom_ads_insights_model,
+)
 from source_facebook_marketing_native.insights.types import (
+    FieldSplitPart,
     JobScope,
     InsightsJob,
 )
@@ -115,6 +128,298 @@ class TestBinarySplit:
         # Verify depth tracking on large splits
         assert result[0].depth == 3
         assert result[1].depth == 3
+
+
+class TestFieldSplitJoinKey:
+    """Tests for the two key lists field splitting needs to keep distinct."""
+
+    @pytest.fixture
+    def job_manager(self) -> FacebookInsightsJobManager:
+        return FacebookInsightsJobManager(
+            http=None,  # type: ignore
+            base_url="https://graph.facebook.com/v21.0",
+            log=logging.getLogger("test"),
+            account_id="test_account",
+        )
+
+    def test_plain_stream_requests_all_its_keys(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Every primary key of ads_insights is a requestable field."""
+        assert job_manager._requested_key_fields(AdsInsights) == [
+            "account_id",
+            "ad_id",
+            "date_start",
+        ]
+        assert job_manager._join_key(AdsInsights) == [
+            "account_id",
+            "ad_id",
+            "date_start",
+        ]
+
+    def test_breakdown_columns_are_keys_but_not_requested(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Breakdown columns key the row but must not be added to `fields`.
+
+        Facebook returns them because the `breakdowns` parameter is unchanged
+        across parts; asking for them as fields would be rejected. They must
+        still join the parts back together, or every demographic row of an
+        ad-day collapses into one record.
+        """
+        requested = job_manager._requested_key_fields(AdsInsightsAgeAndGender)
+        assert requested == ["account_id", "ad_id", "date_start"]
+
+        assert job_manager._join_key(AdsInsightsAgeAndGender) == [
+            "account_id",
+            "ad_id",
+            "age",
+            "date_start",
+            "gender",
+        ]
+
+    def test_every_breakdown_stream_joins_on_its_whole_key(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """No breakdown stream may lose part of its key to the requestable filter."""
+        for model in [
+            AdsInsights,
+            AdsInsightsActionType,
+            AdsInsightsAgeAndGender,
+            AdsInsightsComscoreMarket,
+            AdsInsightsCountry,
+            AdsInsightsPlatformAndDevice,
+            AdsInsightsRegion,
+        ]:
+            pointers = [key.lstrip("/") for key in model.primary_keys]
+            assert job_manager._join_key(model) == pointers, model.name
+
+    def test_custom_model_keys_on_date_start_it_never_requests(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Custom insights models key on `/date_start` without listing it.
+
+        `level_specific_fields()` contributes only the account/campaign/adset/ad
+        id and name columns, so `date_start` is in neither `fields` nor
+        `breakdowns`. Facebook returns it regardless, because `time_increment=1`
+        is always sent - which is why obtainability cannot be decided from the
+        model alone.
+        """
+        model = build_custom_ads_insights_model(
+            InsightsConfig(
+                name="my_custom",
+                level="ad",
+                fields="impressions,clicks",
+                breakdowns="age,gender",
+            )
+        )
+        assert "date_start" not in model.fields
+        assert "date_start" not in model.breakdowns
+
+        assert job_manager._join_key(model) == [
+            "account_id",
+            "ad_id",
+            "age",
+            "date_start",
+            "gender",
+        ]
+
+
+class TestVerifyJoinKey:
+    """Tests for _verify_join_key - the chunk-level guard before merging."""
+
+    @pytest.fixture
+    def job_manager(self) -> FacebookInsightsJobManager:
+        return FacebookInsightsJobManager(
+            http=None,  # type: ignore
+            base_url="https://graph.facebook.com/v21.0",
+            log=logging.getLogger("test"),
+            account_id="test_account",
+        )
+
+    def test_rows_carrying_the_whole_key_pass(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        records = [
+            {"ad_id": "a1", "date_start": "2024-01-01", "age": "25-34", "clicks": 1},
+            {"ad_id": "a1", "date_start": "2024-01-01", "age": "35-44", "clicks": 2},
+        ]
+        job_manager._verify_join_key(
+            records, ["ad_id", "age", "date_start"], ["clicks"], "job"
+        )
+
+    def test_missing_key_column_is_refused(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """A row without a key column cannot be told apart from its siblings."""
+        records = [
+            {"ad_id": "a1", "date_start": "2024-01-01", "clicks": 1},
+            {"ad_id": "a1", "date_start": "2024-01-01", "clicks": 2},
+        ]
+
+        with pytest.raises(CannotSplitFurtherError, match=r"\['age'\]"):
+            job_manager._verify_join_key(
+                records, ["ad_id", "age", "date_start"], ["clicks"], "job"
+            )
+
+    def test_every_missing_column_is_named(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """The error names all of them, not just the first row's."""
+        records = [
+            {"ad_id": "a1", "date_start": "2024-01-01", "age": "25-34"},
+            {"ad_id": "a1", "date_start": "2024-01-01", "gender": "male"},
+        ]
+
+        with pytest.raises(CannotSplitFurtherError, match=r"\['age', 'gender'\]"):
+            job_manager._verify_join_key(
+                records, ["ad_id", "age", "date_start", "gender"], ["clicks"], "job"
+            )
+
+    def test_a_chunk_with_no_rows_has_nothing_to_verify(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Emptiness is not a key violation; it is handled as degradation."""
+        job_manager._verify_join_key([], ["ad_id", "age"], ["clicks"], "job")
+
+
+class TestMergeByPrimaryKey:
+    """Tests for _merge_by_primary_key - re-joining field-split parts."""
+
+    @pytest.fixture
+    def job_manager(self) -> FacebookInsightsJobManager:
+        return FacebookInsightsJobManager(
+            http=None,  # type: ignore
+            base_url="https://graph.facebook.com/v21.0",
+            log=logging.getLogger("test"),
+            account_id="test_account",
+        )
+
+    def test_disjoint_columns_merge_into_one_record(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Parts hold different columns for the same row."""
+        parts = [
+            FieldSplitPart(
+                fields=["impressions"],
+                records=[{"ad_id": "a1", "date_start": "2024-01-01", "impressions": 100}],
+            ),
+            FieldSplitPart(
+                fields=["clicks"],
+                records=[{"ad_id": "a1", "date_start": "2024-01-01", "clicks": 5}],
+            ),
+        ]
+        merged = job_manager._merge_by_primary_key(parts, ["ad_id", "date_start"])
+
+        assert merged == [
+            {
+                "ad_id": "a1",
+                "date_start": "2024-01-01",
+                "impressions": 100,
+                "clicks": 5,
+            }
+        ]
+
+    def test_distinct_rows_stay_distinct(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Different primary keys must not collapse together."""
+        parts = [
+            FieldSplitPart(
+                fields=["impressions"],
+                records=[
+                    {"ad_id": "a1", "date_start": "2024-01-01", "impressions": 1},
+                    {"ad_id": "a2", "date_start": "2024-01-01", "impressions": 2},
+                ],
+            ),
+            FieldSplitPart(
+                fields=["clicks"],
+                records=[
+                    {"ad_id": "a1", "date_start": "2024-01-01", "clicks": 10},
+                    {"ad_id": "a2", "date_start": "2024-01-01", "clicks": 20},
+                ],
+            ),
+        ]
+        merged = job_manager._merge_by_primary_key(parts, ["ad_id", "date_start"])
+
+        assert len(merged) == 2
+        by_ad = {record["ad_id"]: record for record in merged}
+        assert by_ad["a1"]["impressions"] == 1 and by_ad["a1"]["clicks"] == 10
+        assert by_ad["a2"]["impressions"] == 2 and by_ad["a2"]["clicks"] == 20
+
+    def test_row_missing_from_a_part_still_yields_a_record(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Merging over the union, not the intersection.
+
+        Facebook returns primary-key-only rows rather than omitting rows whose
+        metrics are all null, so parts normally align. If one ever doesn't, the
+        row should still surface with whatever was obtained instead of vanishing.
+        """
+        parts = [
+            FieldSplitPart(
+                fields=["impressions"],
+                records=[
+                    {"ad_id": "a1", "date_start": "2024-01-01", "impressions": 1},
+                    {"ad_id": "a2", "date_start": "2024-01-01", "impressions": 2},
+                ],
+            ),
+            FieldSplitPart(
+                fields=["clicks"],
+                records=[{"ad_id": "a1", "date_start": "2024-01-01", "clicks": 10}],
+            ),
+        ]
+        merged = job_manager._merge_by_primary_key(parts, ["ad_id", "date_start"])
+
+        assert len(merged) == 2
+        by_ad = {record["ad_id"]: record for record in merged}
+        assert by_ad["a2"]["impressions"] == 2
+        assert "clicks" not in by_ad["a2"]
+
+    def test_breakdown_rows_of_one_entity_day_stay_distinct(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """The case field splitting exists for: one ad, one day, many segments.
+
+        A single ad-day yields one row per age x gender combination, so joining
+        on only the requestable keys would collapse them all into one record
+        carrying an arbitrary segment's metrics.
+        """
+        segments = [("25-34", "male"), ("25-34", "female"), ("35-44", "male")]
+
+        def part(metric: str, multiplier: int) -> list[dict]:
+            return [
+                {
+                    "account_id": "acct1",
+                    "ad_id": "ad1",
+                    "date_start": "2024-01-01",
+                    "age": age,
+                    "gender": gender,
+                    metric: (index + 1) * multiplier,
+                }
+                for index, (age, gender) in enumerate(segments)
+            ]
+
+        merged = job_manager._merge_by_primary_key(
+            [
+                FieldSplitPart(fields=["impressions"], records=part("impressions", 1)),
+                FieldSplitPart(fields=["clicks"], records=part("clicks", 10)),
+            ],
+            job_manager._join_key(AdsInsightsAgeAndGender),
+        )
+
+        assert len(merged) == len(segments)
+        by_segment = {(r["age"], r["gender"]): r for r in merged}
+        for index, segment in enumerate(segments):
+            record = by_segment[segment]
+            assert record["impressions"] == index + 1
+            assert record["clicks"] == (index + 1) * 10
+
+    def test_no_parts_yields_no_records(
+        self, job_manager: FacebookInsightsJobManager
+    ):
+        """Every field unfetchable means there is nothing to emit."""
+        assert job_manager._merge_by_primary_key([], ["ad_id"]) == []
 
 
 class TestTryParseFacebookApiError:


### PR DESCRIPTION
**Description:**

We've observed async insight jobs consistently fail even when the job has been split to the lowest level (`ad`) for a single ad on a single day. This fails the capture & prevents backfills from completing. We originally deferred implementing logic to split `ad` level jobs into jobs for individual fields, but that appears to be what's needed to get past these occasional roadblocks where Facebook cannot / will not complete a job that includes a certain field on a specific day.

This PR's scope includes:

- **Log Facebook's error code and subcode on failed insights jobs.** The subcode picks between opposite remedies (2/1504038 = too large, 2/1504044 = reads as transient) but only the user-facing prose was logged, and it's identical for both. Also parses `error_message`, names entities in job descriptions, and pairs the job description with its `report_run_id`. These details will help us troubleshoot failing jobs in the future.

- **Split jobs by field when they cannot be split by entity.** Halves the non-PK fields until each part succeeds, carrying primary keys into every part, then merges by primary key. A field that fails alone is dropped after a retry. Measured against the ad behind the escalation: 47 of 48 fields recoverable, with the `actions` field alone as unfetchable. If Facebook refuses every field, the capture stops rather than advancing past data it never obtained.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
