### PR TITLE
go/keyhash: consolidate Flow's packed-key hash into a shared package

### DIFF
--- a/go/keyhash/keyhash.go
+++ b/go/keyhash/keyhash.go
@@ -1,0 +1,24 @@
+// Package keyhash reproduces the packed-key hash that the Flow runtime uses to
+// route documents to shards. Connectors which mirror that routing, for example
+// to derive per-key message ordering identifiers, must compute the same hash
+// bit for bit as the runtime.
+//
+// Reference implementations in the flow repo:
+//   - Go: go/flow/mapping.go PackedKeyHash_HH64
+//   - Rust: crates/doc/src/extractor.rs Extractor::packed_hash
+package keyhash
+
+import (
+	"encoding/hex"
+
+	"github.com/minio/highwayhash"
+)
+
+// PackedKeyHash_HH64 builds a packed key hash from the top 32-bits of a
+// HighwayHash 64-bit checksum computed using a fixed key.
+func PackedKeyHash_HH64(packedKey []byte) uint32 {
+	return uint32(highwayhash.Sum64(packedKey, highwayHashKey) >> 32)
+}
+
+// highwayHashKey is a fixed 32 bytes (as required by HighwayHash) read from /dev/random.
+var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c3488227e011ffa480c022bd3ba")

--- a/go/keyhash/keyhash_test.go
+++ b/go/keyhash/keyhash_test.go
@@ -1,0 +1,37 @@
+package keyhash
+
+import (
+	"testing"
+
+	"github.com/estuary/flow/go/protocols/fdb/tuple"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHighwayHashRegression uses the same fixtures as the flow repo's
+// go/flow/mapping_test.go TestHighwayHashRegression and the Rust
+// test_packed_hash_regression, so a change to either fails here too.
+func TestHighwayHashRegression(t *testing.T) {
+	var cases = []struct {
+		expect uint32
+		given  tuple.Tuple
+	}{
+		// Expect that small (e.x. single bit) changes to the input wildly change the output.
+		{0xb9f08d38, tuple.Tuple{true}},
+		{0x1505e3cb, tuple.Tuple{false}},
+		{0x6ae719f3, tuple.Tuple{"foo", "bar"}},
+		{0x8adddd61, tuple.Tuple{"foobar"}},
+		{0x7273e587, tuple.Tuple{"foobas"}},
+		{0xf4ec4d33, tuple.Tuple{"1"}},
+		{0x1e023d95, tuple.Tuple{"2"}},
+		{0x38a34efe, tuple.Tuple{"3"}},
+		{0x17751bae, tuple.Tuple{"10"}},
+		{0x87d93806, tuple.Tuple{"11"}},
+		{0x3c90c1d9, tuple.Tuple{1}},
+		{0x97901bac, tuple.Tuple{2}},
+		{0xcbc7f1e2, tuple.Tuple{3}},
+		{0xd1d3f3eb, tuple.Tuple{10}},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.expect, PackedKeyHash_HH64(tc.given.Pack()))
+	}
+}

--- a/materialize-google-pubsub/transactor.go
+++ b/materialize-google-pubsub/transactor.go
@@ -2,14 +2,13 @@ package connector
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/estuary/connectors/go/keyhash"
 	m "github.com/estuary/connectors/go/materialize"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	"github.com/minio/highwayhash"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -33,20 +32,6 @@ func (t *transactor) Load(it *m.LoadIterator, _ func(int, json.RawMessage) error
 	return nil
 }
 
-// The hash function and hash key below are copied directly from the Flow repo, go/flow/mapping.go.
-// In the future if the hashed value of the packedKey is added to the materialization connector
-// protocol, the PubSub materialization can be converted to using the hashed value directly instead
-// of computing it separately.
-
-// PackedKeyHash_HH64 builds a packed key hash from the top 32-bits of a
-// HighwayHash 64-bit checksum computed using a fixed key.
-func PackedKeyHash_HH64(packedKey []byte) uint32 {
-	return uint32(highwayhash.Sum64(packedKey, highwayHashKey) >> 32)
-}
-
-// highwayHashKey is a fixed 32 bytes (as required by HighwayHash) read from /dev/random.
-var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c3488227e011ffa480c022bd3ba")
-
 func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 	errGroup, ctx := errgroup.WithContext(it.Context())
 
@@ -55,7 +40,7 @@ func (t *transactor) Store(it *m.StoreIterator) (m.StartCommitFunc, error) {
 
 		msg := &pubsub.Message{
 			Data:        it.RawJSON,
-			OrderingKey: fmt.Sprintf("%08x", PackedKeyHash_HH64(it.PackedKey)),
+			OrderingKey: fmt.Sprintf("%08x", keyhash.PackedKeyHash_HH64(it.PackedKey)),
 		}
 		// Only include an identifier attribute if an identifier has been configured.
 		if binding.identifier != "" {

--- a/materialize-sns/transactor.go
+++ b/materialize-sns/transactor.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/estuary/connectors/go/keyhash"
 	"github.com/estuary/connectors/go/materialize"
 	pf "github.com/estuary/flow/go/protocols/flow"
-	"github.com/minio/highwayhash"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -44,14 +44,6 @@ func (t *transactor) Load(it *materialize.LoadIterator, _ func(int, json.RawMess
 	}
 	return nil
 }
-
-// PackedKeyHash_HH64 and highwayHashKey are copied verbatim from materialize-google-pubsub so SNS
-// FIFO MessageGroupId values match Flow's internal key-hash ordering scheme.
-func PackedKeyHash_HH64(packedKey []byte) uint32 {
-	return uint32(highwayhash.Sum64(packedKey, highwayHashKey) >> 32)
-}
-
-var highwayHashKey, _ = hex.DecodeString("ba737e89155238d47d8067c35aad4d25ecdd1c3488227e011ffa480c022bd3ba")
 
 func (t *transactor) Store(it *materialize.StoreIterator) (materialize.StartCommitFunc, error) {
 	errGroup, ctx := errgroup.WithContext(it.Context())
@@ -89,7 +81,7 @@ func (t *transactor) publishOne(ctx context.Context, errGroup *errgroup.Group, b
 		Message:  aws.String(string(doc)),
 	}
 	if binding.isFifo {
-		input.MessageGroupId = aws.String(fmt.Sprintf("%08x", PackedKeyHash_HH64(packedKey)))
+		input.MessageGroupId = aws.String(fmt.Sprintf("%08x", keyhash.PackedKeyHash_HH64(packedKey)))
 		sum := sha256.Sum256(append(append([]byte{}, packedKey...), doc...))
 		input.MessageDeduplicationId = aws.String(hex.EncodeToString(sum[:]))
 	}


### PR DESCRIPTION
**Description:**

A little refactor that can be performed outside of #4828 

Two connectors carried verbatim copies of Flow's packed-key hash — `uint32(highwayhash.Sum64(packedKey, key) >> 32)` with a fixed 32-byte key. The runtime uses this hash to route documents to shards, and these connectors recompute it to reproduce that routing (SNS FIFO `MessageGroupId`, Pub/Sub `OrderingKey`), so the copies must stay bit-identical to the runtime's hash forever.

This PR moves the function and key into a new shared package, `go/keyhash`, so parity with the runtime is defined and tested in exactly one place:

1. `go/keyhash` holds `PackedKeyHash_HH64` and the key, moved verbatim, with a doc comment citing the reference implementations in the flow repo (Go `go/flow/mapping.go`, Rust `crates/doc/src/extractor.rs`).
2. `go/keyhash/keyhash_test.go` pins the hash with the 14 golden vectors from flow's `TestHighwayHashRegression` (the same table as Rust's `test_packed_hash_regression`) — if the runtime's hash ever diverges, this test fails here.
3. materialize-sns and materialize-google-pubsub now import the package; their local copies are deleted. No behavior change.

We deliberately don't import flow's `go/flow` package, which would drag in the gazette consumer stack.

**Workflow steps:**

No user-facing change — published message group/ordering keys are byte-identical to before.

**Notes for reviewers:**

- materialize-snowflake has a third copy, but it lives only on the unmerged `jgm-snowpipe-streaming-v2` branch (`streamv2_route.go`); it will adopt this package when that branch lands.
- Verified with `go build`/`go vet` on all three packages, `go test ./go/keyhash/`, and `go test -short` on both connectors.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries)) — none: internal refactor, no behavior change
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here — none: internal refactor
