### PR TITLE
source-shopify-native: add `returnShippingFees` and `fulfillmentLineItem` to order_returns

### DIFF
--- a/source-shopify-native/CHANGELOG.md
+++ b/source-shopify-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-18
+
+### Added
+- `order_returns` now captures each return's `returnShippingFees` (the shipping
+  fee charged on the return) and each return line item's `fulfillmentLineItem`
+  (tying it back to the order's original line item).
+
 ## 2026-08-08
 
 ### Added

--- a/source-shopify-native/source_shopify_native/graphql/orders/returns.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/returns.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from logging import Logger
 from typing import AsyncGenerator, Any
 
+from ..common import money_bag_fragment
 from ...models import (
     ConditionalField,
     ShopifyGraphQLResource,
@@ -30,6 +31,12 @@ class OrderReturns(ShopifyGraphQLResource):
                     note
                     reason
                 }
+                returnShippingFees {
+                    id
+                    amountSet {
+                        ..._MoneyBagFields
+                    }
+                }
                 # {{ staffMember }}
                 returnLineItems {
                     edges {
@@ -44,6 +51,14 @@ class OrderReturns(ShopifyGraphQLResource):
                                 deleted
                                 handle
                                 name
+                            }
+                            ... on ReturnLineItem {
+                                fulfillmentLineItem {
+                                    id
+                                    lineItem {
+                                        id
+                                    }
+                                }
                             }
                         }
                     }
@@ -70,6 +85,7 @@ class OrderReturns(ShopifyGraphQLResource):
         }
     }
     """
+    FRAGMENTS = [money_bag_fragment]
     CONDITIONAL_FIELDS = [
         # staffMember requires the read_users scope, which is only grantable on
         # Shopify Plus / Advanced stores or finance embedded apps.

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1078,7 +1078,7 @@
       "cancelReason": null,
       "cancelledAt": null,
       "clientIp": "76.182.0.22",
-      "closedAt": "2026-06-15T13:21:57Z",
+      "closedAt": "2026-08-18T17:51:39Z",
       "confirmationNumber": "ULEG58LMN",
       "confirmed": true,
       "createdAt": "2026-06-11T17:33:51Z",
@@ -6220,6 +6220,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166932996141",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223512109"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27743977517",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6234,6 +6240,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933028909",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223544877"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744010285",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6248,6 +6260,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933061677",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223577645"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744043053",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6262,6 +6280,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933094445",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223610413"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744075821",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6276,6 +6300,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933127213",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223643181"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744108589",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6290,6 +6320,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933159981",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223675949"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744141357",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6304,6 +6340,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933192749",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223708717"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744174125",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6318,6 +6360,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933225517",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223741485"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744206893",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6332,6 +6380,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933258285",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223774253"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744239661",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6346,6 +6400,12 @@
             {
               "__parentId": "gid://shopify/Return/18804736045",
               "customerNote": null,
+              "fulfillmentLineItem": {
+                "id": "gid://shopify/FulfillmentLineItem/18166933291053",
+                "lineItem": {
+                  "id": "gid://shopify/LineItem/50297223807021"
+                }
+              },
               "id": "gid://shopify/ReturnLineItem/27744272429",
               "quantity": 5,
               "refundedQuantity": 5,
@@ -6358,6 +6418,7 @@
               "returnReasonNote": "test reason"
             }
           ],
+          "returnShippingFees": [],
           "status": "CLOSED",
           "totalQuantity": 50
         }


### PR DESCRIPTION
**Description:**

Adds `Return.returnShippingFees` and `ReturnLineItem.fulfillmentLineItem` to the `order_returns` stream's bulk query. A customer needs the shipping fee charged on a return (their returns provider doesn't expose it), and the fulfillment line item to tie each return line item back to its order line item.

**Workflow steps:**

Query-only change in `graphql/orders/returns.py` — no config, schema, or state changes. `order_returns` was already on the bulk path, and both new fields are non-connection fields, so they inline directly into their parent JSONL rows and `process_result` didn't need any changes.

`returnLineItems` is a connection over the `ReturnLineItemType` interface, and `fulfillmentLineItem` only exists on the concrete `ReturnLineItem` (not the sibling `UnverifiedReturnLineItem`), so it's requested via an `... on ReturnLineItem { }` inline fragment. `returnShippingFees.amountSet` reuses this connector's existing shared `_MoneyBagFields` fragment, matching every other `MoneyBag`-typed field in the connector, rather than a narrower one-off shape.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: N/A
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated: N/A — no config/schema changes, discovery/schema is inferred

Closes #5081