### PR TITLE
source-smartsheet: request identity encoding instead of gzip

### DIFF
--- a/source-smartsheet/CHANGELOG.md
+++ b/source-smartsheet/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-24
+
+### Fixed
+
+- Responses are now requested with `Accept-Encoding: identity` instead of gzip.
+  Smartsheet can gzip a response twice while a single layer of encoding is
+  expected, so the body left after the client's one decompression pass is still
+  compressed and fails to parse as JSON.
+
 ## 2026-08-13
 
 ### Fixed

--- a/source-smartsheet/source_smartsheet/__init__.py
+++ b/source-smartsheet/source_smartsheet/__init__.py
@@ -1,6 +1,7 @@
 from logging import Logger
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable, override
 
+import aiohttp
 from estuary_cdk.capture import (
     BaseCaptureConnector,
     Request,
@@ -26,6 +27,33 @@ class Connector(
 ):
     def request_class(self):
         return Request[EndpointConfig, ResourceConfigWithSchedule, ConnectorState]
+
+    @override
+    async def _establish_connection_and_get_response(
+        self,
+        log: Logger,
+        url: str,
+        method: str,
+        params: dict[str, Any] | None,
+        json: dict[str, Any] | None,
+        form: dict[str, Any] | None,
+        with_token: bool,
+        headers: dict[str, Any],
+        timeout: aiohttp.ClientTimeout | None,
+    ) -> aiohttp.ClientResponse:
+        """Set `Accept-Encoding: identity` on every request."""
+
+        return await super()._establish_connection_and_get_response(
+            log,
+            url,
+            method,
+            params,
+            json,
+            form,
+            with_token,
+            {"Accept-Encoding": "identity", **headers},
+            timeout,
+        )
 
     async def spec(self, _: request.Spec, logger: Logger) -> ConnectorSpec:
         return ConnectorSpec(


### PR DESCRIPTION
**Description:**

`aiohttp` advertises `Accept-Encoding: gzip, deflate` by default, but Smartsheet sometimes gzip compresses twice -- a scenario which `aiohttp` deliberately does not handle.

This commit asks for identity encoding on every request instead, trading bandwidth for a body that is never compressed.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [X] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
