### PR TITLE
source-sage-intacct: increase default polling interval to 6 hours

### DIFF
--- a/docs/reference/Connectors/capture-connectors/sage-intacct.md
+++ b/docs/reference/Connectors/capture-connectors/sage-intacct.md
@@ -69,7 +69,7 @@ configuration details specific to the Sage Intacct source connector.
 | Property    | Title    | Description                 | Type   | Required/Default |
 |-------------|----------|-----------------------------|--------|------------------|
 | **`/name`** | Name     | Name of this resource       | string | Required         |
-| `/interval` | Interval | Interval between data syncs | string | PT5M             |
+| `/interval` | Interval | Interval between data syncs | string | PT6H             |
 
 ### Sample
 
@@ -88,7 +88,7 @@ captures:
     bindings:
       - resource:
           name: CUSTOMER
-          interval: PT5M
+          interval: PT6H
         target: ${PREFIX}/CUSTOMER
       {...}
 ```

--- a/source-sage-intacct/CHANGELOG.md
+++ b/source-sage-intacct/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-21
+
+## Fixed
+- Bindings' default polling intervals increased from 5 minutes to 6 hours to reduce the frequency of API calls.
+  This change only affects newly discovered bindings. Existing captures should update their resource configs
+  if they want to poll for changes less frequently.
+
+
 ## 2026-08-04
 
 ### Fixed

--- a/source-sage-intacct/source_sage_intacct/resources.py
+++ b/source-sage-intacct/source_sage_intacct/resources.py
@@ -184,7 +184,7 @@ async def incremental_resource(
             },
             backfill=ResourceState.Backfill(next_page=None, cutoff=started_at),
         ),
-        initial_config=ResourceConfig(name=obj, interval=timedelta(minutes=5)),
+        initial_config=ResourceConfig(name=obj, interval=timedelta(hours=6)),
         schema_inference=True,
     )
 
@@ -218,7 +218,7 @@ async def snapshot_resource(sage: Sage, obj: str) -> common.Resource:
         model=SnapshotResource,
         open=functools.partial(open, obj),
         initial_state=ResourceState(),
-        initial_config=ResourceConfig(name=obj, interval=timedelta(minutes=5)),
+        initial_config=ResourceConfig(name=obj, interval=timedelta(hours=6)),
         schema_inference=True,
     )
 


### PR DESCRIPTION
**Description:**

Sage Intacct charges users for API calls, and users understandably don't want the connector racking up API costs unnecessarily. The quickest way to reduce calls is increasing the polling interval, so that's what this commit does.

**Notes for reviewers:**

We may also want to evaluate whether `source-sage-intacct` needs to be real-time at all & if having data be delayed by ~2 hours (the current delayed stream lag) is acceptable. If so, we could reduce API calls further by remove the real-time subtasks for incremental streams & rely on the delayed subtasks to capture data.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
