### PR TITLE
docs-build-check: address review comments from #5090

### DIFF
--- a/.github/workflows/docs-build-check.yaml
+++ b/.github/workflows/docs-build-check.yaml
@@ -114,19 +114,23 @@ jobs:
           set -euo pipefail
 
           # Copy the PR's working tree rather than pointing the submodule at
-          # the PR head SHA. A fork's head commit is not fetchable with an
-          # estuary-scoped token, so the submodule approach would work for
-          # branches and break for forks. Copying behaves identically for both,
-          # which keeps one code path here.
+          # the PR head SHA. aggregate-docs.sh only runs `submodule update
+          # --init` when its source directory is missing, so pre-populating the
+          # path means the submodule is never initialized and the build never
+          # fetches estuary/connectors a second time.
           #
-          # aggregate-docs.sh only runs `submodule update --init` when its
-          # source directory is missing, so pre-populating this path also stops
-          # the build from reaching for the submodule at all.
+          # An earlier version of this comment justified the copy by fork
+          # support. That reason does not hold: the gate above skips forks
+          # outright, so both approaches would be equally unreachable there.
+          # The reason above is the one that stands.
           mkdir -p docs/external/connectors/docs
           rsync -a --delete connectors/docs/ docs/external/connectors/docs/
 
+          # The whole tree is copied, not just this PR's changed files, because
+          # the build needs every page to resolve links between them. So this
+          # count is the size of the tree being built, not the size of the diff.
           COUNT=$(find docs/external/connectors/docs/reference/Connectors -type f | wc -l | tr -d ' ')
-          echo "Substituted $COUNT files under docs/reference/Connectors from this PR."
+          echo "Built against $COUNT connector doc files (whole tree at this PR's head, not the diff)."
 
       - name: Setup Node
         if: steps.gate.outputs.build == 'true'
@@ -144,12 +148,6 @@ jobs:
       - name: Build
         if: steps.gate.outputs.build == 'true'
         working-directory: docs
-        env:
-          # Same values the production deploy uses, so this build exercises the
-          # same canonical, og:url and sitemap generation. Nothing is published
-          # from here.
-          URL: https://docs.estuary.dev
-          BASE_URL: /
         run: npm run build
 
       - name: Explain a skipped build


### PR DESCRIPTION
**Description:**

Follow-up to #5090, addressing @aeluce's review comments. Comment changes and one deletion. Nothing changes about what the check builds or when it runs.

**1. Dropped `URL` and `BASE_URL` from the Build step.**

The question was whether they were needed, given `estuary/docs`' own `build.yml` sets neither. They are not. `docusaurus.config.js` defaults them to exactly the values that were being passed:

```js
const BASE_URL = process.env.BASE_URL || "/"
const URL = process.env.URL || "https://docs.estuary.dev"
```

So the block was a no-op that implied the build needed configuring to match production. It already did.

**2. Fixed the fork rationale on the substitution step.**

The comment justified copying the doc tree rather than repointing the submodule by saying a fork's head SHA is not fetchable with an `estuary`-scoped token. That reason cannot apply, because the gate skips forks before this step is reached, so both approaches are equally unreachable there.

The reason that does stand is the second one the comment already gave: pre-populating `external/connectors/docs` stops `aggregate-docs.sh` from running `submodule update --init`, so the build never fetches this repo a second time. That is now the only reason given, with a note recording why the fork argument was removed so it does not get reintroduced.

On the underlying question of whether to switch to the submodule approach: not worth it. It would trade a working `rsync` for a fetch that is slower and no more correct, and the fork gap it was supposed to close is closed by the gate instead. The real fix for forks is `estuary/docs` going public, which is tracked separately.

**3. Fixed the count message.**

```
Substituted 236 files under docs/reference/Connectors from this PR.
```

read as a count of changed files. It is the size of the whole tree. The whole tree has to be copied because the build resolves links between pages, so a diff-sized copy would fail on every cross-reference. Now:

```
Built against 236 connector doc files (whole tree at this PR's head, not the diff).
```

**No change: `types:` on the `pull_request` trigger.**

`[opened, reopened, synchronize]` is exactly the GitHub default for `pull_request`, so naming them explicitly would document the behavior without altering it. Left implicit to match the other workflows in this repo, none of which set `types:`.

**Verification:**

`yaml.safe_load` parses the file. The diff is 12 insertions and 14 deletions, all comments plus the `env:` block. The check itself is unchanged, so the `Docs / build check` run on this PR is not exercised (no files under `docs/reference/Connectors/**` are touched); #5090's own runs and the throwaway #5092 runs remain the evidence that it works.

**Documentation links affected:**

None.

**Checklist:**

- [x] Not user-visible connector behavior. No `CHANGELOG.md` entry applies.
