### PR TITLE
docs: drop "Estuary Flow" from Smartsheet, fix Shopify REST API tense

### DIFF
--- a/docs/reference/Connectors/capture-connectors/shopify.md
+++ b/docs/reference/Connectors/capture-connectors/shopify.md
@@ -2,7 +2,7 @@
 # Shopify
 
 :::deprecated
-This connector is deprecated and no longer receives updates, as Shopify is deprecating their REST API
+This connector is deprecated and no longer receives updates, as Shopify has deprecated their REST API
 in favor of their GraphQL API. We recommend using our [Shopify GraphQL connector](./shopify-native.md)
 instead.
 :::

--- a/docs/reference/Connectors/capture-connectors/smartsheet.md
+++ b/docs/reference/Connectors/capture-connectors/smartsheet.md
@@ -1,10 +1,10 @@
 ---
-description: Use the Smartsheet connector to capture sheets, reports, and their rows into Estuary Flow. Authenticates with a Smartsheet API access token and captures sheets incrementally and reports as full-refresh snapshots.
+description: Use the Smartsheet connector to capture sheets, reports, and their rows into Estuary. Authenticates with a Smartsheet API access token and captures sheets incrementally and reports as full-refresh snapshots.
 ---
 
 # Smartsheet
 
-This connector captures data from [Smartsheet](https://www.smartsheet.com/) sheets and reports into Estuary Flow collections.
+This connector captures data from [Smartsheet](https://www.smartsheet.com/) sheets and reports into Estuary collections.
 It authenticates with a Smartsheet [API access token](https://smartsheet.redoc.ly/#section/API-Basics/Authentication) and reads data through the [Smartsheet API 2.0](https://smartsheet.redoc.ly/).
 
 ## Supported data resources


### PR DESCRIPTION
Picks up the two non-blocking wording notes Emily left on #5070 and estuary/flow#3362. Both of those were approved and merged without them.

## Changes

**`smartsheet.md`** — applies Emily's two suggestions from the #5070 review verbatim. The product is Estuary, not "Estuary Flow"; the frontmatter `description` and the opening line both said the latter.

**`shopify.md`** — Emily on flow#3362: "At this point, it would technically be Shopify *has deprecated* their REST API."

She's right. Shopify's REST Admin API became a legacy API on 2024-10-01 and is now in maintenance mode receiving only critical updates, so the present-tense "is deprecating" understates where things actually stand.

## Scope

Both files are byte-identical here and in `flow/site/docs`, so the same change goes to estuary/flow in a companion PR (estuary/flow#3370). #5070 and estuary/docs#31 just brought these trees to zero drift, and fixing only one side would reintroduce drift right before the cutover.

Note this half does not affect production until the cutover; the estuary/flow copy is what readers see today.
