### PR TITLE
materialize-iceberg: offset commits per task, not per EMR application

### DIFF
--- a/materialize-iceberg/CHANGELOG.md
+++ b/materialize-iceberg/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-28
+
+### Changed
+- The commit schedule is now offset per materialization rather than per EMR
+  application. Previously every materialization sharing an EMR Serverless
+  application committed at the same instant, so its `maximumCapacity` had to
+  cover the resulting spike rather than the average. Tasks are now spread across
+  the sync interval. Commit cadence is unchanged; each task shifts to its own
+  offset once, on upgrade.
+
 ## 2026-08-25
 
 ### Added

--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -177,7 +177,7 @@ func (d *materialization) Config() boilerplate.MaterializeCfg {
 			ExtendedLogging: true,
 			AckSchedule: &m.AckScheduleOption{
 				Config: d.cfg.Schedule,
-				Jitter: []byte(d.cfg.Compute.ApplicationId),
+				Jitter: []byte(d.materializationName),
 			},
 			DBTJobTrigger: &d.cfg.DBTJobTrigger,
 		},


### PR DESCRIPTION
## What

Seeds the acknowledgement-schedule jitter with the materialization name instead of the EMR Serverless application ID, so tasks sharing an application spread across the sync interval rather than all committing at the same instant.

## Why

The jitter contract asks for an identifier of the shared resource so materializations using it wake that resource once. Right for a destination billed on uptime — Snowflake, Databricks, BigQuery and Redshift are correct as they stand and are untouched here. EMR Serverless bills per job against an application-level vCPU ceiling, so coinciding commits instead raise the peak the application must be provisioned for while leaving it idle the rest of the interval.

## Evidence

One tenant runs 21 materializations against a single EMR application at a 1h frequency. All 21 commit at `:08:42` — 158 of 158 `nextScheduledAck` values across six hours of logs. Median per-task EMR occupancy is 209s, so mean concurrency is 0.93 jobs against a peak of 21.

Re-seeding on the task name (2000 trials, bootstrapped from the measured durations) drops peak concurrency to a median of 3 and a p95 of 5. Capacity is `peak jobs x vCPU per job` and the vCPU term is unchanged here, so that ratio is the capacity ratio: roughly 3-5x less. A second tenant runs 4 tasks against one application at 30m, all on `:11:11`.

Hashing spreads rather than schedules, so offsets aren't evenly spaced — the p95 of 5 reflects real clustering.

## Impact

Phase only. Cadence, ordering and correctness unchanged, and the seed isn't part of the published config schema (`TestSpec` unchanged), so no spec change, re-publish or backfill. Each task shifts to its own offset once, on upgrade.

`TestIntegration` wasn't run locally — it needs Polaris credentials in `testdata/.local/`.

## Related

estuary/flow#3229 added a model-level sync schedule for runtime v2 that seeds jitter from the tenant prefix rather than the destination, despite the issue specifying an explicit seed field on the model. Migrating connector configs to it is out of scope there and untracked, so this stands on its own — but that seed is worth revisiting before any such migration.
