### PR TITLE
sqlcapture: performance improvements for captures with many bindings

### DIFF
--- a/source-sqlserver-ct/replication.go
+++ b/source-sqlserver-ct/replication.go
@@ -570,7 +570,7 @@ func ctGetChangedTables(ctx context.Context, conn *sql.DB, candidates []*ctTable
 	// Sort candidates by name so the query is stable across polling cycles
 	var sorted = slices.Clone(candidates)
 	slices.SortFunc(sorted, func(a, b *ctTablePollInfo) int {
-		return strings.Compare(a.StreamID.String(), b.StreamID.String())
+		return a.StreamID.Compare(b.StreamID)
 	})
 
 	var args = make([]any, 0, len(sorted))

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"math"
 	"math/rand"
 	"os"
@@ -61,17 +62,29 @@ func (ps *PersistentState) Validate() error {
 	return nil
 }
 
-// BindingsInState returns all the bindings having a particular persisted state, in sorted order for
-// reproducibility.
-func (c *Capture) BindingsInState(modes ...BackfillMode) []*Binding {
-	var bindings []*Binding
-	for _, binding := range c.Bindings {
-		if slices.Contains(modes, BackfillMode(c.State.Streams[binding.StateKey].Mode)) {
-			bindings = append(bindings, binding)
+// bindingsInState yields every binding whose persisted state is one of the given modes, in
+// map iteration order. It exists so that the state predicate lives in exactly one place:
+// callers compose it with slices.SortedFunc when they need a reproducible order, with
+// slices.AppendSeq when the order doesn't matter, or range over it with an early return
+// to test for existence without building a list at all.
+func (c *Capture) bindingsInState(modes ...BackfillMode) iter.Seq[*Binding] {
+	return func(yield func(*Binding) bool) {
+		for _, binding := range c.Bindings {
+			if slices.Contains(modes, BackfillMode(c.State.Streams[binding.StateKey].Mode)) {
+				if !yield(binding) {
+					return
+				}
+			}
 		}
 	}
-	slices.SortFunc(bindings, func(a, b *Binding) int { return a.StreamID.Compare(b.StreamID) })
-	return bindings
+}
+
+// BindingsInState returns all the bindings having a particular persisted state in sorted order for
+// reproducibility.
+func (c *Capture) BindingsInState(modes ...BackfillMode) []*Binding {
+	return slices.SortedFunc(c.bindingsInState(modes...), func(a, b *Binding) int {
+		return a.StreamID.Compare(b.StreamID)
+	})
 }
 
 // BindingsCurrentlyActive returns all the bindings currently being captured.
@@ -103,16 +116,20 @@ func (c *Capture) BindingsCurrentlyBackfilling() []*Binding {
 	return c.BindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill)
 }
 
+// bindingsCurrentlyBackfillingUnsorted is the unordered equivalent of
+// BindingsCurrentlyBackfilling for callers which don't depend on the ordering.
+func (c *Capture) bindingsCurrentlyBackfillingUnsorted() []*Binding {
+	var bindings = make([]*Binding, 0, len(c.Bindings))
+	return slices.AppendSeq(bindings, c.bindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill))
+}
+
 // AnyBindingsCurrentlyBackfilling reports whether any binding is undergoing some sort of
 // backfill. It answers the same question as len(BindingsCurrentlyBackfilling()) > 0 without
 // building and sorting the full list, which dominates the cost when a capture has many
 // bindings.
 func (c *Capture) AnyBindingsCurrentlyBackfilling() bool {
-	for _, binding := range c.Bindings {
-		switch c.State.Streams[binding.StateKey].Mode {
-		case TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill:
-			return true
-		}
+	for range c.bindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill) {
+		return true
 	}
 	return false
 }
@@ -884,7 +901,7 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) (int, error) {
 }
 
 func (c *Capture) backfillStreams(ctx context.Context, discovery map[StreamID]*DiscoveryInfo) error {
-	var bindings = c.BindingsCurrentlyBackfilling()
+	var bindings = c.bindingsCurrentlyBackfillingUnsorted()
 	if len(bindings) == 0 {
 		return nil
 	}
@@ -1103,7 +1120,7 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 
 func (c *Capture) statusUpdate(status string) {
 	// Add backfill information with percentage progress
-	var backfillingBindings = c.BindingsCurrentlyBackfilling()
+	var backfillingBindings = c.bindingsCurrentlyBackfillingUnsorted()
 	if len(backfillingBindings) > 0 {
 		// Build list of tables to query for estimated row counts
 		var tables []TableID

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -70,7 +70,7 @@ func (c *Capture) BindingsInState(modes ...BackfillMode) []*Binding {
 			bindings = append(bindings, binding)
 		}
 	}
-	slices.SortFunc(bindings, func(a, b *Binding) int { return strings.Compare(a.StreamID.String(), b.StreamID.String()) })
+	slices.SortFunc(bindings, func(a, b *Binding) int { return a.StreamID.Compare(b.StreamID) })
 	return bindings
 }
 

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -103,6 +103,20 @@ func (c *Capture) BindingsCurrentlyBackfilling() []*Binding {
 	return c.BindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill)
 }
 
+// AnyBindingsCurrentlyBackfilling reports whether any binding is undergoing some sort of
+// backfill. It answers the same question as len(BindingsCurrentlyBackfilling()) > 0 without
+// building and sorting the full list, which dominates the cost when a capture has many
+// bindings.
+func (c *Capture) AnyBindingsCurrentlyBackfilling() bool {
+	for _, binding := range c.Bindings {
+		switch c.State.Streams[binding.StateKey].Mode {
+		case TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill:
+			return true
+		}
+	}
+	return false
+}
+
 // TableState represents the serializable/resumable state of a particular table's capture.
 // It is mostly concerned with the "backfill" scanning process and the transition from that
 // to logical replication.
@@ -369,7 +383,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		}
 
 		// If any tables are currently backfilling, go perform another backfill iteration.
-		if c.BindingsCurrentlyBackfilling() != nil {
+		if c.AnyBindingsCurrentlyBackfilling() {
 			c.statusUpdate("Backfilling Tables")
 			if err := c.backfillStreams(ctx, discovery); err != nil {
 				return fmt.Errorf("error performing backfill: %w", err)

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -464,16 +464,12 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 	// flag update logic works makes a JSON-patch deletion of the whole thing tricky, but
 	// we could theoretically change this someday if "excessive size of state checkpoints
 	// due to deleted bindings" ever becomes an actual issue in practice.
-	streamExistsInCatalog := func(sk boilerplate.StateKey) bool {
-		for _, b := range c.Bindings {
-			if b.StateKey == sk {
-				return true
-			}
-		}
-		return false
+	var stateKeysInCatalog = make(map[boilerplate.StateKey]bool, len(c.Bindings))
+	for _, b := range c.Bindings {
+		stateKeysInCatalog[b.StateKey] = true
 	}
 	for stateKey, state := range c.State.Streams {
-		if state.Mode != TableStateIgnore && !streamExistsInCatalog(stateKey) {
+		if state.Mode != TableStateIgnore && !stateKeysInCatalog[stateKey] {
 			log.WithField("stateKey", stateKey).Info("binding removed from capture")
 			c.State.Streams[stateKey] = &TableState{
 				Mode:     TableStateIgnore,

--- a/sqlcapture/interface.go
+++ b/sqlcapture/interface.go
@@ -20,6 +20,14 @@ func (s StreamID) String() string {
 	return fmt.Sprintf("%s.%s", s.Schema, s.Table)
 }
 
+// Compare orders StreamIDs by schema and then by table name.
+func (s StreamID) Compare(other StreamID) int {
+	if n := strings.Compare(s.Schema, other.Schema); n != 0 {
+		return n
+	}
+	return strings.Compare(s.Table, other.Table)
+}
+
 // EncodeKey returns an unambiguous string representation of the StreamID
 // suitable for use as a map key in serialized cursors. The schema and table
 // components are encoded so that periods can be used as the separator.


### PR DESCRIPTION
**Description:**

After the `linked_collections` mechanism support was added in https://github.com/estuary/connectors/pull/5038, a user set up a capture with 40,500+ bindings and noticed backfill throughput was significantly slower than anticipated. Captures have never needed to work with that many bindings before, so it's little surprise that there are strategies sprinkled throughout the code that are slow at that scale.

This PR is a coterie of performance improvements for SQL captures so they're more performant in the new `linked_collections` world. The improvements are described in each commit along with benchmarks, but a brief summary of the changes in `sqlcapture/capture.go` is below:
- Avoid allocating in the sort comparator by comparing the `Schema`/`Table` directly instead of using `StreamID.String()`.
- Stop building a list in the main loop guard. Instead of using `if BindingsCurrentlyBackfilling() != nil` which allocated and sorted every backfilling binding just to see if any existed, we perform an exit early scan.
- Use an `iter.Seq` for the binding state predicate, requiring callers to compose with `slices.SortedFunc`, `slices.AppendSeq`, or returning early as necessary.
- Make the removed binding check no longer O(N^2) by using an existence map instead of scanning every binding inside a loop over every state entry.

On my machine, I measured the overall improvements as:
|   |  before | after |
| -- | -- | -- |
| per backfill chunk | 591.80 ms, 225 MB, 11.8M allocs | 15.73 ms, 655 KB, 2 allocs |
| startup binding reconciliation | 33.6 s | 10.5 ms |

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1787100817430129)

**Notes for reviewers:**

~~Additionally, I updated a stale comment that indicated a loop could be removed a couple days after a late 2024 migration. I _almost_ removed it, but Claude figured out that the loop is still necessary so `source-mysql` can detect primary key updates.~~

There may be additional performance improvements we need to make as captures start exercising the `linked_collections` mechanism and increasing the number of bindings

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
