### PR TITLE
sqlcapture: Reduce main loop overhead on large captures

### DIFF
--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -196,6 +196,11 @@ type Capture struct {
 	Output   *boilerplate.PullOutput // The encoder to which records and state updates are written
 	Database Database                // The database-specific interface which is operated by the generic Capture logic
 
+	replStream          ReplicationStream           // The replication stream from which the main capture loop reads change events
+	lastDiscovery       map[StreamID]*DiscoveryInfo // The most recent table discovery results, refreshed on every rediscovery
+	rediscoverAfter     time.Time                   // When the next table rediscovery should occur
+	periodicChecksAfter time.Time                   // When the next periodic database checks should occur
+
 	lastStatus string // Last connectorStatus update. Used to suppress exact duplicates to reduce log noise.
 
 	// dirtyStreams is the set of stream state keys changed since the last checkpoint.
@@ -302,15 +307,15 @@ func (c *Capture) streamingDiagnosticsThreshold() time.Duration {
 func (c *Capture) Run(ctx context.Context) (err error) {
 	// Fetch detailed schema info for the tables that this capture's bindings
 	// reference. We don't need details for every table in the database here.
-	discovery, err := c.Database.DiscoverTableDetails(ctx, c.bindingTableIDs())
+	c.lastDiscovery, err = c.Database.DiscoverTableDetails(ctx, c.bindingTableIDs())
 	if err != nil {
 		return fmt.Errorf("error discovering database tables: %w", err)
-	} else if err := c.emitSourcedSchemas(discovery); err != nil {
+	} else if err := c.emitSourcedSchemas(); err != nil {
 		return err
 	} else if err := c.emitState(); err != nil { // Emit state so any SourcedSchema changes commit immediately.
 		return err
 	}
-	for streamID, discoveryInfo := range discovery {
+	for streamID, discoveryInfo := range c.lastDiscovery {
 		log.WithFields(log.Fields{
 			"table":     streamID,
 			"discovery": discoveryInfo,
@@ -321,22 +326,22 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 		return fmt.Errorf("error reconciling capture state with bindings: %w", err)
 	}
 
-	replStream, err := c.Database.ReplicationStream(ctx, c.State.Cursor)
+	c.replStream, err = c.Database.ReplicationStream(ctx, c.State.Cursor)
 	if err != nil {
 		return fmt.Errorf("error creating replication stream: %w", err)
 	}
 	for _, binding := range c.BindingsCurrentlyActive() {
 		var state = c.State.Streams[binding.StateKey]
 		var streamID = binding.StreamID
-		if err := replStream.ActivateTable(ctx, streamID, state.KeyColumns, discovery[streamID], state.Metadata); err != nil {
+		if err := c.replStream.ActivateTable(ctx, streamID, state.KeyColumns, c.lastDiscovery[streamID], state.Metadata); err != nil {
 			return fmt.Errorf("error activating table %q: %w", streamID, err)
 		}
 	}
-	if err := replStream.StartReplication(ctx, discovery); err != nil {
+	if err := c.replStream.StartReplication(ctx, c.lastDiscovery); err != nil {
 		return fmt.Errorf("error starting replication: %w", err)
 	}
 	defer func() {
-		if streamErr := replStream.Close(ctx); streamErr != nil && errors.Is(err, ErrFenceNotReached) {
+		if streamErr := c.replStream.Close(ctx); streamErr != nil && errors.Is(err, ErrFenceNotReached) {
 			err = streamErr
 		}
 	}()
@@ -345,7 +350,7 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	// and relay them to the replication stream acknowledgement.
 	var acknowledgeWorkerCtx, cancelAcknowledgeWorkerCtx = context.WithCancel(ctx)
 	go func() {
-		if err := c.acknowledgeWorker(acknowledgeWorkerCtx, c.Output, replStream); err != nil {
+		if err := c.acknowledgeWorker(acknowledgeWorkerCtx, c.Output, c.replStream); err != nil {
 			log.WithField("err", err).Fatal("error relaying acknowledgements from stdin")
 		}
 	}()
@@ -358,83 +363,97 @@ func (c *Capture) Run(ctx context.Context) (err error) {
 	// making it easier to know exactly how many transactions are expected from a capture.
 	c.statusUpdate("Catching up on CDC history")
 	if TestShutdownAfterCaughtUp || os.Getenv("SHUTDOWN_AFTER_POLLING") == "yes" {
-		if err := c.streamToFence(ctx, replStream, 0, false); err != nil {
+		if err := c.streamToFence(ctx, 0, false); err != nil {
 			return fmt.Errorf("error streaming until fence: %w", err)
 		} else if err := c.emitState(); err != nil {
 			return fmt.Errorf("error emitting state after catch-up: %w", err)
 		}
-	} else if err := c.streamToFence(ctx, replStream, 0, true); err != nil {
+	} else if err := c.streamToFence(ctx, 0, true); err != nil {
 		return fmt.Errorf("error streaming until fence: %w", err)
 	}
 
 	// Activate any pending streams using the schema information already fetched during
 	// startup, then schedule the first rediscovery a full interval out.
-	if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
+	if err := c.activatePendingStreams(ctx); err != nil {
 		return fmt.Errorf("error initializing pending streams: %w", err)
 	}
-	var rediscoverAfter = c.nextRediscovery()
-	var periodicChecksAfter time.Time
+	c.rediscoverAfter = c.nextRediscovery()
 	for ctx.Err() == nil {
-		if time.Now().After(rediscoverAfter) {
-			log.Debug("rediscovering database tables")
-			discovery, err = c.Database.DiscoverTableDetails(ctx, c.bindingTableIDs())
-			if err != nil {
-				return fmt.Errorf("error discovering database tables: %w", err)
-			} else if err := c.emitSourcedSchemas(discovery); err != nil {
-				return err
-			} else if err := c.emitState(); err != nil { // Emit state so any SourcedSchema changes commit immediately.
-				return err
-			}
-			// If any streams are currently pending, initialize them so they can start backfilling.
-			if err := c.activatePendingStreams(ctx, discovery, replStream); err != nil {
-				return fmt.Errorf("error initializing pending streams: %w", err)
-			}
-			rediscoverAfter = c.nextRediscovery()
-		}
-
-		if time.Now().After(periodicChecksAfter) {
-			if err := c.Database.PeriodicChecks(ctx); err != nil {
-				log.WithError(err).Warn("error running periodic checks")
-			}
-			periodicChecksAfter = time.Now().Add(periodicChecksInterval)
-		}
-
-		// If any tables are currently backfilling, go perform another backfill iteration.
-		if c.AnyBindingsCurrentlyBackfilling() {
-			c.statusUpdate("Backfilling Tables")
-			if err := c.backfillStreams(ctx, discovery); err != nil {
-				return fmt.Errorf("error performing backfill: %w", err)
-			} else if err := c.streamToFence(ctx, replStream, 0, false); err != nil {
-				return fmt.Errorf("error streaming until fence: %w", err)
-			} else if err := c.emitState(); err != nil {
-				return err
-			}
-
-			if TestShutdownAfterBackfill {
-				log.Info("Shutting down after backfill due to TestShutdownAfterBackfill")
-				return nil // In tests we sometimes want to shut down here
-			}
-			continue // Repeat the main loop from the top
-		}
-
-		// We often want to shut down at this point in tests. Before doing so, we emit
-		// a state checkpoint to ensure that streams reliably transition into the Active
-		// state during tests even if there is no backfill work to do.
-		if TestShutdownAfterCaughtUp || os.Getenv("SHUTDOWN_AFTER_POLLING") == "yes" {
-			log.Info("Shutting down due to SHUTDOWN_AFTER_POLLING=yes")
-			if bs, err := json.Marshal(c.State); err == nil {
-				FinalStateCheckpoint = bs // Set final state checkpoint
-			}
-			return c.emitState()
-		}
-
-		// Finally, since there's no other work to do right now, we just stream changes for a period of time.
-		c.statusUpdate("Streaming CDC Events")
-		if err := c.streamToFence(ctx, replStream, StreamingFenceInterval, true); err != nil {
+		if done, err := c.mainLoopIteration(ctx); err != nil {
 			return err
+		} else if done {
+			return nil
 		}
 	}
 	return ctx.Err()
+}
+
+// mainLoopIteration executes a single iteration of the capture's main loop:
+// rediscovery and periodic checks when their next scheduled time has arrived,
+// then either one backfill iteration or one streaming cycle. It returns done
+// as true when the capture should shut down cleanly, which currently happens
+// only via the test/polling shutdown behavior flags.
+func (c *Capture) mainLoopIteration(ctx context.Context) (done bool, err error) {
+	if time.Now().After(c.rediscoverAfter) {
+		log.Debug("rediscovering database tables")
+		c.lastDiscovery, err = c.Database.DiscoverTableDetails(ctx, c.bindingTableIDs())
+		if err != nil {
+			return false, fmt.Errorf("error discovering database tables: %w", err)
+		}
+		if err := c.emitSourcedSchemas(); err != nil {
+			return false, err
+		} else if err := c.emitState(); err != nil { // Emit state so any SourcedSchema changes commit immediately.
+			return false, err
+		}
+		// If any streams are currently pending, initialize them so they can start backfilling.
+		if err := c.activatePendingStreams(ctx); err != nil {
+			return false, fmt.Errorf("error initializing pending streams: %w", err)
+		}
+		c.rediscoverAfter = c.nextRediscovery()
+	}
+
+	if time.Now().After(c.periodicChecksAfter) {
+		if err := c.Database.PeriodicChecks(ctx); err != nil {
+			log.WithError(err).Warn("error running periodic checks")
+		}
+		c.periodicChecksAfter = time.Now().Add(periodicChecksInterval)
+	}
+
+	// If any tables are currently backfilling, go perform another backfill iteration.
+	if c.AnyBindingsCurrentlyBackfilling() {
+		c.statusUpdate("Backfilling Tables")
+		if err := c.backfillStreams(ctx); err != nil {
+			return false, fmt.Errorf("error performing backfill: %w", err)
+		} else if err := c.streamToFence(ctx, 0, false); err != nil {
+			return false, fmt.Errorf("error streaming until fence: %w", err)
+		} else if err := c.emitState(); err != nil {
+			return false, err
+		}
+
+		if TestShutdownAfterBackfill {
+			log.Info("Shutting down after backfill due to TestShutdownAfterBackfill")
+			return true, nil // In tests we sometimes want to shut down here
+		}
+		return false, nil // Repeat the main loop from the top
+	}
+
+	// We often want to shut down at this point in tests. Before doing so, we emit
+	// a state checkpoint to ensure that streams reliably transition into the Active
+	// state during tests even if there is no backfill work to do.
+	if TestShutdownAfterCaughtUp || os.Getenv("SHUTDOWN_AFTER_POLLING") == "yes" {
+		log.Info("Shutting down due to SHUTDOWN_AFTER_POLLING=yes")
+		if bs, err := json.Marshal(c.State); err == nil {
+			FinalStateCheckpoint = bs // Set final state checkpoint
+		}
+		return true, c.emitState()
+	}
+
+	// Finally, since there's no other work to do right now, we just stream changes for a period of time.
+	c.statusUpdate("Streaming CDC Events")
+	if err := c.streamToFence(ctx, StreamingFenceInterval, true); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // reconcileStateWithBindings updates the capture's state to reflect any added or removed bindings.
@@ -517,10 +536,10 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 }
 
 // activatePendingStreams transitions streams from a "Pending" state to being captured once they're eligible.
-func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[StreamID]*DiscoveryInfo, replStream ReplicationStream) error {
+func (c *Capture) activatePendingStreams(ctx context.Context) error {
 	// See if any missing tables have since reappeared, and if so mark them as pending again.
 	for _, binding := range c.BindingsInState(TableStateMissing) {
-		if _, ok := discovery[binding.StreamID]; ok {
+		if _, ok := c.lastDiscovery[binding.StreamID]; ok {
 			c.setStreamState(binding.StateKey, &TableState{Mode: TableStatePending})
 		}
 	}
@@ -534,7 +553,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 		var state = c.State.Streams[stateKey]
 		c.setStreamState(stateKey, state)
 
-		var discoveryInfo = discovery[streamID]
+		var discoveryInfo = c.lastDiscovery[streamID]
 		if discoveryInfo == nil {
 			return fmt.Errorf("stream %q is a configured binding of this capture, but doesn't exist or isn't visible with current permissions", streamID)
 		}
@@ -643,7 +662,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 			}
 		}
 
-		if err := replStream.ActivateTable(ctx, streamID, state.KeyColumns, discoveryInfo, state.Metadata); err != nil {
+		if err := c.replStream.ActivateTable(ctx, streamID, state.KeyColumns, discoveryInfo, state.Metadata); err != nil {
 			return fmt.Errorf("error activating replication for table %q: %w", streamID, err)
 		}
 	}
@@ -686,7 +705,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context, discovery map[Stre
 //
 // The fenceAfter argument is passed to the underlying replication stream, so that
 // it can make sure to stream changes for at least that length of time.
-func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStream, fenceAfter time.Duration, reportFlush bool) error {
+func (c *Capture) streamToFence(ctx context.Context, fenceAfter time.Duration, reportFlush bool) error {
 	log.WithField("fenceAfter", fenceAfter.String()).Debug("streaming to fence")
 
 	// Counters and an interval-start timestamp shared between the deferred final
@@ -760,7 +779,7 @@ func (c *Capture) streamToFence(ctx context.Context, replStream ReplicationStrea
 		logProgress("processed replication events")
 	}()
 
-	if err := replStream.StreamToFence(ctx, fenceAfter, func(event DatabaseEvent) error {
+	if err := c.replStream.StreamToFence(ctx, fenceAfter, func(event DatabaseEvent) error {
 		// Commit events update the checkpoint cursor and may trigger a state update.
 		if event, ok := event.(CommitEvent); ok {
 			flushCount.Add(1)
@@ -892,7 +911,7 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) (int, error) {
 	return 0, fmt.Errorf("table %q in invalid mode %q", streamID, tableState.Mode)
 }
 
-func (c *Capture) backfillStreams(ctx context.Context, discovery map[StreamID]*DiscoveryInfo) error {
+func (c *Capture) backfillStreams(ctx context.Context) error {
 	var bindings = c.bindingsCurrentlyBackfillingUnsorted()
 	if len(bindings) == 0 {
 		return nil
@@ -922,7 +941,7 @@ func (c *Capture) backfillStreams(ctx context.Context, discovery map[StreamID]*D
 		"selected":   streamID,
 	}).Debug("backfilling streams")
 
-	var discoveryInfo, ok = discovery[streamID]
+	var discoveryInfo, ok = c.lastDiscovery[streamID]
 	if !ok {
 		return fmt.Errorf("table %q missing from latest autodiscovery", streamID)
 	}
@@ -1059,10 +1078,10 @@ func (c *Capture) emitState() error {
 }
 
 // emitSourcedSchemas outputs a SourcedSchema update for every capture binding
-// with corresponding discovery info in the provided map.
-func (c *Capture) emitSourcedSchemas(discovery map[StreamID]*DiscoveryInfo) error {
+// with corresponding discovery info in the latest discovery results.
+func (c *Capture) emitSourcedSchemas() error {
 	for _, binding := range c.Bindings {
-		var info, ok = discovery[binding.StreamID]
+		var info, ok = c.lastDiscovery[binding.StreamID]
 		if !ok {
 			continue // Only emit SourcedSchema updates for bindings present in discovery results
 		}

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"math"
 	"math/rand"
 	"os"
@@ -62,29 +61,19 @@ func (ps *PersistentState) Validate() error {
 	return nil
 }
 
-// bindingsInState yields every binding whose persisted state is one of the given modes, in
-// map iteration order. It exists so that the state predicate lives in exactly one place:
-// callers compose it with slices.SortedFunc when they need a reproducible order, with
-// slices.AppendSeq when the order doesn't matter, or range over it with an early return
-// to test for existence without building a list at all.
-func (c *Capture) bindingsInState(modes ...BackfillMode) iter.Seq[*Binding] {
-	return func(yield func(*Binding) bool) {
-		for _, binding := range c.Bindings {
-			if slices.Contains(modes, BackfillMode(c.State.Streams[binding.StateKey].Mode)) {
-				if !yield(binding) {
-					return
-				}
-			}
-		}
-	}
-}
-
 // BindingsInState returns all the bindings having a particular persisted state in sorted order for
 // reproducibility.
 func (c *Capture) BindingsInState(modes ...BackfillMode) []*Binding {
-	return slices.SortedFunc(c.bindingsInState(modes...), func(a, b *Binding) int {
+	var bindings []*Binding
+	for _, binding := range c.Bindings {
+		if slices.Contains(modes, BackfillMode(c.State.Streams[binding.StateKey].Mode)) {
+			bindings = append(bindings, binding)
+		}
+	}
+	slices.SortFunc(bindings, func(a, b *Binding) int {
 		return a.StreamID.Compare(b.StreamID)
 	})
+	return bindings
 }
 
 // BindingsCurrentlyActive returns all the bindings currently being captured.
@@ -111,27 +100,32 @@ func (c *Capture) bindingTableIDs() []TableID {
 	return ids
 }
 
-// BindingsCurrentlyBackfilling returns all the bindings undergoing some sort of backfill.
-func (c *Capture) BindingsCurrentlyBackfilling() []*Binding {
-	return c.BindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill)
-}
-
-// bindingsCurrentlyBackfillingUnsorted is the unordered equivalent of
-// BindingsCurrentlyBackfilling for callers which don't depend on the ordering.
-func (c *Capture) bindingsCurrentlyBackfillingUnsorted() []*Binding {
-	var bindings = make([]*Binding, 0, len(c.Bindings))
-	return slices.AppendSeq(bindings, c.bindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill))
-}
-
-// AnyBindingsCurrentlyBackfilling reports whether any binding is undergoing some sort of
-// backfill. It answers the same question as len(BindingsCurrentlyBackfilling()) > 0 without
-// building and sorting the full list, which dominates the cost when a capture has many
-// bindings.
-func (c *Capture) AnyBindingsCurrentlyBackfilling() bool {
-	for range c.bindingsInState(TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill) {
-		return true
+// bindingsCurrentlyBackfilling returns all the bindings undergoing some sort
+// of backfill, in no particular order.
+func (c *Capture) bindingsCurrentlyBackfilling() []*Binding {
+	var bindings = make([]*Binding, 0, len(c.backfillingStreams))
+	for stateKey := range c.backfillingStreams {
+		bindings = append(bindings, c.bindingForStateKey(stateKey))
 	}
-	return false
+	return bindings
+}
+
+// AnyBindingsCurrentlyBackfilling reports whether any binding is undergoing
+// some sort of backfill.
+func (c *Capture) AnyBindingsCurrentlyBackfilling() bool {
+	return len(c.backfillingStreams) > 0
+}
+
+// bindingForStateKey returns the binding with the given state key, building the
+// state key index on first use.
+func (c *Capture) bindingForStateKey(stateKey boilerplate.StateKey) *Binding {
+	if c.bindingsByStateKey == nil {
+		c.bindingsByStateKey = make(map[boilerplate.StateKey]*Binding, len(c.Bindings))
+		for _, binding := range c.Bindings {
+			c.bindingsByStateKey[binding.StateKey] = binding
+		}
+	}
+	return c.bindingsByStateKey[stateKey]
 }
 
 // TableState represents the serializable/resumable state of a particular table's capture.
@@ -200,11 +194,21 @@ type Capture struct {
 	lastDiscovery       map[StreamID]*DiscoveryInfo // The most recent table discovery results, refreshed on every rediscovery
 	rediscoverAfter     time.Time                   // When the next table rediscovery should occur
 	periodicChecksAfter time.Time                   // When the next periodic database checks should occur
+	statusUpdateAfter   time.Time                   // When the next backfilling status update should occur
 
 	lastStatus string // Last connectorStatus update. Used to suppress exact duplicates to reduce log noise.
 
 	// dirtyStreams is the set of stream state keys changed since the last checkpoint.
 	dirtyStreams map[boilerplate.StateKey]struct{}
+
+	// backfillingStreams is the set of stream state keys currently in one of the backfill
+	// modes. It is seeded from the persisted state during startup and maintained by
+	// setStreamState after that, so per-chunk logic can avoid scanning every binding.
+	backfillingStreams map[boilerplate.StateKey]struct{}
+
+	// bindingsByStateKey indexes the capture's bindings by state key. It is built on
+	// first use, which is safe because bindings never change during a capture run.
+	bindingsByStateKey map[boilerplate.StateKey]*Binding
 
 	reused struct {
 		emitChangeBuf []byte               // A reusable buffer used for serialized JSON documents in emitChange(). Note that this is not thread-safe, but since the capture is single-threaded we're okay for now.
@@ -225,6 +229,7 @@ const (
 	rediscoverInterval        = 15 * time.Minute // The capture will re-run discovery and reinitialize missing/pending tables this frequently.
 	periodicChecksInterval    = 10 * time.Minute // The capture may run some database-specific sanity checks periodically at this interval.
 	streamingProgressInterval = 5 * time.Minute  // How often to log progress and diagnostics during a long-running streaming cycle.
+	statusUpdateInterval      = 10 * time.Second // How often the backfilling status update may be recomputed, since it can be expensive on large captures.
 )
 
 var (
@@ -421,7 +426,14 @@ func (c *Capture) mainLoopIteration(ctx context.Context) (done bool, err error) 
 
 	// If any tables are currently backfilling, go perform another backfill iteration.
 	if c.AnyBindingsCurrentlyBackfilling() {
-		c.statusUpdate("Backfilling Tables")
+		// Computing backfill progress is expensive on captures with many bindings
+		// and this runs once per backfill chunk, so it's throttled to at most once
+		// per interval. The other status updates are already amortized over whole
+		// streaming cycles and don't need this.
+		if time.Now().After(c.statusUpdateAfter) {
+			c.statusUpdate("Backfilling Tables")
+			c.statusUpdateAfter = time.Now().Add(statusUpdateInterval)
+		}
 		if err := c.backfillStreams(ctx); err != nil {
 			return false, fmt.Errorf("error performing backfill: %w", err)
 		} else if err := c.streamToFence(ctx, 0, false); err != nil {
@@ -530,6 +542,13 @@ func (c *Capture) reconcileStateWithBindings(_ context.Context) error {
 		c.State.Cursor = nil
 	}
 
+	// Seed the backfilling-streams set from the reconciled state. Stream states
+	// loaded from a persisted checkpoint don't pass through setStreamState, which
+	// maintains the set for all changes after this point.
+	for stateKey, state := range c.State.Streams {
+		c.updateBackfillSet(stateKey, state.Mode)
+	}
+
 	// Emit the new state to stdout. This isn't strictly necessary but it helps to make
 	// the emitted sequence of state updates a lot more readable.
 	return c.emitState()
@@ -549,9 +568,10 @@ func (c *Capture) activatePendingStreams(ctx context.Context) error {
 		var streamID = binding.StreamID
 		var stateKey = binding.StateKey
 
-		// Look up the stream state and mark it dirty since we intend to update it immediately.
-		var state = c.State.Streams[stateKey]
-		c.setStreamState(stateKey, state)
+		// Copy the stream state. The rest of this loop body updates the copy and
+		// writes it back via setStreamState once its final mode is decided, so the
+		// stored state never holds an intermediate value.
+		var state = *c.State.Streams[stateKey]
 
 		var discoveryInfo = c.lastDiscovery[streamID]
 		if discoveryInfo == nil {
@@ -570,6 +590,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context) error {
 		if !discoveryInfo.BaseTable {
 			log.WithField("stream", streamID).Warn("automatically ignoring a binding whose type is not `BASE TABLE`")
 			state.Mode = TableStateIgnore
+			c.setStreamState(stateKey, &state)
 			continue
 		}
 
@@ -665,6 +686,7 @@ func (c *Capture) activatePendingStreams(ctx context.Context) error {
 		if err := c.replStream.ActivateTable(ctx, streamID, state.KeyColumns, discoveryInfo, state.Metadata); err != nil {
 			return fmt.Errorf("error activating replication for table %q: %w", streamID, err)
 		}
+		c.setStreamState(stateKey, &state)
 	}
 
 	// Transition streams from "Backfill" to "Active" if we're supposed to skip
@@ -681,16 +703,18 @@ func (c *Capture) activatePendingStreams(ctx context.Context) error {
 	// configuration logic, but that would make that logic more complex and I would like
 	// to deprecate the whole 'SkipBackfills' configuration property in the near future
 	// so I have left this little blob of logic nicely self-contained here.
-	for _, binding := range c.BindingsCurrentlyBackfilling() {
+	// This iterates a materialized list rather than the backfilling-streams set
+	// itself, because setStreamState removes entries from the set mid-loop.
+	for _, binding := range c.bindingsCurrentlyBackfilling() {
 		if !c.Database.ShouldBackfill(binding.StreamID) {
-			var state = c.State.Streams[binding.StateKey]
+			var state = *c.State.Streams[binding.StateKey]
 			log.WithFields(log.Fields{
 				"stream":  binding.StreamID,
 				"scanned": state.Scanned,
 			}).Info("skipping backfill for stream")
 			state.Mode = TableStateActive
 			state.Scanned = nil
-			c.setStreamState(binding.StateKey, state)
+			c.setStreamState(binding.StateKey, &state)
 		}
 	}
 	return nil
@@ -912,12 +936,12 @@ func (c *Capture) handleReplicationEvent(event DatabaseEvent) (int, error) {
 }
 
 func (c *Capture) backfillStreams(ctx context.Context) error {
-	var bindings = c.bindingsCurrentlyBackfillingUnsorted()
-	if len(bindings) == 0 {
+	if !c.AnyBindingsCurrentlyBackfilling() {
 		return nil
 	}
 
-	// Make a list of stream IDs for the highest-priority active bindings.
+	// Make a list of stream IDs for the highest-priority backfilling bindings.
+	var bindings = c.bindingsCurrentlyBackfilling()
 	var streams = make([]StreamID, 0, len(bindings))
 	var priority = math.MinInt
 	for _, b := range bindings {
@@ -935,9 +959,9 @@ func (c *Capture) backfillStreams(ctx context.Context) error {
 	var streamID = streams[rand.Intn(len(streams))]
 
 	log.WithFields(log.Fields{
-		"total":      len(bindings), // Total number of active bindings
-		"atPriority": len(streams),  // Number of active bindings in the current priority band
-		"priority":   priority,      // Current priority band
+		"total":      len(c.backfillingStreams), // Total number of backfilling bindings
+		"atPriority": len(streams),              // Number of backfilling bindings in the current priority band
+		"priority":   priority,                  // Current priority band
 		"selected":   streamID,
 	}).Debug("backfilling streams")
 
@@ -1042,6 +1066,20 @@ func (c *Capture) setStreamState(stateKey boilerplate.StateKey, state *TableStat
 		c.dirtyStreams = make(map[boilerplate.StateKey]struct{})
 	}
 	c.dirtyStreams[stateKey] = struct{}{}
+	c.updateBackfillSet(stateKey, state.Mode)
+}
+
+// updateBackfillSet updates the backfilling-streams set to match a stream's current mode.
+func (c *Capture) updateBackfillSet(stateKey boilerplate.StateKey, mode string) {
+	switch mode {
+	case TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill:
+		if c.backfillingStreams == nil {
+			c.backfillingStreams = make(map[boilerplate.StateKey]struct{})
+		}
+		c.backfillingStreams[stateKey] = struct{}{}
+	default:
+		delete(c.backfillingStreams, stateKey)
+	}
 }
 
 func (c *Capture) emitState() error {
@@ -1146,7 +1184,7 @@ func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStre
 
 func (c *Capture) statusUpdate(status string) {
 	// Add backfill information with percentage progress
-	var backfillingBindings = c.bindingsCurrentlyBackfillingUnsorted()
+	var backfillingBindings = c.bindingsCurrentlyBackfilling()
 	if len(backfillingBindings) > 0 {
 		// Build list of tables to query for estimated row counts
 		var tables []TableID

--- a/sqlcapture/capture_bench_test.go
+++ b/sqlcapture/capture_bench_test.go
@@ -90,6 +90,9 @@ func newBenchmarkCapture(b *testing.B, numBindings int, mode string) *Capture {
 		Database: db,
 	}
 	capture.dirtyStreams = make(map[boilerplate.StateKey]struct{})
+	for stateKey, state := range streams {
+		capture.updateBackfillSet(stateKey, state.Mode)
+	}
 	capture.replStream = &mockReplicationStream{}
 	capture.lastDiscovery = discovery
 	capture.rediscoverAfter = time.Now().Add(time.Hour)
@@ -98,9 +101,8 @@ func newBenchmarkCapture(b *testing.B, numBindings int, mode string) *Capture {
 }
 
 // BenchmarkMainLoopBackfill measures one backfill iteration of the main loop
-// with a mock database and a discarded output stream: status update, chunk
-// selection, a zero-row chunk scan, a fence cycle with one commit event, and
-// a checkpoint. All real work is free, so this measures pure framework overhead.
+// with a mock database and a discarded output stream. All real work is free,
+// so this measures pure framework overhead.
 func BenchmarkMainLoopBackfill(b *testing.B) {
 	quietLogging(b)
 	var ctx = context.Background()
@@ -213,33 +215,20 @@ func BenchmarkBackfillStreams(b *testing.B) {
 	}
 }
 
-// BenchmarkStatusUpdate measures the status update done on each main loop
-// iteration. The backfilling case includes a row-count lookup for each
-// backfilling table, with the statistics already cached.
+// BenchmarkStatusUpdate measures the backfill progress computation, which the
+// main loop periodically during backfills. Since it involves calculating stats
+// across all ongoing backfills it can be a bit expensive.
 func BenchmarkStatusUpdate(b *testing.B) {
 	quietLogging(b)
-	b.Run("backfilling", func(b *testing.B) {
-		for _, numBindings := range benchmarkBindingCounts {
-			b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
-				var c = newBenchmarkCapture(b, numBindings, TableStatePreciseBackfill)
-				b.ReportAllocs()
-				for b.Loop() {
-					c.statusUpdate("Backfilling Tables")
-				}
-			})
-		}
-	})
-	b.Run("streaming", func(b *testing.B) {
-		for _, numBindings := range benchmarkBindingCounts {
-			b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
-				var c = newBenchmarkCapture(b, numBindings, TableStateActive)
-				b.ReportAllocs()
-				for b.Loop() {
-					c.statusUpdate("Streaming CDC Events")
-				}
-			})
-		}
-	})
+	for _, numBindings := range benchmarkBindingCounts {
+		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+			var c = newBenchmarkCapture(b, numBindings, TableStatePreciseBackfill)
+			b.ReportAllocs()
+			for b.Loop() {
+				c.statusUpdate("Backfilling Tables")
+			}
+		})
+	}
 }
 
 // BenchmarkActivatePendingStreams measures the activation pass which runs
@@ -281,23 +270,6 @@ func BenchmarkBindingTableIDs(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				c.bindingTableIDs()
-			}
-		})
-	}
-}
-
-// BenchmarkAnyBindingsCurrentlyBackfilling measures the backfill guard check
-// in its worst case, where all bindings are active and the scan finds no match.
-func BenchmarkAnyBindingsCurrentlyBackfilling(b *testing.B) {
-	quietLogging(b)
-	for _, numBindings := range benchmarkBindingCounts {
-		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
-			var c = newBenchmarkCapture(b, numBindings, TableStateActive)
-			b.ReportAllocs()
-			for b.Loop() {
-				if c.AnyBindingsCurrentlyBackfilling() {
-					b.Fatal("expected no backfilling bindings")
-				}
 			}
 		})
 	}

--- a/sqlcapture/capture_bench_test.go
+++ b/sqlcapture/capture_bench_test.go
@@ -1,0 +1,304 @@
+package sqlcapture
+
+// These benchmarks measure the in-memory work of the capture loop as a
+// function of binding count. The loop does this work once per backfill chunk
+// or once per rediscovery, so per-binding costs multiply on large captures.
+//
+// Run with: go test ./sqlcapture/ -run='^$' -bench=.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	"github.com/segmentio/encoding/json"
+	log "github.com/sirupsen/logrus"
+)
+
+// benchmarkBindingCounts are the capture sizes at which each benchmark runs.
+var benchmarkBindingCounts = []int{100, 1_000, 10_000, 50_000, 100_000}
+
+// quietLogging discards log output for the duration of a benchmark. The log
+// level does not change, so each log call keeps its usual formatting cost.
+func quietLogging(b *testing.B) {
+	var prevOut = log.StandardLogger().Out
+	log.SetOutput(io.Discard)
+	b.Cleanup(func() { log.SetOutput(prevOut) })
+}
+
+// newBenchmarkCapture makes a Capture with the given number of bindings, all
+// in the given table state, plus a matching discovery map. The mock database
+// serves zero-row chunks which never complete, and row counts with the same
+// cost as the warm-cache path of the postgres implementation. The replication
+// stream is a default mockReplicationStream, and the rediscovery and periodic
+// check tasks are scheduled far in the future so no iteration triggers them.
+func newBenchmarkCapture(b *testing.B, numBindings int, mode string) *Capture {
+	b.Helper()
+
+	var bindings = make(map[StreamID]*Binding, numBindings)
+	var streams = make(map[boilerplate.StateKey]*TableState, numBindings)
+	var discovery = make(map[StreamID]*DiscoveryInfo, numBindings)
+	var rowCounts = make(map[StreamID]int, numBindings)
+	for i := range numBindings {
+		var table = fmt.Sprintf("table_%06d", i)
+		var streamID = JoinStreamID("public", table)
+		var stateKey = boilerplate.StateKey("public%2F" + table)
+		bindings[streamID] = &Binding{
+			Index:         uint32(i),
+			StreamID:      streamID,
+			StateKey:      stateKey,
+			Resource:      Resource{Namespace: "public", Stream: table},
+			CollectionKey: []string{"/id"},
+		}
+		var state = &TableState{Mode: mode, KeyColumns: []string{"id"}}
+		switch mode {
+		case TableStatePreciseBackfill, TableStateUnfilteredBackfill, TableStateKeylessBackfill:
+			state.Scanned = []byte{0x01}
+		}
+		streams[stateKey] = state
+		discovery[streamID] = &DiscoveryInfo{
+			Name:       table,
+			Schema:     "public",
+			BaseTable:  true,
+			PrimaryKey: []string{"id"},
+		}
+		rowCounts[streamID] = 1_000_000
+	}
+
+	var db = &mockDatabase{
+		FallbackKey: []string{"/_meta/source/fallback"},
+		ScanTableChunkFunc: func(ctx context.Context, info *DiscoveryInfo, state *TableState, backfillFilter string, callback func(event ChangeEvent) error) (bool, []byte, error) {
+			return false, state.Scanned, nil
+		},
+		EstimatedRowCountsFunc: func(ctx context.Context, tables []TableID) (map[TableID]int, error) {
+			var result = make(map[TableID]int)
+			for _, table := range tables {
+				result[table] = rowCounts[JoinStreamID(table.Schema, table.Table)]
+			}
+			return result, nil
+		},
+	}
+
+	var capture = &Capture{
+		Name:     "benchmark/capture",
+		Bindings: bindings,
+		State:    &PersistentState{Streams: streams},
+		Output:   newMockPullOutput(),
+		Database: db,
+	}
+	capture.dirtyStreams = make(map[boilerplate.StateKey]struct{})
+	capture.replStream = &mockReplicationStream{}
+	capture.lastDiscovery = discovery
+	capture.rediscoverAfter = time.Now().Add(time.Hour)
+	capture.periodicChecksAfter = time.Now().Add(time.Hour)
+	return capture
+}
+
+// BenchmarkMainLoopBackfill measures one backfill iteration of the main loop
+// with a mock database and a discarded output stream: status update, chunk
+// selection, a zero-row chunk scan, a fence cycle with one commit event, and
+// a checkpoint. All real work is free, so this measures pure framework overhead.
+func BenchmarkMainLoopBackfill(b *testing.B) {
+	quietLogging(b)
+	var ctx = context.Background()
+	for _, numBindings := range benchmarkBindingCounts {
+		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+			var c = newBenchmarkCapture(b, numBindings, TableStatePreciseBackfill)
+			c.replStream = &mockReplicationStream{
+				StreamToFenceFunc: func(ctx context.Context, fenceAfter time.Duration, callback func(event DatabaseEvent) error) error {
+					return callback(&mockCommitEvent{Cursor: json.RawMessage(`"0/1"`)})
+				},
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if done, err := c.mainLoopIteration(ctx); err != nil {
+					b.Fatal(err)
+				} else if done {
+					b.Fatal("unexpected shutdown")
+				}
+				// In real operation acknowledgements trim the pending cursor list.
+				c.pending.cursors = c.pending.cursors[:0]
+			}
+			b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "chunks/s")
+		})
+	}
+}
+
+// BenchmarkMainLoopStreaming measures one streaming cycle of the main loop.
+// The mock delivers prebuilt change events in transactions, with a checkpoint
+// after each. Replication decode, document serialization, and output I/O cost
+// nothing so this measures framework overhead at different workload shapes.
+
+// A cycle also does fixed bookkeeping which scales with binding count but not
+// with event count, but in production a cycle runs for StreamingFenceInterval
+// so that should amortize to nothing significant.
+func BenchmarkMainLoopStreaming(b *testing.B) {
+	quietLogging(b)
+	var ctx = context.Background()
+	var workloads = []struct {
+		commits int // Transactions per streaming cycle.
+		changes int // Change events per transaction.
+	}{
+		{1_000, 1},   // Many single-row transactions.
+		{100, 100},   // Mid-size transactions.
+		{10, 10_000}, // A few bulk transactions.
+	}
+	for _, workload := range workloads {
+		for _, numBindings := range benchmarkBindingCounts {
+			b.Run(fmt.Sprintf("commits=%d/changes=%d/bindings=%d", workload.commits, workload.changes, numBindings), func(b *testing.B) {
+				var c = newBenchmarkCapture(b, numBindings, TableStateActive)
+
+				// Spread change events across all bindings so lookups touch distinct keys.
+				var streamIDs = make([]StreamID, 0, len(c.Bindings))
+				for streamID := range c.Bindings {
+					streamIDs = append(streamIDs, streamID)
+				}
+				var batch []DatabaseEvent
+				for commit := range workload.commits {
+					for change := range workload.changes {
+						batch = append(batch, &mockChangeEvent{
+							ID:     streamIDs[(commit*workload.changes+change)%len(streamIDs)],
+							RowKey: []byte{0x02},
+							Doc:    json.RawMessage(`{"id":12345,"name":"some benchmark row value","updated_at":"2026-08-24T00:00:00Z"}`),
+						})
+					}
+					batch = append(batch, &mockCommitEvent{Cursor: json.RawMessage(`"0/1"`)})
+				}
+
+				c.replStream = &mockReplicationStream{
+					StreamToFenceFunc: func(ctx context.Context, fenceAfter time.Duration, callback func(event DatabaseEvent) error) error {
+						for _, event := range batch {
+							if err := callback(event); err != nil {
+								return err
+							}
+						}
+						return nil
+					},
+				}
+				b.ReportAllocs()
+				for b.Loop() {
+					if done, err := c.mainLoopIteration(ctx); err != nil {
+						b.Fatal(err)
+					} else if done {
+						b.Fatal("unexpected shutdown")
+					}
+					c.pending.cursors = c.pending.cursors[:0]
+				}
+				b.ReportMetric(float64(b.N)*float64(workload.commits*workload.changes)/b.Elapsed().Seconds(), "events/s")
+			})
+		}
+	}
+}
+
+// BenchmarkBackfillStreams measures backfill stream selection plus a zero-row
+// chunk scan. This is the per-chunk cost without row processing or streaming.
+func BenchmarkBackfillStreams(b *testing.B) {
+	quietLogging(b)
+	var ctx = context.Background()
+	for _, numBindings := range benchmarkBindingCounts {
+		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+			var c = newBenchmarkCapture(b, numBindings, TableStatePreciseBackfill)
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := c.backfillStreams(ctx); err != nil {
+					b.Fatal(err)
+				}
+				// In real operation emitState empties the dirty set after each chunk.
+				clear(c.dirtyStreams)
+			}
+		})
+	}
+}
+
+// BenchmarkStatusUpdate measures the status update done on each main loop
+// iteration. The backfilling case includes a row-count lookup for each
+// backfilling table, with the statistics already cached.
+func BenchmarkStatusUpdate(b *testing.B) {
+	quietLogging(b)
+	b.Run("backfilling", func(b *testing.B) {
+		for _, numBindings := range benchmarkBindingCounts {
+			b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+				var c = newBenchmarkCapture(b, numBindings, TableStatePreciseBackfill)
+				b.ReportAllocs()
+				for b.Loop() {
+					c.statusUpdate("Backfilling Tables")
+				}
+			})
+		}
+	})
+	b.Run("streaming", func(b *testing.B) {
+		for _, numBindings := range benchmarkBindingCounts {
+			b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+				var c = newBenchmarkCapture(b, numBindings, TableStateActive)
+				b.ReportAllocs()
+				for b.Loop() {
+					c.statusUpdate("Streaming CDC Events")
+				}
+			})
+		}
+	})
+}
+
+// BenchmarkActivatePendingStreams measures the activation pass which runs
+// after each rediscovery. With no pending or missing streams, only the
+// binding state scans remain.
+func BenchmarkActivatePendingStreams(b *testing.B) {
+	quietLogging(b)
+	var ctx = context.Background()
+	var scenarios = []struct {
+		name string
+		mode string
+	}{
+		{"backfilling", TableStatePreciseBackfill},
+		{"active", TableStateActive},
+	}
+	for _, scenario := range scenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			for _, numBindings := range benchmarkBindingCounts {
+				b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+					var c = newBenchmarkCapture(b, numBindings, scenario.mode)
+					b.ReportAllocs()
+					for b.Loop() {
+						if err := c.activatePendingStreams(ctx); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkBindingTableIDs measures the sorted table ID list built for each rediscovery.
+func BenchmarkBindingTableIDs(b *testing.B) {
+	quietLogging(b)
+	for _, numBindings := range benchmarkBindingCounts {
+		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+			var c = newBenchmarkCapture(b, numBindings, TableStateActive)
+			b.ReportAllocs()
+			for b.Loop() {
+				c.bindingTableIDs()
+			}
+		})
+	}
+}
+
+// BenchmarkAnyBindingsCurrentlyBackfilling measures the backfill guard check
+// in its worst case, where all bindings are active and the scan finds no match.
+func BenchmarkAnyBindingsCurrentlyBackfilling(b *testing.B) {
+	quietLogging(b)
+	for _, numBindings := range benchmarkBindingCounts {
+		b.Run(fmt.Sprintf("bindings=%d", numBindings), func(b *testing.B) {
+			var c = newBenchmarkCapture(b, numBindings, TableStateActive)
+			b.ReportAllocs()
+			for b.Loop() {
+				if c.AnyBindingsCurrentlyBackfilling() {
+					b.Fatal("expected no backfilling bindings")
+				}
+			}
+		})
+	}
+}

--- a/sqlcapture/mock_test.go
+++ b/sqlcapture/mock_test.go
@@ -1,0 +1,208 @@
+package sqlcapture
+
+// This file provides mock implementations of the Database and ReplicationStream
+// interfaces for unit tests and benchmarks within this package. Methods whose
+// behavior tests typically need to control have a corresponding hook function
+// field, and every hook has a benign default so tests only configure the parts
+// they exercise.
+
+import (
+	"context"
+	"io"
+	"time"
+
+	boilerplate "github.com/estuary/connectors/source-boilerplate"
+	pc "github.com/estuary/flow/go/protocols/capture"
+	"github.com/invopop/jsonschema"
+	"github.com/segmentio/encoding/json"
+	"google.golang.org/grpc/metadata"
+)
+
+// mockDatabase is a configurable in-memory implementation of the Database interface.
+type mockDatabase struct {
+	// Stream is returned by ReplicationStream calls. When nil, a fresh
+	// mockReplicationStream with default behavior is returned instead.
+	Stream ReplicationStream
+
+	// FallbackKey is returned by FallbackCollectionKey calls.
+	FallbackKey []string
+
+	// ScanTableChunkFunc handles ScanTableChunk calls. The default reports the
+	// table as fully backfilled without emitting any rows.
+	ScanTableChunkFunc func(ctx context.Context, info *DiscoveryInfo, state *TableState, backfillFilter string, callback func(event ChangeEvent) error) (bool, []byte, error)
+
+	// ListTablesFunc handles ListTables calls. The default lists no tables.
+	ListTablesFunc func(ctx context.Context) ([]TableID, error)
+
+	// DiscoverTableDetailsFunc handles DiscoverTableDetails calls. The default
+	// returns an empty map.
+	DiscoverTableDetailsFunc func(ctx context.Context, tables []TableID) (map[StreamID]*DiscoveryInfo, error)
+
+	// EstimatedRowCountsFunc handles EstimatedRowCounts calls. The default
+	// reports a count of zero for every requested table.
+	EstimatedRowCountsFunc func(ctx context.Context, tables []TableID) (map[TableID]int, error)
+
+	// ShouldBackfillFunc handles ShouldBackfill calls. The default is to
+	// backfill every table.
+	ShouldBackfillFunc func(streamID StreamID) bool
+}
+
+func (db *mockDatabase) Close(ctx context.Context) error { return nil }
+
+func (db *mockDatabase) ReplicationStream(ctx context.Context, startCursor json.RawMessage) (ReplicationStream, error) {
+	if db.Stream != nil {
+		return db.Stream, nil
+	}
+	return &mockReplicationStream{}, nil
+}
+
+func (db *mockDatabase) ScanTableChunk(ctx context.Context, info *DiscoveryInfo, state *TableState, backfillFilter string, callback func(event ChangeEvent) error) (bool, []byte, error) {
+	if db.ScanTableChunkFunc != nil {
+		return db.ScanTableChunkFunc(ctx, info, state, backfillFilter, callback)
+	}
+	return true, nil, nil
+}
+
+func (db *mockDatabase) ListTables(ctx context.Context) ([]TableID, error) {
+	if db.ListTablesFunc != nil {
+		return db.ListTablesFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (db *mockDatabase) DiscoverTableDetails(ctx context.Context, tables []TableID) (map[StreamID]*DiscoveryInfo, error) {
+	if db.DiscoverTableDetailsFunc != nil {
+		return db.DiscoverTableDetailsFunc(ctx, tables)
+	}
+	return make(map[StreamID]*DiscoveryInfo), nil
+}
+
+func (db *mockDatabase) EstimatedRowCounts(ctx context.Context, tables []TableID) (map[TableID]int, error) {
+	if db.EstimatedRowCountsFunc != nil {
+		return db.EstimatedRowCountsFunc(ctx, tables)
+	}
+	var counts = make(map[TableID]int, len(tables))
+	for _, table := range tables {
+		counts[table] = 0
+	}
+	return counts, nil
+}
+
+func (db *mockDatabase) ShouldBackfill(streamID StreamID) bool {
+	if db.ShouldBackfillFunc != nil {
+		return db.ShouldBackfillFunc(streamID)
+	}
+	return true
+}
+
+func (db *mockDatabase) TranslateDBToJSONType(column ColumnInfo, isPrimaryKey bool) (*jsonschema.Schema, error) {
+	return &jsonschema.Schema{Type: "string"}, nil
+}
+
+func (db *mockDatabase) SourceMetadataSchema(writeSchema bool) *jsonschema.Schema {
+	return &jsonschema.Schema{Type: "object"}
+}
+
+func (db *mockDatabase) HistoryMode() bool                         { return false }
+func (db *mockDatabase) RediscoveryInterval() time.Duration        { return 0 }
+func (db *mockDatabase) ReplicationPollingInterval() time.Duration { return 0 }
+func (db *mockDatabase) FallbackCollectionKey() []string           { return db.FallbackKey }
+func (db *mockDatabase) RequestTxIDs(schema, table string)         {}
+func (db *mockDatabase) SetupPrerequisites(ctx context.Context) []error {
+	return nil
+}
+func (db *mockDatabase) SetupTablePrerequisites(ctx context.Context, tables []TableID) map[TableID]error {
+	return nil
+}
+func (db *mockDatabase) ReplicationDiagnostics(ctx context.Context) error { return nil }
+func (db *mockDatabase) PeriodicChecks(ctx context.Context) error         { return nil }
+
+// mockReplicationStream is a configurable in-memory implementation of the
+// ReplicationStream interface.
+type mockReplicationStream struct {
+	// ActivateTableFunc handles ActivateTable calls. The default is a no-op.
+	ActivateTableFunc func(ctx context.Context, streamID StreamID, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error
+
+	// StreamToFenceFunc handles StreamToFence calls. The default returns
+	// immediately without emitting any events.
+	StreamToFenceFunc func(ctx context.Context, fenceAfter time.Duration, callback func(event DatabaseEvent) error) error
+}
+
+func (s *mockReplicationStream) ActivateTable(ctx context.Context, streamID StreamID, keyColumns []string, info *DiscoveryInfo, metadata json.RawMessage) error {
+	if s.ActivateTableFunc != nil {
+		return s.ActivateTableFunc(ctx, streamID, keyColumns, info, metadata)
+	}
+	return nil
+}
+
+func (s *mockReplicationStream) StartReplication(ctx context.Context, discovery map[StreamID]*DiscoveryInfo) error {
+	return nil
+}
+
+func (s *mockReplicationStream) StreamToFence(ctx context.Context, fenceAfter time.Duration, callback func(event DatabaseEvent) error) error {
+	if s.StreamToFenceFunc != nil {
+		return s.StreamToFenceFunc(ctx, fenceAfter, callback)
+	}
+	return nil
+}
+
+func (s *mockReplicationStream) Acknowledge(ctx context.Context, cursor json.RawMessage) error {
+	return nil
+}
+
+func (s *mockReplicationStream) Close(ctx context.Context) error { return nil }
+
+// mockCommitEvent is a minimal CommitEvent implementation for use with
+// StreamToFence hooks.
+type mockCommitEvent struct {
+	Cursor json.RawMessage
+}
+
+func (*mockCommitEvent) IsDatabaseEvent() {}
+func (*mockCommitEvent) IsCommitEvent()   {}
+
+func (e *mockCommitEvent) String() string { return "mockCommitEvent(" + string(e.Cursor) + ")" }
+
+func (e *mockCommitEvent) AppendJSON(buf []byte) ([]byte, error) {
+	return append(buf, e.Cursor...), nil
+}
+
+// mockChangeEvent is a minimal ChangeEvent implementation for use with
+// StreamToFence hooks. Serialization just appends the prebuilt document.
+type mockChangeEvent struct {
+	ID     StreamID
+	RowKey []byte
+	Doc    json.RawMessage
+}
+
+func (*mockChangeEvent) IsDatabaseEvent() {}
+func (*mockChangeEvent) IsChangeEvent()   {}
+
+func (e *mockChangeEvent) String() string     { return "mockChangeEvent(" + e.ID.String() + ")" }
+func (e *mockChangeEvent) StreamID() StreamID { return e.ID }
+func (e *mockChangeEvent) GetRowKey() []byte  { return e.RowKey }
+
+func (e *mockChangeEvent) AppendJSON(buf []byte) ([]byte, error) {
+	return append(buf, e.Doc...), nil
+}
+
+// newMockPullOutput returns a PullOutput whose underlying stream accepts all
+// messages at zero cost, for tests and benchmarks which exercise code paths
+// that emit documents or checkpoints without caring about the bytes produced.
+func newMockPullOutput() *boilerplate.PullOutput {
+	return &boilerplate.PullOutput{Connector_CaptureServer: mockOutputStream{}}
+}
+
+// mockOutputStream is a no-op implementation of the capture output stream
+// underlying a boilerplate.PullOutput. Sends are discarded and receives
+// report EOF.
+type mockOutputStream struct{}
+
+func (mockOutputStream) Send(*pc.Response) error      { return nil }
+func (mockOutputStream) Recv() (*pc.Request, error)   { return nil, io.EOF }
+func (mockOutputStream) Context() context.Context     { return context.Background() }
+func (mockOutputStream) SendMsg(any) error            { return nil }
+func (mockOutputStream) RecvMsg(any) error            { return io.EOF }
+func (mockOutputStream) SendHeader(metadata.MD) error { return nil }
+func (mockOutputStream) SetHeader(metadata.MD) error  { return nil }
+func (mockOutputStream) SetTrailer(metadata.MD)       {}


### PR DESCRIPTION
**Description:**

I'm not entirely sure whether this change is worthwhile. The headline number here is that at 50k bindings, a capture with an infinitely fast database and output sink previously could only run 39 backfill chunk queries per second (~26ms overhead per chunk) and with these changes that increases to 307 (~3ms overhead per chunk).

This is objectively an improvement and we're no longer doing a bunch of redundant work reconstructing the set of tables currently backfilling each time. But on the other hand, it's ~26ms per backfill chunk and ideally each backfill chunk should take, like, 100 times that long at minimum and this difference is essentially noise.

On the third hand, 26ms per chunk of overhead means that in any backfill of 50k bindings, there will be 22 minutes wasted entirely on a bunch of redundant computation inside our connector. If each table in the source DB is individually small, this could be a non-negligible fraction of the overall backfill time.

Anyway, this commit makes two changes:

- The "Backfilling Tables" status update now runs at most once each ten seconds. Before, the full progress computation ran after every chunk.
- A new backfillingStreams set records the streams that are currently in a backfill mode, so we can just use that instead of recomputing it over and over.

Some of the helper functions seemed kind of pointless after these changes, so `BindingsCurrentlyBackfilling` (sorted version) has been removed, as is the `bindingsInState` iterator (no longer used for anything distinct from BindingsInState).

Benchmark results:

**Main Loop: Backfill**

| bindings | baseline | final | speedup | allocs/iter |
|---|---|---|---|---|
| 100 | 25,872 chunks/s | 57,937 | 2.2x | 31KB → 9.9KB |
| 1,000 | 3,048 | 18,114 | 5.9x | 317KB → 47KB |
| 10,000 | 252 | 1,995 | 7.9x | 3.5MB → 417KB |
| 50,000 | 38.9 | 307 | 7.9x | 17.5MB → 2.1MB |
| 100,000 | 15.5 | 119 | 7.7x | 35.2MB → 4.3MB |

**Main Loop: Streaming**

| workload | bindings | baseline | final | speedup |
|---|---|---|---|---|
| 1,000 commits × 1 row | 100 | 2.35M | 2.27M | ~1x |
| | 10,000 | 695k | 2.03M | 2.9x |
| | 100,000 | 60.6k | 1.58M | 26x |
| 100 commits × 100 rows | 100 | 16.2M | 15.3M | ~1x |
| | 100,000 | 574k | 4.60M | 8.0x |
| 10 commits × 10,000 rows | 100 | 18.5M | 17.6M | ~1x |
| | 100,000 | 2.86M | 4.73M | 1.7x |

At 100,000 bindings, the framework overhead for one backfill chunk went from 64ms to 8.4ms, and the bookkeeping cost of a streaming cycle grows less sharply as binding count increases.

**Workflow steps:**

No action required.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
