### PR TITLE
materialize-iceberg: add EMR max job duration

### DIFF
--- a/materialize-iceberg/CHANGELOG.md
+++ b/materialize-iceberg/CHANGELOG.md
@@ -10,6 +10,9 @@
   the sync interval. Commit cadence is unchanged; each task shifts to its own
   offset once, on upgrade.
 
+### Added
+- Add 4 hour limit to EMR job run time after which the job will be cancelled.
+
 ## 2026-08-25
 
 ### Added

--- a/materialize-iceberg/emr.go
+++ b/materialize-iceberg/emr.go
@@ -22,6 +22,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// maxJobRunDuration is the limit for EMR job runtime.
+const maxJobRunDuration = 4 * time.Hour
+
 type emrClient struct {
 	cfg                 emrConfig
 	catalogAuth         catalogAuthConfig
@@ -180,6 +183,9 @@ func (e *emrClient) runJob(ctx context.Context, input any, entryPointUri, pyFile
 		}
 	}
 
+	jobCtx, cancelJobCtx := context.WithTimeout(ctx, maxJobRunDuration)
+	defer cancelJobCtx()
+
 	var runDetails string
 	for {
 		gotRun, err := e.c.GetJobRun(ctx, &emr.GetJobRunInput{
@@ -209,8 +215,23 @@ func (e *emrClient) runJob(ctx context.Context, input any, entryPointUri, pyFile
 			}
 		default:
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-jobCtx.Done():
+				cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+				defer cancel()
+
+				if _, err := e.c.CancelJobRun(cancelCtx, &emr.CancelJobRunInput{
+					ApplicationId: aws.String(e.cfg.ApplicationId),
+					JobRunId:      start.JobRunId,
+				}); err != nil {
+					log.WithError(err).WithField("runDetails", runDetails).Warn("failed to cancel EMR job run")
+				}
+
+				// If the parent context was cancelled we are stopping the job
+				// due to that, not due to the total job runtime limit.
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return fmt.Errorf("job %s exceeded the maximum allowed duration of %s and was cancelled", *start.JobRunId, maxJobRunDuration)
 			case <-time.After(5 * time.Second):
 				continue
 			}


### PR DESCRIPTION
**Description:**

There was no limit on how long an EMR job can run, and while we don't want it to be too strict it ought to have some limit.  Additionally we would like to cancel old jobs on a best effort basis during shutdown, although this doesn't happen today due to how connectors shutdown.

**Workflow steps:**

No change

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
