### PR TITLE
docs: mark Shopify page deprecated in its heading

### DIFF
--- a/docs/reference/Connectors/capture-connectors/shopify.md
+++ b/docs/reference/Connectors/capture-connectors/shopify.md
@@ -1,5 +1,5 @@
 
-# Shopify
+# Shopify (Deprecated)
 
 :::deprecated
 This connector is deprecated and no longer receives updates, as Shopify is deprecating their REST API


### PR DESCRIPTION
The other 19 pages carrying `:::deprecated` also flag it in the H1, which is what shows in the sidebar and in search results. `shopify.md` did not, so it read as a current connector in both places.

Now `# Shopify (Deprecated)`, matching Mailchimp, Zendesk Support, Stripe and the rest.

Companion to https://github.com/estuary/flow/pull/3371, which makes the same change to the `flow/site/docs` copy that production still serves. The two files are byte-identical.
