### PR TITLE
estuary-cdk: undo chained content codings left on response bodies

### DIFF
--- a/estuary-cdk/estuary_cdk/content_encoding.py
+++ b/estuary-cdk/estuary_cdk/content_encoding.py
@@ -1,0 +1,235 @@
+"""
+Undo the HTTP content codings that aiohttp leaves on a response body.
+
+aiohttp auto-decompresses only when `Content-Encoding` holds a single coding. A
+chained value like `gzip,gzip` matches nothing in its parser, so the body
+arrives with every layer still on it.
+"""
+
+from collections.abc import AsyncGenerator, AsyncIterable
+
+from aiohttp import ClientRequest, hdrs
+from aiohttp.compression_utils import (
+    HAS_BROTLI,
+    HAS_ZSTD,
+    BrotliDecompressor,
+    DecompressionBaseHandler,
+    ZLibDecompressor,
+    ZSTDDecompressor,
+)
+from aiohttp.web_response import ContentCoding
+
+GZIP = ContentCoding.gzip.value
+DEFLATE = ContentCoding.deflate.value
+IDENTITY = ContentCoding.identity.value
+
+# The codings aiohttp has already undone and we must not touch. Its parser
+# matches the whole header value, so this only ever applies to a lone coding.
+#
+# Derived from the `Accept-Encoding` value aiohttp computes at import time,
+# which advertises exactly the codings it can decode (`br`/`zstd` only when
+# their libraries are installed).
+AIOHTTP_AUTO_DECOMPRESSED = frozenset(
+    coding.strip()
+    for coding in ClientRequest.DEFAULT_HEADERS[hdrs.ACCEPT_ENCODING].split(",")
+)
+
+MAX_CODING_CHAIN_DEPTH = 4
+
+
+class UnsupportedContentCoding(RuntimeError):
+    """A response declared a coding we have no decoder for."""
+
+
+class ContentCodingChainTooDeep(RuntimeError):
+    """A response chained more codings than `MAX_CODING_CHAIN_DEPTH` allows."""
+
+
+class TruncatedContentStream(RuntimeError):
+    """A `deflate` stream ended before its end-of-stream marker. This is the
+    truncation check aiohttp's `DeflateBuffer.feed_eof` performs, and the only
+    one this module performs: gzip streams go unchecked, exactly as they do in
+    aiohttp."""
+
+
+def parse_content_codings(header_value: str) -> list[str]:
+    """
+    The codings still on the body, in the order they must be undone.
+    `Content-Encoding` lists codings in the order they were applied, so undoing
+    them runs back to front.
+
+    Raises `ContentCodingChainTooDeep` for a chain deeper than
+    `MAX_CODING_CHAIN_DEPTH`."""
+
+    header_value = header_value.strip().lower()
+
+    if not header_value or header_value in AIOHTTP_AUTO_DECOMPRESSED:
+        return []
+
+    codings = [coding.strip().lower() for coding in header_value.split(",")]
+    remaining = [
+        coding for coding in reversed(codings) if coding and coding != IDENTITY
+    ]
+
+    if len(remaining) > MAX_CODING_CHAIN_DEPTH:
+        raise ContentCodingChainTooDeep(
+            (
+                f"Content-Encoding {header_value!r} chains more than "
+                f"{MAX_CODING_CHAIN_DEPTH} codings."
+            )
+        )
+
+    return remaining
+
+
+def _decompressor(coding: str) -> DecompressionBaseHandler:
+    """
+    aiohttp's decompressor for one canonical coding. This is the dispatch
+    `DeflateBuffer.__init__` performs.
+    """
+    if coding == "br":
+        if not HAS_BROTLI:
+            raise UnsupportedContentCoding(
+                "Cannot decode content coding 'br'. Please install `Brotli`."
+            )
+        return BrotliDecompressor()
+
+    if coding == "zstd":
+        if not HAS_ZSTD:
+            raise UnsupportedContentCoding(
+                "Cannot decode content coding 'zstd'. Please install `backports.zstd`."
+            )
+        return ZSTDDecompressor()
+
+    if coding in (GZIP, DEFLATE):
+        return ZLibDecompressor(encoding=coding)
+
+    raise UnsupportedContentCoding(f"Cannot decode content coding {coding!r}.")
+
+
+class StreamDecompressor:
+    """
+    Incrementally undo one content coding over a stream of bytes.
+
+    Usage:
+      async for chunk in StreamDecompressor(async_bytes, "gzip"):
+          ... # process decompressed bytes
+    """
+
+    input: AsyncIterable[bytes]
+    coding: str
+    decompressor: DecompressionBaseHandler
+    _input_iter: AsyncGenerator[bytes, None] | None
+
+    def __init__(self, input: AsyncIterable[bytes], coding: str = "gzip"):
+        self.input = input
+        # Normalized once here, so `coding` is directly comparable everywhere
+        self.coding = coding.strip().lower()
+        self.decompressor = _decompressor(self.coding)
+        self._input_iter = None
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._input_iter is None:
+            self._input_iter = self._stream()
+
+        return await anext(self._input_iter)
+
+    async def _stream(self) -> AsyncGenerator[bytes, None]:
+        is_first_chunk = True
+
+        async for chunk in self.input:
+            if not chunk:
+                continue
+
+            if is_first_chunk:
+                is_first_chunk = False
+
+                self._maybe_switch_to_raw_deflate(chunk)
+
+            data = await self.decompressor.decompress(chunk)
+            if data:
+                yield data
+
+        # Flush any buffered data at the end of the stream.
+        leftover = self.decompressor.flush()
+        if leftover:
+            yield leftover
+
+        # Mirrors `DeflateBuffer.feed_eof`: deflate is the one coding aiohttp
+        # checks for a missing end-of-stream marker, gated on any input having
+        # been consumed.
+        if (
+            not is_first_chunk
+            and self.coding == DEFLATE
+            and isinstance(self.decompressor, ZLibDecompressor)
+            and not self.decompressor.eof
+        ):
+            raise TruncatedContentStream(
+                (
+                    f"Content coding {self.coding!r} stream ended before its "
+                    "end-of-stream marker."
+                )
+            )
+
+    async def aclose(self) -> None:
+        if self._input_iter is not None:
+            await self._input_iter.aclose()
+
+        input_aclose = getattr(self.input, "aclose", None)
+        if input_aclose is not None:
+            await input_aclose()
+
+    def _maybe_switch_to_raw_deflate(self, first_chunk: bytes) -> None:
+        """
+        Mirrors aiohttp's own fallback for non-compliant `deflate` bodies.
+
+        RFC 1950's first byte carries the compression method in its low nibble,
+        always 8 for a real zlib header. Anything else means the server sent
+        bare RFC 1951 data under the `deflate` coding, which is common enough
+        that aiohttp carries this same switch.
+        """
+        if self.coding == DEFLATE and first_chunk[0] & 0x0F != 8:
+            self.decompressor = ZLibDecompressor(
+                encoding=DEFLATE, suppress_deflate_header=True
+            )
+
+
+def decompress_stream(
+    input: AsyncIterable[bytes], codings: list[str]
+) -> AsyncIterable[bytes]:
+    """
+    Undo `codings` over a stream of bytes, in the order given.
+
+    The one place a coding chain becomes a decoder stack: `decompress` and the
+    streaming response path both decode through here, so a chained body decodes
+    identically whether it was streamed or read whole.
+    """
+    for coding in codings:
+        input = StreamDecompressor(input, coding)
+    return input
+
+
+async def decompress(body: bytes, codings: list[str]) -> bytes:
+    """
+    Undo `codings` over a body already read whole, in the order given.
+
+    Error responses are the only bodies read whole.
+    """
+
+    async def single_chunk() -> AsyncGenerator[bytes, None]:
+        yield body
+
+    stream = decompress_stream(single_chunk(), codings)
+    chunks: list[bytes] = []
+    try:
+        async for chunk in stream:
+            chunks.append(chunk)
+    finally:
+        aclose = getattr(stream, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+    return b"".join(chunks)

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -710,13 +710,13 @@ class HTTPMixin(Mixin, HTTPSession):
                         )
                     else:
                         raise HTTPError(
-                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
+                            f"Encountered HTTP error status {resp.status}.\nURL: {resp.request_info.url}\nResponse:\n{format_error_body(body)}",
                             resp.status,
                         )
                 elif resp.status >= 400 and resp.status < 500:
                     body = await read_error_body(log, resp)
                     raise HTTPError(
-                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
+                        f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nResponse:\n{format_error_body(body)}",
                         resp.status,
                     )
                 else:

--- a/estuary-cdk/estuary_cdk/http.py
+++ b/estuary-cdk/estuary_cdk/http.py
@@ -3,9 +3,11 @@ import asyncio
 import base64
 import json
 import time
+import zlib
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any, AsyncGenerator, Awaitable, Callable, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 import aiohttp
 from google.auth.credentials import TokenState as GoogleTokenState
@@ -15,6 +17,14 @@ from multidict import CIMultiDictProxy
 from pydantic import BaseModel
 
 from . import Mixin
+from .content_encoding import (
+    ContentCodingChainTooDeep,
+    TruncatedContentStream,
+    UnsupportedContentCoding,
+    decompress,
+    decompress_stream,
+    parse_content_codings,
+)
 from .flow import (
     AccessToken,
     AuthorizationCodeFlowOAuth2Credentials,
@@ -80,6 +90,39 @@ class HTTPError(RuntimeError):
         super().__init__(message)
         self.code = code
         self.message = message
+
+
+def _response_codings(resp: aiohttp.ClientResponse) -> list[str]:
+    return parse_content_codings(resp.headers.get(aiohttp.hdrs.CONTENT_ENCODING, ""))
+
+
+async def read_error_body(log: Logger, resp: "aiohttp.ClientResponse") -> bytes:
+    """
+    Read an error response body, undoing any content codings aiohttp left.
+
+    Never raises. A body we can't decode is returned as-is: the caller is in
+    the middle of reporting an HTTP error, and losing that error is worse
+    than reporting it with a mangled body.
+    """
+    body = await resp.read()
+    try:
+        return await decompress(body, _response_codings(resp))
+    except (
+        OSError,
+        EOFError,
+        zlib.error,
+        UnsupportedContentCoding,
+        ContentCodingChainTooDeep,
+        TruncatedContentStream,
+    ) as exc:
+        log.warning(
+            "could not undo content codings on an error response body; reporting it as received",
+            {
+                "content_encoding": resp.headers.get(aiohttp.hdrs.CONTENT_ENCODING),
+                "error": format_error_message(exc),
+            },
+        )
+        return body
 
 
 def format_error_body(body: bytes) -> str:
@@ -652,7 +695,7 @@ class HTTPMixin(Mixin, HTTPSession):
                         )
 
                 elif resp.status >= 500 and resp.status < 600:
-                    body = await resp.read()
+                    body = await read_error_body(log, resp)
 
                     if should_retry is None or should_retry(
                         resp.status, resp.headers, body, attempt
@@ -671,7 +714,7 @@ class HTTPMixin(Mixin, HTTPSession):
                             resp.status,
                         )
                 elif resp.status >= 400 and resp.status < 500:
-                    body = await resp.read()
+                    body = await read_error_body(log, resp)
                     raise HTTPError(
                         f"Encountered HTTP error status {resp.status} which cannot be retried.\nURL: {resp.request_info.url}\nContent-Type: {resp.content_type}\nResponse:\n{format_error_body(body)}",
                         resp.status,
@@ -679,14 +722,33 @@ class HTTPMixin(Mixin, HTTPSession):
                 else:
                     resp.raise_for_status()
 
+                    response_headers = resp.headers
+
+                    if codings := _response_codings(resp):
+                        log.debug(
+                            "undoing content codings left on the response body",
+                            {
+                                "url": url,
+                                "content_encoding": response_headers.get(
+                                    aiohttp.hdrs.CONTENT_ENCODING
+                                ),
+                            },
+                        )
+
                     async def body_generator() -> AsyncGenerator[bytes, None]:
                         try:
-                            async for chunk in resp.content.iter_any():
+                            # The decoder stack must be built inside this
+                            # generator. The caller then iterates it
+                            # directly, so every stop (normal end, decoder
+                            # error, cancellation) runs the `finally` below
+                            # and releases the connection.
+                            async for chunk in decompress_stream(
+                                resp.content.iter_any(), codings
+                            ):
                                 yield chunk
                         finally:
                             await resp.release()
 
-                    response_headers = resp.headers
                     should_release_response = False
                     return (response_headers, body_generator)
 

--- a/estuary-cdk/tests/test_content_encoding.py
+++ b/estuary-cdk/tests/test_content_encoding.py
@@ -1,0 +1,202 @@
+import gzip
+import zlib
+from collections.abc import AsyncGenerator, AsyncIterable
+
+import pytest
+
+from estuary_cdk.content_encoding import (
+    ContentCodingChainTooDeep,
+    StreamDecompressor,
+    TruncatedContentStream,
+    UnsupportedContentCoding,
+    decompress,
+    decompress_stream,
+    parse_content_codings,
+)
+from estuary_cdk.gunzip_stream import GunzipStream
+
+PAYLOAD = b'{"totalRowCount": 2, "rows": [{"id": 1}, {"id": 2}]}'
+
+
+@pytest.mark.parametrize(
+    "header_value, expected",
+    [
+        # Nothing to undo
+        ("", []),
+        ("   ", []),
+        ("identity", []),
+        # A lone coding aiohttp claims: not ours either way
+        ("gzip", []),
+        (" gzip ", []),
+        ("deflate", []),
+        # Claimed case-insensitively, then decoded with the original casing —
+        # so aiohttp fails the request and the body never reaches us
+        ("GZIP", []),
+        # Chains: aiohttp's parser skips them wholesale.
+        ("gzip,gzip", ["gzip", "gzip"]),
+        ("GZIP,Gzip", ["gzip", "gzip"]),
+        ("gzip,gzip,gzip", ["gzip", "gzip", "gzip"]),
+        # Codings are listed as applied, so they're undone in reverse
+        ("gzip, deflate", ["deflate", "gzip"]),
+        ("deflate, gzip", ["gzip", "deflate"]),
+        # `identity` is a no-op
+        ("gzip, identity", ["gzip"]),
+        ("identity, gzip", ["gzip"]),
+        ("identity, identity", []),
+        # Codings we can't undo still parse; the decoders are what reject them.
+        ("gzip, br", ["br", "gzip"]),
+    ],
+)
+def test_parses_what_is_left_to_undo(header_value: str, expected: list[str]) -> None:
+    assert parse_content_codings(header_value) == expected
+
+
+async def chunked(data: bytes) -> AsyncGenerator[bytes, None]:
+    """Chunk finely enough that each coding must be undone incrementally"""
+
+    for i in range(0, len(data), 8):
+        yield data[i : i + 8]
+
+
+async def drain(stream: AsyncIterable[bytes]) -> bytes:
+    return b"".join([chunk async for chunk in stream])
+
+
+def apply_codings(body: bytes, header_value: str) -> bytes:
+    for coding in header_value.split(","):
+        match coding.strip().lower():
+            case "gzip":
+                body = gzip.compress(body)
+            case "deflate":
+                body = zlib.compress(body)
+            case "identity":
+                pass
+            case other:
+                raise AssertionError(f"test cannot apply coding {other!r}")
+    return body
+
+
+ROUND_TRIPS = [
+    "gzip",
+    "deflate",
+    "gzip,gzip",
+    "gzip,gzip,gzip,gzip",  # Exactly MAX_CODING_CHAIN_DEPTH.
+    "gzip,deflate",
+    "deflate,gzip",
+    "gzip,identity,gzip",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header_value", ROUND_TRIPS)
+async def test_stream_round_trips_a_chain(header_value: str) -> None:
+    body = apply_codings(PAYLOAD, header_value)
+    codings = parse_content_codings(header_value) or [header_value]
+
+    assert await drain(decompress_stream(chunked(body), codings)) == PAYLOAD
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header_value", ROUND_TRIPS)
+async def test_bytes_round_trip_a_chain(header_value: str) -> None:
+    body = apply_codings(PAYLOAD, header_value)
+    codings = parse_content_codings(header_value) or [header_value]
+
+    assert await decompress(body, codings) == PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_raw_deflate_is_decoded_despite_the_missing_zlib_header() -> None:
+    """Servers commonly send bare RFC 1951 data under the `deflate` coding."""
+    compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    raw = compressor.compress(PAYLOAD) + compressor.flush()
+
+    assert await decompress(raw, ["deflate"]) == PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_raw_deflate_is_decoded_when_streamed() -> None:
+    compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    raw = compressor.compress(PAYLOAD) + compressor.flush()
+
+    assert await drain(StreamDecompressor(chunked(raw), "deflate")) == PAYLOAD
+
+
+@pytest.mark.asyncio
+async def test_truncated_deflate_raises_rather_than_yield_partial_data() -> None:
+    """Truncated zlib data decodes without error; only the missing
+    end-of-stream marker reveals the loss. deflate is the one coding aiohttp
+    checks it for, and this module matches that."""
+    truncated = zlib.compress(PAYLOAD)[:20]
+
+    with pytest.raises(TruncatedContentStream):
+        _ = await decompress(truncated, ["deflate"])
+
+    with pytest.raises(TruncatedContentStream):
+        _ = await drain(decompress_stream(chunked(truncated), ["deflate"]))
+
+
+@pytest.mark.asyncio
+async def test_truncated_gzip_yields_what_decoded() -> None:
+    """aiohttp performs no end-of-stream check for gzip, and neither does this
+    module: a truncated gzip stream yields whatever decoded, without error."""
+    truncated = gzip.compress(PAYLOAD)[:20]
+
+    assert PAYLOAD.startswith(await decompress(truncated, ["gzip"]))
+
+
+@pytest.mark.asyncio
+async def test_empty_body_is_not_mistaken_for_a_truncated_one() -> None:
+    """The deflate check is gated on input having been consumed, mirroring
+    aiohttp's `size > 0` gate."""
+    assert await decompress(b"", ["deflate"]) == b""
+
+
+@pytest.mark.asyncio
+async def test_bytes_past_the_gzip_stream_end_are_ignored() -> None:
+    """zlib hoards post-stream input in `unused_data` with no error, and
+    aiohttp never inspects it -- so trailing bytes are dropped. This module
+    matches that behavior."""
+    body = gzip.compress(PAYLOAD) + b"trailing garbage"
+
+    assert await decompress(body, ["gzip"]) == PAYLOAD
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("coding", ["compress", "x-gzip", "bogus"])
+async def test_undecodable_codings_raise_rather_than_pass_bytes_through(
+    coding: str,
+) -> None:
+    with pytest.raises(UnsupportedContentCoding):
+        _ = await decompress(gzip.compress(PAYLOAD), [coding])
+
+    with pytest.raises(UnsupportedContentCoding):
+        _ = StreamDecompressor(chunked(b""), coding)
+
+
+@pytest.mark.asyncio
+async def test_gunzip_stream_still_decodes_a_payload_no_header_describes() -> None:
+    """`GunzipStream` is for gzip data that *is* the payload -- a downloaded
+    `.gz` report -- which no `Content-Encoding` covers."""
+    assert parse_content_codings("") == []
+    assert await drain(GunzipStream(chunked(gzip.compress(PAYLOAD)))) == PAYLOAD
+
+
+def test_chains_deeper_than_the_cap_are_rejected() -> None:
+    """`identity` stacks nothing and so doesn't count against the cap."""
+    assert len(parse_content_codings("gzip," * 4 + "identity")) == 4
+
+    with pytest.raises(ContentCodingChainTooDeep):
+        _ = parse_content_codings("gzip," * 5 + "identity")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("coding", ["gzip", "GZIP", " gzip "])
+async def test_stream_normalizes_its_coding(coding: str) -> None:
+    """Casing and whitespace are normalized at construction, so every
+    comparison downstream -- including the raw-deflate check -- sees the
+    canonical spelling."""
+    stream = StreamDecompressor(chunked(gzip.compress(PAYLOAD)), coding)
+
+    assert stream.coding == "gzip"
+    assert await drain(stream) == PAYLOAD

--- a/estuary-cdk/tests/test_error_body.py
+++ b/estuary-cdk/tests/test_error_body.py
@@ -1,0 +1,82 @@
+import gzip
+import logging
+
+import pytest
+from multidict import CIMultiDict, CIMultiDictProxy
+
+from estuary_cdk.http import format_error_body, read_error_body
+
+SMARTSHEET_ERROR = b'{"errorCode":1006,"message":"Not Found","refId":"abc123"}'
+
+
+class FakeResponse:
+    """The surface `read_error_body` touches."""
+
+    def __init__(self, body: bytes, content_encoding: str | None = None) -> None:
+        self._body: bytes = body
+        raw: CIMultiDict[str] = CIMultiDict()
+        if content_encoding is not None:
+            raw["Content-Encoding"] = content_encoding
+        self.headers: CIMultiDictProxy[str] = CIMultiDictProxy(raw)
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, content_encoding",
+    [
+        # Uncompressed, and the single-coding case aiohttp already decoded.
+        (SMARTSHEET_ERROR, None),
+        (SMARTSHEET_ERROR, "gzip"),
+        (SMARTSHEET_ERROR, "identity"),
+        # A chained coding aiohttp's parser skips, so the error body reaches us
+        # gzipped twice.
+        (gzip.compress(gzip.compress(SMARTSHEET_ERROR)), "gzip,gzip"),
+        (gzip.compress(gzip.compress(SMARTSHEET_ERROR)), "gzip, gzip"),
+    ],
+)
+async def test_recovers_the_providers_error_message(
+    body: bytes, content_encoding: str | None, caplog: pytest.LogCaptureFixture
+) -> None:
+    log = logging.getLogger(__name__)
+
+    with caplog.at_level(logging.WARNING):
+        decoded = await read_error_body(log, FakeResponse(body, content_encoding))  # type: ignore[arg-type]
+
+    assert format_error_body(decoded) == SMARTSHEET_ERROR.decode()
+    assert not caplog.records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, content_encoding",
+    [
+        # Truncated mid-stream.
+        (gzip.compress(SMARTSHEET_ERROR)[:20], "gzip,gzip"),
+        # Header claims a coding the body doesn't actually carry.
+        (SMARTSHEET_ERROR, "gzip,gzip"),
+        # Header claims a coding we have no decoder for.
+        (SMARTSHEET_ERROR, "br,gzip"),
+        # Header chains more codings than MAX_CODING_CHAIN_DEPTH allows.
+        (SMARTSHEET_ERROR, "gzip,gzip,gzip,gzip,gzip"),
+    ],
+)
+async def test_reports_rather_than_raises_when_decoding_fails(
+    body: bytes, content_encoding: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A secondary failure here would destroy the HTTP error being reported,
+    so an undecodable body is passed through instead -- with a warning, so the
+    mangled body in the resulting error message is explained somewhere."""
+    log = logging.getLogger(__name__)
+
+    with caplog.at_level(logging.WARNING):
+        decoded = await read_error_body(log, FakeResponse(body, content_encoding))  # type: ignore[arg-type]
+
+    assert decoded == body
+    assert format_error_body(decoded)
+    assert any(
+        "could not undo content codings" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
**Description:**

aiohttp auto-decompresses a response only when Content-Encoding holds a single coding it knows; a chained value like `gzip,gzip` matches nothing in its parser and the body arrives still compressed. Parse the codings aiohttp skipped and undo them ourselves, both on the streaming success path and on error bodies (which fall back to the raw bytes, with a warning, rather than fail while reporting the HTTP error).

Edge-case handling deliberately mirrors aiohttp's `DeflateBuffer`.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
