### PR TITLE
source-airtable-native: inject empty values for fields airtable doesn't include

### DIFF
--- a/source-airtable-native/CHANGELOG.md
+++ b/source-airtable-native/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-08-31
+
+### Fixed
+- Fields cleared in Airtable (e.g. all options removed from a multi-select) are now correctly captured as cleared, instead of permanently retaining their last non-empty value.

--- a/source-airtable-native/config.yaml
+++ b/source-airtable-native/config.yaml
@@ -1,0 +1,17 @@
+credentials:
+    access_token_sops: ENC[AES256_GCM,data:yTYrsuh96z4Owdm8TS2SSVi31lGCDORlpTL9hoCfYHymoX6Kx3EG02lMO2/limF8MdOrDezB8oBdhjH49ueMn03+jVeS+fzk7cukv46DvfXKUg==,iv:7ZAxnPV6U0ieFrKF9u1PRtaq9EPfk5blgZ9lx5N1daM=,tag:7BlJ/zy8JHiCOdq5J1brNQ==,type:str]
+    credentials_title: Private App Credentials
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/estuary-theatre/locations/us-central1/keyRings/connector-keyring/cryptoKeys/connector-repository
+          created_at: "2024-12-02T22:50:13Z"
+          enc: CiQAdmEdwj+A1dBTgkht9vgIrwzjVgH3+QVZNPOHCjyXXAGHUZsSSQAAUDtkbF87TtphcoealDI8o+iX8PwUhi095Lf7HZOw793p3YFUsYReK6/kXkoTZN+V2+lQPWLO31aXvY3WOT4s2LakGs1n03E=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-08-28T19:06:15Z"
+    mac: ENC[AES256_GCM,data:fZql+QZ2PlsLtKldpwBzPs7ZUU3CDdoOIO+dt1+eQKyYWg/D4PbyjLvkTxmdsCFiiTti7AvLnomncLGzyQrB7jFx9VLhRWm2fb+dCL+xpLJkAQmyPHyk3LM3T3sKuxDhyk4uua51tSEMV0xRYbZRA+3Qv2glIPP6ZSBGjoOAEQ4=,iv:1Eo3v2b6X/D0vYpGQszOL16d97dbAVhn7F19IbXbkEc=,tag:v47tR5cRvWYg20b/4EP/8w==,type:str]
+    pgp: []
+    encrypted_suffix: _sops
+    version: 3.9.0

--- a/source-airtable-native/source_airtable_native/api.py
+++ b/source-airtable-native/source_airtable_native/api.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, UTC
 from logging import Logger
 import time
-from typing import AsyncGenerator, TypeVar
+from typing import Any, AsyncGenerator, TypeVar
 
 from estuary_cdk.capture.common import BaseDocument, LogCursor, PageCursor
 import estuary_cdk.emitted_changes_cache as cache
@@ -16,8 +16,10 @@ from .models import (
     TableValidationContext,
     AirtableField,
     AirtableRecord,
+    FieldPresenceContext,
     IncrementalAirtableRecord,
     RecordsResponse,
+    expected_field_defaults,
 )
 
 RecordT = TypeVar("RecordT", bound=AirtableRecord)
@@ -122,6 +124,7 @@ async def _paginate_through_records(
     path: str,
     additionalParams: dict[str, str | list[str]] | None,
     record_cls: type[RecordT],
+    field_defaults: dict[str, Any],
     log: Logger,
 ) -> AsyncGenerator[RecordT, None]:
     url = f"{BASE_URL}/v0/{path}"
@@ -138,6 +141,7 @@ async def _paginate_through_records(
             f"records.item",
             record_cls,
             RecordsResponse,
+            validation_context=FieldPresenceContext(field_defaults),
         )
 
         async for resource in processor:
@@ -156,11 +160,19 @@ async def snapshot_records(
     path: str,
     log: Logger,
 ) -> AsyncGenerator[BaseDocument, None]:
+    # full_refresh_table's SnapshotResource has no reduction_strategy and
+    # registers no model (BaseDocument by default), so its write schema
+    # carries no field-level merge annotation - every poll fully replaces the
+    # prior document regardless of which fields are present. There's no
+    # omission-vs-clear ambiguity to resolve here, so no field defaults are
+    # computed or filled; {} still satisfies normalize_fields' required
+    # context while leaving its fill step a no-op.
     async for record in _paginate_through_records(
         http,
         path,
         None,
         AirtableRecord,
+        {},
         log,
     ):
         yield record
@@ -170,6 +182,7 @@ async def fetch_incremental_records(
     http: HTTPSession,
     path: str,
     record_cls: type[IncrementalAirtableRecord],
+    fields: list[AirtableField],
     horizon: timedelta,
     log: Logger,
     log_cursor: LogCursor,
@@ -183,6 +196,7 @@ async def fetch_incremental_records(
         return
 
     params = _build_incremental_params(record_cls.cursor_field_name, lower_bound, upper_bound)
+    field_defaults = expected_field_defaults(fields, exclude=record_cls.cursor_field_name)
 
     most_recent_dt = log_cursor
 
@@ -191,6 +205,7 @@ async def fetch_incremental_records(
         path,
         params,
         record_cls,
+        field_defaults,
         log,
     ):
         # A record's cursor_value could change mid-pagination. When we start paginating through
@@ -247,15 +262,17 @@ async def backfill_incremental_records(
     params = _build_incremental_params(record_cls.cursor_field_name, lower_bound, upper_bound)
 
     if is_connector_initiated:
-        fields_to_refresh = [f.name for f in fields if f.type == 'formula']
+        formula_fields = [f for f in fields if f.type == 'formula']
 
         # If there are no formula fields in this table, don't perform
         # a formula field refresh.
-        if not fields_to_refresh:
+        if not formula_fields:
             return
 
-        fields_to_refresh.append(record_cls.cursor_field_name)
-        params["fields"] = fields_to_refresh
+        field_defaults = expected_field_defaults(formula_fields)
+        params["fields"] = [f.name for f in formula_fields] + [record_cls.cursor_field_name]
+    else:
+        field_defaults = expected_field_defaults(fields, exclude=record_cls.cursor_field_name)
 
     most_recent_dt = lower_bound
     count = 0
@@ -266,6 +283,7 @@ async def backfill_incremental_records(
         path,
         params,
         record_cls,
+        field_defaults,
         log,
     ):
         # If a document is updated after the cutoff, skip it. It has been updated since we started

--- a/source-airtable-native/source_airtable_native/models.py
+++ b/source-airtable-native/source_airtable_native/models.py
@@ -197,27 +197,147 @@ def _is_formula_error(value: Any) -> bool:
     return False
 
 
+# Field types whose "empty" state, per Airtable's own cell format for the
+# type, can only ever be the single falsy value below - so injecting it back
+# in place of an omitted field is lossless, unlike e.g. injecting 0 for a
+# cleared number field (a real, distinguishable value that just happens to
+# also be falsy). See https://airtable.com/developers/web/api/field-model
+# for each type's documented cell format.
+_UNAMBIGUOUS_EMPTY_BOOLEAN_TYPES = frozenset({
+    "checkbox",  # cell format is "boolean (true only)" - never explicitly false
+})
+_UNAMBIGUOUS_EMPTY_STRING_TYPES = frozenset({
+    "singleLineText", "multilineText", "richText", "email", "url", "phoneNumber",
+})
+_UNAMBIGUOUS_EMPTY_ARRAY_TYPES = frozenset({
+    "multipleSelects", "multipleRecordLinks", "multipleAttachments", "multipleCollaborators",
+    # multipleLookupValues' cell format is unconditionally "array<...>" (V1)
+    # regardless of what the linked field's own type is - the outer shape
+    # never varies, only the element type does, so an omitted field is still
+    # safely "no values to show" as [].
+    "multipleLookupValues",
+})
+# Deliberately NOT included, even though they look plausible at a glance.
+# Every type below still gets covered by this fix - it's just via the
+# `None` fallback in _empty_value_for_field_type, not a type-specific value:
+# - singleSelect: cell format is a string, but it's one of a constrained set
+#   of configured option names, not free text - "" isn't a documented "no
+#   selection" convention the way it is for free-text fields.
+# - formula, rollup: cell format varies per-record based on a nested `result`
+#   type (Airtable's own docs note `result` "can be null if invalid"), so
+#   there's no single static shape to assume from the field's own type.
+# - number-like (number, currency, percent, duration, rating, count,
+#   autoNumber) and date-like (date, dateTime) types: Airtable's docs give no
+#   empty-value convention for these at all, unlike the explicit "", [],
+#   false examples for other types - there's no safe non-null empty value.
+
+assert not (
+    _UNAMBIGUOUS_EMPTY_BOOLEAN_TYPES & _UNAMBIGUOUS_EMPTY_STRING_TYPES
+    | _UNAMBIGUOUS_EMPTY_BOOLEAN_TYPES & _UNAMBIGUOUS_EMPTY_ARRAY_TYPES
+    | _UNAMBIGUOUS_EMPTY_STRING_TYPES & _UNAMBIGUOUS_EMPTY_ARRAY_TYPES
+), "a field type must not appear in more than one _UNAMBIGUOUS_EMPTY_*_TYPES set"
+
+
+def _empty_value_for_field_type(field_type: str) -> Any:
+    """The value to inject when Airtable omits a field of this type because
+    it's empty, per _UNAMBIGUOUS_EMPTY_*_TYPES above. Every other type falls
+    back to `None` here, including field types not yet known to this
+    connector - `None` is always a safe, if less precise, choice.
+    """
+    if field_type in _UNAMBIGUOUS_EMPTY_BOOLEAN_TYPES:
+        return False
+    if field_type in _UNAMBIGUOUS_EMPTY_STRING_TYPES:
+        return ""
+    if field_type in _UNAMBIGUOUS_EMPTY_ARRAY_TYPES:
+        return []
+    return None
+
+
+def expected_field_defaults(
+    fields: list[AirtableField],
+    exclude: str | None = None,
+) -> dict[str, Any]:
+    """Maps each field name Airtable returns by default for a request with no
+    `fields` query param to the value that should be injected if Airtable
+    omits that field from a given record. `exclude` is a record model's
+    cursor field name, when one exists — the cursor is tracked through its
+    own aliased pydantic field, never through this fill, so its literal name
+    must never appear here.
+    """
+    return {
+        f.name: _empty_value_for_field_type(f.type)
+        for f in fields
+        if f.name != exclude
+    }
+
+
+class FieldPresenceContext:
+    def __init__(self, expected_field_defaults: dict[str, Any]):
+        self.expected_field_defaults = expected_field_defaults
+
+
 class AirtableRecordFields(BaseModel, extra="allow"):
-    # When the formula for a formula field results in an error (circular reference, NaN, divide by zero, etc),
-    # Airtable returns an object like {"error": "#ERROR!"} or {"specialValue": "NaN"}.
-    #
-    # Allowing these errors in documents would mangle collections' inferred schemas, and the
-    # inferred schema would end up saying these formula fields could be either the type of the normally calculated value
-    # (like a string or number) or it could be an object. I doubt users will want their inferred schemas to
-    # get widened when these errors occur, so I'm filtering them out before emitting any documents.
     @model_validator(mode='before')
     @classmethod
-    def remove_formula_errors(cls, data: Any) -> Any:
-        """Remove fields that contain formula errors.
+    def normalize_fields(cls, data: Any, info: ValidationInfo) -> Any:
+        """Clean up the raw `fields` object Airtable returns before construction.
 
-        See: https://support.airtable.com/docs/common-formula-errors-and-how-to-fix-them
+        Two things happen here, both hinging on whether a field name is present
+        in the raw response, so they're done together in a single pass instead
+        of as separate validators (a separate "fill missing fields" validator
+        would need to run after this one to see the right picture of what's
+        missing, and Pydantic runs multiple `mode='before'` validators on the
+        same model in reverse declaration order, which is easy to get backwards).
+
+        1. When the formula for a formula field results in an error (circular
+           reference, NaN, divide by zero, etc), Airtable returns an object like
+           {"error": "#ERROR!"} or {"specialValue": "NaN"} instead of the usual
+           scalar result. Allowing these into documents would widen the inferred
+           schema to say these fields could be either their normal scalar type
+           or an object, which likely isn't what users want, so they're removed
+           here. Unlike step 2 below, an error'd field is deliberately left
+           OMITTED rather than filled with a default: the error is Airtable's
+           formula engine transiently choking (a dependent field mid-edit,
+           recompute lag), not evidence the field's real value is now empty, so
+           under `merge` it should read as "no change" and keep whatever value
+           was last known-good - not get overwritten to null.
+           See: https://support.airtable.com/docs/common-formula-errors-and-how-to-fix-them
+
+        2. Airtable omits a field from `fields` entirely once its value becomes
+           empty/falsy - it never sends an explicit null. Under this
+           connector's `merge` reduction strategy, an omitted key means "no
+           change" while an explicit null means "clear it", so a field that's
+           actually been cleared in Airtable would otherwise stay frozen at its
+           last non-empty value forever. `FieldPresenceContext` carries the
+           field names this fetch actually requested from Airtable (excluding
+           a record model's cursor field, which is tracked through its own
+           aliased pydantic field, never through this fill), mapped to the
+           value to inject if still missing - `None` for most field types, or
+           a type-specific falsy value (`""`, `[]`, `False`) for the handful
+           of types where that's the type's only possible empty representation
+           (see _empty_value_for_field_type above). Fields omitted because of
+           step 1's error-stripping are excluded from this fill (see above).
         """
-        if isinstance(data, dict):
-            return {
-                k: v for k, v in data.items()
-                if not _is_formula_error(v)
-            }
-        return data
+        if not info.context or not isinstance(info.context, FieldPresenceContext):
+            raise RuntimeError(f"Validation context must be of type FieldPresenceContext: {info.context}")
+
+        if not isinstance(data, dict):
+            return data
+
+        error_field_names = {
+            k for k, v in data.items()
+            if _is_formula_error(v)
+        }
+        cleaned = {
+            k: v for k, v in data.items()
+            if k not in error_field_names
+        }
+
+        for name, default in info.context.expected_field_defaults.items():
+            if name not in error_field_names:
+                cleaned.setdefault(name, default)
+
+        return cleaned
 
 
 class AirtableRecord(BaseDocument, extra="allow"):

--- a/source-airtable-native/source_airtable_native/resources.py
+++ b/source-airtable-native/source_airtable_native/resources.py
@@ -146,6 +146,7 @@ def incremental_table(
                     http,
                     path,
                     record_cls,
+                    table.fields,
                     REALTIME_LAG,
                 ),
                 LOOKBACK: functools.partial(
@@ -153,6 +154,7 @@ def incremental_table(
                     http,
                     path,
                     record_cls,
+                    table.fields,
                     LOOKBACK_LAG,
                 )
             },

--- a/source-airtable-native/test.flow.yaml
+++ b/source-airtable-native/test.flow.yaml
@@ -6,8 +6,5 @@ captures:
         - python
         - -m
         - source_airtable_native
-        config: 
-          credentials:
-            access_token_sops: placeholder
-            credentials_title: Private App Credentials
+        config: config.yaml
     bindings: []

--- a/source-airtable-native/tests/test_models.py
+++ b/source-airtable-native/tests/test_models.py
@@ -1,0 +1,177 @@
+import pytest
+
+from source_airtable_native.models import (
+    AirtableField,
+    AirtableRecord,
+    AirtableRecordFields,
+    FieldPresenceContext,
+    _empty_value_for_field_type,
+    create_incremental_record_model,
+    expected_field_defaults,
+)
+
+
+def _field(name: str, type: str) -> AirtableField:
+    return AirtableField(id=f"fld{name}", name=name, type=type)
+
+
+# _empty_value_for_field_type
+
+
+def test_empty_value_checkbox_is_false():
+    assert _empty_value_for_field_type("checkbox") is False
+
+
+@pytest.mark.parametrize("field_type", ["singleLineText", "multilineText", "richText", "email", "url", "phoneNumber"])
+def test_empty_value_text_types_are_empty_string(field_type):
+    assert _empty_value_for_field_type(field_type) == ""
+
+
+@pytest.mark.parametrize("field_type", [
+    "multipleSelects", "multipleRecordLinks", "multipleAttachments", "multipleCollaborators",
+    "multipleLookupValues",  # cell format is unconditionally array-shaped regardless of linked field type
+])
+def test_empty_value_array_types_are_empty_array(field_type):
+    assert _empty_value_for_field_type(field_type) == []
+
+
+@pytest.mark.parametrize("field_type", [
+    "number", "currency", "percent", "duration", "rating", "count", "autoNumber",  # no empty-value convention at all
+    "date", "dateTime",  # same
+    "singleSelect",  # constrained option set, "" isn't a documented "no selection" value
+    "formula", "rollup",  # shape varies per-record via a nested `result` type
+    "singleCollaborator", "createdBy", "lastModifiedBy",  # object-shaped, no empty-object convention
+    "somethingAirtableAddsLater",  # unknown types must fail safe
+])
+def test_empty_value_everything_else_is_none(field_type):
+    assert _empty_value_for_field_type(field_type) is None
+
+
+# expected_field_defaults
+
+
+def test_expected_field_defaults_maps_each_name_to_its_type_default():
+    fields = [_field("On Hold", "multipleSelects"), _field("Score", "number")]
+    assert expected_field_defaults(fields) == {"On Hold": [], "Score": None}
+
+
+def test_expected_field_defaults_omits_the_excluded_name():
+    fields = [_field("On Hold", "multipleSelects"), _field("Last Modified", "lastModifiedTime")]
+    assert expected_field_defaults(fields, exclude="Last Modified") == {"On Hold": []}
+
+
+def test_expected_field_defaults_exclude_not_present_is_a_noop():
+    fields = [_field("On Hold", "multipleSelects"), _field("Notes", "singleLineText")]
+    assert expected_field_defaults(fields, exclude="Nonexistent") == {"On Hold": [], "Notes": ""}
+
+
+def test_expected_field_defaults_empty_fields_list():
+    assert expected_field_defaults([]) == {}
+
+
+# AirtableRecordFields.normalize_fields
+
+
+def test_normalize_fields_requires_a_field_presence_context():
+    with pytest.raises(RuntimeError):
+        AirtableRecordFields.model_validate({"Notes": "hi"})
+
+
+def test_normalize_fields_fills_absent_with_its_type_default_and_leaves_present_untouched():
+    # Mirrors the reported bug: "On Hold" (a multi-select) was set once and is
+    # now absent from Airtable's response because it was cleared. An empty
+    # multi-select's only possible value is [], so that's injected instead of
+    # None - which also means no schema widening is needed for this field.
+    fields_obj = AirtableRecordFields.model_validate(
+        {"On Hold": ["Borrower Delay"]},
+        context=FieldPresenceContext(expected_field_defaults([
+            _field("On Hold", "multipleSelects"),
+            _field("Notes", "singleLineText"),
+        ])),
+    )
+
+    assert fields_obj.model_extra == {"On Hold": ["Borrower Delay"], "Notes": ""}
+
+
+def test_normalize_fields_falls_back_to_none_for_a_type_with_no_safe_empty_value():
+    fields_obj = AirtableRecordFields.model_validate(
+        {},
+        context=FieldPresenceContext(expected_field_defaults([_field("Score", "number")])),
+    )
+
+    assert fields_obj.model_extra == {"Score": None}
+
+
+def test_normalize_fields_all_present_is_a_noop():
+    fields_obj = AirtableRecordFields.model_validate(
+        {"Notes": "hello"},
+        context=FieldPresenceContext({"Notes": ""}),
+    )
+
+    assert fields_obj.model_extra == {"Notes": "hello"}
+
+
+def test_normalize_fields_leaves_a_stripped_formula_error_field_omitted():
+    # A formula field in an error state is a transient computation hiccup
+    # (a dependent field mid-edit, recompute lag), not evidence the field's
+    # real value is now empty. It's stripped by _is_formula_error but must
+    # NOT be filled with a default - it should stay omitted so `merge` reads
+    # it as "no change" and keeps whatever value was last known-good, rather
+    # than the error blip overwriting a real value with null.
+    fields_obj = AirtableRecordFields.model_validate(
+        {"Score": {"error": "#ERROR!"}, "Other": "y"},
+        context=FieldPresenceContext(expected_field_defaults([
+            _field("Score", "formula"),
+            _field("Other", "singleLineText"),
+        ])),
+    )
+
+    assert fields_obj.model_extra == {"Other": "y"}
+    assert "Score" not in fields_obj.model_extra
+
+
+def test_normalize_fields_never_touches_the_cursor_field():
+    record_cls = create_incremental_record_model("Last Modified")
+    expected = expected_field_defaults(
+        [_field("Notes", "singleLineText"), _field("Last Modified", "lastModifiedTime")],
+        exclude="Last Modified",
+    )
+    assert expected == {"Notes": ""}
+
+    record = record_cls.model_validate(
+        {
+            "id": "rec1",
+            "createdTime": "2024-01-01T00:00:00.000Z",
+            "fields": {"Last Modified": "2024-01-01T00:00:00.000Z", "Notes": "hi"},
+        },
+        context=FieldPresenceContext(expected),
+    )
+
+    # The cursor value is tracked through its own aliased field, not model_extra,
+    # and must not gain a colliding "Last Modified" entry there.
+    assert "Last Modified" not in record.fields.model_extra
+    assert record.fields.model_extra == {"Notes": "hi"}
+    assert record.cursor_value.isoformat() == "2024-01-01T00:00:00+00:00"
+
+
+def test_normalize_fields_survives_document_emission_serialization():
+    # This is the exact call estuary_cdk's task.py `_captured()` makes when
+    # emitting a document: model_dump_json(by_alias=True, exclude_unset=True).
+    # Covers both a type-aware fill (On Hold -> []) and a None fallback
+    # (Score -> null) surviving the same serialization path.
+    record = AirtableRecord.model_validate(
+        {
+            "id": "recmsClyQuc4xhNk7",
+            "createdTime": "2024-01-01T00:00:00.000Z",
+            "fields": {"Notes": "hi"},
+        },
+        context=FieldPresenceContext(expected_field_defaults([
+            _field("On Hold", "multipleSelects"),
+            _field("Score", "number"),
+            _field("Notes", "singleLineText"),
+        ])),
+    )
+
+    dumped = record.model_dump_json(by_alias=True, exclude_unset=True)
+    assert '"On Hold":[]' in dumped
+    assert '"Score":null' in dumped


### PR DESCRIPTION
**Description:**

Airtable omits an emptied-out field from its API response entirely instead of sending `null`. Under this connector's `merge` reduction strategy (needed so scheduled formula-field refreshes can update just their own fields without erasing the rest of the record), an omitted key means "no change" - so a field that was ever set and then genuinely cleared in Airtable stayed frozen at its last value forever. This showed up as non-cleared out values for documents materialized in users' destinations.

Records are now validated against the set of fields each fetch actually requested, and any still missing afterward are explicitly filled in - with the type's own blank value ("", [], false) where that's the type's only possible empty state, or null otherwise. That turns the ambiguous omission into an explicit clear, so `merge` correctly wipes the field instead of preserving it. A formula field caught mid-computation-error is left alone rather than filled, since that's a transient glitch, not a real clear.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1787690565839629)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
