### PR TITLE
source-shopify-native: add `name` to orders line items

### DIFF
--- a/source-shopify-native/CHANGELOG.md
+++ b/source-shopify-native/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-27
+
+### Added
+- `orders` line items now include `name`, the line item's title as it appears
+  on the order (the product title, with the variant title appended when the
+  variant has one). This identifies what sold on orders whose line items were
+  entered without a `sku`.
+
 ## 2026-08-19
 
 ### Fixed

--- a/source-shopify-native/source_shopify_native/graphql/orders/orders.py
+++ b/source-shopify-native/source_shopify_native/graphql/orders/orders.py
@@ -222,6 +222,7 @@ class Orders(ShopifyGraphQLResource):
             node {
                 # identifiers
                 id
+                name
                 sku
                 vendor
                 image {

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -1195,6 +1195,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "Oatmeal",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1307,6 +1308,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Collection Snowboard: Hydrogen",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1419,6 +1421,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Collection Snowboard: Liquid",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1531,6 +1534,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Collection Snowboard: Oxygen",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1643,6 +1647,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Compare at Price Snowboard",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1755,6 +1760,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Complete Snowboard - Ice",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1867,6 +1873,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Complete Snowboard - Dawn",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -1979,6 +1986,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Complete Snowboard - Powder",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -2091,6 +2099,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Complete Snowboard - Electric",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -2203,6 +2212,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Complete Snowboard - Sunset",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {
@@ -2315,6 +2325,7 @@
           },
           "isGiftCard": false,
           "lineItemGroup": null,
+          "name": "The Videographer Snowboard",
           "nonFulfillableQuantity": 0,
           "originalTotalSet": {
             "presentmentMoney": {


### PR DESCRIPTION
**Description:**

Adds `LineItem.name` to the `orders` bulk query, so each line item carries its title as it appears on the order. A customer has orders whose line items were entered without a `sku`, where `name` is the only field identifying what sold.

**Workflow steps:**

Query-only change in `graphql/orders/orders.py`. `name` is a scalar, so it inlines into the line item's JSONL row and `process_result` needed no changes. No access scope beyond the `read_orders` the stream already requires. Verified with the capture snapshot test against the test store.

Existing captures won't backfill - `name` appears on orders whose `updatedAt` advances after deploy.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: N/A
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated: N/A — no config/schema changes, discovery/schema is inferred
