### PR TITLE
Docs: Update main connector landing page

### DIFF
--- a/docs/reference/Connectors/README.md
+++ b/docs/reference/Connectors/README.md
@@ -10,4 +10,18 @@ A current list and configuration details for Estuary's connectors can be found o
 * [Materialization connectors](./materialization-connectors/)
 * [Dekaf integrations](./dekaf)
 
-You can learn more about how connectors work and how to use them in their [conceptual documentation](../../concepts/connectors.md).
+Connector pages in these sections offer a quick reference for each connector to help you with setup.
+Keep the reference handy while you're creating your capture and materialization tasks.
+Reference guides often include details like:
+
+* Prerequisites for the connector, such as required resources and permissions
+* Connector properties: set these in the dashboard or add to a `flow.yaml` specification file
+* A sample YAML specification for the connector
+* Notable supported features
+* (SaaS captures) A list of supported data streams or API objects
+
+You can also find more general information on working with connectors in the platform docs:
+
+* [Learn how connectors work and how to use them](/concepts/connectors)
+* [Find general information about captures and their specs](/concepts/captures)
+* [Learn more about materializations and their specs](/concepts/materialization)


### PR DESCRIPTION
**Description:**

Slightly fleshes out the main connectors landing page which has been kind of a stub for a while, noting what to expect from connector reference pages and where to find more information.

Only docs changes, no connector code updates.

**Notes for reviewers:**

Connector docs side of https://github.com/estuary/flow/pull/3307 which is being broken up following cutover. Platform docs update available at https://github.com/estuary/docs/pull/43 but neither PR is dependent on the other.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
