### PR TITLE
materialize-boilerplate: detect runtime v2, and test a refused materialization

### DIFF
--- a/materialize-boilerplate/runtime.go
+++ b/materialize-boilerplate/runtime.go
@@ -1,0 +1,30 @@
+package boilerplate
+
+import (
+	"github.com/estuary/flow/go/labels"
+	pf "github.com/estuary/flow/go/protocols/flow"
+)
+
+// RuntimeV2FlagName is the name of the task shard flag that puts a task on the
+// v2 runtime. Connectors that refuse to run outside the v2 runtime name it in
+// their error messages, since setting it is the operator's remedy.
+const RuntimeV2FlagName = "enable-runtime-v2"
+
+const runtimeV2Flag = labels.FlagPrefix + RuntimeV2FlagName
+
+// IsMaterializationSpecRuntimeV2 reports whether the task's shard template
+// carries the runtime-v2 feature flag, meaning the connector is being driven by
+// the v2 runtime. Pass either pm.Request_Open.Materialization or
+// pm.Request_Apply.Materialization, which are the specs the runtime hands to a
+// connector.
+//
+// The template is authoritative for the individual shard the connector is
+// running under: each shard spec is a clone of the template with only runtime
+// labels (key range, r-clock range, split source/target, cordon) layered on, so
+// a shard's feature flags are always exactly the template's. The reactor
+// selects its v1 or v2 code path from this same label.
+func IsMaterializationSpecRuntimeV2(spec *pf.MaterializationSpec) bool {
+	return spec != nil &&
+		spec.ShardTemplate != nil &&
+		spec.ShardTemplate.LabelSet.ValueOf(runtimeV2Flag) == "true"
+}

--- a/materialize-boilerplate/runtime.go
+++ b/materialize-boilerplate/runtime.go
@@ -6,23 +6,14 @@ import (
 )
 
 // RuntimeV2FlagName is the name of the task shard flag that puts a task on the
-// v2 runtime. Connectors that refuse to run outside the v2 runtime name it in
-// their error messages, since setting it is the operator's remedy.
+// v2 runtime.
 const RuntimeV2FlagName = "enable-runtime-v2"
 
 const runtimeV2Flag = labels.FlagPrefix + RuntimeV2FlagName
 
 // IsMaterializationSpecRuntimeV2 reports whether the task's shard template
 // carries the runtime-v2 feature flag, meaning the connector is being driven by
-// the v2 runtime. Pass either pm.Request_Open.Materialization or
-// pm.Request_Apply.Materialization, which are the specs the runtime hands to a
-// connector.
-//
-// The template is authoritative for the individual shard the connector is
-// running under: each shard spec is a clone of the template with only runtime
-// labels (key range, r-clock range, split source/target, cordon) layered on, so
-// a shard's feature flags are always exactly the template's. The reactor
-// selects its v1 or v2 code path from this same label.
+// the v2 runtime.
 func IsMaterializationSpecRuntimeV2(spec *pf.MaterializationSpec) bool {
 	return spec != nil &&
 		spec.ShardTemplate != nil &&

--- a/materialize-boilerplate/runtime_test.go
+++ b/materialize-boilerplate/runtime_test.go
@@ -1,0 +1,78 @@
+package boilerplate
+
+import (
+	"testing"
+
+	"github.com/estuary/flow/go/labels"
+	pf "github.com/estuary/flow/go/protocols/flow"
+	"github.com/stretchr/testify/require"
+	pb "go.gazette.dev/core/broker/protocol"
+	pc "go.gazette.dev/core/consumer/protocol"
+)
+
+func TestIsMaterializationSpecRuntimeV2(t *testing.T) {
+	var withLabels = func(nv ...string) *pf.MaterializationSpec {
+		return &pf.MaterializationSpec{
+			ShardTemplate: &pc.ShardSpec{LabelSet: pb.MustLabelSet(nv...)},
+		}
+	}
+
+	for _, tt := range []struct {
+		name string
+		spec *pf.MaterializationSpec
+		want bool
+	}{
+		{
+			// Spelled out rather than composed from runtimeV2Flag: this label is
+			// a wire contract with the reactor, so the test pins the exact name
+			// the reactor reads.
+			name: "flag set to true",
+			spec: withLabels("estuary.dev/flag/enable-runtime-v2", "true"),
+			want: true,
+		},
+		{
+			name: "flag set to true alongside other flags",
+			spec: withLabels(
+				runtimeV2Flag, "true",
+				labels.FlagPrefix+"something-else", "true",
+			),
+			want: true,
+		},
+		{
+			name: "flag set to false",
+			spec: withLabels(runtimeV2Flag, "false"),
+			want: false,
+		},
+		{
+			name: "flag absent",
+			spec: withLabels(labels.FlagPrefix+"something-else", "true"),
+			want: false,
+		},
+		{
+			name: "no labels at all",
+			spec: withLabels(),
+			want: false,
+		},
+		{
+			// The runtime compares the label value verbatim, so anything but an
+			// exact "true" leaves the task on the V1 runtime.
+			name: "flag set to a truthy value other than true",
+			spec: withLabels(runtimeV2Flag, "TRUE"),
+			want: false,
+		},
+		{
+			name: "nil shard template",
+			spec: &pf.MaterializationSpec{},
+			want: false,
+		},
+		{
+			name: "nil spec",
+			spec: nil,
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsMaterializationSpecRuntimeV2(tt.spec))
+		})
+	}
+}

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -165,6 +165,43 @@ func RunMaterializationTest[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 	cupaloy.SnapshotT(t, snap.String())
 }
 
+// RunMaterializationRefusalTest drives each task of the fixture through
+// `flowctl preview` and requires the connector to refuse it, with a message
+// containing every string in wantErrContains.
+//
+// It exists for a fixture whose purpose is to prove that a configuration is
+// rejected. The connector fails during Apply, before the destination system is
+// touched, so no resources are created and there is nothing to clean up. The
+// refusal message is asserted by substring rather than snapshotted because
+// flowctl's failure output carries timestamps and temporary paths.
+func RunMaterializationRefusalTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
+	t *testing.T,
+	sourcePath string,
+	makeResourceFn func(finalResourcePathPart string, deltaUpdates bool) RC,
+	wantErrContains ...string,
+) {
+	require.NotEmpty(t, wantErrContains, "a refusal test must assert something about the refusal")
+
+	tsSuffix := testItemIdentifier + fmt.Sprintf("%d", time.Now().Unix())
+
+	RunTestAllTasks(t, sourcePath, func(t *testing.T, bundled []byte, taskName string, cfg EC) {
+		rt := rewriteTaskForTest[EC, RC](t, bundled, taskName, tsSuffix, cfg, makeResourceFn)
+
+		output := RunFlowctlExpectErr(
+			t,
+			"preview",
+			"--name", rt.workingTaskName,
+			"--source", rt.sourcePath,
+			"--fixture", relativePath(t, "testdata/integration/fixture.materialize.json"),
+			"--network", "flow-test",
+		)
+
+		for _, want := range wantErrContains {
+			require.Contains(t, output, want)
+		}
+	})
+}
+
 // RunMaterializationTestParallel is like RunMaterializationTest but runs tasks
 // concurrently (up to maxParallelTasks at a time). Use this for connectors
 // where parallel task execution is safe and beneficial.
@@ -1172,16 +1209,14 @@ func shouldCleanup(now time.Time, item string, suffix string) (bool, string) {
 	return false, "from a recent test run"
 }
 
-// RunFlowctl runs the flowctl command with the given arguments, and returns its
-// stdout output. The command is expected to succeed, and any stderr output is
-// logged to the test log.
-func RunFlowctl(t *testing.T, args ...string) []byte {
-	t.Helper()
-
+// flowctlCommand builds a flowctl invocation whose behavior does not vary with
+// the machine running it.
+func flowctlCommand(args ...string) *exec.Cmd {
 	// Set TZ=UTC to make tests always run as if the machine
 	// has UTC timezone, consisent across contributors' machines
 	// and the CI
 	os.Setenv("TZ", "UTC")
+
 	cmd := exec.Command("flowctl", args...)
 	cmd.Env = append(cmd.Environ(),
 		// Set the LOG_FORMAT to text instead of color for better to avoid
@@ -1189,6 +1224,17 @@ func RunFlowctl(t *testing.T, args ...string) []byte {
 		// dumb terminals.
 		"LOG_FORMAT=text",
 	)
+
+	return cmd
+}
+
+// RunFlowctl runs the flowctl command with the given arguments, and returns its
+// stdout output. The command is expected to succeed, and any stderr output is
+// logged to the test log.
+func RunFlowctl(t *testing.T, args ...string) []byte {
+	t.Helper()
+
+	cmd := flowctlCommand(args...)
 
 	stdout, err := cmd.StdoutPipe()
 	require.NoError(t, err)
@@ -1214,6 +1260,21 @@ func RunFlowctl(t *testing.T, args ...string) []byte {
 	wg.Wait()
 
 	return stdoutBuf.Bytes()
+}
+
+// RunFlowctlExpectErr runs the flowctl command with the given arguments and
+// requires it to fail, returning its combined output so the caller can assert
+// against the failure. Output is also logged to the test log, since a test that
+// expects a failure still needs the diagnostics when the failure is the wrong
+// one.
+func RunFlowctlExpectErr(t *testing.T, args ...string) string {
+	t.Helper()
+
+	output, err := flowctlCommand(args...).CombinedOutput()
+	t.Log(string(output))
+	require.Error(t, err, "flowctl was expected to fail")
+
+	return string(output)
 }
 
 func dumpSchema[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger, RC boilerplate.Resourcer[RC, EC], MT boilerplate.MappedTyper](

--- a/materialize-boilerplate/testutil/test_support.go
+++ b/materialize-boilerplate/testutil/test_support.go
@@ -169,10 +169,7 @@ func RunMaterializationTest[EC boilerplate.EndpointConfiger, FC boilerplate.Fiel
 // `flowctl preview` and requires the connector to refuse it, with a message
 // containing every string in wantErrContains.
 //
-// It exists for a fixture whose purpose is to prove that a configuration is
-// rejected. The connector fails during Apply, before the destination system is
-// touched, so no resources are created and there is nothing to clean up. The
-// refusal message is asserted by substring rather than snapshotted because
+// The refusal is asserted by substring rather than snapshotted, because
 // flowctl's failure output carries timestamps and temporary paths.
 func RunMaterializationRefusalTest[EC boilerplate.EndpointConfiger, RC boilerplate.Resourcer[RC, EC]](
 	t *testing.T,
@@ -187,17 +184,18 @@ func RunMaterializationRefusalTest[EC boilerplate.EndpointConfiger, RC boilerpla
 	RunTestAllTasks(t, sourcePath, func(t *testing.T, bundled []byte, taskName string, cfg EC) {
 		rt := rewriteTaskForTest[EC, RC](t, bundled, taskName, tsSuffix, cfg, makeResourceFn)
 
-		output := RunFlowctlExpectErr(
-			t,
+		output, err := flowctlCommand(
 			"preview",
 			"--name", rt.workingTaskName,
 			"--source", rt.sourcePath,
 			"--fixture", relativePath(t, "testdata/integration/fixture.materialize.json"),
 			"--network", "flow-test",
-		)
+		).CombinedOutput()
+		t.Log(string(output))
+		require.Error(t, err, "flowctl was expected to fail")
 
 		for _, want := range wantErrContains {
-			require.Contains(t, output, want)
+			require.Contains(t, string(output), want)
 		}
 	})
 }
@@ -1260,21 +1258,6 @@ func RunFlowctl(t *testing.T, args ...string) []byte {
 	wg.Wait()
 
 	return stdoutBuf.Bytes()
-}
-
-// RunFlowctlExpectErr runs the flowctl command with the given arguments and
-// requires it to fail, returning its combined output so the caller can assert
-// against the failure. Output is also logged to the test log, since a test that
-// expects a failure still needs the diagnostics when the failure is the wrong
-// one.
-func RunFlowctlExpectErr(t *testing.T, args ...string) string {
-	t.Helper()
-
-	output, err := flowctlCommand(args...).CombinedOutput()
-	t.Log(string(output))
-	require.Error(t, err, "flowctl was expected to fail")
-
-	return string(output)
 }
 
 func dumpSchema[EC boilerplate.EndpointConfiger, FC boilerplate.FieldConfiger, RC boilerplate.Resourcer[RC, EC], MT boilerplate.MappedTyper](


### PR DESCRIPTION
**Description:**

Two additions to the shared materialization library. Both are split out of a
larger Snowflake branch, to keep that PR focused.

1. `IsMaterializationSpecRuntimeV2` tells a connector whether the v2
   materialization runtime is driving it. A task runs on the v2 runtime when its
   shard template carries the `enable-runtime-v2` feature flag, so the helper
   reads that label off the spec the runtime hands the connector. The flag name
   is exported too, because a connector that refuses to run without v2 must name
   the flag in its error message — setting it is what the operator has to do.

   The shard template is the right place to read. Every shard of the task is a
   copy of the template with only runtime labels added on top, so a shard's
   feature flags always match the template's.

2. `RunMaterializationRefusalTest` is a test helper for the opposite of the
   usual integration test. It drives each task of a fixture through
   `flowctl preview` and requires the connector to *refuse* it, checking that
   the error message contains the strings you pass. Use it for a fixture whose
   whole point is proving that some configuration is rejected.

   The refusal happens during Apply, before the connector touches the
   destination, so nothing is created and there is nothing to clean up.

**Workflow steps:**

Nothing changes for users. Both are new library functions with no existing
callers.

**Notes for reviewers:**

- The refusal helper checks the message by substring instead of snapshotting it.
  `flowctl`'s failure output carries timestamps and temporary paths, which a
  snapshot cannot hold steady.
- It also logs the whole output, so a test that fails for the wrong reason still
  shows you why.
- Building the `flowctl` command moved into a small shared function, so the
  success and failure helpers set up the environment the same way.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: n/a
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated: n/a, shared library only, no user-visible change
- [x] If there are user-facing behavior changes, documentation has been updated: n/a
