### PR TITLE
source-stripe-native: allow extra fields on incremental `Events` documents & mark all `Events` with `_meta/op = "c"`

### DIFF
--- a/source-stripe-native/CHANGELOG.md
+++ b/source-stripe-native/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-20
 
+### Changed
+- Backfilled `Events` documents are now marked as creations (`_meta/op: c`) instead of
+  updates (`u`).
+
 ### Fixed
 - `Events` documents captured by incremental replication now include every field Stripe
   returns. `request`, `livemode`, `pending_webhooks`, `account`, and `context` were

--- a/source-stripe-native/CHANGELOG.md
+++ b/source-stripe-native/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-08-20
+
+### Fixed
+- `Events` documents captured by incremental replication now include every field Stripe
+  returns. `request`, `livemode`, `pending_webhooks`, `account`, and `context` were
+  previously dropped, so the same event looked different depending on whether it was
+  captured live or by a backfill. Documents captured before this change are not rewritten.
+- Live-captured `Events` documents no longer carry a null `data.previous_attributes` for
+  event types where Stripe omits the field entirely.

--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -277,6 +277,9 @@ async def fetch_backfill(
             if account_id:
                 doc.account_id = account_id
 
+            if cls == Events:
+                doc.meta_ = cls.Meta(op="c")
+
             if doc_ts == start_date:
                 # Yield final document for reference
                 yield doc

--- a/source-stripe-native/source_stripe_native/api.py
+++ b/source-stripe-native/source_stripe_native/api.py
@@ -164,7 +164,11 @@ async def fetch_incremental(
             # Emit documents if we haven't seen them.
             if event_ts >= log_cursor:
                 if cls == Events:
-                    doc = cls.model_validate(event.model_dump())
+                    # exclude_unset keeps the document identical in shape to the
+                    # raw event, and to what fetch_backfill emits. Without it,
+                    # CLSDATA's `previous_attributes` default adds a null the
+                    # API didn't send for *.created events.
+                    doc = cls.model_validate(event.model_dump(exclude_unset=True))
                     doc.meta_ = cls.Meta(op="c")
                 else:
                     doc = cls.model_validate(event.data.object)

--- a/source-stripe-native/source_stripe_native/models.py
+++ b/source-stripe-native/source_stripe_native/models.py
@@ -94,8 +94,8 @@ Item = TypeVar("Item")
 
 
 class EventResult(BaseModel, Generic[Item], extra="forbid"):
-    class Data(BaseModel):
-        class CLSDATA(BaseModel):
+    class Data(BaseModel, extra="allow"):
+        class CLSDATA(BaseModel, extra="allow"):
             object: Item  # type: ignore
             previous_attributes: Dict | None = None
 


### PR DESCRIPTION
**Description:**

`Events` documents captured from the backfill task and the incremental task had slightly different shapes:
1. Documents from the incremental task were missing fields that weren't defined on the `EventResult.Data` model because it was falling back to Pydantic's default `extra="ignore"` behavior.
2. Documents captured from the backfill task were marking immutable events with `_meta/op = "u"` by relying on the CDK's default behavior.

This PR fixes these discrepancies by:
- Overriding Pydantic's default behavior with `extra="allow"` on on the `EventResult.Data` model. This makes it so `Events` documents captured by the incremental task contain the additional fields the API includes beyond those we define on the model.
- Stamping `_meta/op = "c"` on all backfilled `Events` documents.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
