### PR TITLE
source-klaviyo-native: increase eventual consistency lag to 7 days

### DIFF
--- a/source-klaviyo-native/CHANGELOG.md
+++ b/source-klaviyo-native/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-31
+
+### Changed
+- Raised the events lookback horizon from 4 days to 7 days. On upgrade, existing tasks' lookback subtask idles for ~3 days while `now - horizon` catches back up to its cursor; this is expected and no data is skipped.
+
 ## 2026-07-30
 
 ### Fixed

--- a/source-klaviyo-native/CHANGELOG.md
+++ b/source-klaviyo-native/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-31
 
+### Fixed
+- The events backfill's worker pool could declare a window complete while chunks were still in flight between queues, silently skipping unfetched date ranges. Completion is now tracked with exact outstanding-chunk accounting, and a residual accounting bug fails the window loudly instead of checkpointing past a hole.
+
 ### Changed
 - Raised the events lookback horizon from 4 days to 7 days. On upgrade, existing tasks' lookback subtask idles for ~3 days while `now - horizon` catches back up to its cursor; this is expected and no data is skipped.
 

--- a/source-klaviyo-native/source_klaviyo_native/api/events.py
+++ b/source-klaviyo-native/source_klaviyo_native/api/events.py
@@ -103,11 +103,8 @@ class QueueManager:
         except asyncio.TimeoutError:
             return None
 
-    def are_all_queues_empty(self) -> bool:
-        return (
-            self.work_queue.empty() and
-            self.subdivision_request_queue.empty()
-        )
+    def mark_work_chunk_done(self) -> None:
+        self.work_queue.task_done()
 
 
 class WorkManager:
@@ -127,7 +124,7 @@ class WorkManager:
 
         self.worker_tasks: list[asyncio.Task] = []
         self.subdivision_task: Optional[asyncio.Task] = None
-        self.shutdown_monitor_task: Optional[asyncio.Task] = None
+        self.completion_watcher_task: Optional[asyncio.Task] = None
 
         self._active_worker_count = 0
         self.first_worker_error: str | None = None
@@ -141,9 +138,6 @@ class WorkManager:
         if self._active_worker_count <= 0:
             raise Exception(f"A worker attempted to mark itself inactive when the active worker count is {self._active_worker_count}.")
         self._active_worker_count -= 1
-
-    def are_active_workers(self) -> bool:
-        return self._active_worker_count > 0
 
     async def fetch_events_between(
         self,
@@ -209,13 +203,22 @@ class WorkManager:
             )
             self.subdivision_task.add_done_callback(callback)
 
-            self.shutdown_monitor_task = tg.create_task(
-                self._shutdown_monitor(),
-                name="shutdown_monitor"
+            self.completion_watcher_task = tg.create_task(
+                self._completion_watcher(),
+                name="completion_watcher"
             )
-            self.shutdown_monitor_task.add_done_callback(callback)
+            self.completion_watcher_task.add_done_callback(callback)
 
         self.log.debug("Exiting TaskGroup.")
+
+        # A clean shutdown must leave both queues drained.
+        if (
+            not self.queue_manager.work_queue.empty() or
+            not self.queue_manager.subdivision_request_queue.empty()
+        ):
+            raise RuntimeError(
+                "Events backfill worker pool shut down with unprocessed date chunks still queued."
+            )
 
     def _create_initial_chunks(self, start: datetime, end: datetime) -> list[DateChunk]:
         return [
@@ -228,16 +231,17 @@ class WorkManager:
             )
         ]
 
-    async def _shutdown_monitor(self) -> None:
-        self.log.debug("Shutdown monitor started.")
-        while not self.shutdown_event.is_set():
-            if not self.are_active_workers() and self.queue_manager.are_all_queues_empty():
-                self.log.debug("All work complete - shutdown monitor initiating shutdown")
-                self.shutdown_event.set()
-                break
-
-            await asyncio.sleep(1)
-        self.log.debug("Shutdown monitor exited.")
+    async def _completion_watcher(self) -> None:
+        self.log.debug("Completion watcher started.")
+        # Every chunk put on the work queue increments its unfinished-task
+        # count, and a chunk is only marked done after it's fully processed
+        # (or, for a chunk handed off for subdivision, after its replacement
+        # chunks have been enqueued). join() therefore returns only once no
+        # chunk is queued.
+        await self.queue_manager.work_queue.join()
+        self.log.debug("All work complete - completion watcher initiating shutdown")
+        self.shutdown_event.set()
+        self.log.debug("Completion watcher exited.")
 
 
 # chunk_worker pulls a date chunk from the queue and fetches events created in
@@ -277,6 +281,7 @@ async def chunk_worker(
             last_cursor = chunk.start
             is_divisible = chunk.end - chunk.start >= (SMALLEST_KLAVIYO_DATETIME_GRAIN * 3)
             is_dense_date_window = False
+            did_hand_off_chunk = False
 
             events_gen = _fetch_events_updated_between(http, log, chunk.start, chunk.end)
 
@@ -296,6 +301,7 @@ async def chunk_worker(
                         end=chunk.end
                     )
                     queue_manager.put_subdivision_chunk(subdivision_chunk)
+                    did_hand_off_chunk = True
                     break
 
                 last_cursor = event_cursor
@@ -319,6 +325,11 @@ async def chunk_worker(
 
             log.debug(f"Event worker {worker_id} is marking itself inactive.")
             work_manager.mark_worker_inactive()
+
+            # A handed-off chunk stays unfinished until the subdivision worker
+            # enqueues its replacement chunks and marks it done.
+            if not did_hand_off_chunk:
+                queue_manager.mark_work_chunk_done()
 
         log.debug(f"Event worker {worker_id} exited.")
     except CancelledError as e:
@@ -376,6 +387,11 @@ async def subdivision_worker(
         ]
 
         await queue_manager.put_work_chunks(divided_chunks)
+
+        # The parent chunk stays unfinished until its replacements are
+        # enqueued above, so the work queue's unfinished-task count can
+        # never touch zero while a subdivision is in flight.
+        queue_manager.mark_work_chunk_done()
 
     log.debug("Subdivision worker exited.")
 

--- a/source-klaviyo-native/source_klaviyo_native/resources.py
+++ b/source-klaviyo-native/source_klaviyo_native/resources.py
@@ -38,7 +38,7 @@ from .models import (
 # Klaviyo doesn't use the standard "Bearer" token type in the Authorization
 # header. Instead, it uses "Klaviyo-API-Key" as the token type.
 AUTHORIZATION_TOKEN_TYPE = "Klaviyo-API-Key"
-EVENTS_EVENTUAL_CONSISTENCY_HORIZON = timedelta(days=4)
+EVENTS_EVENTUAL_CONSISTENCY_HORIZON = timedelta(days=7)
 
 
 async def validate_credentials(


### PR DESCRIPTION
**Description:**

This PR's scope includes:
- Raising the `events` lookback horizon from 4 days to 7 days. We've observed Klaviyo display eventually consistent behavior beyond 4 days. We've confirmed that 17 days later the missed data was available in the API, but I suspect it was available earlier than 17 days (that was just when the incident was raised and the investigation began) and I'd like to avoid bumping the horizon to 17 days until we have more definitive proof that kind of lag is necessary. 
  - As an aside, I also saw that Klaviyo uses [5 days as a default attribution window for some events](https://help.klaviyo.com/hc/en-us/articles/1260804504250#h_01JC68GA5F1TWGXGE0NCETVXJZ), so bumping the horizon to 7 days will allow us to capture late arriving attributions for events too.
- Fix a race condition bug in the `events` backfill that could cause data loss, even though we haven't observed this race condition cause data loss (yet). The shutdown monitor signaled completion when there were no active workers and both the work queue and subdivision queue were empty. But, it's possible for that to be true briefly when a worker has submitted work to be subdivided; it would mark itself inactive, and both queues would be empty while the subdivision worker was subdividing the work. Now, the shutdown monitor / completion watcher uses the work queue's `.join()` method to make sure all work has been completed before signaling completion. This hasn't been observed to cause data loss, it's mostly a hardening effort that I wanted do while I was looking at the connector.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
