### PR TITLE
Publish connector docs on merge instead of waiting for the cron

### DIFF
--- a/.github/workflows/docs-publish-dispatch.yaml
+++ b/.github/workflows/docs-publish-dispatch.yaml
@@ -1,0 +1,98 @@
+name: Docs / publish dispatch
+
+# Post-merge: tells estuary/docs to publish as soon as connector docs land on
+# main, instead of waiting out its hourly cron.
+#
+# estuary/docs owns docs.estuary.dev and pulls this repo's docs in through a git
+# submodule, so nothing merged here publishes itself. Its deploy runs on a
+# `15 * * * *` cron that advances the submodule, and observed drift on that
+# schedule is up to 34 minutes, so a connector doc change can sit unpublished
+# for over an hour. This dispatch brings that down to the length of one build,
+# measured at 2m57s.
+#
+# The receiving side is the `repository_dispatch` trigger on
+# estuary/docs .github/workflows/deploy-cloudflare.yml, listening for
+# `connector-docs-updated`. The hourly cron there stays as the backstop and
+# must not be removed on the strength of this workflow: a dispatch that never
+# arrives leaves no trace on the receiver, and the cron is what covers that.
+#
+# Requires the "estuary-docs-previews" GitHub App (PREVIEW_APP_ID repo variable
+# + PREVIEW_APP_PRIVATE_KEY secret, installed on both estuary/docs and
+# estuary/connectors). Without them the job skips rather than failing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # The two paths estuary/docs actually reads out of the submodule:
+      # aggregate-docs.sh rsyncs reference/Connectors/ into the site's content
+      # tree, and docusaurus.config.js reads redirects.yaml to build the
+      # connector redirect table. The rest of docs/ is internal engineering
+      # notes that publish nothing, so they should not spend a deploy.
+      - docs/reference/Connectors/**
+      - docs/redirects.yaml
+
+concurrency:
+  # Serialise on the branch, and do not cancel: each merge should result in a
+  # dispatch. Cancelling an in-flight dispatch to start a newer one risks
+  # dropping the only signal for a merge.
+  group: docs-publish-dispatch-main
+  cancel-in-progress: false
+
+# The job only ever uses the App-minted token, scoped to estuary/docs, so it
+# needs none of the ambient GITHUB_TOKEN's scope.
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Dispatch publish to estuary/docs
+    # Skip rather than fail if the App configuration is ever removed. A missed
+    # dispatch degrades to the hourly cron; a red workflow on main does not.
+    if: vars.PREVIEW_APP_ID != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Mint token for estuary/docs
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PREVIEW_APP_ID }}
+          private-key: ${{ secrets.PREVIEW_APP_PRIVATE_KEY }}
+          owner: estuary
+          repositories: docs
+
+      - name: Dispatch publish to estuary/docs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # The receiver ignores client_payload; the SHA is carried so the
+          # dispatch is self-describing when reading the events API or
+          # working out which merge produced a given deploy.
+          gh api repos/estuary/docs/dispatches --input - <<EOF
+          {
+            "event_type": "connector-docs-updated",
+            "client_payload": {
+              "connectors_sha": "${SHA}"
+            }
+          }
+          EOF
+
+      - name: Note what to check
+        run: |
+          {
+            echo "### Publish dispatched"
+            echo
+            echo "Sent \`connector-docs-updated\` to \`estuary/docs\`."
+            echo
+            echo "A green result here means only that the API call returned 204."
+            echo "If \`estuary/docs\` has no matching \`repository_dispatch\`"
+            echo "trigger, the call still succeeds and nothing happens. Confirm"
+            echo "on the receiving side:"
+            echo
+            echo '```'
+            echo "gh run list --repo estuary/docs --workflow deploy-cloudflare.yml \\"
+            echo "  --limit 5 --json createdAt,event,conclusion"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
**Blocked on estuary/docs#38. Do not merge until that lands.** Draft for that reason only; the code is finished.

**Regression?**

No.

**Description:**

`.github/workflows/docs-publish-dispatch.yaml` sends a `repository_dispatch` to `estuary/docs` when connector docs merge to `main`, so a connector doc change publishes in about 3 minutes instead of waiting out the hourly cron.

`estuary/docs` owns `docs.estuary.dev` and pulls this repo's docs in through a git submodule, so nothing merged here publishes itself. Its deploy runs on a `15 * * * *` cron that advances the submodule pin, and observed drift on that schedule is up to 34 minutes. A connector doc change can therefore sit unpublished for over an hour. A full build and deploy is 2m57s, so the wait is almost entirely the cron, not the build.

**Workflow steps:**

No change for authors. After a docs merge to `main`, `estuary/docs` starts a deploy within seconds instead of on the next hour.

**Why this is blocked**

The receiver is the `repository_dispatch` trigger on `estuary/docs` `.github/workflows/deploy-cloudflare.yml`, listening for `connector-docs-updated`. That trigger is added by estuary/docs#38 and is not on `estuary/docs` `main` yet.

What unblocks this is docs#38 **merging**, not rebasing this onto anything. The receiver has to exist on the branch the dispatch is delivered to, which is `estuary/docs` `main`. Nothing about this branch's base changes that, so this is kept independent of PR #5090 rather than stacked on it.

**If this merges early it fails silently, not loudly.** `POST /repos/estuary/docs/dispatches` returns 204 whether or not any workflow listens for the event type. So the workflow would go green on every docs merge while publishing nothing, and the cron would quietly keep doing the work. That is the reason for the draft status rather than just a note.

**Notes for reviewers:**

*Do not use a green run here as evidence the dispatch worked.* Check the receiving side:

```
gh run list --repo estuary/docs --workflow deploy-cloudflare.yml --limit 5 --json createdAt,event,conclusion
```

Look for `event: repository_dispatch`. The workflow's step summary repeats this, so whoever reads the run gets told the same thing.

Note that `gh run list` unscoped is actively misleading on `estuary/docs`: it will show green GitHub Pages runs from the parallel `deploy.yml` while the Cloudflare workflow has had zero runs. Always pass `--workflow deploy-cloudflare.yml`.

*The hourly cron on `estuary/docs` stays.* It is the backstop for a dispatch that never arrives, which by the above leaves no trace on the receiver. It should not be removed on the strength of this workflow.

*`paths:` filter.* Same two paths as PR #5090, and for the same reason: `aggregate-docs.sh` reads `docs/reference/Connectors/` and `docusaurus.config.js` reads `docs/redirects.yaml`. Nothing else under `docs/` publishes, so nothing else should spend a deploy.

*`concurrency` does not cancel in progress.* Every merge should result in a dispatch. Cancelling an in-flight dispatch to start a newer one risks dropping the only signal for a merge, and the dispatch itself is one API call, so there is nothing to save by cancelling.

*`if: vars.PREVIEW_APP_ID != ''`.* Skip rather than fail if the App configuration is ever removed. A missed dispatch degrades to the hourly cron; a red workflow on `main` does not degrade to anything.

*`permissions: {}`.* The job only uses the App-minted token, scoped to `estuary/docs`. `client_payload` carries the merge SHA; the receiver ignores it, but it makes the dispatch self-describing when reading the events API.

**Verification plan, to run after docs#38 merges**

1. Undraft and merge this.
2. Merge a trivial change under `docs/reference/Connectors/` and confirm a `repository_dispatch` run appears in `estuary/docs` with the command above.
3. Confirm the change is live on `docs.estuary.dev` within a few minutes. Take the URL from the sitemap; slug overrides are pervasive and a URL guessed from the file path will mislead.

**Documentation links affected:**

None. This builds CI, not docs.

**Checklist:**

- [x] Not user-visible connector behavior. No `CHANGELOG.md` entry applies.
