### PR TITLE
source-sqlserver: add Azure IAM auth support

### DIFF
--- a/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
+++ b/docs/reference/Connectors/capture-connectors/SQLServer/sqlserver.md
@@ -152,6 +152,32 @@ instead of a password. This requires an RDS Proxy in front of the database; see
 [Amazon RDS for SQL Server](./amazon-rds-sqlserver/#iam-authentication) for
 setup instructions.
 
+For Azure SQL Database, you can authenticate with an Azure App Registration
+instead of a password.
+
+Follow the steps in the [Azure IAM guide][azure-iam] to create an App
+Registration and make note of the Application ID and Tenant ID to use when
+configuring the connector's authentication options.
+
+Ensure that the SQL logical server has Entra authentication enabled and connect
+to the Azure SQL Database as the Entra admin. This can be done from the
+Database Query Editor. Run the following commands to create a user for the App
+Registration, granting it the same permissions as the `flow_capture` user in
+the [Azure SQL Database](#azure-sql-database) setup instructions above:
+
+```sql
+CREATE USER [my-app-registration-name] FROM EXTERNAL PROVIDER;
+GRANT SELECT ON SCHEMA :: dbo TO [my-app-registration-name];
+GRANT SELECT ON SCHEMA :: cdc TO [my-app-registration-name];
+GRANT VIEW DATABASE STATE TO [my-app-registration-name];
+```
+
+When enabling CDC on tables, use the App Registration name as the gating
+`role_name` argument, or grant the App Registration membership in whichever
+gating role your capture instances already use.
+
+[azure-iam]: /guides/iam-auth/azure/
+
 ### Handling DDL Alterations to Source Tables
 
 In SQL Server, adding a column to the source table will not automatically cause it to be added to the CDC change table. Instead [Microsoft's recommended approach](https://learn.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-ver17#handling-changes-to-source-table) is to create a second capture instance which reflects the new state of the source table, transition over to the new instance, and then delete the old one.
@@ -203,10 +229,12 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AWSIAM`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword`, `AWSIAM`, or `AzureIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 | `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
 | `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
+| `/credentials/azure_client_id` | Azure Client ID | Application (client) ID of the App Registration. | string | Required for `AzureIAM` auth |
+| `/credentials/azure_tenant_id` | Azure Tenant ID | Directory (tenant) ID of the App Registration. | string | Required for `AzureIAM` auth |
 
 ##### Discovery Filters
 
@@ -264,6 +292,16 @@ captures:
           namespace: dbo
           primary_key: ["id"]
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate to an Azure SQL Database with [Azure IAM](#iam-authentication)
+instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AzureIAM
+            azure_client_id: "11111111-2222-3333-4444-555555555555"
+            azure_tenant_id: "66666666-7777-8888-9999-000000000000"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/source-sqlserver/.snapshots/TestSpec
+++ b/source-sqlserver/.snapshots/TestSpec
@@ -68,6 +68,34 @@
               "aws_role_arn"
             ],
             "title": "AWS IAM"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/azure-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AzureIAM",
+                "default": "AzureIAM",
+                "order": 0
+              },
+              "azure_client_id": {
+                "type": "string",
+                "title": "Azure Client ID",
+                "description": "Azure App Registration Client ID for Azure Active Directory authentication"
+              },
+              "azure_tenant_id": {
+                "type": "string",
+                "title": "Azure Tenant ID",
+                "description": "Azure Tenant ID for Azure Active Directory authentication"
+              }
+            },
+            "type": "object",
+            "required": [
+              "azure_client_id",
+              "azure_tenant_id"
+            ],
+            "title": "Azure IAM"
           }
         ],
         "type": "object",
@@ -79,7 +107,8 @@
           "propertyName": "auth_type"
         },
         "order": 2,
-        "x-iam-auth": true
+        "x-iam-auth": true,
+        "x-iam-azure-scope": "https://database.windows.net/.default"
       },
       "database": {
         "type": "string",

--- a/source-sqlserver/CHANGELOG.md
+++ b/source-sqlserver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # source-sqlserver
 
+## 2026-08-28
+
+### Added
+- Azure IAM authentication as a new branch of the `credentials` union, using an
+  Entra access token obtained through an Azure App Registration.
+
 ## 2026-08-25
 
 ### Added

--- a/source-sqlserver/config_test.go
+++ b/source-sqlserver/config_test.go
@@ -113,6 +113,23 @@ func TestConfigValidate(t *testing.T) {
 		require.ErrorContains(t, cfg.Validate(), "missing 'aws_region'")
 	})
 
+	t.Run("AzureIAMValid", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AzureIAM}
+		cfg.Credentials.AzureClientID = "11111111-2222-3333-4444-555555555555"
+		cfg.Credentials.AzureTenantID = "66666666-7777-8888-9999-000000000000"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("AzureIAMMissingClientID", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AzureIAM}
+		cfg.Credentials.AzureTenantID = "66666666-7777-8888-9999-000000000000"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'azure_client_id'")
+	})
+
 	t.Run("UnknownAuthType", func(t *testing.T) {
 		var cfg = valid()
 		cfg.Credentials = &CredentialsConfig{AuthType: "Bogus"}
@@ -142,6 +159,33 @@ func TestAWSIAMConfigURI(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t,
 		"sqlserver://flow_capture@example.rds.amazonaws.com:1433?TrustServerCertificate=true&app+name=Flow+CDC+Connector&database=flow&encrypt=true",
+		uri)
+}
+
+func TestAzureIAMConfigURI(t *testing.T) {
+	var cfg = Config{
+		Address:  "example.database.windows.net",
+		User:     "flow_capture",
+		Database: "flow",
+		Credentials: &CredentialsConfig{
+			AuthType: AzureIAM,
+			IAMConfig: iam.IAMConfig{
+				AzureConfig: iam.AzureConfig{
+					AzureClientID: "11111111-2222-3333-4444-555555555555",
+					AzureTenantID: "66666666-7777-8888-9999-000000000000",
+				},
+			},
+		},
+	}
+	cfg.SetDefaults()
+	cfg.normalizeCredentials()
+
+	// The DSN carries no user info at all: the Entra access token supplied
+	// out-of-band identifies the principal.
+	uri, err := cfg.ToURI()
+	require.NoError(t, err)
+	require.Equal(t,
+		"sqlserver://example.database.windows.net:1433?TrustServerCertificate=true&app+name=Flow+CDC+Connector&database=flow&encrypt=true",
 		uri)
 }
 

--- a/source-sqlserver/main.go
+++ b/source-sqlserver/main.go
@@ -74,6 +74,7 @@ type AuthType string
 const (
 	UserPassword AuthType = "UserPassword"
 	AWSIAM       AuthType = "AWSIAM"
+	AzureIAM     AuthType = "AzureIAM"
 )
 
 type UserPasswordConfig struct {
@@ -94,6 +95,7 @@ func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
 	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword),
 		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
 		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)),
+		schemagen.OneOfSubSchema("Azure IAM", iam.AzureConfig{}, string(AzureIAM)),
 	)
 }
 
@@ -104,7 +106,7 @@ func (c *CredentialsConfig) Validate() error {
 			return errors.New("missing 'password'")
 		}
 		return nil
-	case AWSIAM:
+	case AWSIAM, AzureIAM:
 		// The embedded IAMConfig has its own auth_type field which JSON decoding
 		// leaves empty (the outer field shadows it), so sync it before ValidateIAM
 		// switches on it.
@@ -119,7 +121,7 @@ type Config struct {
 	Address     string             `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
 	User        string             `json:"user" jsonschema:"default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
 	Password    string             `json:"password,omitempty" jsonschema:"-"`
-	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=2,x-iam-auth=true"`
+	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=2,x-iam-auth=true,x-iam-azure-scope=https://database.windows.net/.default"`
 	Database    string             `json:"database" jsonschema:"description=Logical database name to capture from." jsonschema_extras:"order=3"`
 	Timezone    string             `json:"timezone,omitempty" jsonschema:"title=Time Zone,default=UTC,description=The IANA timezone name in which datetime columns will be converted to RFC3339 timestamps. Defaults to UTC if left blank." jsonschema_extras:"order=4,nonsensitive=true"`
 	HistoryMode bool               `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=5,nonsensitive=true"`
@@ -273,6 +275,10 @@ func (c *Config) ToURI() (string, error) {
 		userInfo = url.UserPassword(c.User, c.Credentials.Password)
 	case AWSIAM:
 		userInfo = url.User(c.User)
+	case AzureIAM:
+		// The Entra identity is carried entirely by the access token, so the DSN
+		// has no user info at all.
+		userInfo = nil
 	default:
 		return "", fmt.Errorf("unsupported 'auth_type' %q", c.Credentials.AuthType)
 	}
@@ -286,9 +292,12 @@ func (c *Config) ToURI() (string, error) {
 	return connectURL.String(), nil
 }
 
-// buildConnector constructs a driver connector for the configured authentication
-// method. AWS IAM connections fetch a fresh RDS auth token for each new connection
-// the pool opens, so long-running captures outlive the token's 15-minute validity.
+// buildConnector constructs a driver connector for the configured
+// authentication method. AWS IAM connections fetch a fresh RDS auth token for
+// each new connection the pool opens, so long-running captures outlive the
+// token's 15-minute validity. Azure IAM connections use the Entra access token
+// injected into the config by the control plane, which restarts the connector
+// with a fresh token before expiry.
 func (c *Config) buildConnector() (*mssqldb.Connector, error) {
 	var uri, err = c.ToURI()
 	if err != nil {
@@ -310,6 +319,11 @@ func (c *Config) buildConnector() (*mssqldb.Connector, error) {
 			return auth.BuildAuthToken(ctx, c.Address, c.Credentials.AWSRegion, c.User, credProvider)
 		}
 		return mssqldb.NewConnectorWithAccessTokenProvider(uri, tokenProvider)
+	case AzureIAM:
+		var token = c.Credentials.AzureToken()
+		return mssqldb.NewConnectorWithAccessTokenProvider(uri, func(ctx context.Context) (string, error) {
+			return token, nil
+		})
 	default:
 		return nil, fmt.Errorf("unsupported 'auth_type' %q", c.Credentials.AuthType)
 	}


### PR DESCRIPTION
**Description:**

Follow-up to #5131 that extends the feature to support Azure IAM.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
