### PR TITLE
benchmark: fix connection retry loop

### DIFF
--- a/tests/benchmark/gcp-vm.sh
+++ b/tests/benchmark/gcp-vm.sh
@@ -112,7 +112,7 @@ wait_for_ssh() {
       return 0
     fi
     sleep 3
-    (( attempts++ ))
+    (( ++attempts ))
   done
   die "SSH not available after 120s — check VM status with: gcloud compute instances describe $VM_NAME --zone=$ZONE"
 }


### PR DESCRIPTION
Since this script is using errexit, it will exit if a command returns non-zero.  On the first time through the loop attempts is 0, and since it is incremented using postfix increment, the expression is similar to `(( 0 ))`, which returns 1 and exits the script.

Switching to a prefix increment solves this because now it returns the incremented value `(( 1 ))`, which is 0.