### PR TITLE
materialize-databricks: retry COPY INTO on concurrent duplicate-files conflict

### DIFF
--- a/materialize-databricks/CHANGELOG.md
+++ b/materialize-databricks/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-26
+
+### Fixed
+- A commit query failing with `COPY_INTO_DUPLICATED_FILES_COPY_NOT_ALLOWED`
+  is now retried with backoff instead of restarting the connector. The
+  conflicting query is one of a previous connector process that was killed
+  while it was still running, and the retry succeeds once it has finished.
+
 ## 2026-08-25
 
 ### Added

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/databricks/databricks-sdk-go"
 	dbConfig "github.com/databricks/databricks-sdk-go/config"
@@ -849,7 +850,7 @@ func (d *transactor) commitBindingCheckpointItems(ctx context.Context, db *stdsq
 // them in this case.
 func (d *transactor) execQueries(ctx context.Context, db *stdsql.DB, queries []string, tolerateMissing bool) error {
 	for _, query := range queries {
-		if _, err := db.ExecContext(ctx, query); err != nil {
+		if err := d.execQuery(ctx, db, query); err != nil {
 			if tolerateMissing && (strings.Contains(err.Error(), "PATH_NOT_FOUND") || strings.Contains(err.Error(), "Path does not exist") || strings.Contains(err.Error(), "Table doesn't exist") || strings.Contains(err.Error(), "TABLE_OR_VIEW_NOT_FOUND")) {
 				continue
 			}
@@ -857,6 +858,53 @@ func (d *transactor) execQueries(ctx context.Context, db *stdsql.DB, queries []s
 		}
 	}
 	return nil
+}
+
+// retriableErrorClasses are the Databricks error classes of a commit query
+// which succeeds when re-run once the conflicting activity has finished.
+//
+// COPY_INTO_DUPLICATED_FILES_COPY_NOT_ALLOWED: another COPY INTO into the same
+// table committed some of the same files, which usually means a previous
+// primary shard was killed mid-Acknowledge. We retry until that orphaned query
+// has finished, at which point our query skips the already-copied files.
+var retriableErrorClasses = []string{
+	"COPY_INTO_DUPLICATED_FILES_COPY_NOT_ALLOWED",
+}
+
+const maxQueryRetries = 5
+
+// queryRetryDelay is the wait before retry number attempt+1: 15s, 30s, 1m,
+// 2m, 4m.
+var queryRetryDelay = func(attempt int) time.Duration {
+	return time.Duration(1<<attempt) * 15 * time.Second
+}
+
+func isRetriableError(err error) bool {
+	return slices.ContainsFunc(retriableErrorClasses, func(class string) bool {
+		return strings.Contains(err.Error(), class)
+	})
+}
+
+func (d *transactor) execQuery(ctx context.Context, db *stdsql.DB, query string) error {
+	for attempt := 0; ; attempt++ {
+		var _, err = db.ExecContext(ctx, query)
+		if err == nil || !isRetriableError(err) || attempt >= maxQueryRetries {
+			return err
+		}
+
+		var delay = queryRetryDelay(attempt)
+		log.WithFields(log.Fields{
+			"attempt": attempt + 1,
+			"delay":   delay.String(),
+			"err":     err,
+		}).Warn("query failed with a retriable error; retrying")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
 }
 
 // renderCommitQueries renders the queries which commit a set of staged files

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	m "github.com/estuary/connectors/go/materialize"
 	sql "github.com/estuary/connectors/materialize-sql"
@@ -59,6 +60,10 @@ type recordingConn struct{}
 var recording struct {
 	executed []string
 	failWith error
+	// failFirst limits failWith to the first failFirst statements when
+	// non-zero; otherwise failWith fails every statement.
+	failFirst int
+	attempts  int
 }
 
 func (recordingDriver) Open(string) (driver.Conn, error) { return recordingConn{}, nil }
@@ -70,7 +75,8 @@ func (recordingConn) Close() error              { return nil }
 func (recordingConn) Begin() (driver.Tx, error) { return nil, fmt.Errorf("begin is not implemented") }
 
 func (recordingConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
-	if recording.failWith != nil {
+	recording.attempts++
+	if recording.failWith != nil && (recording.failFirst == 0 || recording.attempts <= recording.failFirst) {
 		return nil, recording.failWith
 	}
 	recording.executed = append(recording.executed, query)
@@ -87,7 +93,7 @@ func recordingDB(t *testing.T, failWith error) *stdsql.DB {
 	t.Helper()
 	registerRecordingDriver()
 
-	recording.executed, recording.failWith = nil, failWith
+	recording.executed, recording.failWith, recording.failFirst, recording.attempts = nil, failWith, 0, 0
 	db, err := stdsql.Open("recording", "")
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
@@ -206,6 +212,51 @@ func TestMergePeerStatePatches(t *testing.T) {
 	t.Run("empty patches are a no-op", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
 		require.NoError(t, d.mergePeerStatePatches(nil))
+	})
+}
+
+func TestExecQueriesRetriesRetriableErrors(t *testing.T) {
+	var origDelay = queryRetryDelay
+	queryRetryDelay = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { queryRetryDelay = origDelay })
+
+	var conflict = fmt.Errorf("databricks: execution error: [%s] Duplicated files were committed in a concurrent COPY INTO operation. Please try again later.", retriableErrorClasses[0])
+	var d = testTransactor(fullRangeKey)
+
+	t.Run("succeeds once the concurrent copy has finished", func(t *testing.T) {
+		var db = recordingDB(t, conflict)
+		recording.failFirst = 2
+
+		require.NoError(t, d.execQueries(context.Background(), db, []string{"COPY"}, false))
+		require.Equal(t, 3, recording.attempts)
+		require.Equal(t, []string{"COPY"}, recording.executed)
+	})
+
+	t.Run("gives up after the retry budget", func(t *testing.T) {
+		var db = recordingDB(t, conflict)
+
+		var err = d.execQueries(context.Background(), db, []string{"COPY"}, false)
+		require.ErrorIs(t, err, conflict)
+		require.Equal(t, maxQueryRetries+1, recording.attempts)
+	})
+
+	t.Run("other errors are not retried", func(t *testing.T) {
+		var db = recordingDB(t, fmt.Errorf("[DELTA_CONCURRENT_APPEND] something else"))
+
+		require.Error(t, d.execQueries(context.Background(), db, []string{"COPY"}, false))
+		require.Equal(t, 1, recording.attempts)
+	})
+
+	t.Run("cancellation ends the wait", func(t *testing.T) {
+		queryRetryDelay = func(int) time.Duration { return time.Hour }
+		t.Cleanup(func() { queryRetryDelay = func(int) time.Duration { return 0 } })
+		var db = recordingDB(t, conflict)
+		var ctx, cancel = context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		var err = d.execQueries(ctx, db, []string{"COPY"}, false)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, 1, recording.attempts)
 	})
 }
 


### PR DESCRIPTION
**Description:**

Retries a commit query failing with `COPY_INTO_DUPLICATED_FILES_COPY_NOT_ALLOWED` (backoff 15s → 4m, five attempts) instead of failing the connector. The conflicting query is an orphaned `COPY INTO` of a connector process killed mid-Acknowledge: the warehouse keeps running it while the replacement session re-runs the identical query from the recovered checkpoint. Once it finishes, the retry skips the files it loaded.

**Workflow steps:**

No user-facing change; the conflict now surfaces as a warning log rather than a restart.

**Notes for reviewers:**

Only that exact error class is retried; the `tolerateMissing` recovery handling is unchanged. Unit tests use the recording driver with a new fail-N-times mode.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]