### PR TITLE
source-kafka: correct the local development setup instructions

### DIFF
--- a/source-kafka/README.md
+++ b/source-kafka/README.md
@@ -85,44 +85,33 @@ It supports two [estuary.dev](estuary.dev) extensions to the spec:
 
 #### Local Kafka
 
-You'll need to make sure you have a local Kafka cluster running. This is most
-easily done by using the `infra` tools from the top level of the
-`estuary/connectors` repo.
+The `docker-compose.yaml` in this directory launches a Kafka broker on port 9092
+and a Confluent schema registry on port 8081. Both are needed by the integration
+tests.
+
+The compose file joins an external network named `flow-test`, so create it first
+if it does not already exist:
 
 ```bash
-make start_local_infra
+docker network create flow-test
 ```
 
-This will launch a dockerized Kafka + Zookeeper instance and expose a client listener on port 9092.
-
-#### Mac M1
-
-In order to build this connector on an M1 Mac, you will need to install the
-following packages and make sure their libraries are linked:
-
-```
-brew install openssl
-brew link openssl --force
-brew install librdkafka
+```bash
+docker compose up -d
 ```
 
-You will then need to change the `Cargo.toml` file to use `dynamic-linking` for
-`rdkafka` instead of `cmake-build`:
+#### Build dependencies
 
-```
-#rdkafka = { version = "0.26", features = ["cmake-build", "gssapi", "libz", "sasl", "ssl"], default-features = false }
-rdkafka = { version = "0.29", features = ["dynamic-linking", "gssapi", "libz", "sasl", "ssl"], default-features = false }
-```
+`rdkafka` is built from source via its `cmake-build` feature, so you need
+`cmake` on your PATH:
 
-Moreover, you need to switch to a `vendored` installation of `sasl2-sys`, so add
-the following to `Cargo.toml`:
-
-```
-sasl2-sys = { version = "0.1.14", features = ["vendored" ] }
+```bash
+brew install cmake
 ```
 
-You should now be able to build this connector locally. Note that you should not
-commit these changes to your pull-request.
+No other setup is required, on Apple Silicon included. Do not switch `rdkafka`
+to `dynamic-linking` or vendor `sasl2-sys`; the committed `Cargo.toml` builds as
+it stands.
 
 #### Install `kafkactl`
 
@@ -164,8 +153,11 @@ cargo test --lib
 
 To run the integration tests which connect to Kafka:
 
+These need the broker and schema registry from [Local Kafka](#local-kafka)
+running, and `flowctl` on your PATH. The tests create their own topics and
+fixtures.
+
 ```bash
 cd path/to/estuary/connectors/source-kafka
-make test_setup
 cargo test
 ```


### PR DESCRIPTION
Three parts of `source-kafka/README.md` no longer work. I hit all three setting up local connector dev for the first time.

## What changed

The Local Kafka section tells you to run `make start_local_infra`. There is no Makefile in the repo and no such target. The broker and schema registry the integration tests need come from the `docker-compose.yaml` in this directory, which joins an external network named `flow-test` you have to create first.

The Mac M1 section tells you to install `librdkafka` and `openssl` by hand, then edit `Cargo.toml` to switch `rdkafka` to `dynamic-linking` and vendor `sasl2-sys`, while also warning you not to commit those edits. None of that is needed now: the committed `Cargo.toml` builds on Apple Silicon as it stands. The one build dependency the guide never mentions is `cmake`, which `rdkafka` needs for its `cmake-build` feature.

The integration test section tells you to run `make test_setup`, another target that does not exist. The tests create their own topics and fixtures; they need the broker, the schema registry, and `flowctl` on PATH.

## Why

The old instructions cannot be followed. `make start_local_infra` fails immediately, and the `Cargo.toml` edits it recommends would break the build if anyone committed them.

## Verification

These are the steps I actually used to get the connector building and its integration tests passing on an Apple Silicon Mac: `docker network create flow-test`, `docker compose up -d`, `brew install cmake`, then `cargo test` green including the integration tests against the compose broker. I did not re-follow them from a wiped machine, so the `brew install cmake` line is the only step I cannot confirm is sufficient on a Mac with no prior Rust or Homebrew setup.
