### PR TITLE
testctl: add _sops suffix stripping

### DIFF
--- a/materialize-boilerplate/testutil/resources.go
+++ b/materialize-boilerplate/testutil/resources.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -261,11 +262,28 @@ func ReadConfigFile(path string) (json.RawMessage, error) {
 	if encrypted, err := isSopsEncrypted(raw); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	} else if encrypted {
-		out, err := exec.Command("sops", "--decrypt", "--output-type", "json", path).Output()
+		var sopsStderr bytes.Buffer
+		sopsCmd := exec.Command("sops", "--decrypt", "--output-type", "json", path)
+		sopsCmd.Stderr = &sopsStderr
+
+		jqCmd := exec.Command("jq", `walk( if type == "object" then with_entries(.key |= rtrimstr("_sops")) else . end)`)
+
+		jqCmd.Stdin, err = sopsCmd.StdoutPipe()
 		if err != nil {
+			return nil, err
+		}
+		if err := sopsCmd.Start(); err != nil {
+			return nil, err
+		}
+		out, err := jqCmd.Output()
+		if err != nil {
+			return nil, err
+		}
+
+		if err := sopsCmd.Wait(); err != nil {
 			var exitErr *exec.ExitError
 			if errors.As(err, &exitErr) {
-				return nil, fmt.Errorf("decrypting %s with sops: %s", path, strings.TrimSpace(string(exitErr.Stderr)))
+				return nil, fmt.Errorf("decrypting %s with sops: %s", path, strings.TrimSpace(sopsStderr.String()))
 			}
 			return nil, fmt.Errorf("decrypting %s with sops (is it installed?): %w", path, err)
 		}


### PR DESCRIPTION
This command did not strip _sops suffixes that we typically use, which prevented cleanup from operating correctly during benchmarks.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
