### PR TITLE
go/capture: drive Go capture tests with `flowctl raw preview-next`

### DIFF
--- a/go/capture/blackbox/.snapshots/TestInvalidConfig
+++ b/go/capture/blackbox/.snapshots/TestInvalidConfig
@@ -2,7 +2,7 @@
 acmeCo/test_capture/events
 
 === Run: With Invalid Config ===
-Error: flowctl preview failed: exit status 1
+Error: flowctl raw preview-next failed: exit status 1
 stderr: 2025-12-17T22:55:57.956874Z  WARN flowctl: You are not authenticated. Run `auth login` to login to Flow.
 2025-12-17T22:55:58.107594Z  WARN ops: time="2025-12-17T16:55:58-06:00" level=info msg="Initializing connector" eventType=connectorStatus fields={}
 2025-12-17T22:55:58.228167Z  WARN ops: time="2025-12-17T16:55:58-06:00" level=info msg="Initializing connector" eventType=connectorStatus fields={}

--- a/go/capture/blackbox/capture.go
+++ b/go/capture/blackbox/capture.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/tidwall/gjson"
@@ -27,6 +28,10 @@ type Capture struct {
 	Checkpoint      json.RawMessage // Persistent checkpoint state between captures
 	DiscoveryFilter *regexp.Regexp  // Filter for discovered bindings (nil = no filtering)
 	Logger          func(...any)    // Log function (defaults to stderr, set to t.Log in tests)
+
+	// Timeout bounds a single capture run, and is enforced by the harness rather
+	// than by flowctl. Exceeding it is an error. Zero means the default.
+	Timeout time.Duration
 
 	// Env holds environment variables applied to each flowctl invocation, and so inherited
 	// by the connector process flowctl spawns. Settings which alter connector behavior have
@@ -170,12 +175,54 @@ func (c *Capture) writeCatalog() (catalogFile, catalogDir string, err error) {
 	if err != nil {
 		return "", "", fmt.Errorf("creating temp directory: %w", err)
 	}
+	catalog, err := withLockstepTransactions(c.Catalog)
+	if err != nil {
+		os.RemoveAll(catalogDir)
+		return "", "", err
+	}
 	catalogFile = catalogDir + "/flow.json"
-	if err := os.WriteFile(catalogFile, c.Catalog, 0644); err != nil {
+	if err := os.WriteFile(catalogFile, catalog, 0644); err != nil {
 		os.RemoveAll(catalogDir)
 		return "", "", fmt.Errorf("writing catalog: %w", err)
 	}
 	return catalogFile, catalogDir, nil
+}
+
+// withLockstepTransactions returns the catalog with every capture's transaction
+// duration window collapsed, so that each connector checkpoint sequence commits
+// as exactly one runtime transaction.
+//
+// The runtime otherwise batches checkpoints into larger transactions, which
+// emits documents in collection-key order rather than connector-emission order,
+// and reduces repeated changes to a key into a single document.
+func withLockstepTransactions(catalog json.RawMessage) (json.RawMessage, error) {
+	var parsed map[string]any
+	if err := json.Unmarshal(catalog, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing catalog: %w", err)
+	}
+	captures, ok := parsed["captures"].(map[string]any)
+	if !ok {
+		return catalog, nil // No captures to pin, so nothing to do.
+	}
+	for name, spec := range captures {
+		capture, ok := spec.(map[string]any)
+		if !ok {
+			continue
+		}
+		shards, ok := capture["shards"].(map[string]any)
+		if !ok {
+			shards = make(map[string]any)
+			capture["shards"] = shards
+		}
+		shards["minTxnDuration"] = "0s"
+		shards["maxTxnDuration"] = "1ns"
+		captures[name] = capture
+	}
+	result, err := json.Marshal(parsed)
+	if err != nil {
+		return nil, fmt.Errorf("encoding catalog: %w", err)
+	}
+	return result, nil
 }
 
 func (c *Capture) Spec() (json.RawMessage, error) {
@@ -292,7 +339,7 @@ func (c *Capture) Discover() (json.RawMessage, error) {
 					}
 					// Sort filtered bindings by target name. Sometimes `flowctl raw discover`
 					// will yield bindings in different orders, and that seems to influence the
-					// ordering of `flowctl preview` documents within a single transaction, so
+					// ordering of `flowctl raw preview-next` documents within a single transaction, so
 					// sorting by name here improves test stability.
 					sort.Slice(filtered, func(i, j int) bool {
 						return filtered[i]["target"].(string) < filtered[j]["target"].(string)
@@ -328,6 +375,18 @@ func (c *Capture) Discover() (json.RawMessage, error) {
 	return c.Catalog, nil
 }
 
+// defaultRunTimeout bounds a capture run which never ends on its own. A deadline
+// can only truncate a capture mid-stream, so it's set far longer than any test's
+// expected runtime.
+const defaultRunTimeout = 2 * time.Minute
+
+func (c *Capture) timeout() time.Duration {
+	if c.Timeout != 0 {
+		return c.Timeout
+	}
+	return defaultRunTimeout
+}
+
 func (c *Capture) Run(sessions int) ([]byte, error) {
 	return c.RunWithContext(context.Background(), sessions)
 }
@@ -342,11 +401,16 @@ func (c *Capture) RunWithContext(ctx context.Context, sessions int) ([]byte, err
 	}
 	defer os.RemoveAll(tempdir)
 
-	fc, err := c.startFlowctl(ctx, "preview",
+	// The run is bounded here rather than with preview-next's --timeout, which
+	// stops the capture gracefully: flowctl would exit zero having dropped
+	// whatever it hadn't reached.
+	runCtx, cancelRun := context.WithTimeout(ctx, c.timeout())
+	defer cancelRun()
+
+	fc, err := c.startFlowctl(runCtx, "raw", "preview-next",
 		"--log-json",
 		"--source", path,
 		fmt.Sprintf("--sessions=%d", sessions),
-		"--timeout=30s",
 		"--output-state",
 		"--initial-state", string(c.Checkpoint),
 	)
@@ -409,10 +473,13 @@ func (c *Capture) RunWithContext(ctx context.Context, sessions int) ([]byte, err
 		return nil, fmt.Errorf("scanning output: %w", err)
 	}
 	if err := fc.Wait(); err != nil {
-		if fc.lastError != "" {
-			return nil, fmt.Errorf("flowctl preview failed:\n%s", fc.lastError)
+		if runCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("capture did not finish within %s", c.timeout())
 		}
-		return nil, fmt.Errorf("flowctl preview failed: %w", err)
+		if fc.lastError != "" {
+			return nil, fmt.Errorf("flowctl raw preview-next failed:\n%s", fc.lastError)
+		}
+		return nil, fmt.Errorf("flowctl raw preview-next failed: %w", err)
 	}
 
 	return documents, nil

--- a/go/capture/blackbox/capture_test.go
+++ b/go/capture/blackbox/capture_test.go
@@ -71,3 +71,40 @@ func TestInvalidConfig(t *testing.T) {
 	tc.Run("With Invalid Config", 1)
 	cupaloy.SnapshotT(t, tc.Transcript.String())
 }
+
+// TestLockstepTransactions covers the catalog rewrite which every capture
+// snapshot in this repository depends upon.
+func TestLockstepTransactions(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		catalog string
+		expect  string
+	}{
+		{
+			name:    "adds shards when absent",
+			catalog: `{"captures":{"acmeCo/test":{"bindings":[]}}}`,
+			expect:  `{"captures":{"acmeCo/test":{"bindings":[],"shards":{"minTxnDuration":"0s","maxTxnDuration":"1ns"}}}}`,
+		},
+		{
+			name:    "preserves other shard settings",
+			catalog: `{"captures":{"acmeCo/test":{"shards":{"logLevel":"debug"}}}}`,
+			expect:  `{"captures":{"acmeCo/test":{"shards":{"logLevel":"debug","minTxnDuration":"0s","maxTxnDuration":"1ns"}}}}`,
+		},
+		{
+			name:    "applies to every capture",
+			catalog: `{"captures":{"acmeCo/a":{},"acmeCo/b":{}}}`,
+			expect:  `{"captures":{"acmeCo/a":{"shards":{"minTxnDuration":"0s","maxTxnDuration":"1ns"}},"acmeCo/b":{"shards":{"minTxnDuration":"0s","maxTxnDuration":"1ns"}}}}`,
+		},
+		{
+			name:    "leaves a catalog without captures alone",
+			catalog: `{"collections":{"acmeCo/c":{}}}`,
+			expect:  `{"collections":{"acmeCo/c":{}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := withLockstepTransactions([]byte(tc.catalog))
+			require.NoError(t, err)
+			require.JSONEq(t, tc.expect, string(result))
+		})
+	}
+}

--- a/source-mysql/README.md
+++ b/source-mysql/README.md
@@ -73,7 +73,7 @@ captures:
     bindings: []
 EOF
 $ flowctl raw discover --source acmeCo/flow.yaml
-$ flowctl preview --source acmeCo/flow.yaml
+$ flowctl raw preview-next --source acmeCo/flow.yaml
 ```
 
 It's usually not necessary to build a Docker image locally, but you can with:

--- a/source-postgres-batch/README.md
+++ b/source-postgres-batch/README.md
@@ -34,7 +34,7 @@ env UPDATE_SNAPSHOTS=1 go test -timeout=10m ./source-postgres-batch
 
 ### Flowctl Preview
 
-You can run the connector under `flowctl preview` and `flowctl raw discover`
+You can run the connector under `flowctl raw preview-next` and `flowctl raw discover`
 without building a Docker image:
 
 ```bash
@@ -54,5 +54,5 @@ captures:
 EOF
 
 flowctl raw discover --source acmeCo/flow.yaml
-flowctl preview --source acmeCo/flow.yaml
+flowctl raw preview-next --source acmeCo/flow.yaml
 ```

--- a/source-postgres/.snapshots/TestCaptureAfterSlotDropped
+++ b/source-postgres/.snapshots/TestCaptureAfterSlotDropped
@@ -54,12 +54,12 @@ sql> INSERT INTO test.captureafterslotdropped_144833 VALUES (2, 'two'), (3, 'thr
 sql> SELECT pg_drop_replication_slot('flow_slot')
 sql> INSERT INTO test.captureafterslotdropped_144833 VALUES (4, 'four'), (5, 'five')
 === Run: Capture After Slot Dropped (Should Fail) ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error starting replication: ERROR: replication slot "flow_slot" does not exist (SQLSTATE 42704)
 
 sql> INSERT INTO test.captureafterslotdropped_144833 VALUES (6, 'six'), (7, 'seven')
 === Run: Capture Still Failing ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error starting replication: ERROR: replication slot "flow_slot" does not exist (SQLSTATE 42704)
 
 === Run: Capture After Backfill Counter Bumped ===

--- a/source-postgres/.snapshots/TestMissingTable
+++ b/source-postgres/.snapshots/TestMissingTable
@@ -5,7 +5,7 @@ acmeCo/test_capture/test/missingtable_551059_a
 acmeCo/test_capture/test/missingtable_551059_b
 sql> DROP TABLE test.missingtable_551059_b
 === Run: Capture ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - user "flow_capture" cannot read from table "test.missingtable_551059_b"
 

--- a/source-postgres/.snapshots/TestPrerequisites
+++ b/source-postgres/.snapshots/TestPrerequisites
@@ -70,7 +70,7 @@ acmeCo/test_capture/test/prerequisites_944868_c
 }
 sql> DROP TABLE test.prerequisites_944868_c
 === Run: Capture A+B+C (Table C Dropped) ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - user "flow_capture" cannot read from table "test.prerequisites_944868_c"
 

--- a/source-sqlserver-ct/.snapshots/TestBackfillWithoutKey
+++ b/source-sqlserver-ct/.snapshots/TestBackfillWithoutKey
@@ -3,12 +3,12 @@ sql> INSERT INTO dbo.BackfillWithoutKey_571434 VALUES (0, 'A'), (1, 'bbb'), (2, 
 === Discover: Discover Tables ===
 acmeCo/test_capture/dbo/backfillwithoutkey_571434
 === Run: Backfill ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error initializing pending streams: error activating replication for table "dbo.backfillwithoutkey_571434": configured primary key [] does not match the table's current primary key ["id"]; Change Tracking requires matching keys
 
 sql> INSERT INTO dbo.BackfillWithoutKey_571434 VALUES (3, 'more'), (4, 'data')
 === Run: Replication ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error initializing pending streams: error activating replication for table "dbo.backfillwithoutkey_571434": configured primary key [] does not match the table's current primary key ["id"]; Change Tracking requires matching keys
 
 

--- a/source-sqlserver-ct/.snapshots/TestBasics-MissingTable
+++ b/source-sqlserver-ct/.snapshots/TestBasics-MissingTable
@@ -5,7 +5,7 @@ acmeCo/test_capture/dbo/basics_missingtable_199221_a
 acmeCo/test_capture/dbo/basics_missingtable_199221_b
 sql> DROP TABLE dbo.Basics_MissingTable_199221_b
 === Run: Capture ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - table "dbo.basics_missingtable_199221_b" does not exist
 

--- a/source-sqlserver-ct/.snapshots/TestBasics-PrimaryKeyOverride
+++ b/source-sqlserver-ct/.snapshots/TestBasics-PrimaryKeyOverride
@@ -3,12 +3,12 @@ sql> INSERT INTO dbo.Basics_PrimaryKeyOverride_836524 VALUES (1, 'charlie', 100)
 === Discover: Discover Tables ===
 acmeCo/test_capture/dbo/basics_primarykeyoverride_836524
 === Run: Backfill ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error initializing pending streams: error activating replication for table "dbo.basics_primarykeyoverride_836524": configured primary key ["name"] does not match the table's current primary key ["id"]; Change Tracking requires matching keys
 
 sql> INSERT INTO dbo.Basics_PrimaryKeyOverride_836524 VALUES (3, 'bob', 300), (4, 'dave', 400)
 === Run: Replication ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 error initializing pending streams: error activating replication for table "dbo.basics_primarykeyoverride_836524": configured primary key ["name"] does not match the table's current primary key ["id"]; Change Tracking requires matching keys
 
 

--- a/source-sqlserver-ct/.snapshots/TestChangeTrackingDisabled
+++ b/source-sqlserver-ct/.snapshots/TestChangeTrackingDisabled
@@ -129,7 +129,7 @@ sql> INSERT INTO dbo.ChangeTrackingDisabled_568912 VALUES (3, 'three'), (4, 'fou
 }
 sql> ALTER TABLE dbo.ChangeTrackingDisabled_568912 DISABLE CHANGE_TRACKING
 === Run: After CT Disabled ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - Change Tracking is not enabled for table "dbo.changetrackingdisabled_568912" and user "flow_capture" cannot enable it
 

--- a/source-sqlserver-ct/.snapshots/TestPrerequisites-captureMissingTable
+++ b/source-sqlserver-ct/.snapshots/TestPrerequisites-captureMissingTable
@@ -6,7 +6,7 @@ acmeCo/test_capture/dbo/prerequisites_capturemissingtable_597017_a
 acmeCo/test_capture/dbo/prerequisites_capturemissingtable_597017_b
 sql> DROP TABLE dbo.Prerequisites_captureMissingTable_597017_b
 === Run: Capture With Missing Table ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - table "dbo.prerequisites_capturemissingtable_597017_b" does not exist
 

--- a/source-sqlserver/.snapshots/TestBasics-MissingTable
+++ b/source-sqlserver/.snapshots/TestBasics-MissingTable
@@ -5,7 +5,7 @@ acmeCo/test_capture/dbo/basics_missingtable_199221_a
 acmeCo/test_capture/dbo/basics_missingtable_199221_b
 sql> DROP TABLE dbo.Basics_MissingTable_199221_b
 === Run: Capture ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - table "dbo.basics_missingtable_199221_b" has no capture instances and user "flow_capture" cannot create one
 

--- a/source-sqlserver/.snapshots/TestCaptureInstanceCleanup-WithoutDBO
+++ b/source-sqlserver/.snapshots/TestCaptureInstanceCleanup-WithoutDBO
@@ -2,7 +2,7 @@ sql> CREATE TABLE dbo.CaptureInstanceCleanup_WithoutDBO_648852 (id INTEGER PRIMA
 === Discover: Discover Tables ===
 acmeCo/test_capture/dbo/captureinstancecleanup_withoutdbo_648852
 === Run: Initial Backfill ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - user "flow_capture" does not have the "db_owner" role which is required for automatic change table cleanup
 

--- a/source-sqlserver/.snapshots/TestPrerequisites-captureMissingTable
+++ b/source-sqlserver/.snapshots/TestPrerequisites-captureMissingTable
@@ -6,7 +6,7 @@ acmeCo/test_capture/dbo/prerequisites_capturemissingtable_597017_a
 acmeCo/test_capture/dbo/prerequisites_capturemissingtable_597017_b
 sql> DROP TABLE dbo.Prerequisites_captureMissingTable_597017_b
 === Run: Capture With Missing Table ===
-error: flowctl preview failed:
+error: flowctl raw preview-next failed:
 the capture cannot run due to the following error(s):
  - table "dbo.prerequisites_capturemissingtable_597017_b" has no capture instances and user "flow_capture" cannot create one
 

--- a/source-sqs/BENCHMARKS.md
+++ b/source-sqs/BENCHMARKS.md
@@ -63,7 +63,7 @@ All five were run during development.
 |---|---|---|
 | 1. Go test suite (CI) | connector code, LocalStack SQS | correctness, FIFO semantics |
 | 2. Local stress tests | full `Pull` pipeline, LocalStack | relative regressions, CPU profiles |
-| 3. `flowctl preview` | runtime protocol machinery | protocol correctness end-to-end |
+| 3. `flowctl raw preview-next` | runtime protocol machinery | protocol correctness end-to-end |
 | 4. mise stack + LocalStack | real recovery log + journals | commit+ack latency, per-shard ingest |
 | 5. EC2 + real AWS SQS | real SQS | absolute receive+delete rate |
 
@@ -205,7 +205,7 @@ high-throughput mode enabled, since the default FIFO quota caps at 3,000
 msg/sec, and `STRESS_GROUPS` in the hundreds, or the run measures group
 locking rather than capacity. Expected ceiling ≈ `groups × 10 / round-trip`.
 
-### flowctl preview smoke test (tier 3)
+### flowctl raw preview-next smoke test (tier 3)
 
 Cheap to re-run after connector changes:
 
@@ -217,7 +217,7 @@ STRESS_TEST=yes TEST_DATABASE=yes STRESS_MESSAGES=50000 \
   STRESS_QUEUE_URL=http://localhost.localstack.cloud:4566/000000000000/preview-stress \
   go test ./source-sqs/ -v -run TestStressSeed
 
-flowctl preview --source sqs-preview.flow.yaml --network flow-test --log-json \
+flowctl raw preview-next --source sqs-preview.flow.yaml --network flow-test --log-json \
   > preview-docs.jsonl 2> preview-logs.jsonl
 ```
 

--- a/source-stripe-native/CLAUDE.md
+++ b/source-stripe-native/CLAUDE.md
@@ -17,7 +17,7 @@ catalog and `source_stripe_native/resources.py` for binding wiring.
   for lock timeouts.
 
 All buckets are well above the 20 req/hr threshold that triggers the add-stream
-skill's budget rule, so `flowctl preview`, `pytest`, and live captures can run
+skill's budget rule, so `flowctl raw preview-next`, `pytest`, and live captures can run
 freely without per-call consent (subject to `config.yaml` being clean — Law #4).
 
 ## Silent-default-filter audit (as of 2026-06-01)


### PR DESCRIPTION
**Description:**

Switches the Go capture blackbox harness from `flowctl preview` to `flowctl raw
preview-next`, so Go captures run against the V2 runtime. All of the code change
is in `go/capture/blackbox/capture.go`; every Go capture suite picks it up.

Two things are needed beyond swapping the command:

- **Lockstep transactions.** V2 runs the production transaction-close policy, so
  a capture emitting N checkpoints yields anywhere from 1 to N transactions.
  Batching corrupts snapshots two ways: documents in one transaction are emitted
  in collection-key order rather than emission order, and two changes to the same
  key reduce to one document. `withLockstepTransactions` rewrites the catalog on
  the way out, injecting `shards.maxTxnDuration: 1ns` into every capture, which
  admits exactly one checkpoint sequence per transaction — matching what V1's
  harness did by construction. (Not `0`, which livelocks the leader;
  `minTxnDuration` stays unset because the build clamps `max` up to `min`, and
  `--delay` is incompatible for the same reason.)
- **Timeout moved into the harness.** `--timeout=30s` is no longer passed.
  V1 read it as an idle bound; V2 reads it as wall-clock from process start and
  stops *gracefully*, so flowctl would exit 0 having silently dropped whatever it
  hadn't reached. The bound is now a context deadline in `RunWithContext`
  (default 2m, reachable only by a genuine hang) and overrunning it is an error.

Snapshot changes are limited to 15 lines across 12 files, all of them the
harness's own error prefix (`flowctl preview failed:` →
`flowctl raw preview-next failed:`), isolated in 25cb4d57a. No test expectations
change. Remaining commit updates prose in four READMEs that told contributors to
run `flowctl preview` directly.

New `TestLockstepTransactions` covers the catalog rewrite — nothing else asserts
it applies, and every snapshot in the repo depends on it.

**Notes for reviewers:**

Only the truncation coupling fails loudly. If `maxTxnDuration` doesn't take
effect, ordering and reduction regressions regenerate into green, meaningless
tests — a batched `TestReplicationUpdates` would silently drop the insert and
assert only the final state. So this is verified by diffing against committed
V1-era snapshots, not by refreshing them; `UPDATE_SNAPSHOTS` was never set.

- `source-postgres`: 3/3 full-suite passes with snapshots frozen, zero failures.
  All 108 transcript snapshots byte-identical.
- `source-sqlserver`, `source-sqlserver-ct`, `source-ga4-bigquery`: **unverified
  locally.** A failure showing added, removed or reordered fixture records means
  `maxTxnDuration` isn't taking effect there — stop and investigate, don't
  refresh.

Built against flowctl `v0.6.13-48-g964f4b438dc`, which includes `d61eeef3798`
(estuary/flow#3356) — that commit changed error text on both paths, so baselines
taken before it are stale.

Deciding which tests *should* exercise V2's batching is out of scope. Follow-on:
add a per-test opt-*out* back to the production close policy (with a positive
`--sessions` count invalid when opted out) and move tests off lockstep one at a
time.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: n/a
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated — n/a, test-harness only
- [ ] If there are user-facing behavior changes, documentation has been updated — n/a, no connector behavior changes
