### PR TITLE
source-stripe-native: stop leaking a logger per connected-account subtask

### DIFF
--- a/source-stripe-native/CHANGELOG.md
+++ b/source-stripe-native/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-31
+
+### Fixed
+- Memory no longer grows without bound while capturing from connected accounts. Every
+  per-account subtask registered a permanently-retained logger, leaking roughly 0.6 KB
+  per subtask until the connector exceeded its memory limit. Subtask names and the log
+  `source` field no longer embed the account id; it is carried in the `subtask_id` log
+  field instead.
+
 ## 2026-08-20
 
 ### Changed

--- a/source-stripe-native/source_stripe_native/priority_capture.py
+++ b/source-stripe-native/source_stripe_native/priority_capture.py
@@ -20,6 +20,7 @@ from estuary_cdk.capture.common import (
     ResourceConfig,
     FetchSnapshotFn,
 )
+from estuary_cdk.utils import format_error_message
 
 from .protocols import FetchChangesFnFactory, FetchPageFnFactory
 
@@ -268,14 +269,21 @@ class SubtaskExecutor:
         self.main_task = main_task
 
     async def _execute_incremental_subtask(self, work_item: WorkItem, task: Task):
-        await _binding_incremental_task_with_work_item(
-            self.binding,
-            self.binding_index,
-            work_item.incremental_fetch_fn,
-            work_item.incremental_state,
-            task,
-            work_item
-        )
+        try:
+            await _binding_incremental_task_with_work_item(
+                self.binding,
+                self.binding_index,
+                work_item.incremental_fetch_fn,
+                work_item.incremental_state,
+                task,
+                work_item
+            )
+        except Exception as exc:
+            task.log.error(
+                "incremental subtask failed",
+                {"subtask_id": work_item.account_id, "error": format_error_message(exc)},
+            )
+            raise
 
     async def _execute_backfill_subtask(self, work_item: WorkItem, task: Task):
         if not work_item.has_backfill_work():
@@ -284,38 +292,45 @@ class SubtaskExecutor:
         assert work_item.backfill_fetch_fn is not None
         assert work_item.backfill_state is not None
 
-        self.main_task.connector_status.inc_backfilling(self.binding_index)
+        try:
+            self.main_task.connector_status.inc_backfilling(self.binding_index)
 
-        await _binding_backfill_task_with_work_item(
-            self.binding,
-            self.binding_index,
-            work_item.backfill_fetch_fn,
-            work_item.backfill_state,
-            self.resource_state.last_initialized,
-            self.resource_state.is_connector_initiated,
-            task,
-            work_item
-        )
+            await _binding_backfill_task_with_work_item(
+                self.binding,
+                self.binding_index,
+                work_item.backfill_fetch_fn,
+                work_item.backfill_state,
+                self.resource_state.last_initialized,
+                self.resource_state.is_connector_initiated,
+                task,
+                work_item
+            )
 
-        # Update the resource state to reflect backfill completion.
-        # This ensures PriorityCalculator sees the completed backfill during periodic re-prioritization.
-        if isinstance(self.resource_state.backfill, dict):
-            self.resource_state.backfill[work_item.account_id] = None
+            # Update the resource state to reflect backfill completion.
+            # This ensures PriorityCalculator sees the completed backfill during periodic re-prioritization.
+            if isinstance(self.resource_state.backfill, dict):
+                self.resource_state.backfill[work_item.account_id] = None
 
-        self.main_task.connector_status.dec_backfilling(self.binding_index)
+            self.main_task.connector_status.dec_backfilling(self.binding_index)
+        except Exception as exc:
+            task.log.error(
+                "backfill subtask failed",
+                {"subtask_id": work_item.account_id, "error": format_error_message(exc)},
+            )
+            raise
 
     async def execute_work_item(self, work_item: WorkItem, task: Task):
         subtasks: list[asyncio.Task] = []
 
         if work_item.has_backfill_work():
             backfill_task = task.spawn_child(
-                f"backfill.{work_item.account_id}",
+                "backfill",
                 lambda t: self._execute_backfill_subtask(work_item, t)
             )
             subtasks.append(backfill_task)
 
         incremental_task = task.spawn_child(
-            f"incremental.{work_item.account_id}",
+            "incremental",
             lambda t: self._execute_incremental_subtask(work_item, t)
         )
         subtasks.append(incremental_task)


### PR DESCRIPTION
**Description:**

There's been a slow memory leak present in the `priority_capture.py` code for `source-stripe-native`, and Claude helped me finally figure out what's causing it.

`Task.spawn_child` derives the child's logger from the name suffix via `Logger.getChild`, and Python's logging registry retains every distinct logger name for the life of the process. The priority queue named each subtask "backfill.<acct>" / "incremental.<acct>" under one of 40 rotating worker `Task`s, so every rotation registered a new ~0.6 KB logger and the connector climbed into its 1 GiB limit with tens of thousands of accounts.

This PR fixes the memory leak by naming the children "backfill" / "incremental" so the registry is bounded by `bindings x workers x 2`, and log a subtask failure with its `subtask_id` before re-raising so the account stays attributable.

Closes https://github.com/estuary/connectors/issues/3887.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
