### PR TITLE
Docs: Redirect removed Facebook connector page

### DIFF
--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -15,3 +15,5 @@
 # Point `to` at the best surviving destination: a replacement connector if
 # one exists, otherwise the connector category index. Avoid case-only renames
 # (e.g. foo -> Foo); they collide on case-insensitive filesystems.
+- from: /reference/Connectors/capture-connectors/facebook-marketing/
+  to: /reference/Connectors/capture-connectors/facebook-marketing-native/


### PR DESCRIPTION
**Description:**

Following #5093 this adds a redirect from the removed docs page to the native Facebook marketing connector reference page. Just in case there are old blog posts or external sites linking to the deleted URL, this will redirect users to the newer version of the connector rather than returning a 404, which could indicate the source system is unsupported.

Docs-only change; no connector code updated.

**Notes for reviewers:**

Thanks for reviewing!

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
