### PR TITLE
source-sqlserver: add IAM auth support

### DIFF
--- a/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/amazon-rds-sqlserver.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: Capture Amazon RDS SQL Server changes with Estuary’s CDC connector. Setup guide includes database/table CDC setup, permissions, SSH tunneling, and DDL handling.
+description: Capture Amazon RDS SQL Server changes with Estuary’s CDC connector. Setup guide includes database/table CDC setup, permissions, IAM authentication, SSH tunneling, and DDL handling.
 ---
 
 # Amazon RDS for SQL Server
@@ -27,6 +27,8 @@ To capture change events from SQL Server tables using this connector, you need:
   - `SELECT` permissions on the CDC schema and the schemas that contain tables to be captured.
   - Access to the change tables created as part of the SQL Server CDC process.
   - The `VIEW DATABASE STATE` or (in newer versions of SQL Server) `VIEW DATABASE PERFORMANCE STATE` permission.
+
+- When using [IAM authentication](#iam-authentication), an RDS Proxy with the database as a target.
 
 ## Setup
 
@@ -63,6 +65,35 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foobar', @r
 ```
 
 6. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+
+### IAM Authentication
+
+Instead of username/password authentication, you can optionally use an AWS IAM
+role with this connector.
+
+To do this, you will need to use [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html).
+This proxy accepts IAM connections from the connector and connects to the
+database using a password stored in AWS Secrets Manager.
+
+RDS Proxy cannot typically be accessed from the internet, so it is recommended
+to configure [SSH tunneling](/guides/connect-network/). Ensure the security
+group for the proxy allows MSSQL connections from the security group of the EC2
+instance.
+
+The proxy must be configured with IAM authentication set to `Allowed` or
+`Required`. Add a Secrets Manager secret to the RDS Proxy corresponding to the
+`flow_capture` user you created above. You can do this in the AWS Console by
+selecting the RDS Proxy, and clicking on `Actions -> Modify` followed by "create
+a new secret". Add the username and password for that user and select the
+correct database instance. Make sure that the proxy's authentication role allows
+the proxy access to read this secret.
+
+Instead of connecting directly to the database endpoint, you will set the
+connector's `address` to one of the proxy endpoints listed on the proxy. Then
+set `credentials.auth_type` to `AWSIAM` and provide the `aws_region` and the
+`aws_role_arn` for Estuary to assume. The connector fetches a fresh RDS auth
+token for every connection it opens, so long-running captures are unaffected by
+the token's limited lifetime.
 
 ### Handling DDL Alterations to Source Tables
 
@@ -108,13 +139,36 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/address`**                  | Server Address      | The host or host:port at which the database can be reached.                                                                                 | string  | Required                   |
 | **`/database`**                 | Database            | Logical database name to capture from.                                                                                                      | string  | Required                   |
 | **`/user`**                     | User                | The database user to authenticate as.                                                                                                       | string  | Required, `"flow_capture"` |
-| **`/password`**                 | Password            | Password for the specified database user.                                                                                                   | string  | Required                   |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AWSIAM`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
+| `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
+
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object |  |
 | `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. | string array |  |
 | `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array |  |
 | `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array |  |
 | `/discoveryFilters/discover_only_enabled` | Discover Only CDC-Enabled Tables | When set, the connector only discovers tables which already have CDC capture instances enabled. Combined as a union with the equivalent setting under Advanced Options. | boolean |  |
+
+##### Advanced options
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/backfill_chunk_size` | Backfill Chunk Size | The number of rows which should be fetched from the database in a single backfill query.                                                    | integer | `4096`                     |
 | `/advanced/skip_backfills`      | Skip Backfills      | A comma-separated list of fully-qualified table names which should not be backfilled.                                                       | string  |                            |
@@ -144,13 +198,25 @@ captures:
           address: "<host>:1433"
           database: "my_db"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           stream: ${TABLE_NAME}
           namespace: dbo
           primary_key: ["id"]
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate with [IAM](#iam-authentication) instead, point `address` at your
+RDS Proxy endpoint and replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AWSIAM
+            aws_region: "us-east-1"
+            aws_role_arn: "arn:aws:iam::123456789012:role/estuary-sqlserver-capture"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/google-cloud-sql-sqlserver.md
@@ -108,13 +108,34 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/address`**                  | Server Address      | The host or host:port at which the database can be reached.                                                                                 | string  | Required                   |
 | **`/database`**                 | Database            | Logical database name to capture from.                                                                                                      | string  | Required                   |
 | **`/user`**                     | User                | The database user to authenticate as.                                                                                                       | string  | Required, `"flow_capture"` |
-| **`/password`**                 | Password            | Password for the specified database user.                                                                                                   | string  | Required                   |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. Google Cloud SQL for SQL Server supports `UserPassword`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object |  |
 | `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. | string array |  |
 | `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array |  |
 | `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array |  |
 | `/discoveryFilters/discover_only_enabled` | Discover Only CDC-Enabled Tables | When set, the connector only discovers tables which already have CDC capture instances enabled. Combined as a union with the equivalent setting under Advanced Options. | boolean |  |
+
+##### Advanced options
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/backfill_chunk_size` | Backfill Chunk Size | The number of rows which should be fetched from the database in a single backfill query.                                                    | integer | `4096`                     |
 | `/advanced/skip_backfills`      | Skip Backfills      | A comma-separated list of fully-qualified table names which should not be backfilled.                                                       | string  |                            |
@@ -144,7 +165,9 @@ captures:
           address: "<host>:1433"
           database: "my_db"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           stream: ${TABLE_NAME}

--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -145,6 +145,13 @@ EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'foobar', @r
 
    - Find the instance's host under Server Name. The port is always `1433`. Together, you'll use the host:port as the `address` property when you configure the connector.
 
+### IAM Authentication
+
+For databases hosted on Amazon RDS, you can authenticate with an AWS IAM role
+instead of a password. This requires an RDS Proxy in front of the database; see
+[Amazon RDS for SQL Server](./amazon-rds-sqlserver/#iam-authentication) for
+setup instructions.
+
 ### Handling DDL Alterations to Source Tables
 
 In SQL Server, adding a column to the source table will not automatically cause it to be added to the CDC change table. Instead [Microsoft's recommended approach](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-ver17#handling-changes-to-source-table) is to create a second capture instance which reflects the new state of the source table, transition over to the new instance, and then delete the old one.
@@ -189,13 +196,36 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | **`/address`**                  | Server Address      | The host or host:port at which the database can be reached.                                                                                 | string  | Required                   |
 | **`/database`**                 | Database            | Logical database name to capture from.                                                                                                      | string  | Required                   |
 | **`/user`**                     | User                | The database user to authenticate as.                                                                                                       | string  | Required, `"flow_capture"` |
-| **`/password`**                 | Password            | Password for the specified database user.                                                                                                   | string  | Required                   |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AWSIAM`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
+| `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
+
+##### Discovery Filters
+
+Options that restrict which tables are surfaced by discovery. These take effect
+when discovery runs. If your capture has automatic discovery enabled, a table
+these filters exclude will be deactivated the next time discovery runs.
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/discoveryFilters` | Discovery Filters | Options that restrict which tables are visible to discovery. | object |  |
 | `/discoveryFilters/include_schemas` | Include Schemas | If specified, only tables in the listed schemas are discovered. | string array |  |
 | `/discoveryFilters/exclude_schemas` | Exclude Schemas | Tables in the listed schemas are excluded from discovery. | string array |  |
 | `/discoveryFilters/table_patterns` | Table Patterns | If specified, only tables matching at least one of these glob patterns are discovered. A pattern containing a `.` matches against the qualified `schema.table` name. A pattern without a `.` matches the unqualified table name in any schema. Use `*` or `?` as wildcards. | string array |  |
 | `/discoveryFilters/discover_only_enabled` | Discover Only CDC-Enabled Tables | When set, the connector only discovers tables which already have CDC capture instances enabled. Combined as a union with the equivalent setting under Advanced Options. | boolean |  |
+
+##### Advanced options
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
 | `/advanced`                     | Advanced Options    | Options for advanced users. You should not typically need to modify these.                                                                  | object  |                            |
 | `/advanced/backfill_chunk_size` | Backfill Chunk Size | The number of rows which should be fetched from the database in a single backfill query.                                                    | integer | `4096`                     |
 | `/advanced/skip_backfills`      | Skip Backfills      | A comma-separated list of fully-qualified table names which should not be backfilled.                                                       | string  |                            |
@@ -225,7 +255,9 @@ captures:
           address: "<host>:1433"
           database: "my_db"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           stream: ${TABLE_NAME}

--- a/source-sqlserver/.snapshots/TestSpec
+++ b/source-sqlserver/.snapshots/TestSpec
@@ -16,11 +16,70 @@
         "default": "flow_capture",
         "order": 1
       },
-      "password": {
-        "type": "string",
-        "description": "Password for the specified database user.",
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "UserPassword",
+                "default": "UserPassword",
+                "order": 0
+              },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "Password for the specified database user.",
+                "order": 1,
+                "secret": true
+              }
+            },
+            "type": "object",
+            "required": [
+              "password"
+            ],
+            "title": "Password"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "UserPassword"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
         "order": 2,
-        "secret": true
+        "x-iam-auth": true
       },
       "database": {
         "type": "string",
@@ -201,7 +260,7 @@
     "required": [
       "address",
       "user",
-      "password",
+      "credentials",
       "database",
       "historyMode"
     ],

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # source-sqlserver
 
+## 2026-08-25
+
+### Added
+- New `credentials` configuration union supporting username/password and AWS IAM
+  authentication (RDS auth tokens, refreshed per connection). Existing configs
+  with the legacy top-level `password` field keep working and are folded into
+  the new shape automatically.
+
 ## 2026-08-18
 
 ### Added

--- a/source-sqlserver/config_test.go
+++ b/source-sqlserver/config_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeCredentials(t *testing.T) {
+	t.Run("LegacyPasswordPromotes", func(t *testing.T) {
+		var cfg = Config{Address: "example.com:1433", User: "flow_capture", Password: "secret1234", Database: "flow"}
+
+		cfg.normalizeCredentials()
+
+		require.Empty(t, cfg.Password)
+		require.NotNil(t, cfg.Credentials)
+		require.Equal(t, UserPassword, cfg.Credentials.AuthType)
+		require.Equal(t, "secret1234", cfg.Credentials.Password)
+	})
+
+	t.Run("CredentialsWinOverLegacyPassword", func(t *testing.T) {
+		var cfg = Config{
+			Address:  "example.com:1433",
+			User:     "flow_capture",
+			Password: "stale-legacy-password",
+			Database: "flow",
+			Credentials: &CredentialsConfig{
+				AuthType:           UserPassword,
+				UserPasswordConfig: UserPasswordConfig{Password: "current-password"},
+			},
+		}
+
+		cfg.normalizeCredentials()
+
+		require.Empty(t, cfg.Password)
+		require.Equal(t, "current-password", cfg.Credentials.Password)
+	})
+
+	t.Run("NormalizedShapeInURI", func(t *testing.T) {
+		var legacy = Config{Address: "example.com:1433", User: "flow_capture", Password: "secret1234", Database: "flow"}
+		var union = Config{
+			Address:  "example.com:1433",
+			User:     "flow_capture",
+			Database: "flow",
+			Credentials: &CredentialsConfig{
+				AuthType:           UserPassword,
+				UserPasswordConfig: UserPasswordConfig{Password: "secret1234"},
+			},
+		}
+
+		legacy.normalizeCredentials()
+		union.normalizeCredentials()
+
+		unionURI, err := union.ToURI()
+		require.NoError(t, err)
+		legacyURI, err := legacy.ToURI()
+		require.NoError(t, err)
+		require.Equal(t, unionURI, legacyURI)
+	})
+}
+
+func TestConfigValidate(t *testing.T) {
+	var valid = func() Config {
+		return Config{Address: "example.com:1433", User: "flow_capture", Database: "flow", Credentials: &CredentialsConfig{
+			AuthType:           UserPassword,
+			UserPasswordConfig: UserPasswordConfig{Password: "secret1234"},
+		}}
+	}
+
+	t.Run("UserPasswordCredentials", func(t *testing.T) {
+		var cfg = valid()
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("LegacyPasswordOnly", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = nil
+		cfg.Password = "secret1234"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("NoCredentialsAtAll", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = nil
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'credentials'")
+	})
+
+	t.Run("EmptyPasswordCredentials", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials.Password = ""
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'password'")
+	})
+
+	t.Run("AWSIAMValid", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AWSIAM}
+		cfg.Credentials.AWSRegion = "us-east-1"
+		cfg.Credentials.AWSRole = "arn:aws:iam::123456789012:role/flow-capture"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("AWSIAMMissingRegion", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AWSIAM}
+		cfg.Credentials.AWSRole = "arn:aws:iam::123456789012:role/flow-capture"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'aws_region'")
+	})
+
+	t.Run("UnknownAuthType", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: "Bogus"}
+
+		require.ErrorContains(t, cfg.Validate(), "unknown 'auth_type'")
+	})
+}
+
+func TestAWSIAMConfigURI(t *testing.T) {
+	var cfg = Config{
+		Address:  "example.rds.amazonaws.com",
+		User:     "flow_capture",
+		Database: "flow",
+		Credentials: &CredentialsConfig{
+			AuthType: AWSIAM,
+			IAMConfig: iam.IAMConfig{
+				AWSConfig: iam.AWSConfig{AWSRegion: "us-east-1", AWSRole: "arn:aws:iam::123456789012:role/flow-capture"},
+			},
+		},
+	}
+	cfg.SetDefaults()
+	cfg.normalizeCredentials()
+
+	// The DSN carries the user but no password: the RDS auth token is supplied
+	// out-of-band by the connector's access token provider.
+	uri, err := cfg.ToURI()
+	require.NoError(t, err)
+	require.Equal(t,
+		"sqlserver://flow_capture@example.rds.amazonaws.com:1433?TrustServerCertificate=true&app+name=Flow+CDC+Connector&database=flow&encrypt=true",
+		uri)
+}
+
+func TestUnsupportedAuthTypeURI(t *testing.T) {
+	var cfg = Config{
+		Address:     "example.com:1433",
+		User:        "flow_capture",
+		Database:    "flow",
+		Credentials: &CredentialsConfig{AuthType: "Bogus"},
+	}
+
+	_, err := cfg.ToURI()
+	require.ErrorContains(t, err, `unsupported 'auth_type' "Bogus"`)
+
+	_, err = cfg.buildConnector()
+	require.ErrorContains(t, err, `unsupported 'auth_type' "Bogus"`)
+}

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/capture/sqlserver/datatypes"
 	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
@@ -67,14 +69,60 @@ var featureFlagDefaults = map[string]bool{
 	"discover_rowversion_as_bytes": false,
 }
 
+type AuthType string
+
+const (
+	UserPassword AuthType = "UserPassword"
+	AWSIAM       AuthType = "AWSIAM"
+)
+
+type UserPasswordConfig struct {
+	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=1"`
+}
+
+// CredentialsConfig is a flat union of the supported authentication methods,
+// discriminated by AuthType. The JSON Schema presents it as a oneOf with one
+// branch per method.
+type CredentialsConfig struct {
+	AuthType AuthType `json:"auth_type"`
+
+	UserPasswordConfig
+	iam.IAMConfig
+}
+
+func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
+	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword),
+		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
+		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)),
+	)
+}
+
+func (c *CredentialsConfig) Validate() error {
+	switch c.AuthType {
+	case UserPassword:
+		if c.Password == "" {
+			return errors.New("missing 'password'")
+		}
+		return nil
+	case AWSIAM:
+		// The embedded IAMConfig has its own auth_type field which JSON decoding
+		// leaves empty (the outer field shadows it), so sync it before ValidateIAM
+		// switches on it.
+		c.IAMConfig.AuthType = iam.AuthType(c.AuthType)
+		return c.ValidateIAM()
+	}
+	return fmt.Errorf("unknown 'auth_type' %q", c.AuthType)
+}
+
 // Config tells the connector how to connect to and interact with the source database.
 type Config struct {
-	Address     string `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User        string `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password    string `json:"password" jsonschema:"description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Database    string `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
-	Timezone    string `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4,nonsensitive=true"`
-	HistoryMode bool   `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5,nonsensitive=true"`
+	Address     string             `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string             `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string             `json:"password,omitempty" jsonschema:"-"`
+	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=2,x-iam-auth=true"`
+	Database    string             `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
+	Timezone    string             `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4,nonsensitive=true"`
+	HistoryMode bool               `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5,nonsensitive=true"`
 
 	DiscoveryFilters discoveryFilters `json:"discoveryFilters,omitempty" jsonschema:"title=Discovery Filters,description=Options that restrict which tables are visible to discovery."`
 	Advanced         advancedConfig   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
@@ -111,13 +159,22 @@ func (c *Config) Validate() error {
 	var requiredProperties = [][]string{
 		{"address", c.Address},
 		{"user", c.User},
-		{"password", c.Password},
 		{"database", c.Database},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
+	}
+
+	// Validation runs before normalizeCredentials, so both the legacy flat
+	// password and the credentials union must be accepted here.
+	if c.Credentials == nil {
+		if c.Password == "" {
+			return errors.New("missing 'credentials'")
+		}
+	} else if err := c.Credentials.Validate(); err != nil {
+		return err
 	}
 
 	if c.Timezone != "" {
@@ -178,24 +235,84 @@ func (c *Config) SetDefaults() {
 	}
 }
 
-// ToURI converts the Config to a DSN string.
+// normalizeCredentials folds a legacy top-level password into c.Credentials as a
+// UserPassword credential, so that code downstream of it only ever reads one
+// credentials shape. When both are supplied the explicit credentials win.
+func (c *Config) normalizeCredentials() {
+	var legacyPassword = c.Password
+	c.Password = ""
+
+	if c.Credentials != nil {
+		if legacyPassword != "" {
+			log.Warn("both legacy 'password' and 'credentials' are set; the former will be ignored in favour of the latter")
+		}
+		return
+	}
+	c.Credentials = &CredentialsConfig{
+		AuthType:           UserPassword,
+		UserPasswordConfig: UserPasswordConfig{Password: legacyPassword},
+	}
+}
+
+// ToURI converts the Config to a DSN string. It requires normalizeCredentials
+// to have run, and only reads the credentials union.
 //
 // The DSN host is always the real server address, even when tunneling. We dial localhost (the
 // tunnel) via tunnelDialer, but advertise the real server address as the LOGIN7 ServerName and
 // TLS SNI for SQL Server instances that rely on those being accurate.
-func (c *Config) ToURI() string {
+func (c *Config) ToURI() (string, error) {
 	var params = make(url.Values)
 	params.Add("app name", "Flow CDC Connector")
 	params.Add("encrypt", "true")
 	params.Add("TrustServerCertificate", "true")
 	params.Add("database", c.Database)
+
+	var userInfo *url.Userinfo
+	switch c.Credentials.AuthType {
+	case UserPassword:
+		userInfo = url.UserPassword(c.User, c.Credentials.Password)
+	case AWSIAM:
+		userInfo = url.User(c.User)
+	default:
+		return "", fmt.Errorf("unsupported 'auth_type' %q", c.Credentials.AuthType)
+	}
+
 	var connectURL = &url.URL{
 		Scheme:   "sqlserver",
-		User:     url.UserPassword(c.User, c.Password),
+		User:     userInfo,
 		Host:     c.Address,
 		RawQuery: params.Encode(),
 	}
-	return connectURL.String()
+	return connectURL.String(), nil
+}
+
+// buildConnector constructs a driver connector for the configured authentication
+// method. AWS IAM connections fetch a fresh RDS auth token for each new connection
+// the pool opens, so long-running captures outlive the token's 15-minute validity.
+func (c *Config) buildConnector() (*mssqldb.Connector, error) {
+	var uri, err = c.ToURI()
+	if err != nil {
+		return nil, err
+	}
+
+	switch c.Credentials.AuthType {
+	case UserPassword:
+		return mssqldb.NewConnector(uri)
+	case AWSIAM:
+		credProvider, err := c.Credentials.AWSCredentialsProvider()
+		if err != nil {
+			return nil, err
+		}
+		// Tokens are built against the configured address (which SetDefaults has
+		// already given a port), so with a network tunnel the token matches the
+		// real server endpoint just like the DSN host does.
+		var tokenProvider = func(ctx context.Context) (string, error) {
+			return auth.BuildAuthToken(ctx, c.Address, c.Credentials.AWSRegion, c.User, credProvider)
+		}
+		return mssqldb.NewConnectorWithAccessTokenProvider(uri, tokenProvider)
+	default:
+		return nil, fmt.Errorf("unsupported 'auth_type' %q", c.Credentials.AuthType)
+	}
 }
 
 // tunnelDialer redirects connections to the local end of the SSH tunnel while the driver keeps
@@ -236,6 +353,7 @@ func connectSQLServer(ctx context.Context, name string, cfg json.RawMessage) (sq
 		return nil, fmt.Errorf("error parsing config json: %w", err)
 	}
 	config.SetDefaults()
+	config.normalizeCredentials()
 
 	var featureFlags = common.ParseFeatureFlags(config.Advanced.FeatureFlags, featureFlagDefaults)
 	if config.Advanced.FeatureFlags != "" {
@@ -316,7 +434,7 @@ func (db *sqlserverDatabase) connect(ctx context.Context) error {
 		"user":    db.config.User,
 	}).Info("connecting to database")
 
-	connector, err := mssqldb.NewConnector(db.config.ToURI())
+	connector, err := db.config.buildConnector()
 	if err != nil {
 		return fmt.Errorf("error creating connector: %w", err)
 	}

--- a/source-sqlserver/main_test.go
+++ b/source-sqlserver/main_test.go
@@ -89,6 +89,21 @@ func runTests(m *testing.M) int {
 	return m.Run()
 }
 
+// controlConfigURI builds a DSN for a test control connection to the database.
+func controlConfigURI() (string, error) {
+	var credentials = &CredentialsConfig{
+		AuthType:           UserPassword,
+		UserPasswordConfig: UserPasswordConfig{Password: *dbControlPass},
+	}
+	var cfg = Config{
+		Address:     *dbControlAddress,
+		User:        *dbControlUser,
+		Credentials: credentials,
+		Database:    *dbName,
+	}
+	return cfg.ToURI()
+}
+
 // startManualCDCScanner stops the SQL Agent capture job and drives log scanning from the
 // test harness instead, returning a function which restores the job.
 //
@@ -103,12 +118,10 @@ func runTests(m *testing.M) int {
 // frequent scans make a fence available sooner, but the connector's default one second
 // poll still quantizes every fence to a one second boundary.
 func startManualCDCScanner() (func(), error) {
-	var controlURI = (&Config{
-		Address:  *dbControlAddress,
-		User:     *dbControlUser,
-		Password: *dbControlPass,
-		Database: *dbName,
-	}).ToURI()
+	controlURI, err := controlConfigURI()
+	if err != nil {
+		return nil, fmt.Errorf("building scanner connection DSN: %w", err)
+	}
 	conn, err := sql.Open("sqlserver", controlURI)
 	if err != nil {
 		return nil, fmt.Errorf("opening scanner connection: %w", err)
@@ -223,13 +236,9 @@ func blackboxTestSetup(t testing.TB) (*sqlserverTestDatabase, *blackbox.Transcri
 	tc.CheckpointSanitizers = checkpointSanitizers
 
 	// Setup: Connect to target database
-	var controlURI = (&Config{
-		Address:  *dbControlAddress,
-		User:     *dbControlUser,
-		Password: *dbControlPass,
-		Database: *dbName,
-	}).ToURI()
 	t.Logf("opening control connection: addr=%q, user=%q", *dbControlAddress, *dbControlUser)
+	controlURI, err := controlConfigURI()
+	require.NoError(t, err)
 	connector, err := mssqldb.NewConnector(controlURI)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:**

Existing configurations keep their top-level `password`, which is now hidden from the schema and folded into the union as a `UserPassword` credential by `normalizeCredentials`, so everything downstream of config loading reads exactly one credentials shape.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
