### PR TITLE
source-sqlserver: ignore DDL history rows whose change table is gone

### DIFF
--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Azure IAM authentication as a new branch of the `credentials` union, using an
   Entra access token obtained through an Azure App Registration.
 
+### Fixed
+- Automatic capture instance management no longer rotates a table's capture
+  instance indefinitely when there are rows in `cdc.ddl_history` naming
+  a change table which no longer exists.
+
 ## 2026-08-25
 
 ### Added

--- a/source-sqlserver/capture_test.go
+++ b/source-sqlserver/capture_test.go
@@ -395,3 +395,65 @@ func TestCatalogPrimaryKey(t *testing.T) {
 	tc.Run("Replication", -1)
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
+
+// TestDDLHistoryFiltering verifies that cdcGetDDLHistory reports an alteration only while
+// the change table which recorded it still exists.
+//
+// A row in `cdc.ddl_history` names the change table it concerns, and is cleared by
+// dropping that capture instance. A row naming a change table which is already gone is
+// therefore cleared by nothing. Automatic capture instance management treats any row for a
+// table as evidence that the table just changed, so while those rows were reported it
+// rotated the capture instance every management interval forever: each rotation left the
+// row which provoked it untouched, and the next pass read it again.
+func TestDDLHistoryFiltering(t *testing.T) {
+	t.Parallel()
+	var db, _ = blackboxTestSetup(t)
+
+	db.CreateTable(t, `<NAME>`, `(id INTEGER PRIMARY KEY, data TEXT)`)
+
+	var schemaName = *testSchemaName
+	var tableName = db.Expand(`<NAME>`)
+	var shortName = tableName[len(schemaName)+1:]
+	var streamID = sqlcapture.JoinStreamID(schemaName, shortName)
+
+	// Plant a row naming a change table which does not exist. Object IDs are positive, so
+	// a negative one cannot collide with any change table, now or later.
+	const strandedObjectID = -1
+	db.QuietExec(t, fmt.Sprintf(`INSERT INTO cdc.ddl_history (source_object_id, object_id, required_column_update, ddl_command, ddl_lsn, ddl_time) `+
+		`VALUES (OBJECT_ID('%s'), %d, 0, 'ALTER TABLE %s ADD stranded INTEGER', 0x00000000000000000000, GETDATE())`,
+		tableName, strandedObjectID, tableName))
+
+	// Dropping the table clears the rows naming its own change table, but by construction
+	// never this one, so it has to go explicitly. Cleanups run in reverse order of
+	// registration, so this one runs while the table still exists.
+	t.Cleanup(func() {
+		db.QuietExec(t, fmt.Sprintf(`DELETE FROM cdc.ddl_history WHERE source_object_id = OBJECT_ID('%s') AND object_id = %d`,
+			tableName, strandedObjectID))
+	})
+
+	ddlHistory, err := cdcGetDDLHistory(context.Background(), db.conn)
+	require.NoError(t, err)
+	require.Empty(t, ddlHistory[streamID], "a DDL history row whose change table no longer exists must not be reported as an alteration")
+
+	// A real alteration of the same table still has to be reported. The capture job records
+	// it asynchronously, so wait for it rather than assuming it has already happened.
+	db.Exec(t, `ALTER TABLE <NAME> ADD extra TEXT`)
+	db.Exec(t, `INSERT INTO <NAME> (id, data) VALUES (1, 'one')`)
+
+	var deadline = time.Now().Add(60 * time.Second)
+	for {
+		ddlHistory, err = cdcGetDDLHistory(context.Background(), db.conn)
+		require.NoError(t, err)
+		if len(ddlHistory[streamID]) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for the alteration of %q to be reported", tableName)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	for _, event := range ddlHistory[streamID] {
+		require.NotContains(t, event.Command, "stranded", "the stranded row must not be reported alongside the real alteration")
+	}
+}

--- a/source-sqlserver/replication.go
+++ b/source-sqlserver/replication.go
@@ -1358,6 +1358,7 @@ type ddlHistoryEntry struct {
 func cdcGetDDLHistory(ctx context.Context, conn *sql.DB) (map[sqlcapture.StreamID][]*ddlHistoryEntry, error) {
 	const query = `SELECT sch.name, tbl.name, hist.required_column_update, hist.ddl_command, hist.ddl_lsn, hist.ddl_time
 				     FROM cdc.ddl_history AS hist
+					 JOIN cdc.change_tables AS ct ON hist.object_id = ct.object_id
 					 JOIN sys.tables AS tbl ON hist.source_object_id = tbl.object_id
 					 JOIN sys.schemas AS sch ON tbl.schema_id = sch.schema_id
 					 ORDER BY hist.ddl_lsn;`


### PR DESCRIPTION
**Description:**

Automatic capture instance management rotates a table's capture instance when `cdc.ddl_history` holds any rows for it. The connector assumes that dropping an instance clears the rows which provoked the rotation. But `sp_cdc_disable_table` clears only the rows naming the instance being dropped. We've observed a capture constantly running `sp_cdc_enable_table` and `sp_cdc_disable_table` against a database, so we're suspecting that _somehow_ a row for a deleted instance has been orphaned in `cdc.ddl_history`, which would trigger the connector to rotate that table's capture instance forever. Planting such a row reproduces the behaviour exactly; how one comes to exist in the first place we have not worked out.

The query now joins `cdc.change_tables`, which excludes any orphaned rows and should prevent orphaned rows from triggering the connector to rotate capture instances.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1787676665505609)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
