### PR TITLE
ci: don't run Go & Rust connectors' CI workflow when only Python connectors are edited

### DIFF
--- a/.github/actions/classify-changes/action.yaml
+++ b/.github/actions/classify-changes/action.yaml
@@ -1,0 +1,87 @@
+name: Classify Changed Paths
+description: >
+  Decide which connector CI lanes a change affects.
+  Python connectors are recognised by a top-level
+  pyproject.toml rather than by name.
+
+outputs:
+  python:
+    description: Whether the Python connector workflow needs to run.
+    value: ${{ steps.classify.outputs.python }}
+  go_rust:
+    description: Whether the Go & Rust connector workflow needs to run.
+    value: ${{ steps.classify.outputs.go_rust }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Classify the changed paths
+      id: classify
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+
+        # Every failure path below runs both lanes.
+        fallback() {
+          echo "$1; running both lanes to be safe"
+          printf 'python=true\ngo_rust=true\n' >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+
+        # Which paths changed comes from the API rather than from git history
+        # for various reasons, mostly to avoid re-engineering the "which paths
+        # have changed?" logic ourselves.
+        #
+        # The catch is that neither endpoint promises the full list - they cap
+        # out at 300 or 3000 files and truncate silently. A missing path can only
+        # turn a lane off, so each branch proves its list is complete before a
+        # "false" is believed.
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # Paginated but capped at 3000 files. A list sitting at the 3000
+          # path cap cannot be assumed complete.
+          gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename' > changed.txt ||
+            fallback "could not list pull request files"
+
+          COUNT=$(wc -l < changed.txt)
+          [ "$COUNT" -lt 3000 ] ||
+            fallback "listed ${COUNT} files at the API's 3000-file cap"
+        else
+          # The compare endpoint reports at most 300 files and does not paginate
+          # them. They appear only on the first page, so a diff sitting at
+          # the 300 path cap cannot be assumed complete.
+          gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
+            --jq '.files[].filename' > changed.txt ||
+            fallback "could not compare ${{ github.event.before }}...${{ github.sha }}"
+
+          COUNT=$(wc -l < changed.txt)
+          [ "$COUNT" -lt 300 ] ||
+            fallback "compare returned ${COUNT} files at the API's 300-file cap"
+        fi
+
+        echo "${COUNT} changed path(s)"
+
+        # An empty list contradicts the workflow having triggered at all, so read
+        # it as a broken enumeration rather than as "nothing to do".
+        if [ "$COUNT" -eq 0 ]; then
+          fallback "no paths enumerated"
+        fi
+
+        SCRIPT="${{ github.workspace }}/.github/scripts/classify-changed-paths.sh"
+        if ! VERDICT=$("$SCRIPT" < changed.txt); then
+          fallback "classifier exited non-zero"
+        fi
+
+        # Guard the shape of the verdict too: an empty or malformed value would
+        # compare unequal to 'true' in the callers' `if:` and skip everything.
+        if ! grep -Eq '^python=(true|false)$' <<< "$VERDICT" ||
+           ! grep -Eq '^go_rust=(true|false)$' <<< "$VERDICT"; then
+          fallback "classifier gave '${VERDICT}'"
+        fi
+
+        echo "verdict:"
+        echo "$VERDICT"
+        echo "$VERDICT" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/classify-changed-paths.sh
+++ b/.github/scripts/classify-changed-paths.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Work out which connector CI lanes a set of changed paths affects.
+#
+# Reads changed paths on stdin, one per line, and writes two lines to stdout:
+#
+#   python=true|false     the Python connector workflow must run
+#   go_rust=true|false    the Go & Rust connector workflow must run
+#
+# The lane chosen for each path is logged to stderr.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+python=false
+go_rust=false
+
+# Read stdin up front so it can be scanned before classifying. Deleting a
+# connector takes its pyproject.toml off disk, so the changed paths are the only
+# evidence it was a Python one. `|| true` because grep exits non-zero when
+# nothing matches, which `set -e` would treat as fatal.
+input=$(cat)
+changed_pyproject_dirs=$(
+    grep -E "^[^/]+/pyproject\.toml$" <<< "$input" | cut -d/ -f1 | sort -u || true
+)
+
+# `|| [ -n "$path" ]` so a final line with no trailing newline is still read.
+# Without it that path is silently dropped from the verdict, which could skip a
+# build for a change it didn't notice.
+while IFS= read -r path || [ -n "$path" ]; do
+    [ -n "$path" ] || continue
+
+    lane=""
+    case "$path" in
+        # Documentation and agent tooling build nothing.
+        *.md | docs/* | .claude/*) lane="none" ;;
+
+        # Each workflow is triggered by edits to itself so a change to one
+        # verifies itself rather than waiting on an unrelated connector edit.
+        # estuary-cdk.yaml drives its own separate workflow.
+        .github/workflows/python.yaml) lane="python" ;;
+        .github/workflows/ci.yaml) lane="go_rust" ;;
+        .github/workflows/estuary-cdk.yaml) lane="none" ;;
+
+        # Shared build plumbing that both workflows invoke.
+        .github/actions/* | fetch-flow.sh) lane="both" ;;
+    esac
+
+    if [ -z "$lane" ]; then
+        # Python connectors and estuary-cdk all carry a top-level pyproject.toml.
+        # The check is one level deep on purpose. materialize-iceberg/python has
+        # a pyproject.toml of its own, and a recursive check that would classify a
+        # Go connector as Python and stop building it.
+        #
+        # "$top" != "$path" keeps top-level files such as go.mod out of this
+        # branch. $changed_pyproject_dirs covers a connector deleted by this
+        # change whose manifest is gone from disk but still listed among the
+        # changed paths.
+        top=${path%%/*}
+        if [ "$top" != "$path" ] &&
+           # Is there a pyproject.toml in the connector's root?
+           { [ -f "$REPO_ROOT/$top/pyproject.toml" ] ||
+             # Or does $top appear as a complete line, matched literally, in the set of
+             # directories whose pyproject.toml this change touched? This catches the
+             # case where a Python connector is deleted wholesale.
+             grep -qxF "$top" <<< "$changed_pyproject_dirs"; }; then
+            lane="python"
+        else
+            # Go and Rust connectors, the shared Go packages, go.mod, base-image,
+            # tests/.
+            lane="go_rust"
+        fi
+    fi
+
+    case "$lane" in
+        python) python=true ;;
+        go_rust) go_rust=true ;;
+        both)
+            python=true
+            go_rust=true
+            ;;
+    esac
+
+    echo "  ${lane}: ${path}" >&2
+done <<< "$input"
+
+echo "python=${python}"
+echo "go_rust=${go_rust}"

--- a/.github/scripts/test_classify_changed_paths.py
+++ b/.github/scripts/test_classify_changed_paths.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Unit tests for classify-changed-paths.sh.
+
+The classifier decides whether each connector CI workflow runs.
+These tests pin both the routing rules and the "when in doubt, build" behaviour.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "classify-changed-paths.sh"
+
+
+def classify(*paths: str, terminate: bool = True) -> tuple[bool, bool]:
+    """Run the classifier, returning (python, go_rust)."""
+    stdin = "\n".join(paths) + ("\n" if terminate else "")
+    proc = subprocess.run(
+        [str(SCRIPT)], input=stdin, capture_output=True, text=True, check=True
+    )
+    verdict = dict(
+        line.split("=", 1) for line in proc.stdout.strip().splitlines() if "=" in line
+    )
+    return verdict["python"] == "true", verdict["go_rust"] == "true"
+
+
+class TestLanes(unittest.TestCase):
+    def test_python_connector_is_python_only(self):
+        self.assertEqual(classify("source-sentry/source_sentry/api.py"), (True, False))
+
+    def test_python_cdk_is_python_only(self):
+        self.assertEqual(classify("estuary-cdk/estuary_cdk/http.py"), (True, False))
+
+    def test_go_connector_is_go_only(self):
+        self.assertEqual(classify("source-postgres/main.go"), (False, True))
+
+    def test_shared_go_package_is_go_only(self):
+        self.assertEqual(classify("sqlcapture/backfill.go"), (False, True))
+
+    def test_rust_connector_is_go_only(self):
+        self.assertEqual(classify("source-kafka/src/main.rs"), (False, True))
+
+    def test_top_level_file_is_go_only(self):
+        self.assertEqual(classify("go.mod"), (False, True))
+
+    def test_shared_plumbing_is_both(self):
+        self.assertEqual(classify(".github/actions/setup/action.yaml"), (True, True))
+        self.assertEqual(classify("fetch-flow.sh"), (True, True))
+
+    def test_docs_are_neither(self):
+        self.assertEqual(classify("CLAUDE.md"), (False, False))
+        self.assertEqual(classify("docs/contexts/captures.md"), (False, False))
+        self.assertEqual(classify(".claude/skills/add-stream/SKILL.md"), (False, False))
+
+    def test_connector_changelog_is_neither(self):
+        self.assertEqual(classify("source-postgres/CHANGELOG.md"), (False, False))
+
+    def test_each_workflow_triggers_itself(self):
+        self.assertEqual(classify(".github/workflows/python.yaml"), (True, False))
+        self.assertEqual(classify(".github/workflows/ci.yaml"), (False, True))
+
+    def test_estuary_cdk_workflow_triggers_neither_connector_lane(self):
+        self.assertEqual(classify(".github/workflows/estuary-cdk.yaml"), (False, False))
+
+    def test_nested_pyproject_does_not_make_a_go_connector_python(self):
+        # materialize-iceberg/python/pyproject.toml exists. Classing its parent as
+        # Python would stop ci.yaml building a Go connector.
+        self.assertEqual(classify("materialize-iceberg/python/foo.py"), (False, True))
+
+    def test_mixed_change_runs_both(self):
+        self.assertEqual(
+            classify("source-sentry/api.py", "sqlcapture/backfill.go"), (True, True)
+        )
+
+    def test_unknown_path_builds_rather_than_skipping(self):
+        self.assertEqual(classify("some-new-thing/file.txt"), (False, True))
+
+    def test_deleted_connector_is_still_python(self):
+        # source-gone/ is not on disk, so its manifest appearing among the
+        # changed paths is the only thing identifying it as a Python connector.
+        self.assertEqual(
+            classify("source-gone/api.py", "source-gone/pyproject.toml"), (True, False)
+        )
+
+    def test_renamed_connector_is_python_on_both_sides(self):
+        self.assertEqual(
+            classify(
+                "source-old/pyproject.toml",
+                "source-old/api.py",
+                "source-new/pyproject.toml",
+                "source-new/api.py",
+            ),
+            (True, False),
+        )
+
+    def test_deleted_nested_pyproject_still_does_not_count(self):
+        # The one-level anchor has to hold for the changed-paths check too.
+        self.assertEqual(
+            classify("materialize-iceberg/python/pyproject.toml"), (False, True)
+        )
+
+
+class TestRobustness(unittest.TestCase):
+    def test_final_line_without_newline_is_still_read(self):
+        # `while read` drops an unterminated final line, which would silently
+        # omit that path from the verdict.
+        self.assertEqual(
+            classify("source-sentry/api.py", "sqlcapture/backfill.go", terminate=False),
+            (True, True),
+        )
+
+    def test_blank_lines_are_ignored(self):
+        self.assertEqual(classify("", "source-sentry/api.py", ""), (True, False))
+
+    def test_change_touching_no_manifest_is_not_fatal(self):
+        # The manifest scan greps for pyproject.toml and finds none here. Without
+        # `|| true` that non-zero exit would kill the script under `set -e`,
+        # breaking nearly every change.
+        self.assertEqual(classify("sqlcapture/backfill.go"), (False, True))
+
+    def test_empty_input_claims_nothing(self):
+        # The caller treats an empty path list as a broken enumeration and runs
+        # both lanes; the script itself just reports that it saw nothing.
+        self.assertEqual(classify(), (False, False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,37 @@ concurrency:
 on:
   push:
     branches: [main]
+    paths-ignore: &non_code_paths
+      - "**.md"
+      - "docs/**"
+      - ".claude/**"
+      - ".github/workflows/python.yaml"
+      - ".github/workflows/estuary-cdk.yaml"
+
   pull_request:
     branches: [main]
+    paths-ignore: *non_code_paths
 
 jobs:
+  # Which connectors did this change touch? This job classifies every changed
+  # path, and the build jobs below gate on its answer.
+  #
+  # It can't be a `paths` filter because dynamically telling a Python connector
+  # from a Go or Rust one means looking for a pyproject.toml, which needs the
+  # checked out tree & nothing is checked out when `paths` filters are evaluated.
+  classify_changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.classify.outputs.go_rust }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: classify
+        uses: ./.github/actions/classify-changes
+
   fetch_flow:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +46,8 @@ jobs:
         uses: ./.github/actions/fetch-flow-artifact
 
   build_base_image:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +102,8 @@ jobs:
 
   build_connectors:
     runs-on: ubuntu-24.04
-    needs: [build_base_image, fetch_flow]
+    needs: [classify_changes, build_base_image, fetch_flow]
+    if: needs.classify_changes.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/classify-changes.yaml
+++ b/.github/workflows/classify-changes.yaml
@@ -1,0 +1,30 @@
+name: Change Classifier
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths: &classifier_paths
+      - ".github/scripts/classify-changed-paths.sh"
+      - ".github/scripts/test_classify_changed_paths.py"
+      - ".github/actions/classify-changes/action.yaml"
+      - ".github/workflows/classify-changes.yaml"
+
+  pull_request:
+    branches: [main]
+    paths: *classifier_paths
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Classifier unit tests
+        run: cd .github/scripts && python3 -m unittest test_classify_changed_paths -v

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,167 +3,41 @@ name: Python Connectors
 on:
   push:
     branches: [main]
-    paths:
-      # This workflow and the plumbing it runs, so a change to either verifies
-      # itself rather than waiting on an unrelated connector edit to trigger.
-      - ".github/workflows/python.yaml"
-      - ".github/actions/fetch-flow-artifact/**"
-      - ".github/actions/restore-flow-binaries/**"
-      - ".github/actions/setup/**"
-      - ".github/actions/deploy/**"
-      - "fetch-flow.sh"
-
-      - "estuary-cdk/**"
-      - "source-airtable/**"
-      - "source-asana/**"
-      - "source-gladly/**"
-      - "source-google-ads/**"
-      - "source-google-sheets-native/**"
-      - "source-hubspot-native/**"
-      - "source-hubspot/**"
-      - "source-notion/**"
-      - "source-linkedin-pages/**"
-      - "source-linkedin-ads-v2/**"
-      - "source-klaviyo/**"
-      - "source-recharge/**"
-      - "source-stripe-native/**"
-      - "source-zendesk-support/**"
-      - "source-iterable/**"
-      - "source-pendo/**"
-      - "source-twilio/**"
-      - "source-jira-legacy/**"
-      - "source-mixpanel-native/**"
-      - "source-brevo/**"
-      - "source-impact-native/**"
-      - "source-front/**"
-      - "source-genesys/**"
-      - "source-braintree-native/**"
-      - "source-intercom-native/**"
-      - "source-shopify-native/**"
-      - "source-zendesk-support-native/**"
-      - "source-iterate/**"
-      - "source-google-analytics-data-api-native/**"
-      - "source-monday/**"
-      - "source-salesforce-native/**"
-      - "source-gainsight-nxt/**"
-      - "source-chargebee-native/**"
-      - "source-sage-intacct/**"
-      - "source-outreach/**"
-      - "source-jira-native/**"
-      - "source-looker/**"
-      - "source-qualtrics/**"
-      - "source-google-play/**"
-      - "source-apple-app-store/**"
-      - "source-datadog/**"
-      - "source-klaviyo-native/**"
-      - "source-sentry/**"
-      - "source-dynamics-365-finance-and-operations/**"
-      - "source-incident-io/**"
-      - "source-navan/**"
-      - "source-facebook-marketing-native/**"
-      - "source-quickbooks/**"
-      - "source-airtable-native/**"
-      - "source-ada/**"
-      - "source-zoho/**"
-      - "source-iterable-native/**"
-      - "source-ringcentral/**"
-      - "source-posthog/**"
-      - "source-ashby/**"
-      - "source-gong/**"
-      - "source-greenhouse-native/**"
-      - "source-calendly/**"
-      - "source-appsflyer/**"
-      - "source-zuora/**"
-      - "source-smartsheet/**"
-      - "source-mailchimp-native/**"
-      - "source-criteo/**"
-      - "source-commercetools/**"
+    paths-ignore: &non_code_paths
+      - "**.md"
+      - "docs/**"
+      - ".claude/**"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/estuary-cdk.yaml"
 
   pull_request:
     branches: [main]
-    paths:
-      # This workflow and the plumbing it runs, so a change to either verifies
-      # itself rather than waiting on an unrelated connector edit to trigger.
-      - ".github/workflows/python.yaml"
-      - ".github/actions/fetch-flow-artifact/**"
-      - ".github/actions/restore-flow-binaries/**"
-      - ".github/actions/setup/**"
-      - ".github/actions/deploy/**"
-      - "fetch-flow.sh"
-
-      - "estuary-cdk/**"
-      - "source-airtable/**"
-      - "source-asana/**"
-      - "source-gladly/**"
-      - "source-google-ads/**"
-      - "source-google-sheets-native/**"
-      - "source-hubspot-native/**"
-      - "source-hubspot/**"
-      - "source-notion/**"
-      - "source-linkedin-pages/**"
-      - "source-linkedin-ads-v2/**"
-      - "source-recharge/**"
-      - "source-klaviyo/**"
-      - "source-recharge/**"
-      - "source-stripe-native/**"
-      - "source-zendesk-support/**"
-      - "source-iterable/**"
-      - "source-pendo/**"
-      - "source-twilio/**"
-      - "source-jira-legacy/**"
-      - "source-mixpanel-native/**"
-      - "source-brevo/**"
-      - "source-impact-native/**"
-      - "source-front/**"
-      - "source-genesys/**"
-      - "source-braintree-native/**"
-      - "source-intercom-native/**"
-      - "source-shopify-native/**"
-      - "source-zendesk-support-native/**"
-      - "source-iterate/**"
-      - "source-google-analytics-data-api-native/**"
-      - "source-monday/**"
-      - "source-salesforce-native/**"
-      - "source-gainsight-nxt/**"
-      - "source-chargebee-native/**"
-      - "source-sage-intacct/**"
-      - "source-outreach/**"
-      - "source-jira-native/**"
-      - "source-looker/**"
-      - "source-qualtrics/**"
-      - "source-google-play/**"
-      - "source-apple-app-store/**"
-      - "source-datadog/**"
-      - "source-klaviyo-native/**"
-      - "source-sentry/**"
-      - "source-dynamics-365-finance-and-operations/**"
-      - "source-incident-io/**"
-      - "source-navan/**"
-      - "source-facebook-marketing-native/**"
-      - "source-quickbooks/**"
-      - "source-airtable-native/**"
-      - "source-ada/**"
-      - "source-zoho/**"
-      - "source-iterable-native/**"
-      - "source-ringcentral/**"
-      - "source-posthog/**"
-      - "source-ashby/**"
-      - "source-gong/**"
-      - "source-greenhouse-native/**"
-      - "source-calendly/**"
-      - "source-appsflyer/**"
-      - "source-zuora/**"
-      - "source-smartsheet/**"
-      - "source-mailchimp-native/**"
-      - "source-criteo/**"
-      - "source-commercetools/**"
+    paths-ignore: *non_code_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Which connectors did this change touch? This job classifies every changed
+  # path, and the build jobs below gate on its answer.
+  #
+  # It can't be a `paths` filter because dynamically telling a Python connector
+  # from a Go or Rust one means looking for a pyproject.toml, which needs the
+  # checked out tree & nothing is checked out when `paths` filters are evaluated.
+  classify_changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.classify.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: classify
+        uses: ./.github/actions/classify-changes
+
   fetch_flow:
+    needs: classify_changes
+    if: needs.classify_changes.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +53,8 @@ jobs:
 
   py_connector:
     runs-on: ubuntu-24.04
-    needs: fetch_flow
+    needs: [classify_changes, fetch_flow]
+    if: needs.classify_changes.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description:**

We've been running the `ci.yaml` workflow for Go & Rust connectors on _any_ changes in the repo. As the repo has grown to include Claude skills, docs, Python CDK & connectors, we've been running the `ci.yaml` workflow when no Go or Rust connector code has changed. This PR makes it so we don't run the Go & Rust connectors' `ci.yaml` workflow when a PR only contains unrelated changes.

~~Additionally, I reduced some duplication in the various `paths` and `paths-ignore` portions by using [YAML anchors](https://yaml.org/spec/1.2.2/#692-node-anchors).~~

I'm hoping that by removing extraneous CI runs, we run into fewer issues with concurrent CI runs fighting with each other for common resources.

**Notes for reviewers:**

~~I chose to use a `paths-ignore` for `ci.yaml` instead of an allow list since we're already in the habit of updating these workflow files any time we add a new Python connector, so updating one more spot shouldn't be a massive burden.~~

I recognize that there's more precise ways to structure CI runs (i.e. only run a connector's workflow when code affecting it changes ex: don't exercise the `source-postgres` tests when only `source-sqs` code changes), but that's a pretty hefty change I'd like to punt on. Don't let perfect be the enemy of better and all that.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
