### PR TITLE
tests: pin the temp-data-plane captures to the V1 runtime

### DIFF
--- a/tests/template.flow.yaml
+++ b/tests/template.flow.yaml
@@ -10,6 +10,9 @@ collections:
 
 captures:
   tests/${CONNECTOR}/from-source:
+    shards:
+      flags:
+        enable-runtime-v2: "false"
     endpoint:
       connector:
         image: "${CONNECTOR_IMAGE}"


### PR DESCRIPTION
**Description:**

Captures now default to the V2 task runtime, which does not work under `flowctl-go temp-data-plane`. The capture shard fails to start, the test times out, and the data plane then hangs on shutdown.

Pin these captures to the V1 runtime instead, as an interim measure.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
