### PR TITLE
tests/benchmark: make the materialize harness work for cloud connectors

### DIFF
--- a/materialize-boilerplate/testutil/resources.go
+++ b/materialize-boilerplate/testutil/resources.go
@@ -258,11 +258,6 @@ func ReadConfigFile(path string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	// Every cloud connector's configuration in this repository is stored
-	// sops-encrypted, so decrypt one rather than requiring the caller to leave
-	// a plaintext copy of its credentials on disk. Decryption goes through the
-	// sops binary, as flowctl does it, so the key material a caller already has
-	// access to is the key material this uses.
 	if encrypted, err := isSopsEncrypted(raw); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	} else if encrypted {
@@ -289,8 +284,6 @@ func ReadConfigFile(path string) (json.RawMessage, error) {
 	return out, nil
 }
 
-// isSopsEncrypted reports whether a configuration document carries a sops
-// stanza, which is how sops records the metadata it needs to decrypt one.
 func isSopsEncrypted(raw []byte) (bool, error) {
 	var doc struct {
 		Sops any `yaml:"sops"`

--- a/materialize-boilerplate/testutil/resources.go
+++ b/materialize-boilerplate/testutil/resources.go
@@ -3,8 +3,10 @@ package testutil
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -256,6 +258,25 @@ func ReadConfigFile(path string) (json.RawMessage, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
+	// Every cloud connector's configuration in this repository is stored
+	// sops-encrypted, so decrypt one rather than requiring the caller to leave
+	// a plaintext copy of its credentials on disk. Decryption goes through the
+	// sops binary, as flowctl does it, so the key material a caller already has
+	// access to is the key material this uses.
+	if encrypted, err := isSopsEncrypted(raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	} else if encrypted {
+		out, err := exec.Command("sops", "--decrypt", "--output-type", "json", path).Output()
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				return nil, fmt.Errorf("decrypting %s with sops: %s", path, strings.TrimSpace(string(exitErr.Stderr)))
+			}
+			return nil, fmt.Errorf("decrypting %s with sops (is it installed?): %w", path, err)
+		}
+		return json.RawMessage(out), nil
+	}
+
 	var intermediate any
 	if err := yaml.Unmarshal(raw, &intermediate); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
@@ -266,4 +287,16 @@ func ReadConfigFile(path string) (json.RawMessage, error) {
 	}
 
 	return out, nil
+}
+
+// isSopsEncrypted reports whether a configuration document carries a sops
+// stanza, which is how sops records the metadata it needs to decrypt one.
+func isSopsEncrypted(raw []byte) (bool, error) {
+	var doc struct {
+		Sops any `yaml:"sops"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return false, err
+	}
+	return doc.Sops != nil, nil
 }

--- a/tests/benchmark/gcp-vm.sh
+++ b/tests/benchmark/gcp-vm.sh
@@ -148,8 +148,16 @@ do_sync() {
   _rsync_transport
 
   info "syncing codebase to ${VM_NAME}"
+  # .gitignore excludes binaries named "connector" and re-includes the
+  # cmd/connector source directories with "!*/cmd/connector". rsync's
+  # gitignore merge does not honour git's negation, so without these two
+  # rules every connector's main package is silently dropped and nothing
+  # can be built on the VM. First matching rule wins, so they precede the
+  # merge.
   rsync -az \
     --exclude='.git' \
+    --filter='+ /*/cmd/connector/' \
+    --filter='+ /*/cmd/connector/**' \
     --filter=':- .gitignore' \
     -e "$RSYNC_TRANSPORT" \
     "${ROOT_DIR}/" \

--- a/tests/benchmark/materialize/README.md
+++ b/tests/benchmark/materialize/README.md
@@ -151,21 +151,7 @@ Each run produces:
 ## Cleanup
 
 A run names its task `bench/<connector>_flow_test_<timestamp>` and removes what
-it created, so a benchmark neither inherits state nor leaves any behind.
-
-Both matter for the measurement, not just for tidiness. A task's checkpoint is
-stored by the destination for connectors whose destination is authoritative, and
-a resumed task skips the prefix of the fixture it has already read through, so a
-second run of a scenario would silently measure part of it. The fixture is also
-deterministic in its seed, so a table left behind by an earlier run turns the
-next run's inserts into merges.
-
-Each binding's resource is dropped before the run as well as after it, so a run
-starts against an empty destination however the previous one ended, and the
-teardown runs on failure and on Ctrl-C as well as on success. Dropping goes
-through `tests/materialize/testctl`, which drives the connector's own
-`DeleteResource`. Pass `--keep` to leave the destination in place for
-inspection.
+it created.
 
 If a run is killed outright, its table survives until the next run of that
 scenario drops it, and its task metadata until swept:

--- a/tests/benchmark/materialize/README.md
+++ b/tests/benchmark/materialize/README.md
@@ -148,6 +148,36 @@ Each run produces:
 | `preview.log`      | flowctl preview stderr (per-tx commit boundaries live here). |
 | `results.json`     | Aggregate `{ wall_seconds, total_docs, total_bytes, mb_per_sec, transactions: [...] }`. |
 
+## Cleanup
+
+A run names its task `bench/<connector>_flow_test_<timestamp>` and removes what
+it created, so a benchmark neither inherits state nor leaves any behind.
+
+Both matter for the measurement, not just for tidiness. A task's checkpoint is
+stored by the destination for connectors whose destination is authoritative, and
+a resumed task skips the prefix of the fixture it has already read through, so a
+second run of a scenario would silently measure part of it. The fixture is also
+deterministic in its seed, so a table left behind by an earlier run turns the
+next run's inserts into merges.
+
+Each binding's resource is dropped before the run as well as after it, so a run
+starts against an empty destination however the previous one ended, and the
+teardown runs on failure and on Ctrl-C as well as on success. Dropping goes
+through `tests/materialize/testctl`, which drives the connector's own
+`DeleteResource`. Pass `--keep` to leave the destination in place for
+inspection.
+
+If a run is killed outright, its table survives until the next run of that
+scenario drops it, and its task metadata until swept:
+
+```bash
+go run ./tests/materialize/testctl \
+    -connector materialize-redshift \
+    -config materialize-redshift/testdata/config.local.yaml \
+    -resource <a resource config from a run directory> \
+    -mode sweep
+```
+
 ## Verifying overlap correctness
 
 The fixture is fully deterministic given `--seed`. To sanity-check that a

--- a/tests/benchmark/materialize/generate_spec.py
+++ b/tests/benchmark/materialize/generate_spec.py
@@ -149,7 +149,14 @@ def build_spec(
     else:
         endpoint = {
             "local": {
-                "command": [f"./{connector}/connector"],
+                # Absolute, because flowctl resolves a relative command
+                # against the spec file's directory and the spec is written
+                # into the run's output directory, not the repo root.
+                "command": [
+                    os.path.join(
+                        os.environ.get("ROOT_DIR", "."), connector, "connector"
+                    )
+                ],
                 "protobuf": True,
                 "config": config,
             }

--- a/tests/benchmark/materialize/generate_spec.py
+++ b/tests/benchmark/materialize/generate_spec.py
@@ -149,9 +149,6 @@ def build_spec(
     else:
         endpoint = {
             "local": {
-                # Absolute, because flowctl resolves a relative command
-                # against the spec file's directory and the spec is written
-                # into the run's output directory, not the repo root.
                 "command": [
                     os.path.join(
                         os.environ.get("ROOT_DIR", "."), connector, "connector"

--- a/tests/benchmark/materialize/run.sh
+++ b/tests/benchmark/materialize/run.sh
@@ -110,6 +110,15 @@ if (( DOCKER )); then echo "mode:      docker"; else echo "mode:      local"; fi
 echo "seed:      $SEED"
 echo "out-dir:   $OUT_DIR"
 
+# Every run gets its own task name. A task's stored checkpoint otherwise
+# carries over between runs, and a resumed task skips the prefix of the fixture
+# it has already read through, so the run would silently measure part of its
+# scenario. The _flow_test_<timestamp> shape is what `testctl -mode sweep`
+# recognises, so a run killed outright can still be cleaned up afterwards.
+RUN_SUFFIX="_flow_test_$(date +%s)"
+TASK="bench/${CONNECTOR}${RUN_SUFFIX}"
+echo "task:      $TASK"
+
 # Bring up the connector's docker-compose stack (DB only). Some connectors
 # keep it under tests/materialize/<connector>/ (the integration-test convention),
 # others keep it at the connector root. Try both.
@@ -123,20 +132,69 @@ done
 if [[ -n "$COMPOSE_FILE" ]]; then
   echo "starting docker-compose: $COMPOSE_FILE"
   docker compose -f "$COMPOSE_FILE" up --wait
-  cleanup() {
-    if (( ! KEEP )); then
-      echo "tearing down docker-compose"
-      docker compose -f "$COMPOSE_FILE" down -v || true
-    else
-      echo "--keep set; leaving docker-compose running"
-    fi
-  }
-  trap cleanup EXIT
   # Same grace period as tests/materialize/<connector>/setup.sh.
   sleep 5
 else
   echo "no docker-compose for $CONNECTOR; assuming endpoint is reachable"
 fi
+
+# Removing the destination is what keeps a scenario measuring what it
+# describes: the fixture is deterministic in its seed, so a table left behind by
+# an earlier run turns this run's inserts into merges. It also keeps a shared
+# warehouse from accumulating what benchmarks leave behind.
+#
+# Both go through testctl, which drives the connector's own DeleteResource, so
+# this works for every connector rather than only the SQL ones, and needs no
+# per-connector script here.
+TESTCTL="$OUT_DIR/testctl"
+echo "building testctl"
+(cd "$ROOT_DIR" && go build -tags nozstd -o "$TESTCTL" ./tests/materialize/testctl)
+
+# drop_destination removes each binding's resource. Dropping one that is not
+# there fails, which is the ordinary case before a run, so a failure is
+# reported rather than fatal.
+drop_destination() {
+  local when="$1" res
+  for res in "$OUT_DIR"/resource-*.json; do
+    [[ -f "$res" ]] || continue
+    if "$TESTCTL" -connector "$CONNECTOR" -config "$CONFIG" -resource "$res" \
+         -task "$TASK" -mode drop >>"$OUT_DIR/cleanup.log" 2>&1; then
+      echo "  dropped $(basename "$res" .json) ($when)"
+    else
+      echo "  no $(basename "$res" .json) to drop ($when)"
+    fi
+  done
+}
+
+# sweep_run removes this run's task metadata, which for a SQL connector is its
+# row in the checkpoints table, along with test items an older run left behind.
+sweep_run() {
+  local res
+  for res in "$OUT_DIR"/resource-*.json; do
+    [[ -f "$res" ]] || continue
+    "$TESTCTL" -connector "$CONNECTOR" -config "$CONFIG" -resource "$res" \
+      -task "$TASK" -mode sweep -run-suffix "$RUN_SUFFIX" \
+      >>"$OUT_DIR/cleanup.log" 2>&1 || echo "  sweep reported errors (see cleanup.log)"
+    return
+  done
+}
+
+cleanup() {
+  local status=$?
+  if (( KEEP )); then
+    echo "--keep set; leaving the destination and docker-compose in place"
+  else
+    echo "cleaning up"
+    drop_destination "teardown"
+    sweep_run
+    if [[ -n "$COMPOSE_FILE" ]]; then
+      echo "tearing down docker-compose"
+      docker compose -f "$COMPOSE_FILE" down -v || true
+    fi
+  fi
+  return $status
+}
+trap cleanup EXIT INT TERM
 
 # Per-connector setup hook. Runs after docker-compose is up but before the
 # preview. Used for steps like creating an S3 bucket that the connector
@@ -154,6 +212,7 @@ SPEC_ARGS=(
   --connector "$CONNECTOR"
   --config    "$CONFIG"
   --output    "$SPEC"
+  --task      "$TASK"
 )
 if (( DOCKER )); then
   SPEC_ARGS+=(--docker)
@@ -161,7 +220,23 @@ fi
 echo "rendering spec: $SPEC"
 python3 "$BENCH_DIR/generate_spec.py" "${SPEC_ARGS[@]}"
 
-TASK="bench/$CONNECTOR"
+# One resource configuration file per binding, for testctl.
+python3 - "$SPEC" "$OUT_DIR" <<'RESOURCES'
+import json, sys, yaml
+
+spec_path, out_dir = sys.argv[1], sys.argv[2]
+with open(spec_path) as f:
+    spec = yaml.safe_load(f)
+materialization = next(iter(spec["materializations"].values()))
+for index, binding in enumerate(materialization["bindings"]):
+    with open(f"{out_dir}/resource-{index}.json", "w") as f:
+        json.dump(binding["resource"], f)
+RESOURCES
+
+# Drop whatever an earlier run left behind, so this run starts against an empty
+# destination however that run ended.
+echo "preparing destination"
+drop_destination "before run"
 
 # Set up FIFO + background generator.
 FIFO="$OUT_DIR/fixture.fifo"

--- a/tests/benchmark/materialize/run.sh
+++ b/tests/benchmark/materialize/run.sh
@@ -111,10 +111,9 @@ echo "seed:      $SEED"
 echo "out-dir:   $OUT_DIR"
 
 # Every run gets its own task name. A task's stored checkpoint otherwise
-# carries over between runs, and a resumed task skips the prefix of the fixture
-# it has already read through, so the run would silently measure part of its
-# scenario. The _flow_test_<timestamp> shape is what `testctl -mode sweep`
-# recognises, so a run killed outright can still be cleaned up afterwards.
+# carries over between runs. The _flow_test_<timestamp> shape is what
+# `testctl -mode sweep` recognises, so a run that has been killed can still
+# be cleaned up afterwards.
 RUN_SUFFIX="_flow_test_$(date +%s)"
 TASK="bench/${CONNECTOR}${RUN_SUFFIX}"
 echo "task:      $TASK"
@@ -138,21 +137,11 @@ else
   echo "no docker-compose for $CONNECTOR; assuming endpoint is reachable"
 fi
 
-# Removing the destination is what keeps a scenario measuring what it
-# describes: the fixture is deterministic in its seed, so a table left behind by
-# an earlier run turns this run's inserts into merges. It also keeps a shared
-# warehouse from accumulating what benchmarks leave behind.
-#
-# Both go through testctl, which drives the connector's own DeleteResource, so
-# this works for every connector rather than only the SQL ones, and needs no
-# per-connector script here.
+# clean up the destination resources using testctl
 TESTCTL="$OUT_DIR/testctl"
 echo "building testctl"
 (cd "$ROOT_DIR" && go build -tags nozstd -o "$TESTCTL" ./tests/materialize/testctl)
 
-# drop_destination removes each binding's resource. Dropping one that is not
-# there fails, which is the ordinary case before a run, so a failure is
-# reported rather than fatal.
 drop_destination() {
   local when="$1" res
   for res in "$OUT_DIR"/resource-*.json; do
@@ -166,8 +155,6 @@ drop_destination() {
   done
 }
 
-# sweep_run removes this run's task metadata, which for a SQL connector is its
-# row in the checkpoints table, along with test items an older run left behind.
 sweep_run() {
   local res
   for res in "$OUT_DIR"/resource-*.json; do

--- a/tests/benchmark/materialize/run.sh
+++ b/tests/benchmark/materialize/run.sh
@@ -85,8 +85,16 @@ if (( DOCKER )); then
   (cd "$ROOT_DIR" && ./build-local.sh "$CONNECTOR")
 else
   CONNECTOR_BIN="$ROOT_DIR/$CONNECTOR/connector"
-  echo "building connector binary: $CONNECTOR_BIN"
-  (cd "$ROOT_DIR" && go build -v -tags nozstd -o "$CONNECTOR_BIN" ./$CONNECTOR/...)
+  # Connectors structured as a library plus a cmd/ main (all the SQL ones)
+  # match more than one package under ./<connector>/..., which `go build -o
+  # <file>` refuses. Prefer the cmd package when there is one.
+  if [[ -d "$ROOT_DIR/$CONNECTOR/cmd" ]]; then
+    BUILD_PKG="./$CONNECTOR/cmd/..."
+  else
+    BUILD_PKG="./$CONNECTOR/..."
+  fi
+  echo "building connector binary: $CONNECTOR_BIN (from $BUILD_PKG)"
+  (cd "$ROOT_DIR" && go build -v -tags nozstd -o "$CONNECTOR_BIN" "$BUILD_PKG")
 fi
 
 # Output directory.
@@ -218,9 +226,11 @@ echo "preview exit: $PREVIEW_RC"
 # Build results.json from state log + per-commit timestamps.
 # timestamps.json has one entry per connectorState line: the first is Apply
 # (DDL), the rest are data transactions.
-python3 - "$STATE_LOG" "$TIMESTAMPS" "$PREVIEW_RC" "$CONNECTOR" "$SCENARIO" "$SEED" >"$OUT_DIR/results.json" <<'PY'
-import json, sys, os
+python3 - "$STATE_LOG" "$TIMESTAMPS" "$PREVIEW_RC" "$CONNECTOR" "$SCENARIO" "$SEED" "$PREVIEW_LOG" >"$OUT_DIR/results.json" <<'PY'
+import json, sys, os, re
+from datetime import datetime
 state_path, ts_path, rc, connector, scenario, seed = sys.argv[1:7]
+preview_log = sys.argv[7] if len(sys.argv) > 7 else None
 with open(state_path) as f:
     state = json.load(f)
 try:
@@ -238,9 +248,78 @@ if len(timestamps) >= 2:
     for i in range(2, len(timestamps)):
         tx_boundaries.append((timestamps[i - 1], timestamps[i]))
 
+
+def boundaries_from_log(path):
+    """Derive per-round boundaries from flowctl's own log.
+
+    The connectorState-line method assumes one state line for Apply and one
+    per transaction. That holds only for connectors that emit a state document
+    at Apply; a connector whose destination is authoritative emits none, so
+    every boundary shifts by one and Apply absorbs the first transaction.
+
+    Each data round is bracketed by "started reading load requests" and
+    "finished materialization commit", both emitted once per round. Some
+    records arrive interleaved into another line and without their own
+    timestamp, so the most recent timestamp seen is used; the error is far
+    below the resolution that matters here.
+
+    Returns (apply_seconds, [(start_ns, end_ns)], rounds_observed).
+    """
+    ansi = re.compile("\x1b\\[[0-9;]*m|\\\\x1b\\[[0-9;]*m")
+    stamp_re = re.compile(r"(\d{4}-\d{2}-\d{2}T[\d:.]+Z)")
+    start_re = re.compile(r"started reading load requests\s+round=(-?\d+)")
+    end_re = re.compile(r"finished materialization commit\s+round=(-?\d+)")
+
+    starts, ends = {}, {}
+    first_ts = last_ts = cur = None
+    with open(path, errors="replace") as f:
+        for line in f:
+            line = ansi.sub("", line)
+            st = stamp_re.search(line)
+            if st:
+                cur = int(
+                    datetime.strptime(
+                        st.group(1)[:26].ljust(26, "0"), "%Y-%m-%dT%H:%M:%S.%f"
+                    ).timestamp() * 1e9
+                )
+                if first_ts is None:
+                    first_ts = cur
+                last_ts = cur
+            if cur is None:
+                continue
+            for m in start_re.finditer(line):
+                rnd = int(m.group(1))
+                if rnd >= 0:
+                    starts.setdefault(rnd, cur)
+            for m in end_re.finditer(line):
+                rnd = int(m.group(1))
+                if rnd >= 0:
+                    ends[rnd] = cur
+
+    if not starts or first_ts is None:
+        return None, [], 0
+    rounds = sorted(starts)
+    apply_s = (starts[rounds[0]] - first_ts) / 1e9
+    bounds = [(starts[r], ends.get(r, last_ts)) for r in rounds]
+    return apply_s, bounds, len(rounds)
+
+
+rounds_observed = len(tx_boundaries)
+timing_source = "connector-state"
+if preview_log and os.path.exists(preview_log):
+    log_apply, log_bounds, log_rounds = boundaries_from_log(preview_log)
+    if log_bounds:
+        apply_seconds, tx_boundaries = log_apply, log_bounds
+        rounds_observed, timing_source = log_rounds, "flowctl-log"
+
 txs = []
 total_docs = 0
 total_bytes = 0
+# Throughput must divide by what actually ran. A run can cover fewer
+# transactions than the scenario describes, and dividing the scenario's
+# totals by the observed wall overstates the result.
+observed_docs = 0
+observed_bytes = 0
 for i, tx in enumerate(state["transactions"]):
     bytes_ = tx["doc_count"] * tx["doc_size"]
     total_docs  += tx["doc_count"]
@@ -255,6 +334,8 @@ for i, tx in enumerate(state["transactions"]):
         "overlaps":  tx["overlaps"],
     }
     if i < len(tx_boundaries):
+        observed_docs += tx["doc_count"]
+        observed_bytes += bytes_
         start_ns, end_ns = tx_boundaries[i]
         wall_s = (end_ns - start_ns) / 1e9
         entry["wall_seconds"] = wall_s
@@ -263,7 +344,9 @@ for i, tx in enumerate(state["transactions"]):
     txs.append(entry)
 
 # Data wall = end of Apply to end of last data tx (excludes Apply).
-if len(timestamps) >= 3:
+if timing_source == "flowctl-log" and tx_boundaries:
+    data_wall = (tx_boundaries[-1][1] - tx_boundaries[0][0]) / 1e9
+elif len(timestamps) >= 3:
     data_wall = (timestamps[-1] - timestamps[1]) / 1e9
 else:
     data_wall = 0.0
@@ -275,10 +358,15 @@ print(json.dumps({
     "preview_exit_code": int(rc),
     "apply_seconds": apply_seconds,
     "wall_seconds": data_wall,
+    "timing_source": timing_source,
+    "rounds_observed": rounds_observed,
+    "scenario_transactions": len(state["transactions"]),
     "total_docs":   total_docs,
     "total_bytes":  total_bytes,
-    "docs_per_sec": (total_docs  / data_wall) if data_wall > 0 else None,
-    "mb_per_sec":   (total_bytes / data_wall / (1024*1024)) if data_wall > 0 else None,
+    "observed_docs":  observed_docs,
+    "observed_bytes": observed_bytes,
+    "docs_per_sec": (observed_docs  / data_wall) if data_wall > 0 else None,
+    "mb_per_sec":   (observed_bytes / data_wall / (1024*1024)) if data_wall > 0 else None,
     "transactions": txs,
 }, indent=2))
 PY

--- a/tests/benchmark/materialize/runs/baselines/materialize-redshift/large-docs.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-redshift/large-docs.json
@@ -3,8 +3,8 @@
   "scenario": "large-docs.yaml",
   "seed": 0,
   "preview_exit_code": 0,
-  "apply_seconds": 3.345326848,
-  "wall_seconds": 108.980493056,
+  "apply_seconds": 3.916447744,
+  "wall_seconds": 94.767565056,
   "timing_source": "flowctl-log",
   "rounds_observed": 2,
   "scenario_transactions": 2,
@@ -12,8 +12,8 @@
   "total_bytes": 10485760000,
   "observed_docs": 10000,
   "observed_bytes": 10485760000,
-  "docs_per_sec": 91.7595408093948,
-  "mb_per_sec": 91.7595408093948,
+  "docs_per_sec": 105.52133521728459,
+  "mb_per_sec": 105.52133521728459,
   "transactions": [
     {
       "index": 0,
@@ -27,9 +27,9 @@
         "op": "c"
       },
       "overlaps": [],
-      "wall_seconds": 54.49479424,
-      "mb_per_sec": 91.75188327126345,
-      "docs_per_sec": 91.75188327126345
+      "wall_seconds": 44.2570432,
+      "mb_per_sec": 112.9763680190908,
+      "docs_per_sec": 112.9763680190908
     },
     {
       "index": 1,
@@ -49,9 +49,9 @@
           "count": 2000
         }
       ],
-      "wall_seconds": 54.485698816,
-      "mb_per_sec": 91.76719962581676,
-      "docs_per_sec": 91.76719962581676
+      "wall_seconds": 50.510958848,
+      "mb_per_sec": 98.98841982085986,
+      "docs_per_sec": 98.98841982085986
     }
   ]
 }

--- a/tests/benchmark/materialize/runs/baselines/materialize-redshift/large-docs.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-redshift/large-docs.json
@@ -3,12 +3,17 @@
   "scenario": "large-docs.yaml",
   "seed": 0,
   "preview_exit_code": 0,
-  "apply_seconds": 43.206757557,
-  "wall_seconds": 0.0,
+  "apply_seconds": 3.345326848,
+  "wall_seconds": 108.980493056,
+  "timing_source": "flowctl-log",
+  "rounds_observed": 2,
+  "scenario_transactions": 2,
   "total_docs": 10000,
   "total_bytes": 10485760000,
-  "docs_per_sec": null,
-  "mb_per_sec": null,
+  "observed_docs": 10000,
+  "observed_bytes": 10485760000,
+  "docs_per_sec": 91.7595408093948,
+  "mb_per_sec": 91.7595408093948,
   "transactions": [
     {
       "index": 0,
@@ -21,7 +26,10 @@
         "count": 5000,
         "op": "c"
       },
-      "overlaps": []
+      "overlaps": [],
+      "wall_seconds": 54.49479424,
+      "mb_per_sec": 91.75188327126345,
+      "docs_per_sec": 91.75188327126345
     },
     {
       "index": 1,
@@ -40,7 +48,10 @@
           "with": 0,
           "count": 2000
         }
-      ]
+      ],
+      "wall_seconds": 54.485698816,
+      "mb_per_sec": 91.76719962581676,
+      "docs_per_sec": 91.76719962581676
     }
   ]
 }

--- a/tests/benchmark/materialize/runs/baselines/materialize-redshift/small-docs.json
+++ b/tests/benchmark/materialize/runs/baselines/materialize-redshift/small-docs.json
@@ -1,0 +1,62 @@
+{
+  "connector": "materialize-redshift",
+  "scenario": "small-docs.yaml",
+  "seed": 0,
+  "preview_exit_code": 0,
+  "apply_seconds": 3.792225024,
+  "wall_seconds": 974.761574144,
+  "timing_source": "flowctl-log",
+  "rounds_observed": 2,
+  "scenario_transactions": 2,
+  "total_docs": 50000000,
+  "total_bytes": 6400000000,
+  "observed_docs": 50000000,
+  "observed_bytes": 6400000000,
+  "docs_per_sec": 51294.59482838988,
+  "mb_per_sec": 6.261547220262437,
+  "transactions": [
+    {
+      "index": 0,
+      "collection": "bench/tiny",
+      "doc_count": 25000000,
+      "doc_size": 128,
+      "bytes": 3200000000,
+      "fresh": {
+        "start": 0,
+        "count": 25000000,
+        "op": "c"
+      },
+      "overlaps": [],
+      "wall_seconds": 475.962422016,
+      "mb_per_sec": 6.411762087380528,
+      "docs_per_sec": 52525.155019821286
+    },
+    {
+      "index": 1,
+      "collection": "bench/tiny",
+      "doc_count": 25000000,
+      "doc_size": 128,
+      "bytes": 3200000000,
+      "fresh": {
+        "start": 25000000,
+        "count": 21250000,
+        "op": "c"
+      },
+      "overlaps": [
+        {
+          "op": "u",
+          "with": 0,
+          "count": 2500000
+        },
+        {
+          "op": "d",
+          "with": 0,
+          "count": 1250000
+        }
+      ],
+      "wall_seconds": 498.799152128,
+      "mb_per_sec": 6.118209703205087,
+      "docs_per_sec": 50120.373888656075
+    }
+  ]
+}

--- a/tests/materialize/testctl/main.go
+++ b/tests/materialize/testctl/main.go
@@ -137,6 +137,7 @@ func main() {
 		taskName  = flag.String("task", "materialize-testctl", "materialization name to connect as, which only labels the connection")
 		logLevel  = flag.String("log-level", "info", "logging verbosity; debug reports the items a sweep left in place")
 		dryRun    = flag.Bool("dry-run", false, "for sweep, report what would be removed without removing it")
+		runSuffix = flag.String("run-suffix", "", "for sweep, the name suffix of the calling run's own items, which are swept regardless of age")
 	)
 	flag.Parse()
 
@@ -151,12 +152,12 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	if err := run(ctx, *connector, *config, *resource, *mode, *taskName, *dryRun); err != nil {
+	if err := run(ctx, *connector, *config, *resource, *mode, *taskName, *runSuffix, *dryRun); err != nil {
 		log.WithFields(log.Fields{"mode": *mode, "error": err}).Fatal("materialize-testctl failed")
 	}
 }
 
-func run(ctx context.Context, connector, configPath, resourcePath, mode, taskName string, dryRun bool) error {
+func run(ctx context.Context, connector, configPath, resourcePath, mode, taskName, runSuffix string, dryRun bool) error {
 	openConnector, ok := connectors[connector]
 	if !ok {
 		return fmt.Errorf("unknown connector %q: expected one of %s", connector, strings.Join(slices.Sorted(maps.Keys(connectors)), ", "))
@@ -197,7 +198,7 @@ func run(ctx context.Context, connector, configPath, resourcePath, mode, taskNam
 		log.WithField("action", description).Info("dropped the resource")
 		return nil
 	default:
-		return sweep(ctx, m, path, dryRun)
+		return sweep(ctx, m, path, runSuffix, dryRun)
 	}
 }
 
@@ -207,11 +208,13 @@ func run(ctx context.Context, connector, configPath, resourcePath, mode, taskNam
 //
 // The resource path only locates the namespace to sweep: what goes is decided by
 // what is actually present, which is the point of sweeping rather than dropping
-// by name. An empty run suffix says this program has no resources of its own to
-// clean up, so only leftovers are considered.
-func sweep(ctx context.Context, m materializer, path []string, dryRun bool) error {
-	resources, resourcesErr := testutil.SweepTestResources(ctx, m, [][]string{path}, "", dryRun)
-	tasks, tasksErr := testutil.SweepTestTasks(ctx, m, "", dryRun)
+// by name. An empty run suffix says this program has no items of its own to
+// clean up, so only leftovers are considered; a caller that names its items with
+// a run suffix passes it to sweep them whatever their age, which is how a run
+// cleans up after itself rather than waiting to age into a later sweep.
+func sweep(ctx context.Context, m materializer, path []string, runSuffix string, dryRun bool) error {
+	resources, resourcesErr := testutil.SweepTestResources(ctx, m, [][]string{path}, runSuffix, dryRun)
+	tasks, tasksErr := testutil.SweepTestTasks(ctx, m, runSuffix, dryRun)
 
 	var errs = []error{resourcesErr, tasksErr}
 	for _, swept := range []struct {

--- a/tests/materialize/testctl/main.go
+++ b/tests/materialize/testctl/main.go
@@ -209,9 +209,9 @@ func run(ctx context.Context, connector, configPath, resourcePath, mode, taskNam
 // The resource path only locates the namespace to sweep: what goes is decided by
 // what is actually present, which is the point of sweeping rather than dropping
 // by name. An empty run suffix says this program has no items of its own to
-// clean up, so only leftovers are considered; a caller that names its items with
-// a run suffix passes it to sweep them whatever their age, which is how a run
-// cleans up after itself rather than waiting to age into a later sweep.
+// clean up, so only leftovers are considered; when the run suffix is provided
+// explicitly, the cleanup ignores the age check and cleans up everything under
+// that suffix
 func sweep(ctx context.Context, m materializer, path []string, runSuffix string, dryRun bool) error {
 	resources, resourcesErr := testutil.SweepTestResources(ctx, m, [][]string{path}, runSuffix, dryRun)
 	tasks, tasksErr := testutil.SweepTestTasks(ctx, m, runSuffix, dryRun)


### PR DESCRIPTION
**Description:**

Fixes to the materialization benchmark harness, which did not work as a local
binary and did not measure what its scenarios describe.

- Builds the connector's `cmd` package, since `go build -o` refuses the more
  than one package that `./<connector>/...` matches.
- Gives the rendered spec an absolute path to the connector binary, which
  flowctl otherwise resolves against the spec's own directory.
- Syncs connector main packages to a benchmark VM: rsync's gitignore merge does
  not honour git's `!*/cmd/connector` negation, so nothing could be built there.
- Takes transaction boundaries from flowctl's round markers instead of
  `connectorState` lines, which appear per-transaction only for connectors that
  emit state at Apply.
- Divides throughput by the work that actually ran, and records
  `timing_source`, `rounds_observed`, `scenario_transactions`, `observed_docs`
  and `observed_bytes` so a partial run is visible.
- Gives each run its own task name, so it does not resume a checkpoint the
  destination stored for an earlier run and measure part of its fixture.
- Drops each binding's resource before and after a run, so a run starts against
  an empty destination and leaves nothing behind. Teardown also covers failure
  and Ctrl-C.
- Teaches `testutil.ReadConfigFile` to decrypt sops-protected configurations,
  which `testctl` needs to reach a cloud endpoint.
- Adds `testctl -run-suffix`, so a run can sweep its own items rather than
  waiting for them to age past the threshold that protects a concurrent run.

**Workflow steps:**

**Notes for reviewers:**

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
