### PR TITLE
sqlcapture: Add 'Additional Backfill Filter' advanced option to resource configs

### DIFF
--- a/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -140,6 +140,9 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database](https://mariadb.com/kb/en/understanding-mariadb-architecture/#databases) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                                 | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.

--- a/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -138,6 +138,9 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database](https://mariadb.com/kb/en/understanding-mariadb-architecture/#databases) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                                 | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.

--- a/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -264,6 +264,9 @@ these filters exclude will be deactivated the next time discovery runs.
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.

--- a/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -170,6 +170,9 @@ these filters exclude will be deactivated the next time discovery runs.
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.

--- a/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -145,6 +145,9 @@ these filters exclude will be deactivated the next time discovery runs.
 | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
 | **`/namespace`** | Namespace | The [database/schema](https://dev.mysql.com/doc/refman/8.0/en/show-databases.html) in which the table resides. | string | Required         |
 | **`/stream`**    | Stream    | Name of the table to be captured from the database.                                                            | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 :::info
 When you configure this connector in the web application, the automatic **discovery** process sets up a binding for _most_ tables it finds in your database, but there are exceptions.

--- a/docs/reference/Connectors/capture-connectors/OracleDB/OracleDB.md
+++ b/docs/reference/Connectors/capture-connectors/OracleDB/OracleDB.md
@@ -169,6 +169,9 @@ To allow secure connections via SSH tunneling:
 |------------------|-----------|--------------------------------------------------------------------------------------------|--------|------------------|
 | **`/namespace`** | Namespace | The [owner/schema](https://docs.oracle.com/database/121/CNCPT/intro.htm#CNCPT940) of the table.                                                         | string | Required         |
 | **`/stream`**    | Stream    | Table name.                                                                                | string | Required         |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 
 ### Sample

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/PostgreSQL.md
@@ -451,6 +451,7 @@ these filters exclude will be deactivated the next time discovery runs.
 | **`/stream`**    | Stream    | Table name.     | string | Required         |
 | `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
 | `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 #### SSL Mode
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/Supabase.md
@@ -187,6 +187,7 @@ these filters exclude will be deactivated the next time discovery runs.
 | **`/stream`**    | Stream    | Table name.     | string | Required         |
 | `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
 | `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 #### SSL Mode
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/amazon-rds-postgres.md
@@ -273,6 +273,7 @@ these filters exclude will be deactivated the next time discovery runs.
 | **`/stream`**    | Stream    | Table name.     | string | Required         |
 | `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
 | `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 #### SSL Mode
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/google-cloud-sql-postgres.md
@@ -207,6 +207,7 @@ these filters exclude will be deactivated the next time discovery runs.
 | **`/stream`**    | Stream    | Table name.     | string | Required         |
 | `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
 | `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
+++ b/docs/reference/Connectors/capture-connectors/PostgreSQL/neon-postgres.md
@@ -227,6 +227,7 @@ these filters exclude will be deactivated the next time discovery runs.
 | **`/stream`**    | Stream    | Table name.     | string | Required         |
 | `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
 | `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -127,7 +127,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------- |
 | **`/namespace`** | Namespace           | The [namespace/schema](https://learn.microsoft.com/en-us/sql/relational-databases/databases/databases?view=sql-server-ver16#basic-information-about-databases) of the table. | string                                                        | Required         |
 | **`/stream`**    | Stream              | Table name.                                                                                                                                                                  | string                                                        | Required         |
-| `/primary_key`   | Primary Key Columns | array                                                                                                                                                                        | The columns which together form the primary key of the table. |                  |
+| `/primary_key`   | Primary Key Columns | The columns which together form the primary key of the table.                                                                                                                | array                                                          |                  |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -127,7 +127,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------- |
 | **`/namespace`** | Namespace           | The [namespace/schema](https://learn.microsoft.com/en-us/sql/relational-databases/databases/databases?view=sql-server-ver16#basic-information-about-databases) of the table. | string                                                        | Required         |
 | **`/stream`**    | Stream              | Table name.                                                                                                                                                                  | string                                                        | Required         |
-| `/primary_key`   | Primary Key Columns | array                                                                                                                                                                        | The columns which together form the primary key of the table. |                  |
+| `/primary_key`   | Primary Key Columns | The columns which together form the primary key of the table.                                                                                                                | array                                                          |                  |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver-change-tracking.md
@@ -178,6 +178,7 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/namespace`** | Table Schema      | The schema in which the table resides.                                                                                                                                                                                    | string  | Required         |
 | **`/stream`**    | Table Name        | The name of the table to be captured.                                                                                                                                                                                     | string  | Required         |
 | `/priority`      | Backfill Priority | An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities will cause a binding to be backfilled after others. | integer |                  |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -208,7 +208,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------- |
 | **`/namespace`** | Namespace           | The [namespace/schema](https://learn.microsoft.com/en-us/sql/relational-databases/databases/databases?view=sql-server-ver16#basic-information-about-databases) of the table. | string                                                        | Required         |
 | **`/stream`**    | Stream              | Table name.                                                                                                                                                                  | string                                                        | Required         |
-| `/primary_key`   | Primary Key Columns | array                                                                                                                                                                        | The columns which together form the primary key of the table. |                  |
+| `/primary_key`   | Primary Key Columns | The columns which together form the primary key of the table.                                                                                                                | array                                                          |                  |
+| `/mode` | [Backfill Mode](/reference/backfilling-data/#resource-configuration-backfill-modes) | How the preexisting contents of the table should be backfilled. This should generally not be changed. | string | `""` |
+| `/priority` | Backfill Priority | Optional priority for this binding. The highest priority binding(s) will be backfilled completely before any others. Negative priorities are allowed and will cause a binding to be backfilled after others. | integer | `0` |
+| `/advanced/additional_backfill_filter` | Additional Backfill Filter | Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option. | string | |
 
 ### Sample
 

--- a/go/capture/sqlserver/backfill/backfill.go
+++ b/go/capture/sqlserver/backfill/backfill.go
@@ -17,13 +17,14 @@ func BuildBackfillQuery(
 	schema, table string,
 	columnTypes map[string]any,
 	chunkSize int,
+	backfillFilter string,
 ) (string, []any, error) {
 	var streamID = sqlcapture.JoinStreamID(schema, table)
 	var keyColumns = state.KeyColumns
 
 	switch state.Mode {
 	case sqlcapture.TableStateKeylessBackfill:
-		var query = keylessScanQuery(schema, table, chunkSize)
+		var query = keylessScanQuery(schema, table, chunkSize, backfillFilter)
 		var args = []any{state.BackfilledCount}
 		return query, args, nil
 
@@ -43,10 +44,10 @@ func BuildBackfillQuery(
 				}
 				resumeKey[idx] = retyped
 			}
-			var query = buildScanQuery(false, keyColumns, columnTypes, schema, table, chunkSize)
+			var query = buildScanQuery(false, keyColumns, columnTypes, schema, table, chunkSize, backfillFilter)
 			return query, resumeKey, nil
 		}
-		var query = buildScanQuery(true, keyColumns, columnTypes, schema, table, chunkSize)
+		var query = buildScanQuery(true, keyColumns, columnTypes, schema, table, chunkSize, backfillFilter)
 		return query, nil, nil
 
 	default:
@@ -101,9 +102,18 @@ func retypeResumeKey(value any, columnType any) (any, error) {
 
 // keylessScanQuery builds a query for scanning a table without a primary key.
 // It uses %%physloc%% ordering and OFFSET/FETCH for pagination.
-func keylessScanQuery(schemaName, tableName string, chunkSize int) string {
+func keylessScanQuery(schemaName, tableName string, chunkSize int, backfillFilter string) string {
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "SELECT * FROM [%s].[%s]", schemaName, tableName)
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
+	}
 	fmt.Fprintf(query, " ORDER BY %%%%physloc%%%%")
 	fmt.Fprintf(query, " OFFSET @p1 ROWS FETCH FIRST %d ROWS ONLY;", chunkSize)
 	return query.String()
@@ -112,7 +122,7 @@ func keylessScanQuery(schemaName, tableName string, chunkSize int) string {
 // buildScanQuery builds a query for scanning a table with a primary key.
 // If start is true, scans from the beginning; otherwise resumes after the given key values.
 // The columnTypes map is used to determine which columns need special text collation handling.
-func buildScanQuery(start bool, keyColumns []string, columnTypes map[string]any, schemaName, tableName string, chunkSize int) string {
+func buildScanQuery(start bool, keyColumns []string, columnTypes map[string]any, schemaName, tableName string, chunkSize int, backfillFilter string) string {
 	var pkey []string
 	var args []string
 	for idx, colName := range keyColumns {
@@ -125,6 +135,29 @@ func buildScanQuery(start bool, keyColumns []string, columnTypes map[string]any,
 		pkey = append(pkey, quotedName)
 	}
 
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
+	if !start {
+		var predicate = new(strings.Builder)
+		for i := range len(pkey) {
+			if i == 0 {
+				predicate.WriteString("(")
+			} else {
+				predicate.WriteString(") OR (")
+			}
+
+			for j := 0; j < i; j++ {
+				fmt.Fprintf(predicate, "%s = %s AND ", pkey[j], args[j])
+			}
+			fmt.Fprintf(predicate, "%s > %s", pkey[i], args[i])
+		}
+		predicate.WriteString(")")
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", predicate.String()))
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "BEGIN ")
 	if !start {
@@ -135,20 +168,8 @@ func buildScanQuery(start bool, keyColumns []string, columnTypes map[string]any,
 		}
 	}
 	fmt.Fprintf(query, "SELECT * FROM [%s].[%s]", schemaName, tableName)
-	if !start {
-		for i := range len(pkey) {
-			if i == 0 {
-				fmt.Fprintf(query, " WHERE (")
-			} else {
-				fmt.Fprintf(query, ") OR (")
-			}
-
-			for j := 0; j < i; j++ {
-				fmt.Fprintf(query, "%s = %s AND ", pkey[j], args[j])
-			}
-			fmt.Fprintf(query, "%s > %s", pkey[i], args[i])
-		}
-		fmt.Fprintf(query, ")")
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
 	}
 	fmt.Fprintf(query, " ORDER BY %s", strings.Join(pkey, ", "))
 	fmt.Fprintf(query, " OFFSET 0 ROWS FETCH FIRST %d ROWS ONLY;", chunkSize)

--- a/go/capture/sqlserver/backfill/backfill_test.go
+++ b/go/capture/sqlserver/backfill/backfill_test.go
@@ -58,10 +58,55 @@ func TestResumeKeyBinding(t *testing.T) {
 				Mode:       sqlcapture.TableStatePreciseBackfill,
 				KeyColumns: []string{"k", "node"},
 				Scanned:    packed,
-			}, "dbo", "events", map[string]any{"k": tc.columnType, "node": "int"}, 1000)
+			}, "dbo", "events", map[string]any{"k": tc.columnType, "node": "int"}, 1000, "")
 			require.NoError(t, err)
 			require.Len(t, args, 2)
 			require.Equal(t, tc.wantBound, args[0])
+		})
+	}
+}
+
+// TestBackfillFilter checks that a user-provided backfill filter is ANDed into the
+// WHERE clause of every backfill query shape.
+func TestBackfillFilter(t *testing.T) {
+	var columnTypes = map[string]any{"k": "int"}
+	var packed, err = sqlcapture.PackTuple([]tuple.TupleElement{int64(7)})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		state     *sqlcapture.TableState
+		filter    string
+		wantQuery string
+	}{
+		{
+			name:      "keyless_without_filter",
+			state:     &sqlcapture.TableState{Mode: sqlcapture.TableStateKeylessBackfill},
+			wantQuery: "SELECT * FROM [dbo].[events] ORDER BY %%physloc%% OFFSET @p1 ROWS FETCH FIRST 1000 ROWS ONLY;",
+		},
+		{
+			name:      "keyless_with_filter",
+			state:     &sqlcapture.TableState{Mode: sqlcapture.TableStateKeylessBackfill},
+			filter:    "k > 123",
+			wantQuery: "SELECT * FROM [dbo].[events] WHERE (k > 123) ORDER BY %%physloc%% OFFSET @p1 ROWS FETCH FIRST 1000 ROWS ONLY;",
+		},
+		{
+			name:      "keyed_initial_with_filter",
+			state:     &sqlcapture.TableState{Mode: sqlcapture.TableStatePreciseBackfill, KeyColumns: []string{"k"}},
+			filter:    "a > 1 OR b > 2",
+			wantQuery: "BEGIN SELECT * FROM [dbo].[events] WHERE (a > 1 OR b > 2) ORDER BY [k] OFFSET 0 ROWS FETCH FIRST 1000 ROWS ONLY; END",
+		},
+		{
+			name:      "keyed_resume_with_filter",
+			state:     &sqlcapture.TableState{Mode: sqlcapture.TableStatePreciseBackfill, KeyColumns: []string{"k"}, Scanned: packed},
+			filter:    "a > 1 OR b > 2",
+			wantQuery: "BEGIN SELECT * FROM [dbo].[events] WHERE (([k] > @p1)) AND (a > 1 OR b > 2) ORDER BY [k] OFFSET 0 ROWS FETCH FIRST 1000 ROWS ONLY; END",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			query, _, err := BuildBackfillQuery(tc.state, "dbo", "events", columnTypes, 1000, tc.filter)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantQuery, query)
 		})
 	}
 }

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -244,6 +244,20 @@
         "type": "integer",
         "title": "Backfill Priority",
         "description": "An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others."
+      },
+      "advanced": {
+        "properties": {
+          "additional_backfill_filter": {
+            "type": "string",
+            "title": "Additional Backfill Filter",
+            "description": "Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-mysql/CHANGELOG.md
+++ b/source-mysql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # source-mysql
 
+## 2026-08-18
+
+### Added
+- New `additional_backfill_filter` advanced option on each binding. When set,
+  the filter clause is applied to all backfill queries for that table, so rows
+  which the filter excludes are never backfilled. Setting or changing the
+  filter requires re-backfilling the binding, while clearing it does not.
+  Filters cannot be combined with the `Precise` backfill mode.
+
 ## 2026-07-30
 
 ### Added

--- a/source-mysql/backfill.go
+++ b/source-mysql/backfill.go
@@ -15,7 +15,7 @@ import (
 
 var statementTimeoutRegexp = regexp.MustCompile(`maximum statement execution time exceeded`)
 
-func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
+func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, backfillFilter string, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	var keyColumns = state.KeyColumns
 	var resumeAfter = state.Scanned
 	var schema, table = info.Schema, info.Name
@@ -36,7 +36,7 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.Di
 			"stream": streamID,
 			"offset": state.BackfilledCount,
 		}).Debug("scanning keyless table chunk")
-		query = db.keylessScanQuery(info, schema, table)
+		query = db.keylessScanQuery(info, schema, table, backfillFilter)
 		args = []any{state.BackfilledCount}
 	case sqlcapture.TableStatePreciseBackfill, sqlcapture.TableStateUnfilteredBackfill:
 		var isPrecise = (state.Mode == sqlcapture.TableStatePreciseBackfill)
@@ -62,13 +62,13 @@ func (db *mysqlDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.Di
 			for i := range resumeKey {
 				args = append(args, resumeKey[:i+1]...)
 			}
-			query = db.buildScanQuery(false, isPrecise, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(false, isPrecise, keyColumns, columnTypes, schema, table, backfillFilter)
 		} else {
 			logrus.WithFields(logrus.Fields{
 				"stream":     streamID,
 				"keyColumns": keyColumns,
 			}).Debug("scanning initial table chunk")
-			query = db.buildScanQuery(true, isPrecise, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(true, isPrecise, keyColumns, columnTypes, schema, table, backfillFilter)
 		}
 	default:
 		return false, nil, fmt.Errorf("invalid backfill mode %q", state.Mode)
@@ -215,15 +215,24 @@ var columnBinaryKeyComparison = map[string]bool{
 	"longtext":   true,
 }
 
-func (db *mysqlDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
+func (db *mysqlDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName, backfillFilter string) string {
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
 	var query = new(strings.Builder)
 	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
+	}
 	fmt.Fprintf(query, " LIMIT %d", db.config.Advanced.BackfillChunkSize)
 	fmt.Fprintf(query, " OFFSET ?;")
 	return query.String()
 }
 
-func (db *mysqlDatabase) buildScanQuery(start, isPrecise bool, keyColumns []string, columnTypes map[string]interface{}, schemaName, tableName string) string {
+func (db *mysqlDatabase) buildScanQuery(start, isPrecise bool, keyColumns []string, columnTypes map[string]interface{}, schemaName, tableName, backfillFilter string) string {
 	// Construct lists of key specifiers and placeholders. They will be joined with commas and used in the query itself.
 	var pkey []string
 	for _, colName := range keyColumns {
@@ -237,24 +246,34 @@ func (db *mysqlDatabase) buildScanQuery(start, isPrecise bool, keyColumns []stri
 		}
 	}
 
-	// Construct the query itself.
-	var query = new(strings.Builder)
-	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
-
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
 	if !start {
+		var predicate = new(strings.Builder)
 		for i := 0; i != len(pkey); i++ {
 			if i == 0 {
-				fmt.Fprintf(query, " WHERE (")
+				predicate.WriteString("(")
 			} else {
-				fmt.Fprintf(query, ") OR (")
+				predicate.WriteString(") OR (")
 			}
 
 			for j := 0; j != i; j++ {
-				fmt.Fprintf(query, "%s = ? AND ", pkey[j])
+				fmt.Fprintf(predicate, "%s = ? AND ", pkey[j])
 			}
-			fmt.Fprintf(query, "%s > ?", pkey[i])
+			fmt.Fprintf(predicate, "%s > ?", pkey[i])
 		}
-		fmt.Fprintf(query, ")")
+		predicate.WriteString(")")
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", predicate.String()))
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
+	// Construct the query itself.
+	var query = new(strings.Builder)
+	fmt.Fprintf(query, "SELECT * FROM `%s`.`%s`", schemaName, tableName)
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
 	}
 	fmt.Fprintf(query, " ORDER BY %s", strings.Join(pkey, ", "))
 	fmt.Fprintf(query, " LIMIT %d;", db.config.Advanced.BackfillChunkSize)

--- a/source-oracle/.snapshots/TestGeneric-SpecResponse
+++ b/source-oracle/.snapshots/TestGeneric-SpecResponse
@@ -32,6 +32,7 @@
         "type": "boolean",
         "description": "Capture change events without reducing them to a final state.",
         "default": false,
+        "nonsensitive": true,
         "order": 5
       },
       "advanced": {
@@ -49,13 +50,15 @@
             "type": "integer",
             "title": "Backfill Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single backfill query. Only applies to tables with a primary key.",
-            "default": 50000
+            "default": 50000,
+            "nonsensitive": true
           },
           "incremental_chunk_size": {
             "type": "integer",
             "title": "Incremental Chunk Size",
             "description": "The number of rows which should be fetched from the database in a single incremental query.",
-            "default": 10000
+            "default": 10000,
+            "nonsensitive": true
           },
           "discover_schemas": {
             "items": {
@@ -63,12 +66,14 @@
             },
             "type": "array",
             "title": "Discovery Schema Selection",
-            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas."
+            "description": "If this is specified only tables in the selected schema(s) will be automatically discovered. Omit all entries to discover tables from all schemas.",
+            "nonsensitive": true
           },
           "node_id": {
             "type": "integer",
             "title": "Node ID",
-            "description": "Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value."
+            "description": "Node ID for the capture. Each node in a replication cluster must have a unique 32-bit ID. The specific value doesn't matter so long as it is unique. If unset or zero the connector will pick a value.",
+            "nonsensitive": true
           },
           "dictionary_mode": {
             "type": "string",
@@ -78,12 +83,14 @@
               "smart"
             ],
             "title": "Dictionary Mode",
-            "description": "How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to smart which automatically switches between the two modes based on requirements."
+            "description": "How should dictionaries be used in Logminer: one of online or extract. When using online mode schema changes to the table may break the capture but resource usage is limited. When using extract mode schema changes are handled gracefully but more resources of your database (including disk) are used by the process. Defaults to smart which automatically switches between the two modes based on requirements.",
+            "nonsensitive": true
           },
           "source_tag": {
             "type": "string",
             "title": "Source Tag",
-            "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document."
+            "description": "When set the capture will add this value as the property 'tag' in the source metadata of each document.",
+            "nonsensitive": true
           },
           "rediscovery_interval": {
             "type": "string",
@@ -95,7 +102,8 @@
           "feature_flags": {
             "type": "string",
             "title": "Feature Flags",
-            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support."
+            "description": "This property is intended for Estuary internal use. You should only modify this field as directed by Estuary support.",
+            "nonsensitive": true
           }
         },
         "additionalProperties": false,
@@ -180,6 +188,20 @@
         "type": "integer",
         "title": "Backfill Priority",
         "description": "An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others."
+      },
+      "advanced": {
+        "properties": {
+          "additional_backfill_filter": {
+            "type": "string",
+            "title": "Additional Backfill Filter",
+            "description": "Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-oracle/CHANGELOG.md
+++ b/source-oracle/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-18
+
+### Added
+- New `additional_backfill_filter` advanced option on each binding. When set,
+  the filter clause is applied to all backfill queries for that table, so rows
+  which the filter excludes are never backfilled. Setting or changing the
+  filter requires re-backfilling the binding, while clearing it does not.
+  Filters cannot be combined with the `Precise` backfill mode.
+
 ## 2026-07-30
 
 ### Added

--- a/source-oracle/backfill.go
+++ b/source-oracle/backfill.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from `resumeKey` if non-nil.
-func (db *oracleDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
+func (db *oracleDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, backfillFilter string, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	logrus.WithField("state", state).Debug("backfill: ScanChunk")
 	var keyColumns = state.KeyColumns
 	var resumeAfter = state.Scanned
@@ -46,7 +46,7 @@ func (db *oracleDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.D
 
 		logEntry.WithField("rowid", afterRowID).Debug("backfill: scanning keyless table chunk")
 
-		query, rowidRangeEnd = db.keylessScanQuery(info, schema, table, afterRowID, db.backfillRowIDRanges[streamID])
+		query, rowidRangeEnd = db.keylessScanQuery(info, schema, table, afterRowID, db.backfillRowIDRanges[streamID], backfillFilter)
 
 	case sqlcapture.TableStatePreciseBackfill, sqlcapture.TableStateUnfilteredBackfill:
 		if resumeAfter != nil {
@@ -61,13 +61,13 @@ func (db *oracleDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.D
 				"keyColumns": keyColumns,
 				"resumeKey":  resumeKey,
 			}).Debug("backfill: scanning subsequent table chunk")
-			query = db.buildScanQuery(false, info, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(false, info, keyColumns, columnTypes, schema, table, backfillFilter)
 			for idx, k := range resumeKey {
 				args = append(args, sql.Named(fmt.Sprintf("p%d", idx+1), k))
 			}
 		} else {
 			logEntry.WithField("keyColumns", keyColumns).Debug("scanning initial table chunk")
-			query = db.buildScanQuery(true, info, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(true, info, keyColumns, columnTypes, schema, table, backfillFilter)
 		}
 	default:
 		return false, nil, fmt.Errorf("invalid backfill mode %q", state.Mode)
@@ -394,7 +394,7 @@ func base64cmp(a, b string) int {
 // Keyless scan uses ROWID to order the rows. Note that this only ensures eventual consistency
 // since ROWIDs are not always increasing (new rows can use smaller ROWIDs if space is available in an earlier block)
 // but since we will capture changes since the start of the backfill using SCN tracking, we will eventually be consistent
-func (db *oracleDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName, afterRowID string, rowidRanges []string) (string, string) {
+func (db *oracleDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schemaName, tableName, afterRowID string, rowidRanges []string, backfillFilter string) (string, string) {
 	var query = new(strings.Builder)
 	var columnSelect []string
 	for _, col := range info.Columns {
@@ -426,15 +426,23 @@ func (db *oracleDatabase) keylessScanQuery(info *sqlcapture.DiscoveryInfo, schem
 	var rowidStart = rowidRanges[idx]
 	var rowidEnd = rowidRanges[idx+1]
 
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses = []string{
+		fmt.Sprintf("ROWID >= '%s'", rowidStart),
+		fmt.Sprintf("ROWID <= '%s'", rowidEnd),
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
 	// It is faster to first find the smallest and the largest ROWIDs of the range we want to cover and then query
 	// all of the data in that range, instead of ordering all rows based on ROWID and then filtering the ROWID
 	fmt.Fprintf(query, `SELECT ROWID, %s FROM "%s"."%s"`, strings.Join(columnSelect, ","), schemaName, tableName)
-	fmt.Fprintf(query, ` WHERE ROWID >= '%s'`, rowidStart)
-	fmt.Fprintf(query, ` AND ROWID <= '%s'`, rowidEnd)
+	fmt.Fprintf(query, ` WHERE %s`, strings.Join(whereClauses, " AND "))
 	return query.String(), rowidEnd
 }
 
-func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryInfo, keyColumns []string, columnTypes map[string]oracleColumnType, schemaName, tableName string) string {
+func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryInfo, keyColumns []string, columnTypes map[string]oracleColumnType, schemaName, tableName, backfillFilter string) string {
 	// Construct lists of key specifiers and placeholders. They will be joined with commas and used in the query itself.
 	var pkey []string
 	var args []string
@@ -463,21 +471,32 @@ func (db *oracleDatabase) buildScanQuery(start bool, info *sqlcapture.DiscoveryI
 	for _, col := range info.Columns {
 		columnSelect = append(columnSelect, castColumn(col))
 	}
-	fmt.Fprintf(query, `SELECT * FROM (SELECT ROWID, %s FROM "%s"."%s"`, strings.Join(columnSelect, ","), schemaName, tableName)
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses []string
 	if !start {
+		var predicate = new(strings.Builder)
 		for i := 0; i != len(pkey); i++ {
 			if i == 0 {
-				fmt.Fprintf(query, " WHERE (")
+				predicate.WriteString("(")
 			} else {
-				fmt.Fprintf(query, ") OR (")
+				predicate.WriteString(") OR (")
 			}
 
 			for j := 0; j != i; j++ {
-				fmt.Fprintf(query, "%s = %s AND ", pkey[j], args[j])
+				fmt.Fprintf(predicate, "%s = %s AND ", pkey[j], args[j])
 			}
-			fmt.Fprintf(query, "%s > %s", pkey[i], args[i])
+			fmt.Fprintf(predicate, "%s > %s", pkey[i], args[i])
 		}
-		fmt.Fprintf(query, ")")
+		predicate.WriteString(")")
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", predicate.String()))
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
+	fmt.Fprintf(query, `SELECT * FROM (SELECT ROWID, %s FROM "%s"."%s"`, strings.Join(columnSelect, ","), schemaName, tableName)
+	if len(whereClauses) > 0 {
+		fmt.Fprintf(query, " WHERE %s", strings.Join(whereClauses, " AND "))
 	}
 	fmt.Fprintf(query, " ORDER BY %s ASC", strings.Join(pkey, ", "))
 	fmt.Fprintf(query, `) WHERE ROWNUM <= %d`, db.config.Advanced.BackfillChunkSize)

--- a/source-postgres/.snapshots/TestBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestBackfillQueryGeneration
@@ -23,4 +23,14 @@ SELECT * FROM "public"."special_users" ORDER BY "user-id", "group.name" COLLATE 
 
 SELECT * FROM "public"."special_users" WHERE ("user-id", "group.name" COLLATE "C") > ($1, $2) ORDER BY "user-id", "group.name" COLLATE "C" LIMIT 100;
 
+--- integer_key_with_backfill_filter ---
+SELECT * FROM "public"."users" WHERE (created_at > '2025-01-01' OR updated_at > '2025-01-01') ORDER BY "id" LIMIT 100;
+
+SELECT * FROM "public"."users" WHERE ("id") > ($1) AND (created_at > '2025-01-01' OR updated_at > '2025-01-01') ORDER BY "id" LIMIT 100;
+
+--- backfill_filter_with_min_xid ---
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) AND (id > 123) ORDER BY "name" LIMIT 100;
+
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ("name") > ($1) AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) AND (id > 123) ORDER BY "name" LIMIT 100;
+
 

--- a/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
+++ b/source-postgres/.snapshots/TestKeylessBackfillQueryGeneration
@@ -4,4 +4,10 @@ SELECT * FROM "public"."users" WHERE ctid > $1 AND ctid <= $2
 --- with_xid_filtering ---
 SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ctid > $1 AND ctid <= $2 AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0)))
 
+--- with_backfill_filter ---
+SELECT * FROM "public"."users" WHERE ctid > $1 AND ctid <= $2 AND (id > 123)
+
+--- with_xid_filtering_and_backfill_filter ---
+SELECT xmin::text AS xmin, * FROM "public"."users" WHERE ctid > $1 AND ctid <= $2 AND ((RANDOM() < 0.001) OR ((xmin::text::bigint >= 3) AND ((((xmin::text::bigint - 12345::bigint)<<32)>>32) >= 0) AND ((((txid_snapshot_xmax(txid_current_snapshot()) - xmin::text::bigint)<<32)>>32) >= 0))) AND (id > 123)
+
 

--- a/source-postgres/.snapshots/TestSpec
+++ b/source-postgres/.snapshots/TestSpec
@@ -390,6 +390,20 @@
         "type": "integer",
         "title": "Backfill Priority",
         "description": "An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others."
+      },
+      "advanced": {
+        "properties": {
+          "additional_backfill_filter": {
+            "type": "string",
+            "title": "Additional Backfill Filter",
+            "description": "Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-postgres/CHANGELOG.md
+++ b/source-postgres/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-18
+
+### Added
+- New `additional_backfill_filter` advanced option on each binding. When set,
+  the filter clause is applied to all backfill queries for that table, so rows
+  which the filter excludes are never backfilled. Setting or changing the
+  filter requires re-backfilling the binding, while clearing it does not.
+  Filters cannot be combined with the `Precise` backfill mode. The filter
+  combines with the `min_backfill_xid` setting when both are in use.
+
 ## 2026-07-30
 
 ### Added

--- a/source-postgres/backfill.go
+++ b/source-postgres/backfill.go
@@ -18,7 +18,7 @@ import (
 var statementTimeoutRegexp = regexp.MustCompile(`canceling statement due to statement timeout`)
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from `resumeKey` if non-nil.
-func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
+func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, backfillFilter string, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	var keyColumns = state.KeyColumns
 	var resumeAfter = state.Scanned
 	var schema, table = info.Schema, info.Name
@@ -78,7 +78,7 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 		untilCTID.OffsetNumber = 0
 
 		logEntry.WithField("after", afterCTID).WithField("until", untilCTID).Debug("scanning keyless table chunk")
-		query = db.keylessScanQuery(info, schema, table)
+		query = db.keylessScanQuery(info, schema, table, backfillFilter)
 		args = []any{afterCTID, untilCTID}
 		usingCTID = true
 	case sqlcapture.TableStatePreciseBackfill, sqlcapture.TableStateUnfilteredBackfill:
@@ -95,11 +95,11 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 				"keyColumns": keyColumns,
 				"resumeKey":  resumeKey,
 			}).Debug("scanning subsequent table chunk")
-			query = db.buildScanQuery(false, isPrecise, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(false, isPrecise, keyColumns, columnTypes, schema, table, backfillFilter)
 			args = resumeKey
 		} else {
 			logEntry.WithField("keyColumns", keyColumns).Debug("scanning initial table chunk")
-			query = db.buildScanQuery(true, isPrecise, keyColumns, columnTypes, schema, table)
+			query = db.buildScanQuery(true, isPrecise, keyColumns, columnTypes, schema, table, backfillFilter)
 		}
 	default:
 		return false, nil, fmt.Errorf("invalid backfill mode %q", state.Mode)
@@ -163,13 +163,13 @@ func (db *postgresDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture
 			var resultIndex = slices.Index(resultColumnNames, colName)
 			if resultIndex < 0 {
 				return false, nil, fmt.Errorf(
-				"key column %q not found in result columns for %q (got columns: [%s]):"+
-					" the backfill query uses SELECT * which must return all key columns."+
-					" Common causes: (1) the capture user lacks table-level SELECT and only has"+
-					" column-level grants that don't include this column,"+
-					" (2) row-level security (RLS) policies are restricting query results",
-				colName, streamID, strings.Join(resultColumnNames, ", "),
-			)
+					"key column %q not found in result columns for %q (got columns: [%s]):"+
+						" the backfill query uses SELECT * which must return all key columns."+
+						" Common causes: (1) the capture user lacks table-level SELECT and only has"+
+						" column-level grants that don't include this column,"+
+						" (2) row-level security (RLS) policies are restricting query results",
+					colName, streamID, strings.Join(resultColumnNames, ", "),
+				)
 			}
 			keyIndices[idx] = resultIndex
 		}
@@ -344,25 +344,31 @@ func (db *postgresDatabase) backfillQueryFilterXMIN() string {
 	return ""
 }
 
-func (db *postgresDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName string) string {
+func (db *postgresDatabase) keylessScanQuery(_ *sqlcapture.DiscoveryInfo, schemaName, tableName, backfillFilter string) string {
+	// Generate a list of individual WHERE clauses which should be ANDed together
+	var whereClauses = []string{"ctid > $1", "ctid <= $2"}
+	var xidFiltered = db.config.Advanced.MinimumBackfillXID != ""
+	if xidFiltered {
+		whereClauses = append(whereClauses, db.backfillQueryFilterXMIN())
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
+	}
+
 	var query = new(strings.Builder)
 
 	// Include xmin when using XID filtering
-	var xidFiltered = db.config.Advanced.MinimumBackfillXID != ""
 	if xidFiltered {
 		fmt.Fprintf(query, `SELECT xmin::text AS xmin, * FROM "%s"."%s"`, schemaName, tableName)
 	} else {
 		fmt.Fprintf(query, `SELECT * FROM "%s"."%s"`, schemaName, tableName)
 	}
 
-	fmt.Fprintf(query, ` WHERE ctid > $1 AND ctid <= $2`)
-	if xidFiltered {
-		fmt.Fprintf(query, ` AND %s`, db.backfillQueryFilterXMIN())
-	}
+	fmt.Fprintf(query, ` WHERE %s`, strings.Join(whereClauses, " AND "))
 	return query.String()
 }
 
-func (db *postgresDatabase) buildScanQuery(start, isPrecise bool, keyColumns []string, columnTypes map[string]interface{}, schemaName, tableName string) string {
+func (db *postgresDatabase) buildScanQuery(start, isPrecise bool, keyColumns []string, columnTypes map[string]interface{}, schemaName, tableName, backfillFilter string) string {
 	// Construct lists of key specifiers and placeholders. They will be joined with commas and used in the query itself.
 	var pkey []string
 	var args []string
@@ -387,6 +393,9 @@ func (db *postgresDatabase) buildScanQuery(start, isPrecise bool, keyColumns []s
 	var xidFiltered = db.config.Advanced.MinimumBackfillXID != ""
 	if xidFiltered {
 		whereClauses = append(whereClauses, db.backfillQueryFilterXMIN())
+	}
+	if backfillFilter != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", backfillFilter))
 	}
 
 	// Construct the query itself

--- a/source-postgres/backfill_test.go
+++ b/source-postgres/backfill_test.go
@@ -16,6 +16,7 @@ func TestBackfillQueryGeneration(t *testing.T) {
 		schemaName     string
 		tableName      string
 		minBackfillXID string
+		backfillFilter string
 	}{
 		{
 			name:        "integer_key_precise",
@@ -58,6 +59,25 @@ func TestBackfillQueryGeneration(t *testing.T) {
 			schemaName:  "public",
 			tableName:   "special_users",
 		},
+		{
+			name:           "integer_key_with_backfill_filter",
+			isPrecise:      true,
+			keyColumns:     []string{"id"},
+			columnTypes:    map[string]interface{}{"id": "integer"},
+			schemaName:     "public",
+			tableName:      "users",
+			backfillFilter: "created_at > '2025-01-01' OR updated_at > '2025-01-01'",
+		},
+		{
+			name:           "backfill_filter_with_min_xid",
+			isPrecise:      false,
+			keyColumns:     []string{"name"},
+			columnTypes:    map[string]interface{}{"name": "text"},
+			schemaName:     "public",
+			tableName:      "users",
+			minBackfillXID: "12345",
+			backfillFilter: "id > 123",
+		},
 	}
 
 	var result = new(strings.Builder)
@@ -70,8 +90,8 @@ func TestBackfillQueryGeneration(t *testing.T) {
 				},
 			},
 		}
-		var startQuery = db.buildScanQuery(true, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName)
-		var subsequentQuery = db.buildScanQuery(false, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName)
+		var startQuery = db.buildScanQuery(true, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName, tc.backfillFilter)
+		var subsequentQuery = db.buildScanQuery(false, tc.isPrecise, tc.keyColumns, tc.columnTypes, tc.schemaName, tc.tableName, tc.backfillFilter)
 
 		// Add to cumulative result string
 		result.WriteString("--- " + tc.name + " ---\n")
@@ -85,6 +105,7 @@ func TestKeylessBackfillQueryGeneration(t *testing.T) {
 	var testCases = []struct {
 		name           string
 		minBackfillXID string
+		backfillFilter string
 	}{
 		{
 			name: "no_xid_filtering",
@@ -92,6 +113,15 @@ func TestKeylessBackfillQueryGeneration(t *testing.T) {
 		{
 			name:           "with_xid_filtering",
 			minBackfillXID: "12345",
+		},
+		{
+			name:           "with_backfill_filter",
+			backfillFilter: "id > 123",
+		},
+		{
+			name:           "with_xid_filtering_and_backfill_filter",
+			minBackfillXID: "12345",
+			backfillFilter: "id > 123",
 		},
 	}
 
@@ -105,7 +135,7 @@ func TestKeylessBackfillQueryGeneration(t *testing.T) {
 				},
 			},
 		}
-		var query = db.keylessScanQuery(nil, "public", "users")
+		var query = db.keylessScanQuery(nil, "public", "users", tc.backfillFilter)
 		result.WriteString("--- " + tc.name + " ---\n")
 		result.WriteString(query + "\n\n")
 	}

--- a/source-sqlserver-ct/.snapshots/TestSpec
+++ b/source-sqlserver-ct/.snapshots/TestSpec
@@ -200,6 +200,20 @@
         "title": "Backfill Priority",
         "description": "An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others.",
         "nonsensitive": true
+      },
+      "advanced": {
+        "properties": {
+          "additional_backfill_filter": {
+            "type": "string",
+            "title": "Additional Backfill Filter",
+            "description": "Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-sqlserver-ct/CHANGELOG.md
+++ b/source-sqlserver-ct/CHANGELOG.md
@@ -1,5 +1,14 @@
 # source-sqlserver-ct
 
+## 2026-08-18
+
+### Added
+- New `additional_backfill_filter` advanced option on each binding. When set,
+  the filter clause is applied to all backfill queries for that table, so rows
+  which the filter excludes are never backfilled. Setting or changing the
+  filter requires re-backfilling the binding, while clearing it does not.
+  Filters cannot be combined with the `Precise` backfill mode.
+
 ## 2026-07-30
 
 ### Added

--- a/source-sqlserver-ct/backfill.go
+++ b/source-sqlserver-ct/backfill.go
@@ -52,7 +52,7 @@ func (db *sqlserverDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 }
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
-func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
+func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, backfillFilter string, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	var keyColumns = state.KeyColumns
 	var schema, table = info.Schema, info.Name
 	var streamID = sqlcapture.JoinStreamID(schema, table)
@@ -63,7 +63,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	}
 
 	// Compute backfill query and arguments list
-	query, args, err := backfill.BuildBackfillQuery(state, schema, table, columnTypes, db.config.Advanced.BackfillChunkSize)
+	query, args, err := backfill.BuildBackfillQuery(state, schema, table, columnTypes, db.config.Advanced.BackfillChunkSize, backfillFilter)
 	if err != nil {
 		return false, nil, err
 	}

--- a/source-sqlserver-ct/main.go
+++ b/source-sqlserver-ct/main.go
@@ -205,6 +205,8 @@ type CTResource struct {
 	Namespace string `json:"namespace" jsonschema:"title=Schema,description=The schema (namespace) in which the table resides.,readOnly=true"`
 	Stream    string `json:"stream" jsonschema:"title=Table Name,description=The name of the table to be captured.,readOnly=true"`
 	Priority  int    `json:"priority,omitempty" jsonschema:"title=Backfill Priority,description=An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others." jsonschema_extras:"nonsensitive=true"`
+
+	Advanced *sqlcapture.AdvancedResourceOptions `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
 }
 
 func resourceSchema() json.RawMessage {

--- a/source-sqlserver/.snapshots/TestSpec
+++ b/source-sqlserver/.snapshots/TestSpec
@@ -240,6 +240,20 @@
         "type": "integer",
         "title": "Backfill Priority",
         "description": "An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others."
+      },
+      "advanced": {
+        "properties": {
+          "additional_backfill_filter": {
+            "type": "string",
+            "title": "Additional Backfill Filter",
+            "description": "Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "Advanced Options",
+        "description": "Options for advanced users. You should not typically need to modify these.",
+        "advanced": true
       }
     },
     "type": "object",

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # source-sqlserver
 
+## 2026-08-18
+
+### Added
+- New `additional_backfill_filter` advanced option on each binding. When set,
+  the filter clause is applied to all backfill queries for that table, so rows
+  which the filter excludes are never backfilled. Setting or changing the
+  filter requires re-backfilling the binding, while clearing it does not.
+  Filters cannot be combined with the `Precise` backfill mode.
+
 ## 2026-07-31
 
 ### Fixed

--- a/source-sqlserver/backfill.go
+++ b/source-sqlserver/backfill.go
@@ -53,7 +53,7 @@ func (db *sqlserverDatabase) ShouldBackfill(streamID sqlcapture.StreamID) bool {
 }
 
 // ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `resumeAfter` row key if non-nil.
-func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
+func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcapture.DiscoveryInfo, state *sqlcapture.TableState, backfillFilter string, callback func(event sqlcapture.ChangeEvent) error) (bool, []byte, error) {
 	var keyColumns = state.KeyColumns
 	var schema, table = info.Schema, info.Name
 	var streamID = sqlcapture.JoinStreamID(schema, table)
@@ -72,7 +72,7 @@ func (db *sqlserverDatabase) ScanTableChunk(ctx context.Context, info *sqlcaptur
 	}
 
 	// Compute backfill query and arguments list
-	query, args, err := backfill.BuildBackfillQuery(state, schema, table, columnTypes, db.config.Advanced.BackfillChunkSize)
+	query, args, err := backfill.BuildBackfillQuery(state, schema, table, columnTypes, db.config.Advanced.BackfillChunkSize, backfillFilter)
 	if err != nil {
 		return false, nil, err
 	}

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -544,6 +544,12 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 			state.KeyColumns = binding.Resource.PrimaryKey
 		}
 
+		// Log when a user-provided backfill filter is set, since it's an expert
+		// feature whose presence is important context when anything goes wrong.
+		if filter := binding.Resource.BackfillFilter(); filter != "" {
+			log.WithFields(log.Fields{"stream": streamID, "filter": filter}).Info("user-provided backfill filter is set")
+		}
+
 		// Select the appropriate state transition depending on the backfill mode in the resource config.
 		log.WithFields(log.Fields{
 			"stream":   streamID,
@@ -554,6 +560,12 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 		case BackfillModeAutomatic:
 			if discoveryInfo.UnpredictableKeyOrdering {
 				log.WithField("stream", streamID).Info("autoselected unfiltered (normal) backfill mode (database key ordering is unpredictable)")
+				state.Mode = TableStateUnfilteredBackfill
+			} else if binding.Resource.BackfillFilter() != "" {
+				// Precise backfills could lose changes to filter-excluded rows beyond the
+				// backfill cursor, since those replication events are dropped on the
+				// assumption that the backfill will observe the row later.
+				log.WithField("stream", streamID).Info("autoselected unfiltered (normal) backfill mode (backfill filter is set)")
 				state.Mode = TableStateUnfilteredBackfill
 			} else {
 				log.WithField("stream", streamID).Info("autoselected precise backfill mode")
@@ -905,7 +917,7 @@ func (c *Capture) backfillStream(ctx context.Context, streamID StreamID, discove
 	var eventCount int
 	var backfillDocumentBytes = 0
 	var backfillChunkStarted = time.Now()
-	backfillComplete, resumeCursor, err := c.Database.ScanTableChunk(ctx, discoveryInfo, streamState, func(event ChangeEvent) error {
+	backfillComplete, resumeCursor, err := c.Database.ScanTableChunk(ctx, discoveryInfo, streamState, binding.Resource.BackfillFilter(), func(event ChangeEvent) error {
 		if streamState.Mode == TableStatePreciseBackfill {
 			// Sanity check that when performing a "precise" backfill the DB's ordering of
 			// result rows must match our own bytewise lexicographic ordering of serialized

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -278,8 +278,10 @@ type Database interface {
 
 	// ScanTableChunk fetches a chunk of rows from the specified table, resuming from the `state.Scanned` cursor
 	// position if non-nil.
+	// The `backfillFilter` string, when non-empty, is a user-provided SQL expression which must be
+	// ANDed into the WHERE clause of the backfill query (parenthesized, so disjunctions work).
 	// The `backfillComplete` boolean will be true after scanning the final chunk of the table.
-	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, callback func(event ChangeEvent) error) (backfillComplete bool, nextResumeCursor []byte, err error)
+	ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, backfillFilter string, callback func(event ChangeEvent) error) (backfillComplete bool, nextResumeCursor []byte, err error)
 	// ListTables returns all tables visible for capture after the connector's
 	// configured discovery filters are applied.
 	ListTables(ctx context.Context) ([]TableID, error)

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -27,6 +27,8 @@ type Resource struct {
 
 	Priority int `json:"priority,omitempty" jsonschema:"title=Backfill Priority,description=An optional integer priority for this binding. The highest priority binding(s) will be backfilled completely before any others. The default priority is zero. Negative priorities are allowed and will cause a binding to be backfilled after others."`
 
+	Advanced *AdvancedResourceOptions `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
+
 	// PrimaryKey allows the user to override the "scan key" columns which will be used
 	// to perform backfill queries and merge replicated changes. If left unset we default
 	// to the collection's key, which is basically always what the user wants, so we omit
@@ -35,6 +37,20 @@ type Resource struct {
 	PrimaryKey []string `json:"primary_key,omitempty" jsonschema:"-"`
 
 	DeprecatedSyncMode string `json:"syncMode,omitempty" jsonschema:"-"` // Unused, only supported to avoid breaking existing captures
+}
+
+// AdvancedResourceOptions holds the rarely-used per-binding settings.
+type AdvancedResourceOptions struct {
+	AdditionalBackfillFilter string `json:"additional_backfill_filter,omitempty" jsonschema:"title=Additional Backfill Filter,description=Optional filter clause which will be applied to all backfill queries for this binding. Contact Estuary support for assistance before using this option."`
+}
+
+// BackfillFilter returns the user-configured backfill filter expression, or an
+// empty string when no filter is set.
+func (r Resource) BackfillFilter() string {
+	if r.Advanced == nil {
+		return ""
+	}
+	return r.Advanced.AdditionalBackfillFilter
 }
 
 // BackfillMode represents different ways we might want to backfill the preexisting contents of a table.
@@ -67,6 +83,13 @@ const (
 func (r Resource) Validate() error {
 	if !slices.Contains([]BackfillMode{BackfillModeAutomatic, BackfillModeNormal, BackfillModePrecise, BackfillModeOnlyChanges, BackfillModeWithoutKey}, r.Mode) {
 		return fmt.Errorf("invalid backfill mode %q", r.Mode)
+	}
+	// Precise backfills drop replication events for rows beyond the backfill cursor, on
+	// the assumption that the backfill will observe those rows later. A backfill filter
+	// could violate that assumption for the rows it excludes, in which case changes to
+	// those rows might be lost entirely. Better to require unfiltered mode instead.
+	if r.Mode == BackfillModePrecise && r.BackfillFilter() != "" {
+		return fmt.Errorf("backfill filters cannot be used in the %q backfill mode", BackfillModePrecise)
 	}
 	if r.Namespace == "" {
 		return fmt.Errorf("table namespace unspecified")
@@ -256,6 +279,16 @@ func (d *Driver) Validate(ctx context.Context, req *pc.Request_Validate) (*pc.Re
 		// a corresponding backfill counter increment, that's an error.
 		if prevBinding, ok := previousBindings[streamID]; ok && res.Mode != prevBinding.Resource.Mode && binding.Backfill <= prevBinding.Backfill {
 			var err = fmt.Errorf("must re-backfill when changing backfill mode: table %q changed from %q to %q", streamID, prevBinding.Resource.Mode, res.Mode)
+			log.WithError(err).Debug("prerequisite error")
+			errs = append(errs, err)
+		}
+
+		// Setting or changing the backfill filter requires a corresponding backfill
+		// counter increment, while clearing it doesn't (so a stale filter can be removed
+		// after a backfill completes). It's not entirely clear that changes need to be
+		// forbidden here, but doing so removes one source of possible user error.
+		if prevBinding, ok := previousBindings[streamID]; ok && res.BackfillFilter() != prevBinding.Resource.BackfillFilter() && res.BackfillFilter() != "" && binding.Backfill <= prevBinding.Backfill {
+			var err = fmt.Errorf("must re-backfill when changing the backfill filter: table %q changed from %q to %q", streamID, prevBinding.Resource.BackfillFilter(), res.BackfillFilter())
 			log.WithError(err).Debug("prerequisite error")
 			errs = append(errs, err)
 		}

--- a/sqlcapture/main.go
+++ b/sqlcapture/main.go
@@ -84,6 +84,13 @@ func (r Resource) Validate() error {
 	if !slices.Contains([]BackfillMode{BackfillModeAutomatic, BackfillModeNormal, BackfillModePrecise, BackfillModeOnlyChanges, BackfillModeWithoutKey}, r.Mode) {
 		return fmt.Errorf("invalid backfill mode %q", r.Mode)
 	}
+	// Forbid backfill filters which are non-empty but contain only whitespace. This is
+	// always a mistake (typically a failed attempt to clear the field), and if it counted
+	// as a set filter the resulting errors would guide the user into an unnecessary and
+	// irreversible backfill.
+	if filter := r.BackfillFilter(); filter != "" && strings.TrimSpace(filter) == "" {
+		return fmt.Errorf("invalid backfill filter %q: must be empty or contain a filter expression", filter)
+	}
 	// Precise backfills drop replication events for rows beyond the backfill cursor, on
 	// the assumption that the backfill will observe those rows later. A backfill filter
 	// could violate that assumption for the rows it excludes, in which case changes to

--- a/sqlcapture/main_test.go
+++ b/sqlcapture/main_test.go
@@ -1,0 +1,54 @@
+package sqlcapture
+
+import "testing"
+
+func TestResourceValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		res     Resource
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			res:  Resource{Namespace: "public", Stream: "foo"},
+		},
+		{
+			name:    "invalid_mode",
+			res:     Resource{Namespace: "public", Stream: "foo", Mode: "Bogus"},
+			wantErr: true,
+		},
+		{
+			name: "filter_with_automatic_mode",
+			res: Resource{Namespace: "public", Stream: "foo",
+				Advanced: &AdvancedResourceOptions{AdditionalBackfillFilter: "id > 123"}},
+		},
+		{
+			name: "filter_with_normal_mode",
+			res: Resource{Namespace: "public", Stream: "foo", Mode: BackfillModeNormal,
+				Advanced: &AdvancedResourceOptions{AdditionalBackfillFilter: "id > 123"}},
+		},
+		{
+			name: "filter_with_precise_mode",
+			res: Resource{Namespace: "public", Stream: "foo", Mode: BackfillModePrecise,
+				Advanced: &AdvancedResourceOptions{AdditionalBackfillFilter: "id > 123"}},
+			wantErr: true,
+		},
+		{
+			name: "precise_mode_without_filter",
+			res:  Resource{Namespace: "public", Stream: "foo", Mode: BackfillModePrecise},
+		},
+		{
+			name: "precise_mode_with_empty_advanced_options",
+			res:  Resource{Namespace: "public", Stream: "foo", Mode: BackfillModePrecise, Advanced: &AdvancedResourceOptions{}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var err = tc.res.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected an error but got none")
+			} else if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/sqlcapture/main_test.go
+++ b/sqlcapture/main_test.go
@@ -41,6 +41,17 @@ func TestResourceValidate(t *testing.T) {
 			name: "precise_mode_with_empty_advanced_options",
 			res:  Resource{Namespace: "public", Stream: "foo", Mode: BackfillModePrecise, Advanced: &AdvancedResourceOptions{}},
 		},
+		{
+			name: "whitespace_only_filter",
+			res: Resource{Namespace: "public", Stream: "foo",
+				Advanced: &AdvancedResourceOptions{AdditionalBackfillFilter: "  "}},
+			wantErr: true,
+		},
+		{
+			name: "filter_with_surrounding_whitespace",
+			res: Resource{Namespace: "public", Stream: "foo",
+				Advanced: &AdvancedResourceOptions{AdditionalBackfillFilter: " id > 123 "}},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var err = tc.res.Validate()


### PR DESCRIPTION
**Description:**

Adds an Advanced Options section to the resource spec with a new 'additional_backfill_filter' property, a SQL expression which is ANDed into the WHERE clause of every backfill query for that binding. This allows a power user (hopefully guided by support) to use application knowledge to make large re-backfills more efficient.

On PostgreSQL it composes with the existing XMIN filtering option.

Currently validation requires a re-backfill of the binding whenever the option is set or changed (clearing is exempt so you can remove it afterwards). I'm not certain whether this is desirable but it seemed like the safer approach to start with.

Because precise backfills drop replication events for rows beyond the backfill cursor on the assumption that they'll be read later on, and a backfill filter can violate that assumption, we force unfiltered backfill mode when a filter is set.

(Arguably we should be doing that any time an incremental backfill is performed, since deletions also violate this assumption. Precise backfills are kind of an impressive trick but practically speaking they're a giant headache.)

**Workflow steps:**

1. In the Estuary dashboard, edit the capture and open the configuration of the relevant binding.
2. Expand **Advanced Options** and fill out the "Additional Backfill Filter" field.
3. Trigger a backfill of that binding, making sure "Incremental backfill" is selected in the backfill drop-down, and publish.

   Selecting a [Dataflow Reset](#dataflow-reset) instead would drop the filter-excluded rows from destination tables entirely, so only choose that if a filtered subset is the intended end state.

   A publication which sets or changes the filter must also trigger a backfill of that binding, and will otherwise fail validation.
4. After the backfill completes, clear the field and publish again. Clearing it does not require another backfill. This prevents a stale filter from being applied to future backfills by mistake.

**Notes for reviewers:**

This is the first and only instance of an "Advanced Options" sub-object in a binding's resource config, but we've got a couple of other options (like "Backfill Mode") which arguably ought to be in there as well and it seemed like a situation where eventually we just have to bite the bullet and add the category with a single option in it so that it's there when we go to add another advanced toggle.

The UI's handling of a sub-group on a resource config hasn't really been exercised before since AFAICT we don't have any of those anywhere, but it's using the same rendering as the endpoint configs and seems to work fine in practice.

Collapsed:
<img width="2323" height="1008" alt="2026-08-18-151925_3840x2160_scrot" src="https://github.com/user-attachments/assets/aff98d88-1432-46e9-afc4-381f2ce47d23" />

Expanded:
<img width="2299" height="1004" alt="2026-08-18-151933_3840x2160_scrot" src="https://github.com/user-attachments/assets/c15d2aa8-8238-4df7-add6-97475e4ac129" />

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
