### PR TITLE
source-shopify-native: gate `resourcePublications` & `publications` fields behind the `read_publications` scope

### DIFF
--- a/source-shopify-native/CHANGELOG.md
+++ b/source-shopify-native/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-19
+
+### Fixed
+- `products`, `custom_collections`, and `smart_collections` no longer fail
+  entirely for stores whose access token doesn't grant `read_publications`.
+  The connector now omits publication data instead of failing the whole
+  export when that scope is missing.
+
 ## 2026-08-18
 
 ### Added

--- a/source-shopify-native/source_shopify_native/graphql/collections/collections.py
+++ b/source-shopify-native/source_shopify_native/graphql/collections/collections.py
@@ -3,7 +3,13 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator, ClassVar, Literal
 
-from ...models import ShopifyGraphQLResource, SortKey, StoreCapabilities
+from ...models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+    requires_any_scope,
+)
 
 
 class _Collections(ShopifyGraphQLResource):
@@ -30,7 +36,12 @@ class _Collections(ShopifyGraphQLResource):
             }
         }
     }
-    publications {
+    # {{ publications }}
+    """
+    CONDITIONAL_FIELDS = [
+        ConditionalField(
+            placeholder="# {{ publications }}",
+            fields="""publications {
         edges {
             node {
                 __typename
@@ -41,8 +52,10 @@ class _Collections(ShopifyGraphQLResource):
                 }
             }
         }
-    }
-    """
+    }""",
+            is_available=requires_any_scope("read_publications"),
+        ),
+    ]
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/source-shopify-native/source_shopify_native/graphql/products/products.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/products.py
@@ -3,7 +3,13 @@ from logging import Logger
 import json
 from typing import Any, AsyncGenerator
 
-from source_shopify_native.models import ShopifyGraphQLResource, SortKey, StoreCapabilities
+from source_shopify_native.models import (
+    ConditionalField,
+    ShopifyGraphQLResource,
+    SortKey,
+    StoreCapabilities,
+    requires_any_scope,
+)
 
 
 class Products(ShopifyGraphQLResource):
@@ -57,22 +63,7 @@ class Products(ShopifyGraphQLResource):
         position
         values
     }
-    resourcePublications {
-        edges {
-            node {
-                isPublished
-                publication {
-                    id
-                    name
-                    catalog {
-                        id
-                        title
-                        status
-                    }
-                }
-            }
-        }
-    }
+    # {{ resourcePublications }}
     featuredMedia {
         id
         alt
@@ -123,6 +114,28 @@ class Products(ShopifyGraphQLResource):
         precision
     }
     """
+    CONDITIONAL_FIELDS = [
+        ConditionalField(
+            placeholder="# {{ resourcePublications }}",
+            fields="""resourcePublications {
+        edges {
+            node {
+                isPublished
+                publication {
+                    id
+                    name
+                    catalog {
+                        id
+                        title
+                        status
+                    }
+                }
+            }
+        }
+    }""",
+            is_available=requires_any_scope("read_publications"),
+        ),
+    ]
 
     @staticmethod
     def build_query(

--- a/source-shopify-native/tests/test_conditional_fields.py
+++ b/source-shopify-native/tests/test_conditional_fields.py
@@ -7,8 +7,13 @@ from datetime import datetime, UTC
 
 import pytest
 
+from source_shopify_native.graphql.collections.collections import (
+    CustomCollections,
+    SmartCollections,
+)
 from source_shopify_native.graphql.disputes import Disputes
 from source_shopify_native.graphql.orders.orders import Orders
+from source_shopify_native.graphql.products.products import Products
 from source_shopify_native.models import (
     ConditionalField,
     ShopifyGraphQLResource,
@@ -142,6 +147,33 @@ def test_disputes_evidence_included_only_with_evidence_scope():
     assert "disputeEvidence" not in without_evidence
     # The placeholder itself must not leak into the emitted query.
     assert "{{ disputeEvidence }}" not in without_evidence
+
+
+def test_products_resource_publications_included_only_with_read_publications():
+    with_scope = Products.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_publications"}))
+    )
+    without_scope = Products.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_products"}))
+    )
+
+    assert "resourcePublications" in with_scope
+    assert "resourcePublications" not in without_scope
+    assert "{{ resourcePublications }}" not in without_scope
+
+
+@pytest.mark.parametrize("collection_resource", [CustomCollections, SmartCollections])
+def test_collections_publications_included_only_with_read_publications(collection_resource):
+    with_scope = collection_resource.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_publications"}))
+    )
+    without_scope = collection_resource.build_query(
+        START, END, capabilities=StoreCapabilities(scopes=frozenset({"read_products"}))
+    )
+
+    assert "publications" in with_scope
+    assert "publications" not in without_scope
+    assert "{{ publications }}" not in without_scope
 
 
 def test_predicate_can_gate_on_plan_tier():


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Only including the `resourcePublications` and `publications` fields in queries when the provided credentials have the `read_publications` scope.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1786994079261659)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
