### PR TITLE
materialize-snowflake, go/writer: accept number values larger than int64 max

### DIFF
--- a/go/writer/parquet.go
+++ b/go/writer/parquet.go
@@ -878,6 +878,13 @@ func getNumberVal(val any) (got float64, err error) {
 		got = float64(v)
 	case int64:
 		got = float64(v)
+	case uint64:
+		got = float64(v)
+	case *big.Int:
+		got, _ = v.Float64()
+		if math.IsInf(got, 0) {
+			err = fmt.Errorf("big.Int value %q outside of float64 range", v.String())
+		}
 	case string:
 		if p, parseErr := strconv.ParseFloat(v, 64); parseErr != nil {
 			err = fmt.Errorf("unable to parse string %q as float64: %w", v, parseErr)

--- a/go/writer/parquet_test.go
+++ b/go/writer/parquet_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"math/big"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -531,4 +533,31 @@ func TestParquetEOFReadingByteArrayRegression(t *testing.T) {
 	defLvls := make([]int16, numRows)
 	_, _, err = cr.(*file.ByteArrayColumnChunkReader).ReadBatch(int64(numRows), vals, defLvls, nil)
 	require.NoError(t, err)
+}
+
+func TestGetNumberVal(t *testing.T) {
+	bigVal, _ := new(big.Int).SetString("184467440737095516160", 10)
+	tooBig, _ := new(big.Int).SetString("1"+strings.Repeat("0", 400), 10)
+
+	for _, tt := range []struct {
+		name  string
+		input any
+		want  float64
+	}{
+		{name: "float64", input: float64(1.5), want: 1.5},
+		{name: "float32", input: float32(1.5), want: 1.5},
+		{name: "int64", input: int64(-5), want: -5},
+		{name: "uint64", input: uint64(18446744073709551615), want: 18446744073709551615},
+		{name: "big.Int", input: bigVal, want: 184467440737095516160},
+		{name: "string", input: "1.5", want: 1.5},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNumberVal(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	_, err := getNumberVal(tooBig)
+	require.Error(t, err)
 }

--- a/materialize-snowflake/CHANGELOG.md
+++ b/materialize-snowflake/CHANGELOG.md
@@ -1,5 +1,12 @@
 # materialize-snowflake
 
+## 2026-08-24
+
+### Fixed
+- A `number` column no longer fails the transaction when it receives a whole
+  number larger than the `int64` maximum. These values arrive as `uint64` or
+  `big.Int`, and the connector now converts them to a float.
+
 ## 2026-07-23
 
 ### Changed

--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -799,6 +799,13 @@ func getNum(val any) (got float64, err error) {
 		got = float64(v)
 	case int64:
 		got = float64(v)
+	case uint64:
+		got = float64(v)
+	case *big.Int:
+		got, _ = v.Float64()
+		if math.IsInf(got, 0) {
+			err = fmt.Errorf("big.Int value %q outside of float64 range", v.String())
+		}
 	case string:
 		// The sqlgen element converter converts these to strings for JSON
 		// serialization. It's kind of silly to have to convert them back again

--- a/materialize-snowflake/bdec_test.go
+++ b/materialize-snowflake/bdec_test.go
@@ -287,3 +287,29 @@ func decrypt(t *testing.T, enc []byte, key []byte, iv uint64) []byte {
 
 	return dec
 }
+
+func TestGetNum(t *testing.T) {
+	bigVal, _ := new(big.Int).SetString("184467440737095516160", 10)
+	tooBig, _ := new(big.Int).SetString("1"+strings.Repeat("0", 400), 10)
+
+	for _, tt := range []struct {
+		name  string
+		input any
+		want  float64
+	}{
+		{name: "float64", input: float64(1.5), want: 1.5},
+		{name: "float32", input: float32(1.5), want: 1.5},
+		{name: "int64", input: int64(-5), want: -5},
+		{name: "uint64", input: uint64(18446744073709551615), want: 18446744073709551615},
+		{name: "big.Int", input: bigVal, want: 184467440737095516160},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNum(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	_, err := getNum(tooBig)
+	require.Error(t, err)
+}


### PR DESCRIPTION
**Description:**

Fixes #5113. A materialize-snowflake task crash-looped for about 12 hours. Every commit failed with `getNum for column "PRICE": getNum unhandled type: uint64`, and the task only recovered when the source data was edited.

Flow encodes a whole number as `uint64` (not `int64`) once it is too big to fit in `int64`, and as `*big.Int` when it is bigger still. A column whose schema says `number` can receive one of those, for example when one document holds an integer where the rest hold decimals. The two functions that turn a value into a float for a `number` column only knew about `int64`, so they returned an error and failed the whole transaction.

Both now accept `uint64` and `*big.Int`:

1. `getNum` in materialize-snowflake, which writes FLOAT columns on the Snowpipe streaming path. This is the one that crashed.
2. `getNumberVal` in the shared parquet writer, which has the same gap. Eight materializations use that writer, so they were all exposed to the same crash.

A `*big.Int` too large for a float64 turns into infinity. We treat that as an error instead of silently writing `+Inf`.

**Workflow steps:**

Nothing to do. A `number` column that used to fail the task now materializes the value as a float.

**Notes for reviewers:**

- Two commits, tests first: the tests fail on `uint64` and `*big.Int` before the fix.
- Only materialize-snowflake gets a changelog entry, since that is where the crash was seen. Tell me if you would rather see one in each of the other connectors that use the parquet writer.
- The full materialize-snowflake suite passes, integration tests included.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated — no docs change needed, this only stops a crash.
