### PR TITLE
materialize-clickhouse: widen retry budget for ClickHouse Cloud idle wake-ups

### DIFF
--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-26
+
+### Fixed
+- A ClickHouse Cloud service waking up from idle scaling could take longer to
+  respond than the connector's retry budget allowed, failing the shard with a
+  handshake timeout instead of waiting it out. The retry budget is now wider
+  (16 attempts over up to 10 minutes, up from 8 over 5). A separate query run
+  while recovering from a restart was not retried at all and has the same
+  protection now.
+
 ## 2026-08-25
 
 ### Added

--- a/materialize-clickhouse/client.go
+++ b/materialize-clickhouse/client.go
@@ -61,11 +61,14 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 	var database = c.ep.Config.Database
 
 	// Query tables from system.tables.
-	var tableRows, err = c.db.QueryContext(ctx, fmt.Sprintf(
-		"SELECT database, name FROM system.tables WHERE database = %s",
-		c.ep.Dialect.Literal(database),
-	))
-	if err != nil {
+	var tableRows *stdsql.Rows
+	if err := transientRetryPolicy.retry(ctx, "querying system.tables", isTransientErr, func() (err error) {
+		tableRows, err = c.db.QueryContext(ctx, fmt.Sprintf(
+			"SELECT database, name FROM system.tables WHERE database = %s",
+			c.ep.Dialect.Literal(database),
+		))
+		return err
+	}); err != nil {
 		return fmt.Errorf("querying system.tables: %w", err)
 	}
 	defer tableRows.Close()
@@ -82,8 +85,7 @@ func (c *client) PopulateInfoSchema(ctx context.Context, is *boilerplate.InfoSch
 	}
 
 	// Query columns from system.columns.
-	var colRows *stdsql.Rows
-	colRows, err = c.db.QueryContext(ctx, fmt.Sprintf(
+	var colRows, err = c.db.QueryContext(ctx, fmt.Sprintf(
 		"SELECT database, table, name, type, default_expression, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = %s",
 		c.ep.Dialect.Literal(database),
 	))

--- a/materialize-clickhouse/retry.go
+++ b/materialize-clickhouse/retry.go
@@ -23,13 +23,14 @@ type retryPolicy struct {
 	maxElapsed     time.Duration
 }
 
-// transientRetryPolicy rides out a ClickHouse Cloud replica recycle, which
-// typically resolves within seconds to a couple of minutes.
+// transientRetryPolicy rides out a ClickHouse Cloud replica recycle, or an
+// idle-scaled service waking back up, either of which can take several
+// minutes to resolve.
 var transientRetryPolicy = retryPolicy{
-	maxAttempts:    8,
+	maxAttempts:    16,
 	initialBackoff: time.Second,
 	maxBackoff:     30 * time.Second,
-	maxElapsed:     5 * time.Minute,
+	maxElapsed:     10 * time.Minute,
 }
 
 // retry invokes op, retrying with exponential backoff while retryable reports


### PR DESCRIPTION
**Description:**

ClickHouse Cloud idle-scales down and takes time to wake up. When our commit landed mid wake-up, the connection handshake timed out. We already retry these, but the retry budget (5 minutes) was too short — logs showed it sometimes needed up to 9. Widened it to 10 minutes / 16 attempts, and added the same retry to a recovery-path query that had none.

**Workflow steps:**

None — internal retry timing only, no user-facing change.

**Notes for reviewers:**

- 16 attempts / 10 min is a round number above the worst case seen (~9.1 min).
- Added a test that locks in the budget so it can't shrink back down later.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: N/A
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated — N/A, no config/workflow change