### PR TITLE
source-mongodb: don't checkpoint a mid-split resume token

### DIFF
--- a/source-mongodb/CHANGELOG.md
+++ b/source-mongodb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-26
+
+### Fixed
+
+- Captures of databases with pre-images enabled no longer fail permanently with
+  `received fragment N without first fragment`. MongoDB delivers change events
+  larger than 16MB as a series of fragments, and the connector could checkpoint
+  a resume token pointing partway through one of them. Restarting from that
+  position delivers only the remaining fragments, which cannot be reassembled
+  into the original event, so every subsequent restart failed the same way.
+  Resume tokens are now only checkpointed at a position between whole events.
+
 ## 2026-08-17
 
 ### Fixed

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -577,3 +577,26 @@ func extractTimestamp(token bson.Raw) (primitive.Timestamp, error) {
 
 	return primitive.Timestamp{T: timestampSeconds, I: increment}, nil
 }
+
+// isMidSplitEvent reports whether a change event is a non-final fragment of an
+// event split by $changeStreamSplitLargeEvent. A resume token for such an event
+// must never be checkpointed: resuming from a fragment's token delivers the
+// *next* fragment, and the fragments already consumed live only in the
+// transcoder's memory, which does not survive a restart.
+//
+// An event carrying a splitEvent which cannot be read is reported as mid-split.
+// The two outcomes are not symmetric: suppressing a checkpoint costs nothing
+// more than a delayed resume token, while checkpointing a fragment position
+// wedges the capture in a way it cannot recover from on its own.
+func isMidSplitEvent(raw bson.Raw) bool {
+	if _, err := raw.LookupErr("splitEvent"); err != nil {
+		return false
+	}
+
+	fragment, fragmentOk := raw.Lookup("splitEvent", "fragment").Int32OK()
+	of, ofOk := raw.Lookup("splitEvent", "of").Int32OK()
+	if !fragmentOk || !ofOk {
+		return true
+	}
+	return fragment < of
+}

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -29,6 +29,10 @@ type changeStream struct {
 	ms                 *mongo.ChangeStream
 	db                 string
 	lastPbrtCheckpoint time.Time
+	// midSplit is true when the last event consumed from this stream was a
+	// non-final fragment of a split event, meaning the stream's current
+	// position is not a safe place to checkpoint.
+	midSplit bool
 }
 
 type streamEvent struct {
@@ -370,9 +374,10 @@ type processedEvent struct {
 }
 
 // handleIdleBatch processes an empty batch (idle signal), emitting a PBRT checkpoint
-// if enough time has passed. Returns the opTime extracted from the resume token.
+// if enough time has passed and the stream is not parked mid-split. Returns the
+// opTime extracted from the resume token.
 func (c *capture) handleIdleBatch(s *changeStream, token bson.Raw) (primitive.Timestamp, error) {
-	if time.Since(s.lastPbrtCheckpoint) > pbrtCheckpointInterval {
+	if !s.midSplit && time.Since(s.lastPbrtCheckpoint) > pbrtCheckpointInterval {
 		if err := c.emitPbrtCheckpoint(s, token); err != nil {
 			return primitive.Timestamp{}, err
 		}
@@ -421,6 +426,8 @@ func (c *capture) processBatch(
 
 	for i, resp := range responses {
 		ev := batch.events[i]
+
+		s.midSplit = isMidSplitEvent(ev.raw)
 
 		c.mu.Lock()
 		c.processedStreamEvents++
@@ -502,7 +509,7 @@ func (c *capture) processBatch(
 			c.lastEventClusterTime[s.db] = lastOpTime
 		}
 		c.mu.Unlock()
-	} else if time.Since(s.lastPbrtCheckpoint) > pbrtCheckpointInterval {
+	} else if !s.midSplit && time.Since(s.lastPbrtCheckpoint) > pbrtCheckpointInterval {
 		// No documents emitted, but we can still emit a PBRT checkpoint
 		lastEvent := batch.events[len(batch.events)-1]
 		if err := c.emitPbrtCheckpoint(s, lastEvent.resumeToken); err != nil {

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -31,7 +31,9 @@ type changeStream struct {
 	lastPbrtCheckpoint time.Time
 	// midSplit is true when the last event consumed from this stream was a
 	// non-final fragment of a split event, meaning the stream's current
-	// position is not a safe place to checkpoint.
+	// position is not a safe place to checkpoint. Checkpoints are suppressed
+	// for as long as it is set. The fragments of one event are delivered back
+	// to back, so that is only ever briefly.
 	midSplit bool
 }
 
@@ -202,7 +204,7 @@ func (c *capture) streamChanges(
 					return fmt.Errorf("processing batch for %q: %w", s.db, err)
 				}
 
-				if coordinator.gotCaughtUp(s.db, opTime) && catchup {
+				if !s.midSplit && coordinator.gotCaughtUp(s.db, opTime) && catchup {
 					cancelProducer()
 					<-producerDone
 					return nil

--- a/source-mongodb/change_stream.go
+++ b/source-mongodb/change_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 
 	m "github.com/estuary/connectors/go/materialize"
@@ -26,6 +27,10 @@ var (
 )
 
 type changeStream struct {
+	// mu guards ms, which the producer goroutine replaces when it repositions
+	// the stream, while the consumer goroutine may be closing it. Every other
+	// access to ms is from the producer alone and needs no lock.
+	mu                 sync.Mutex
 	ms                 *mongo.ChangeStream
 	db                 string
 	lastPbrtCheckpoint time.Time
@@ -35,6 +40,9 @@ type changeStream struct {
 	// for as long as it is set. The fragments of one event are delivered back
 	// to back, so that is only ever briefly.
 	midSplit bool
+	// reopenAt reopens this stream at a cluster time, used to reposition a
+	// stream which resumed partway through a split event.
+	reopenAt func(ctx context.Context, at primitive.Timestamp) (*mongo.ChangeStream, error)
 }
 
 type streamEvent struct {
@@ -117,14 +125,21 @@ func (c *capture) initializeStreams(
 			logEntry.Info("using fullDocument 'whenAvailable' mode (changeStreamPreAndPostImages enabled on all collections)")
 			fullDocOpt = options.WhenAvailable
 		}
-		opts := options.ChangeStream().SetFullDocument(fullDocOpt)
-		if maxAwaitTime != nil {
-			opts = opts.SetMaxAwaitTime(*maxAwaitTime)
+		baseOpts := func() *options.ChangeStreamOptions {
+			opts := options.ChangeStream().SetFullDocument(fullDocOpt)
+			if maxAwaitTime != nil {
+				opts = opts.SetMaxAwaitTime(*maxAwaitTime)
+			}
+			if requestPreImages {
+				opts = opts.SetFullDocumentBeforeChange(options.WhenAvailable)
+			}
+			return opts
 		}
+
 		if requestPreImages {
-			opts = opts.SetFullDocumentBeforeChange(options.WhenAvailable)
 			pl = append(pl, bson.D{{Key: "$changeStreamSplitLargeEvent", Value: bson.D{}}}) // must be the last stage in the pipeline
 		}
+		opts := baseOpts()
 
 		if t, ok := c.state.DatabaseResumeTokens[db]; ok {
 			logEntry = logEntry.WithField("resumeToken", t)
@@ -145,6 +160,12 @@ func (c *capture) initializeStreams(
 		out = append(out, &changeStream{
 			ms: ms,
 			db: db,
+			// Reopening uses the same pipeline and options, so a repositioned
+			// stream delivers events exactly as the original would have,
+			// pre-images included.
+			reopenAt: func(ctx context.Context, at primitive.Timestamp) (*mongo.ChangeStream, error) {
+				return c.client.Database(db).Watch(ctx, pl, baseOpts().SetStartAtOperationTime(&at))
+			},
 		})
 	}
 
@@ -179,7 +200,7 @@ func (c *capture) streamChanges(
 
 	for _, s := range streams {
 		group.Go(func() error {
-			defer s.ms.Close(groupCtx)
+			defer s.closeStream(groupCtx)
 
 			// Channel for batches with buffer size 4. This allows prefetching up to 4
 			// MongoDB batches while the consumer processes.
@@ -285,6 +306,79 @@ func (c *capture) streamChanges(
 	}
 }
 
+// rewindToSplitEvent repositions a stream which resumed partway through a split
+// event back to the event itself, so that MongoDB delivers it whole. It reports
+// whether the stream was repositioned, and errors if it should not continue.
+//
+// Every fragment carries the cluster time of the event it belongs to, so a
+// fragment which arrives without the ones before it names the position to
+// return to. The event itself is never captured twice: fragments emit no
+// document until the last one arrives, so an event interrupted partway was
+// never emitted, and neither was anything after it.
+//
+// Events sharing that cluster time are re-delivered, since a position is only
+// precise to a timestamp and its increment: the other writes of a transaction
+// or of a batched insert are captured again. Documents reduce last-write-wins,
+// so re-capturing one already captured is absorbed.
+//
+// A reopen which fails, for any reason, fails the capture. Fragments are only
+// ever delivered from an oplog entry which still exists, so if the oplog has
+// moved past the event the capture fails on resume before a fragment arrives,
+// as it does for any other position the oplog no longer reaches. A failure here
+// is therefore transient, and a restart re-runs this recovery from the same
+// checkpoint. Skipping the event instead would be silent data loss.
+//
+// This rewindToSplitEvent functionality should only be needed for recovery of
+// a capture that checkpointed a mid-split resume token prior to that being
+// prevented. Once that recovery is completed, we could remove all this handling
+// since the situation it addresses will no longer be possible.
+func (c *capture) rewindToSplitEvent(ctx context.Context, s *changeStream) (bool, error) {
+	if s.reopenAt == nil {
+		return false, nil
+	}
+
+	at, err := extractTimestamp(getToken(s))
+	if err != nil {
+		return false, fmt.Errorf("reading the cluster time of a split event which resumed partway through, for %q: %w", s.db, err)
+	}
+
+	ms, err := s.reopenAt(ctx, at)
+	if err != nil {
+		return false, fmt.Errorf("repositioning change stream for %q to recover a split event: %w", s.db, err)
+	}
+
+	if previous := s.replaceStream(ms); previous != nil {
+		if err := previous.Close(ctx); err != nil {
+			log.WithField("db", s.db).WithError(err).Debug("error closing change stream which was repositioned")
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"db":          s.db,
+		"clusterTime": at,
+	}).Info("repositioned change stream to recover a split event it had resumed partway through")
+
+	return true, nil
+}
+
+// closeStream closes the stream's current cursor. This is the only access to ms
+// from outside the producer goroutine.
+func (s *changeStream) closeStream(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ms.Close(ctx)
+}
+
+// replaceStream swaps in a repositioned cursor, returning the one it replaced
+// so the caller can close it.
+func (s *changeStream) replaceStream(ms *mongo.ChangeStream) *mongo.ChangeStream {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.ms
+	s.ms = ms
+	return previous
+}
+
 func getToken(s *changeStream) bson.Raw {
 	tok := s.ms.ResumeToken()
 	if tok == nil {
@@ -307,6 +401,13 @@ func (c *capture) produceStreamBatches(
 ) {
 	defer close(batches)
 
+	// A stream which resumed from a position partway through a split event
+	// delivers that event's remaining fragments first, and they cannot be
+	// reassembled without the fragments which preceded them. Only the first
+	// event read after opening can be affected.
+	var checkedResumePosition bool
+
+outer:
 	for {
 		var events []streamEvent
 		var batchBytes int64
@@ -316,6 +417,22 @@ func (c *capture) produceStreamBatches(
 		// to exactly one MongoDB cursor batch.
 		readStart := time.Now()
 		for s.ms.TryNext(ctx) {
+			if !checkedResumePosition {
+				checkedResumePosition = true
+				if fragment, _, ok := splitEventFragment(s.ms.Current); ok && fragment > 1 {
+					rewound, err := c.rewindToSplitEvent(ctx, s)
+					if err != nil {
+						select {
+						case batches <- streamBatch{err: err}:
+						case <-ctx.Done():
+						}
+						return
+					} else if rewound {
+						continue outer
+					}
+				}
+			}
+
 			rawCopy := make(bson.Raw, len(s.ms.Current))
 			copy(rawCopy, s.ms.Current)
 			batchBytes += int64(len(rawCopy))
@@ -602,10 +719,21 @@ func isMidSplitEvent(raw bson.Raw) bool {
 		return false
 	}
 
-	fragment, fragmentOk := raw.Lookup("splitEvent", "fragment").Int32OK()
-	of, ofOk := raw.Lookup("splitEvent", "of").Int32OK()
-	if !fragmentOk || !ofOk {
+	fragment, of, ok := splitEventFragment(raw)
+	if !ok {
 		return true
 	}
 	return fragment < of
+}
+
+// splitEventFragment reports an event's position within an event split by
+// $changeStreamSplitLargeEvent. ok is false when the event is not a fragment,
+// and also when it carries a splitEvent which cannot be read.
+func splitEventFragment(raw bson.Raw) (fragment int32, of int32, ok bool) {
+	fragment, fragmentOk := raw.Lookup("splitEvent", "fragment").Int32OK()
+	of, ofOk := raw.Lookup("splitEvent", "of").Int32OK()
+	if !fragmentOk || !ofOk {
+		return 0, 0, false
+	}
+	return fragment, of, true
 }

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"google.golang.org/grpc/metadata"
 )
@@ -296,6 +297,7 @@ var _ pc.Connector_CaptureServer = (*testServer)(nil)
 
 type testServer struct {
 	sent []string
+	docs []json.RawMessage
 }
 
 func (t *testServer) Send(m *pc.Response) error {
@@ -311,6 +313,7 @@ func (t *testServer) Send(m *pc.Response) error {
 			return err
 		}
 		t.sent = append(t.sent, c.Id)
+		t.docs = append(t.docs, m.Captured.DocJson)
 	} else {
 		panic(fmt.Sprintf("unhandled message: %v", m))
 	}
@@ -544,4 +547,207 @@ collect:
 		require.False(t, checkpointedTokens[tok],
 			"checkpointed a resume token for a non-final fragment of a split event")
 	}
+}
+
+// TestSplitEventResumedPartway reproduces a capture resuming from a checkpoint
+// taken partway through a split event, which is the state a capture wedged
+// itself in before mid-split positions stopped being checkpointed. The event's
+// remaining fragments cannot be reassembled by a transcoder which never saw the
+// first one, so the stream is repositioned to the event itself and captures it
+// whole. A reopen which fails, for any reason, fails the capture rather than
+// skipping the event.
+func TestSplitEventResumedPartway(t *testing.T) {
+	ctx := context.Background()
+	client, _ := testClient(t)
+
+	testDb := "testDb"
+	testColl1 := "testColl1"
+
+	prevInterval := pbrtCheckpointInterval
+	pbrtCheckpointInterval = 0
+	t.Cleanup(func() { pbrtCheckpointInterval = prevInterval })
+
+	require.NoError(t, client.Database(testDb).Drop(ctx))
+	t.Cleanup(func() { require.NoError(t, client.Database(testDb).Drop(ctx)) })
+
+	bindings := []bindingInfo{
+		{resource: resource{Database: testDb, Collection: testColl1}, index: 0},
+	}
+
+	newCapture := func(srv *testServer, tokens map[string]bson.Raw) capture {
+		transcoder, err := NewTranscoder(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { transcoder.Stop() })
+
+		return capture{
+			client:     client,
+			output:     &boilerplate.PullOutput{Connector_CaptureServer: srv},
+			transcoder: transcoder,
+			trackedChangeStreamBindings: map[string]bindingInfo{
+				resourceId(testDb, testColl1): bindings[0],
+			},
+			fullDocRequired:      map[string]bool{},
+			state:                captureState{DatabaseResumeTokens: tokens},
+			lastEventClusterTime: map[string]primitive.Timestamp{},
+		}
+	}
+
+	// Collects batches from a stream until stop says to finish, or the deadline
+	// passes. produceStreamBatches never closes its channel, so a deadline is
+	// what keeps a stream which does not split from hanging the package.
+	collect := func(c *capture, stream *changeStream, stop func(streamBatch) bool) error {
+		batches := make(chan streamBatch, 4)
+		producerCtx, cancelProducer := context.WithCancel(ctx)
+		producerDone := make(chan struct{})
+		go func() {
+			defer close(producerDone)
+			c.produceStreamBatches(producerCtx, stream, batches)
+		}()
+		defer func() {
+			cancelProducer()
+			<-producerDone
+		}()
+
+		deadline, cancelDeadline := context.WithTimeout(ctx, 60*time.Second)
+		defer cancelDeadline()
+
+		for {
+			select {
+			case batch := <-batches:
+				if batch.err != nil {
+					return batch.err
+				}
+				if stop(batch) {
+					return nil
+				}
+			case <-deadline.Done():
+				return nil
+			}
+		}
+	}
+
+	require.NoError(t, client.Database(testDb).CreateCollection(ctx, testColl1,
+		&options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
+
+	// Observe a split event, and remember the resume token of its first
+	// fragment: that is the poisoned position a capture could previously
+	// persist. Events are only inspected here, never transcoded.
+	observer := newCapture(&testServer{}, map[string]bson.Raw{})
+	streams, err := observer.initializeStreams(ctx, bindings, nil, true, true, false, map[string][]string{}, map[string]bool{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(streams))
+
+	val := map[string]string{"_id": "hugeDocument"}
+	for i := 1; i <= 9; i++ {
+		val[fmt.Sprintf("key%d", i)] = strings.Repeat(fmt.Sprintf("value%d", i), 200000)
+	}
+	_, err = client.Database(testDb).Collection(testColl1).InsertOne(ctx, val)
+	require.NoError(t, err)
+
+	val["key1"] = "updated"
+	_, err = client.Database(testDb).Collection(testColl1).UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+
+	// Captured after the split event, and expected to survive either outcome.
+	_, err = client.Database(testDb).Collection(testColl1).InsertOne(ctx, bson.D{{Key: "_id", Value: "afterTheSplit"}})
+	require.NoError(t, err)
+
+	var firstFragmentToken bson.Raw
+	require.NoError(t, collect(&observer, streams[0], func(batch streamBatch) bool {
+		for _, ev := range batch.events {
+			fragment, of, ok := splitEventFragment(ev.raw)
+			if ok && fragment == 1 && of > 1 {
+				firstFragmentToken = ev.resumeToken
+				return true
+			}
+		}
+		return false
+	}))
+	require.NotNil(t, firstFragmentToken, "change stream never delivered a split event")
+
+	// resumePartway resumes from partway through that split event with a
+	// transcoder which has never seen its first fragment. A non-nil reopen
+	// replaces the stream's own, standing in for a reopen which fails.
+	resumePartway := func(t *testing.T, reopen func(context.Context, primitive.Timestamp) (*mongo.ChangeStream, error)) (*testServer, error) {
+		srv := &testServer{}
+		c := newCapture(srv, map[string]bson.Raw{testDb: firstFragmentToken})
+		resumed, err := c.initializeStreams(ctx, bindings, nil, true, true, false, map[string][]string{}, map[string]bool{})
+		require.NoError(t, err)
+		if reopen != nil {
+			resumed[0].reopenAt = reopen
+		}
+
+		collectErr := collect(&c, resumed[0], func(batch streamBatch) bool {
+			_, err := c.processBatch(ctx, resumed[0], batch)
+			require.NoError(t, err, "capture failed on a split event it could not reassemble")
+			return slices.Contains(srv.sent, "afterTheSplit")
+		})
+
+		return srv, collectErr
+	}
+
+	t.Run("repositioned to recover the event", func(t *testing.T) {
+		srv, err := resumePartway(t, nil)
+		require.NoError(t, err)
+		require.Contains(t, srv.sent, "hugeDocument", "the split event was not recovered")
+		require.Contains(t, srv.sent, "afterTheSplit", "capture did not carry on past the split event")
+
+		// The event must be recovered whole, not merely present. Its post-image
+		// carries the updated value, and its pre-image arrives in a later
+		// fragment, so finding both proves every fragment was reassembled.
+		type capturedDoc struct {
+			ID   string `json:"_id"`
+			Key1 string `json:"key1"`
+			Meta struct {
+				Op     string          `json:"op"`
+				Before json.RawMessage `json:"before"`
+			} `json:"_meta"`
+		}
+		var recovered capturedDoc
+		var found bool
+		for _, doc := range srv.docs {
+			// Declared per iteration: encoding/json leaves fields absent from
+			// the payload untouched, so a reused value could assert against a
+			// previous document.
+			var candidate capturedDoc
+			require.NoError(t, json.Unmarshal(doc, &candidate))
+			if candidate.ID == "hugeDocument" {
+				recovered, found = candidate, true
+				break
+			}
+		}
+		require.True(t, found, "no recovered document for the split event")
+		require.Equal(t, "u", recovered.Meta.Op)
+		require.Equal(t, "updated", recovered.Key1, "recovered document does not carry the post-image of the event")
+		require.NotEmpty(t, recovered.Meta.Before, "recovered document is missing the pre-image, which arrives in a later fragment")
+	})
+
+	t.Run("fails when the oplog no longer reaches the event", func(t *testing.T) {
+		// Skipping the event would be silent data loss. Failing is consistent
+		// with how any other position the oplog no longer reaches is handled.
+		historyLost := func(context.Context, primitive.Timestamp) (*mongo.ChangeStream, error) {
+			return nil, mongo.CommandError{Code: 286, Name: "ChangeStreamHistoryLost", Message: "Resume of change stream was not possible"}
+		}
+
+		srv, err := resumePartway(t, historyLost)
+		require.Error(t, err, "expected the capture to fail rather than skip the event")
+		require.Contains(t, err.Error(), "repositioning change stream")
+		require.NotContains(t, srv.sent, "hugeDocument")
+	})
+
+	t.Run("fails on a transient reopen error", func(t *testing.T) {
+		// Anything which is not the oplog having moved on is retryable, and a
+		// restart re-runs this recovery from the same checkpoint. Skipping here
+		// would discard a real change event over an election or a dropped
+		// connection.
+		notPrimary := func(context.Context, primitive.Timestamp) (*mongo.ChangeStream, error) {
+			return nil, mongo.CommandError{Code: 189, Message: "PrimarySteppedDown"}
+		}
+
+		srv, err := resumePartway(t, notPrimary)
+		require.Error(t, err, "expected the capture to fail rather than skip the event")
+		require.Contains(t, err.Error(), "repositioning change stream")
+		require.NotContains(t, srv.sent, "hugeDocument")
+	})
 }

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -334,3 +334,62 @@ func filterDocs(sent []string) []string {
 	}
 	return docs
 }
+
+func TestIsMidSplitEvent(t *testing.T) {
+	splitEvent := func(v any) bson.D {
+		return bson.D{
+			{Key: "operationType", Value: "update"},
+			{Key: "splitEvent", Value: v},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		event bson.D
+		want  bool
+	}{
+		{
+			name:  "not a split event",
+			event: bson.D{{Key: "operationType", Value: "insert"}},
+			want:  false,
+		},
+		{
+			name:  "first fragment of three",
+			event: splitEvent(bson.D{{Key: "fragment", Value: int32(1)}, {Key: "of", Value: int32(3)}}),
+			want:  true,
+		},
+		{
+			name:  "middle fragment of three",
+			event: splitEvent(bson.D{{Key: "fragment", Value: int32(2)}, {Key: "of", Value: int32(3)}}),
+			want:  true,
+		},
+		{
+			name:  "final fragment of three",
+			event: splitEvent(bson.D{{Key: "fragment", Value: int32(3)}, {Key: "of", Value: int32(3)}}),
+			want:  false,
+		},
+		{
+			name:  "single fragment is complete",
+			event: splitEvent(bson.D{{Key: "fragment", Value: int32(1)}, {Key: "of", Value: int32(1)}}),
+			want:  false,
+		},
+		{
+			name:  "unreadable splitEvent is treated as mid-split",
+			event: splitEvent("nonsense"),
+			want:  true,
+		},
+		{
+			name:  "splitEvent missing 'of' is treated as mid-split",
+			event: splitEvent(bson.D{{Key: "fragment", Value: int32(1)}}),
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := bson.Marshal(tt.event)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, isMidSplitEvent(bson.Raw(raw)))
+		})
+	}
+}

--- a/source-mongodb/change_stream_test.go
+++ b/source-mongodb/change_stream_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	boilerplate "github.com/estuary/connectors/source-boilerplate"
 	pc "github.com/estuary/flow/go/protocols/capture"
@@ -391,5 +392,156 @@ func TestIsMidSplitEvent(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.want, isMidSplitEvent(bson.Raw(raw)))
 		})
+	}
+}
+
+// TestSplitEventCheckpointSafety asserts the invariant that a resume token is
+// never checkpointed for a non-final fragment of a split event. Resuming from
+// such a token makes MongoDB deliver the *next* fragment, and the fragments
+// already consumed live only in the transcoder's memory, so a restart from that
+// position leaves the transcoder unable to reassemble the event.
+func TestSplitEventCheckpointSafety(t *testing.T) {
+	ctx := context.Background()
+	client, _ := testClient(t)
+
+	testDb := "testDb"
+	testColl1 := "testColl1"
+
+	// Force the PBRT checkpoint branch to be eligible on every batch, which is
+	// the path that used to checkpoint a mid-split token.
+	prevInterval := pbrtCheckpointInterval
+	pbrtCheckpointInterval = 0
+	t.Cleanup(func() { pbrtCheckpointInterval = prevInterval })
+
+	require.NoError(t, client.Database(testDb).Drop(ctx))
+	t.Cleanup(func() { require.NoError(t, client.Database(testDb).Drop(ctx)) })
+
+	bindings := []bindingInfo{
+		{resource: resource{Database: testDb, Collection: testColl1}, index: 0},
+	}
+
+	transcoder, err := NewTranscoder(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { transcoder.Stop() })
+
+	c := capture{
+		client:     client,
+		output:     &boilerplate.PullOutput{Connector_CaptureServer: &testServer{}},
+		transcoder: transcoder,
+		trackedChangeStreamBindings: map[string]bindingInfo{
+			resourceId(testDb, testColl1): bindings[0],
+		},
+		fullDocRequired:      map[string]bool{},
+		state:                captureState{DatabaseResumeTokens: map[string]bson.Raw{}},
+		lastEventClusterTime: map[string]primitive.Timestamp{},
+	}
+
+	require.NoError(t, client.Database(testDb).CreateCollection(ctx, testColl1,
+		&options.CreateCollectionOptions{ChangeStreamPreAndPostImages: bson.D{{Key: "enabled", Value: true}}}))
+
+	streams, err := c.initializeStreams(ctx, bindings, nil, true, true, false, map[string][]string{}, map[string]bool{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(streams))
+	stream := streams[0]
+
+	batches := make(chan streamBatch, 4)
+	producerCtx, cancelProducer := context.WithCancel(ctx)
+	defer cancelProducer()
+
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		c.produceStreamBatches(producerCtx, stream, batches)
+	}()
+	defer func() {
+		cancelProducer()
+		<-producerDone
+	}()
+
+	// First batch establishes the resume token.
+	for batch := range batches {
+		require.NoError(t, batch.err)
+		_, err := c.processBatch(ctx, stream, batch)
+		require.NoError(t, err)
+		break
+	}
+
+	// A document large enough that an update carrying both fullDocument and
+	// fullDocumentBeforeChange exceeds the 16MB event limit and is split.
+	val := map[string]string{"_id": "hugeDocument"}
+	for i := 1; i <= 9; i++ {
+		val[fmt.Sprintf("key%d", i)] = strings.Repeat(fmt.Sprintf("value%d", i), 200000)
+	}
+	_, err = client.Database(testDb).Collection(testColl1).InsertOne(ctx, val)
+	require.NoError(t, err)
+
+	val["key1"] = "updated"
+	res, err := client.Database(testDb).Collection(testColl1).UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: val["_id"]}}, bson.D{{Key: "$set", Value: val}})
+	require.NoError(t, err)
+	require.Equal(t, 1, int(res.ModifiedCount))
+
+	// Resume tokens which must never be checkpointed, and every token which
+	// actually was. The fragment position is deliberately re-derived from the
+	// raw event here rather than by calling isMidSplitEvent, so that a wrong
+	// predicate cannot make this assertion agree with it.
+	unsafeTokens := make(map[string]bool)
+	checkpointedTokens := make(map[string]bool)
+	var sawCompletedSplit bool
+	var batchesAfterSplit int
+
+	// produceStreamBatches never closes its channel, so the loop needs its own
+	// deadline: without one, a change stream which never splits would block here
+	// until the package-wide test timeout took down every test in the package.
+	loopCtx, cancelLoop := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelLoop()
+
+collect:
+	for {
+		var batch streamBatch
+		select {
+		case batch = <-batches:
+		case <-loopCtx.Done():
+			break collect
+		}
+
+		require.NoError(t, batch.err)
+
+		for _, ev := range batch.events {
+			fragment, fragmentOk := ev.raw.Lookup("splitEvent", "fragment").Int32OK()
+			of, ofOk := ev.raw.Lookup("splitEvent", "of").Int32OK()
+			if !fragmentOk || !ofOk {
+				continue
+			}
+			if fragment < of {
+				unsafeTokens[string(ev.resumeToken)] = true
+			} else {
+				sawCompletedSplit = true
+			}
+		}
+
+		_, err := c.processBatch(ctx, stream, batch)
+		require.NoError(t, err)
+
+		if tok, ok := c.state.DatabaseResumeTokens[testDb]; ok {
+			checkpointedTokens[string(tok)] = true
+		}
+
+		// Keep going past the split so that the checkpoints taken once the
+		// event completes are collected too.
+		if sawCompletedSplit {
+			batchesAfterSplit++
+			if batchesAfterSplit >= 3 {
+				break collect
+			}
+		}
+	}
+
+	require.True(t, sawCompletedSplit, "change stream never delivered a complete split event")
+	require.NotEmpty(t, unsafeTokens, "change stream never delivered a non-final fragment")
+
+	for tok := range unsafeTokens {
+		require.False(t, checkpointedTokens[tok],
+			"checkpointed a resume token for a non-final fragment of a split event")
 	}
 }


### PR DESCRIPTION
**Description:**

### Problem

We observed a capture failing with `Error: Fragment("received fragment 2 without first fragment")`. That's indicating that the connector started up, used the checkpointed resume token, then received the second fragment of a change event. The only way I can see that happening is if the connector checkpointed a resume token in the middle of split change event.

Some background:

With pre-images enabled the connector appends `$changeStreamSplitLargeEvent`, so MongoDB delivers change events over 16MB as fragments. The transcoder reassembles them in process memory: fragments `1..N-1` return a `skip`, only fragment `N` returns a document.

`processBatch` checkpoints a post-batch resume token when a batch emitted no documents, with no regard for split state. That is the normal path for a fragment, not a rare race: a split event exceeds 16MB and a `getMore` reply is capped at 16MB, so fragments can never share a cursor batch; a batch of only fragments emits nothing, which is exactly the fallback's trigger; and the once-a-minute throttle means fragment 1's batch usually wins.

MongoDB resumes a fragment's token at the *next* fragment. So on the next restart, fragment 2 arrives into a fresh, empty accumulator and the transcoder exits. The restart reads the same token and fails identically, forever. **The capture cannot recover on its own**; rolling back to
runtime v1 changed nothing, because the bad token is in persisted connector state.

### Solution

Enforce one invariant: a resume token is only persisted for an event that is not a non-final fragment of a split event.

| Path | Token used | Status |
|---|---|---|
| `processBatch`, `emittedCount > 0` | last **emitted** document's token | Already safe — the transcoder only returns a document for a completed split or a non-split event. Unchanged. |
| `processBatch`, PBRT fallback | last event in the batch | Was unsafe. Now gated. |
| `handleIdleBatch` | post-batch resume token | Was unsafe when the cursor stopped mid-split. Now gated. |

1. **`isMidSplitEvent`** reads `splitEvent` off the raw BSON, which the pipeline already projects — no transcoder protocol change. It fails closed: suppressing a checkpoint costs a delayed resume token, checkpointing a fragment position is unrecoverable.
2. **Gate the two unsafe sites** on a `midSplit` flag, updated for every event consumed since it tracks where the cursor is, not what was captured.
3. **Don't finish catch-up mid-split.** Load-bearing, not a nicety: with (2) in place the last checkpoint is *before* the split, so re-opening the stream during backfill replays fragment 1 into an accumulator already holding it. (2) alone would trade one crash for another. Also adds a 5-minute warning, since suppressed checkpointing would otherwise let a stalled stream look healthy while its resume token froze.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
