### PR TITLE
source-kinesis: get ARN from `ListStreams` response instead of `DescribeStreamSummary`

### DIFF
--- a/source-kinesis/capture_test.go
+++ b/source-kinesis/capture_test.go
@@ -572,6 +572,14 @@ func buildGlueHeader(t *testing.T, schemaVersionId string) []byte {
 }
 
 func advanceCapture(t testing.TB, cs *st.CaptureSpec) {
+	// 100ms is enough for the LocalStack emulator, but not for real Kinesis.
+	// The harness counts the checkpoint that pruneShards always emits as data
+	// received, so the shutdown countdown starts before any records have been
+	// read.
+	if useRealAWS() {
+		advanceCaptureWithTimeout(t, cs, 10*time.Second)
+		return
+	}
 	advanceCaptureWithTimeout(t, cs, 100*time.Millisecond)
 }
 

--- a/source-kinesis/capture_test.go
+++ b/source-kinesis/capture_test.go
@@ -75,6 +75,11 @@ func TestDiscover(t *testing.T) {
 	cleanup()
 	t.Cleanup(cleanup)
 
+	// Wait for the streams to be fully deleted if they existed
+	for _, s := range testStreams {
+		awaitStreamDeleted(t, ctx, client, s)
+	}
+
 	for _, s := range testStreams {
 		s := s
 		_, err = client.CreateStream(ctx, &kinesis.CreateStreamInput{
@@ -109,6 +114,11 @@ func TestCapture(t *testing.T) {
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+
+	// Wait for the streams to be fully deleted if they existed
+	for _, s := range testStreams {
+		awaitStreamDeleted(t, ctx, client, s)
+	}
 
 	for _, s := range testStreams {
 		s := s
@@ -200,6 +210,9 @@ func TestCaptureParsing(t *testing.T) {
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+
+	// Wait for stream to be fully deleted if it existed
+	awaitStreamDeleted(t, ctx, client, testStream)
 
 	_, err = client.CreateStream(ctx, &kinesis.CreateStreamInput{
 		StreamName: aws.String(testStream),

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -118,8 +119,8 @@ type kinesisStream struct {
 }
 
 func listStreams(ctx context.Context, client *kinesis.Client) ([]kinesisStream, error) {
-	var out []kinesisStream
 	var streamNames []string
+	var streamARNs = make(map[string]string)
 
 	input := &kinesis.ListStreamsInput{}
 	for {
@@ -130,36 +131,65 @@ func listStreams(ctx context.Context, client *kinesis.Client) ([]kinesisStream, 
 
 		streamNames = append(streamNames, res.StreamNames...)
 
-		if !*res.HasMoreStreams {
+		// ListStreams reports a summary for each stream which includes its ARN.
+		// StreamSummaries is not a required field of the response
+		// though, so any stream that doesn't have one is described via
+		// DescribeStreamSummary
+		for _, s := range res.StreamSummaries {
+			if s.StreamName != nil && s.StreamARN != nil {
+				streamARNs[*s.StreamName] = *s.StreamARN
+			}
+		}
+
+		if !aws.ToBool(res.HasMoreStreams) {
+			break
+		} else if res.NextToken != nil {
+			input.NextToken = res.NextToken
+		} else if len(streamNames) > 0 {
+			// Older versions of the API paginate by asking for streams
+			// following the last one that was returned.
+			lastName := streamNames[len(streamNames)-1]
+			input.NextToken = nil
+			input.ExclusiveStartStreamName = &lastName
+		} else {
+			// There's no way to ask for the next page, so stop
+			// here rather than requesting the same page forever.
 			break
 		}
-		input.NextToken = res.NextToken
 	}
 
-	// ListStreams only includes stream names and no ARNs, so the
-	// DescribeStreamSummary API is used to get the ARN for each individual
-	// stream.
+	// DescribeStreamSummary is limited to 20 transactions per second for the
+	// entire AWS account, and that budget is shared with everything else the
+	// account is doing, so these requests are rate limited to well under it.
+	// They are also usually not needed at all since ListStreams almost always
+	// reports the ARN of every stream it returns.
 	var mu sync.Mutex
+	limiter := rate.NewLimiter(10, 10)
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(5)
 
 	for _, n := range streamNames {
-		n := n
+		if _, ok := streamARNs[n]; ok {
+			continue
+		}
+
 		group.Go(func() error {
+			if err := limiter.Wait(groupCtx); err != nil {
+				return fmt.Errorf("waiting for rate limiter: %w", err)
+			}
+
 			desc, err := client.DescribeStreamSummary(groupCtx, &kinesis.DescribeStreamSummaryInput{
 				StreamName: &n,
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("describing stream %q: %w", n, err)
+			} else if desc.StreamDescriptionSummary == nil || desc.StreamDescriptionSummary.StreamARN == nil {
+				return fmt.Errorf("stream %q was described without an ARN", n)
 			}
 
 			mu.Lock()
 			defer mu.Unlock()
-
-			out = append(out, kinesisStream{
-				name: n,
-				arn:  *desc.StreamDescriptionSummary.StreamARN,
-			})
+			streamARNs[n] = *desc.StreamDescriptionSummary.StreamARN
 
 			return nil
 		})
@@ -167,6 +197,11 @@ func listStreams(ctx context.Context, client *kinesis.Client) ([]kinesisStream, 
 
 	if err := group.Wait(); err != nil {
 		return nil, err
+	}
+
+	var out = make([]kinesisStream, 0, len(streamNames))
+	for _, n := range streamNames {
+		out = append(out, kinesisStream{name: n, arn: streamARNs[n]})
 	}
 
 	slices.SortFunc(out, func(a, b kinesisStream) int { return cmp.Compare(a.name, b.name) })

--- a/source-kinesis/connection.go
+++ b/source-kinesis/connection.go
@@ -60,15 +60,14 @@ func getAwsCfg(ctx context.Context, cfg *Config) (*aws.Config, error) {
 		),
 		awsConfig.WithRegion(cfg.Region),
 		awsConfig.WithRetryer(func() aws.Retryer {
-			// 5 attempts (vs the SDK default of 3) is a small bump for resilience against
-			// transient throttling/network blips while staying well under the test alarm
-			// when the endpoint is unreachable: 5 × ~30s dial timeout from the SDK's
-			// default BuildableClient ≈ 2.5 minutes worst case.
+			// Bump up the number of retry maximum attempts from the default of 3. The maximum retry
+			// duration is 20 seconds, so this gives us around 5 minutes of retrying retryable
+			// errors before giving up and crashing the connector.
 			//
 			// Ref: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.RateLimiter = ratelimit.None // rely on the standard error backoff for rate limiting
-				o.MaxAttempts = 5
+				o.MaxAttempts = 20
 			})
 		}),
 	}


### PR DESCRIPTION
**Description:**

We've observed auto-discovery and validation consistently failing for a Kinesis capture with:
```
  listing streams: operation error Kinesis: DescribeStreamSummary,
  exceeded maximum number of attempts, 5
```

`listStreams` is describing every stream in the AWS account five at a time to determine their ARNs. But, `DescribeStreamSummary` is capped at 20 TPS per account per region. The connector's bursty `DescribeStreamSummary` calls can easily exhaust the 20 TPS budget. When a stream exhausts its retries, it fails the listing & causes the capture to fail with the error above.

This PR fixes this by taking ARNs from the `ListStreams` response instead of making `DescribeStreamSummary` calls for each stream. The `ListStreams` response already carries a `StreamSummaries` entry per stream that contains its ARN, so when it's present, we take the ARN from there. However, `StreamSummaries` isn't a required response field, so any stream arriving without one is still described individually via `DescribeStreamSummary`. We also now rate-limite our `DescribeStreamSummary` calls to remain below the AWS enforced budget.

While I was in the connector, I made a few additional changes:
- **Restored `MaxAttempts` to 20.** The reduction to 5 in #4335 is no longer what prevents the CI hang it was made for. The same PR gated those tests behind `testing.Short()` and passes `-short` in the Dockerfile. The lower budget applied to every AWS call, including the `GetRecords` retries it had been raised for originally.
- **Fixed three latent bugs in the `listStreams` function:** nil dereferences of `HasMoreStreams` and of the described `StreamARN`, and a pagination loop that would re-request the same page forever if `HasMoreStreams` was set without a `NextToken`.
- **Wait for asynchronous stream deletion in tests** before recreating same-named streams, which fails against real AWS with `ResourceInUseException`.
- **Give captures longer to shut down against real AWS**, since the test harness counts `pruneShards`' checkpoint as "data received" and collapses the watchdog to 100ms before any record is read.

Behavior and changes were verified against a real AWS Kinesis instance. Confirmed the ARN taken from the `ListStreams` response is the same as the one we had been getting from `DescribeStreamSummary`.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
