### PR TITLE
fix(facebook-marketing-native): retain reduced page size

### DIFF
--- a/source-facebook-marketing-native/source_facebook_marketing_native/client.py
+++ b/source-facebook-marketing-native/source_facebook_marketing_native/client.py
@@ -220,6 +220,7 @@ class FacebookAPIClient:
         self.base_url = BASE_URL
         self.log = log
         self.permission_manager = PermissionManager(http, BASE_URL, log)
+        self._page_size_limits: dict[str, int] = {}
 
     def _make_should_retry(
         self,
@@ -303,14 +304,24 @@ class FacebookAPIClient:
                 )
 
         request_params = params.model_dump(exclude_none=True)
-        response = adapter.validate_json(
-            await self.http.request(
-                self.log,
-                url,
-                params=request_params,
-                should_retry=self._make_should_retry(request_params),
-            )
+        if learned_limit := self._page_size_limits.get(url):
+            request_params["limit"] = min(request_params["limit"], learned_limit)
+
+        response_body = await self.http.request(
+            self.log,
+            url,
+            params=request_params,
+            should_retry=self._make_should_retry(request_params),
         )
+
+        current_limit = request_params.get("limit")
+        if current_limit:
+            self._page_size_limits[url] = min(
+                current_limit,
+                self._page_size_limits.get(url, current_limit),
+            )
+
+        response = adapter.validate_json(response_body)
 
         if response.error:
             raise FacebookAPIError(response.error)

--- a/source-facebook-marketing-native/tests/unit/test_client.py
+++ b/source-facebook-marketing-native/tests/unit/test_client.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Any
+
+from source_facebook_marketing_native.client import (
+    FacebookAPIClient,
+    FacebookRequestParams,
+)
+from source_facebook_marketing_native.models import Campaigns
+
+
+class ReducingHTTPSession:
+    def __init__(self) -> None:
+        self.initial_limits: list[int] = []
+
+    async def request(
+        self,
+        log: logging.Logger,
+        url: str,
+        params: dict[str, Any],
+        **kwargs: Any,
+    ) -> bytes:
+        self.initial_limits.append(params["limit"])
+
+        if len(self.initial_limits) == 1:
+            should_retry = kwargs["should_retry"]
+            assert should_retry(
+                500,
+                {},
+                b'{"error":{"message":"Please reduce the amount of data requested"}}',
+                1,
+            )
+
+        return b'{"data":[]}'
+
+
+async def test_reduced_page_size_is_reused_for_later_request_to_same_url() -> None:
+    http = ReducingHTTPSession()
+    client = FacebookAPIClient(
+        http=http,  # type: ignore[arg-type]
+        log=logging.getLogger("test_reduced_page_size"),
+    )
+    adapter = client._build_adapter(Campaigns)
+    url = client._build_url(Campaigns, "account")
+
+    await client._fetch_resource_data(
+        Campaigns,
+        adapter,
+        url,
+        FacebookRequestParams(fields=Campaigns.fields),
+        include_deleted=False,
+    )
+    await client._fetch_resource_data(
+        Campaigns,
+        adapter,
+        url,
+        FacebookRequestParams(fields=Campaigns.fields),
+        include_deleted=False,
+    )
+
+    assert http.initial_limits == [25, 12]


### PR DESCRIPTION
Meta can return a recoverable server error asking clients to reduce the requested page size. The connector already retries with a smaller limit, but subsequent paginated requests restart at the configured limit and repeat the same failed request.\n\nCache the smallest successful limit per resource URL for the lifetime of the client and reuse it on later requests. This keeps the existing retry behavior while avoiding repeated oversized requests.\n\nValidation: source-facebook-marketing-native unit tests pass (15 tests).