### PR TITLE
materialize-sql: carry a binding's state key onto tables resolved for Apply

### DIFF
--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -454,9 +454,6 @@ func getTable[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]]
 	if err != nil {
 		return Table{}, err
 	}
-	// Carried here rather than by each caller, so that a table resolved for an
-	// Apply action names the binding's generation as one resolved for a
-	// transactor does.
 	table.StateKey = binding.StateKey
 
 	return table, nil

--- a/materialize-sql/driver.go
+++ b/materialize-sql/driver.go
@@ -384,7 +384,6 @@ func (s *sqlMaterialization[EC, RC]) NewTransactor(
 		if err != nil {
 			return nil, fmt.Errorf("getting table for binding %d: %w", binding.Index, err)
 		}
-		table.StateKey = binding.StateKey
 		tables = append(tables, table)
 	}
 
@@ -451,7 +450,16 @@ func getTable[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]]
 		return Table{}, fmt.Errorf("getting parameters for binding %d: %w", binding.Index, err)
 	}
 	tableShape := BuildTableShape(materializationName, &binding.MaterializationSpec_Binding, binding.Index, path, delta)
-	return ResolveTable(tableShape, endpoint.Dialect)
+	table, err := ResolveTable(tableShape, endpoint.Dialect)
+	if err != nil {
+		return Table{}, err
+	}
+	// Carried here rather than by each caller, so that a table resolved for an
+	// Apply action names the binding's generation as one resolved for a
+	// transactor does.
+	table.StateKey = binding.StateKey
+
+	return table, nil
 }
 
 // TxDefuser.MaybeRollback calls Rollback on a Tx, unless Defuse has previously

--- a/materialize-sql/driver_test.go
+++ b/materialize-sql/driver_test.go
@@ -1,0 +1,109 @@
+package sql
+
+import (
+	"context"
+	"testing"
+	"text/template"
+
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/stretchr/testify/require"
+)
+
+type stateKeyTestConfig struct{}
+
+func (stateKeyTestConfig) Validate() error                         { return nil }
+func (stateKeyTestConfig) DefaultNamespace() string                { return "public" }
+func (stateKeyTestConfig) FeatureFlags() (string, map[string]bool) { return "", nil }
+
+type stateKeyTestResource struct{}
+
+func (stateKeyTestResource) Validate() error { return nil }
+func (stateKeyTestResource) Parameters() ([]string, bool, error) {
+	return []string{"a_database", "public", "a_table"}, true, nil
+}
+func (r stateKeyTestResource) WithDefaults(boilerplate.EndpointConfiger) Resource { return r }
+
+// recordingClient captures the TableCreate it is given, so a test can inspect
+// the table the Apply path resolved.
+type recordingClient struct {
+	created TableCreate
+}
+
+func (c *recordingClient) CreateTable(ctx context.Context, tc TableCreate) error {
+	c.created = tc
+	return nil
+}
+
+func (c *recordingClient) ExecStatements(ctx context.Context, statements []string) error { return nil }
+func (c *recordingClient) InstallFence(ctx context.Context, checkpoints Table, fence Fence) (Fence, error) {
+	return fence, nil
+}
+func (c *recordingClient) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSchema, resourcePaths [][]string) error {
+	return nil
+}
+func (c *recordingClient) DeleteTable(ctx context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
+	return "", nil, nil
+}
+func (c *recordingClient) AlterTable(ctx context.Context, ta TableAlter) (string, boilerplate.ActionApplyFn, error) {
+	return "", nil, nil
+}
+func (c *recordingClient) TruncateTable(ctx context.Context, path []string) (string, boilerplate.ActionApplyFn, error) {
+	return "", nil, nil
+}
+func (c *recordingClient) MustRecreateResource(req *pm.Request_Apply, lastBinding, newBinding *pf.MaterializationSpec_Binding) (bool, error) {
+	return false, nil
+}
+func (c *recordingClient) ListCheckpointsEntries(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+func (c *recordingClient) DeleteCheckpointsEntry(ctx context.Context, taskName string) error {
+	return nil
+}
+func (c *recordingClient) SnapshotTestTable(ctx context.Context, path []string) ([]string, [][]any, error) {
+	return nil, nil, nil
+}
+func (c *recordingClient) Close() {}
+
+// A connector's CreateTable may need the state key of the binding the table is
+// being created for, to record in the destination which generation of the
+// binding owns the table. The transactor path has always had it; this asserts
+// that the Apply path does too.
+func TestCreateResourceCarriesStateKey(t *testing.T) {
+	var client = new(recordingClient)
+
+	var s = &sqlMaterialization[boilerplate.EndpointConfiger, Resource]{
+		materializationName: "a/materialization",
+		endpoint: &Endpoint[boilerplate.EndpointConfiger]{
+			Config:              stateKeyTestConfig{},
+			Dialect:             newTestDialect(),
+			CreateTableTemplate: template.Must(template.New("createTargetTable").Parse(`CREATE TABLE {{$.Identifier}};`)),
+		},
+		client: client,
+	}
+
+	var binding = boilerplate.MappedBinding[boilerplate.EndpointConfiger, Resource, MappedType]{
+		MaterializationSpec_Binding: pf.MaterializationSpec_Binding{
+			StateKey: "a_table.v3",
+			Collection: pf.CollectionSpec{
+				Name: "a/collection",
+				Projections: []pf.Projection{{
+					Field: "id",
+					Inference: pf.Inference{
+						Types:  []string{"integer"},
+						Exists: pf.Inference_MUST,
+					},
+				}},
+			},
+			FieldSelection: pf.FieldSelection{Keys: []string{"id"}},
+		},
+		Config: stateKeyTestResource{},
+	}
+
+	_, apply, err := s.CreateResource(context.Background(), binding)
+	require.NoError(t, err)
+	require.NoError(t, apply(context.Background()))
+
+	require.Equal(t, "a_table.v3", client.created.StateKey)
+}


### PR DESCRIPTION
**Description:**

Every binding of a materialization has a *state key*: the name the connector
stores that binding's checkpoint state under. It also identifies which
generation of the binding we are on, so it changes when the binding is
backfilled.

`getTable` builds the `Table` value that the shared SQL code hands to a
connector. Two paths call it: `NewTransactor`, for the tables a task writes to,
and Apply, for the tables it creates or alters. Only `NewTransactor` was
attaching the state key afterwards, so a table resolved for Apply arrived with
an empty one.

This moves the assignment inside `getTable`, so both paths get it.

**Workflow steps:**

Nothing changes for users. No connector reads the state key during Apply today,
so this only makes the field available to one that wants to.

**Notes for reviewers:**

- Split out of a larger Snowflake branch to keep that PR focused. A follow-up
  needs the state key at Apply time, to record in each table which generation of
  the binding created it.
- The assignment lives in `getTable` rather than in each caller, so a third
  caller cannot forget it.
- The new test goes through `CreateResource`, which is the Apply path, and
  checks the `TableCreate` handed to the client. It fails on `main`: the state
  key arrives empty.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: n/a
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated: n/a, shared library only, no user-visible change
- [x] If there are user-facing behavior changes, documentation has been updated: n/a

