### PR TITLE
docs: replay hubspot /_meta/op property name fix from flow/site

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/hubspot.md
+++ b/docs/reference/Connectors/materialization-connectors/hubspot.md
@@ -46,10 +46,13 @@ lowercased, leading underscores are removed as well as other symbols
 characters, and if the field begins with a number it will be prefixed with
 `n`. Names are truncated to 100 characters.
 
+To view the property name for a field in the UI, refresh the field selection
+and hover over the Outcome column.
+
 ## Deletions
 
 Hard deletes are not supported. To track deletions, ensure your collection
-documents include the `/_meta/op` field and create a corresponding `meta_op`
+documents include the `/_meta/op` field and create a corresponding `metaop`
 property in HubSpot.
 
 Backfills do not remove existing HubSpot records.


### PR DESCRIPTION
**Description:**

Replays [flow#3368](https://github.com/estuary/flow/pull/3368) into this repo. That PR fixed the HubSpot materialization property name from `meta_op` to `metaop` and added a note on how to find a field's property name in the UI. It landed in `flow/site` on 2026-08-17, after the final reconciliation base for the docs-repo cutover, so this copy never received it.

The result of the replay is byte-identical to the `flow/site` version of this page.

**Workflow steps:**

No behavior change. This is the connector doc page only.

Once `docs.estuary.dev` moves off `flow/site`, this file is what gets published. Without the replay, the cutover would publish the wrong property name (`meta_op`) and drop the UI note, i.e. it would silently undo #3368 for readers.

**Notes for reviewers:**

Found by the pre-cutover top-up diff of `flow/site/docs` against `docs/` in this repo. It is the only file where `flow/site` carries content this repo lacks; the other differences are all pages where this repo is deliberately ahead, adjudicated in #5070.

The diff is 4 insertions and 1 deletion, matching #3368's own stat exactly.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: n/a, this restores content that was never copied across rather than fixing a regression in this repo
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated: n/a, no connector behavior change
- [x] If there are user-facing behavior changes, documentation has been updated, or the docs PR is linked here: this is the documentation change
