### PR TITLE
source-dynamodb: add idleBackoffMax option to slow polling of idle shards

### DIFF
--- a/docs/reference/Connectors/capture-connectors/amazon-dynamodb.md
+++ b/docs/reference/Connectors/capture-connectors/amazon-dynamodb.md
@@ -152,6 +152,7 @@ You configure connectors either in the Estuary web app, or by directly editing t
 | **`/credentials`**                   | Credentials             | Credentials for authentication.                                                                               | [Credentials](#credentials) | Required |
 | `advanced/backfillSegments`          | Backfill Table Segments | Number of segments to use for backfill table scans. Has no effect if changed after the backfill has started.  | integer |                  |
 | `advanced/endpoint`                  | AWS Endpoint            | The AWS endpoint URI to connect to. Use if you're capturing from a compatible API that isn't provided by AWS. | string  |                  |
+| `advanced/idleBackoffMax`            | Idle Poll Backoff Maximum | Maximum wait between polls of an open stream shard whose reads keep returning no records. Polling returns to once per second as soon as records appear. Accepts Go duration strings between `1s` and `10m`. | string  | `1s`             |
 | `advanced/scanLimit`                 | Scan Limit              | Limit the number of items to evaluate for each table backfill scan request.                                   | integer |                  |
 
 #### Credentials
@@ -224,6 +225,10 @@ If your DynamoDB tables don't appear when configuring the capture:
 - Verify DynamoDB Streams is enabled on the table
 - Verify the stream view type is set to "New and old images"
 - Verify your IAM policy includes `ListTables` permission on `table/*`
+
+### High DynamoDB Streams request charges on low-traffic tables
+
+DynamoDB bills every `GetRecords` request the capture makes, even when no records are returned, and open stream shards are polled once per second by default. On tables with many shards and few writes, these polls can make up most of the stream's cost. Set `advanced/idleBackoffMax` (for example, `1m`) to let polling slow down on shards that keep returning no records. Polling returns to once per second as soon as records appear, so new data is delayed by at most the configured value.
 
 ### "dynamodb:ListTables... AccessDeniedException"
 

--- a/scripts/obfuscation/config_allowlist.txt
+++ b/scripts/obfuscation/config_allowlist.txt
@@ -124,6 +124,7 @@ incremental_chunk_size
 incremental_scn_range
 backfillSegments
 scanLimit
+idleBackoffMax
 rcuAllocation
 priority
 node_id

--- a/source-dynamodb/.snapshots/TestSpec
+++ b/source-dynamodb/.snapshots/TestSpec
@@ -96,6 +96,14 @@
             "description": "Limit the number of items to evaluate for each table backfill scan request.",
             "nonsensitive": true
           },
+          "idleBackoffMax": {
+            "type": "string",
+            "title": "Idle Poll Backoff Maximum",
+            "description": "Maximum wait between polls of an open stream shard whose reads keep returning no records. Polling returns to once per second as soon as records appear. Accepts Go duration strings between '1s' and '10m'. Defaults to '1s'. Higher values reduce billed DynamoDB Streams requests on idle shards but delay capture of new records by up to the configured wait.",
+            "default": "1s",
+            "nonsensitive": true,
+            "pattern": "^[0-9]+(ms|s|m|h)$"
+          },
           "endpoint": {
             "type": "string",
             "title": "AWS Endpoint",

--- a/source-dynamodb/CHANGELOG.md
+++ b/source-dynamodb/CHANGELOG.md
@@ -1,5 +1,14 @@
 # source-dynamodb
 
+## 2026-09-01
+
+### Added
+- New advanced option `idleBackoffMax` slows polling of open stream shards
+  that keep returning no records. After a minute of empty reads the wait
+  between polls grows to at most this value, and drops back to once per
+  second as soon as records appear. Accepts Go duration strings between
+  `1s` and `10m`. At the default of `1s` polling is unchanged.
+
 ## 2026-07-30
 
 ### Changed

--- a/source-dynamodb/capture.go
+++ b/source-dynamodb/capture.go
@@ -53,6 +53,10 @@ type capture struct {
 
 	listShardsLimiter *rate.Limiter
 	sem               *semaphore.Weighted
+
+	// idleBackoffMax is the endpoint's configured maximum wait between polls
+	// of an idle open stream shard.
+	idleBackoffMax time.Duration
 }
 
 func (c *capture) getSegmentState(sk boilerplate.StateKey, segment int) segmentState {

--- a/source-dynamodb/main.go
+++ b/source-dynamodb/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
@@ -99,6 +100,7 @@ type config struct {
 type advancedConfig struct {
 	BackfillSegments int    `json:"backfillSegments,omitempty" jsonschema:"title=Backfill Table Segments,description=Number of segments to use for backfill table scans. Has no effect if changed after the backfill has started." jsonschema_extras:"nonsensitive=true"`
 	ScanLimit        int    `json:"scanLimit,omitempty" jsonschema:"title=Scan Limit,description=Limit the number of items to evaluate for each table backfill scan request." jsonschema_extras:"nonsensitive=true"`
+	IdleBackoffMax   string `json:"idleBackoffMax,omitempty" jsonschema:"title=Idle Poll Backoff Maximum,default=1s,description=Maximum wait between polls of an open stream shard whose reads keep returning no records. Polling returns to once per second as soon as records appear. Accepts Go duration strings between '1s' and '10m'. Defaults to '1s'. Higher values reduce billed DynamoDB Streams requests on idle shards but delay capture of new records by up to the configured wait." jsonschema_extras:"pattern=^[0-9]+(ms|s|m|h)$,nonsensitive=true"`
 	Endpoint         string `json:"endpoint,omitempty" jsonschema:"title=AWS Endpoint,description=The AWS endpoint URI to connect to. Use if you're capturing from a compatible API that isn't provided by AWS."`
 }
 
@@ -129,8 +131,31 @@ func (c *config) Validate() error {
 	if c.Advanced.ScanLimit < 0 {
 		return fmt.Errorf("scanLimit cannot be negative")
 	}
+	if _, err := c.parseIdleBackoffMax(); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+// parseIdleBackoffMax returns the configured maximum wait between polls of an idle open stream
+// shard, or defaultIdleBackoffMax when unset. The upper bound keeps waits well below the 15
+// minute expiry of DynamoDB Streams shard iterators, which the connector holds across the wait.
+func (c *config) parseIdleBackoffMax() (time.Duration, error) {
+	if c.Advanced.IdleBackoffMax == "" {
+		return defaultIdleBackoffMax, nil
+	}
+	d, err := time.ParseDuration(c.Advanced.IdleBackoffMax)
+	if err != nil {
+		return 0, fmt.Errorf("invalid idleBackoffMax %q: %w", c.Advanced.IdleBackoffMax, err)
+	}
+	if d < time.Second {
+		return 0, fmt.Errorf("idleBackoffMax %q must be at least 1s", c.Advanced.IdleBackoffMax)
+	}
+	if d > 10*time.Minute {
+		return 0, fmt.Errorf("idleBackoffMax %q must not exceed 10m", c.Advanced.IdleBackoffMax)
+	}
+	return d, nil
 }
 
 func (c *config) CredentialsProvider(ctx context.Context) (aws.CredentialsProvider, error) {

--- a/source-dynamodb/pull.go
+++ b/source-dynamodb/pull.go
@@ -84,6 +84,11 @@ func (driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) error 
 		checkpoint.Tables = make(map[boilerplate.StateKey]tableState)
 	}
 
+	idleBackoffMax, err := cfg.parseIdleBackoffMax()
+	if err != nil {
+		return fmt.Errorf("parsing idleBackoffMax: %w", err)
+	}
+
 	c := capture{
 		client:            client,
 		stream:            stream,
@@ -91,6 +96,7 @@ func (driver) Pull(open *pc.Request_Open, stream *boilerplate.PullOutput) error 
 		state:             checkpoint,
 		listShardsLimiter: rate.NewLimiter(rate.Limit(listShardsPerSecond), 1),
 		sem:               semaphore.NewWeighted(globalConcurrencyLimit),
+		idleBackoffMax:    idleBackoffMax,
 	}
 
 	if err := stream.Ready(false); err != nil {

--- a/source-dynamodb/stream.go
+++ b/source-dynamodb/stream.go
@@ -207,6 +207,30 @@ func (c *capture) readShardTree(
 	}
 }
 
+// DynamoDB Streams bills every GetRecords request, so continuously polling an idle open shard
+// wastes money. If idleBackoffMax is raised above its 1 second default, a shard whose reads have
+// come back empty idleGraceEmpties times in a row waits longer between polls, doubling from
+// idleBackoffMin up to idleBackoffMax. A read that returns records resets the wait.
+//
+// The grace period exists because an empty read does not prove the shard is caught up (see the
+// note in captureTable): holding full speed for the first minute should help keep catch-up reads fast.
+const (
+	idleGraceEmpties      = 60
+	idleBackoffMin        = 2 * time.Second
+	defaultIdleBackoffMax = time.Second
+)
+
+// idleBackoff returns the extra wait to apply after the consecutiveEmpties'th consecutive empty
+// read of an open shard, given the wait that was applied after the previous one and the maximum
+// wait configured for the endpoint. A maximum of one second or less means no extra wait at all,
+// because the base limiter already spaces polls one second apart.
+func idleBackoff(consecutiveEmpties int, prev, maxWait time.Duration) time.Duration {
+	if maxWait <= time.Second || consecutiveEmpties <= idleGraceEmpties {
+		return 0
+	}
+	return min(max(2*prev, idleBackoffMin), maxWait)
+}
+
 func (c *capture) readShard(
 	ctx context.Context,
 	t *table,
@@ -237,11 +261,17 @@ func (c *capture) readShard(
 	// DynamoDB streams are billed per GetRecords request, and GetRecords returns immediately if
 	// there is no data. Limit GetRecords requests to once per second to avoid excessively frequent
 	// calls to GetRecords when tailing an open shard where there may be minimal new data available.
+	// An open shard whose reads keep coming back empty is paced down further by an additional,
+	// growing wait; see idleBackoff.
 	limiter := rate.NewLimiter(rate.Every(time.Second), 1)
-	if shard.SequenceNumberRange.EndingSequenceNumber != nil {
+	isOpen := shard.SequenceNumberRange.EndingSequenceNumber == nil
+	if !isOpen {
 		// If this shard is closed, read it to the end as fast as possible.
 		limiter.SetLimit(rate.Inf)
 	}
+
+	var consecutiveEmpties int
+	var backoff time.Duration
 
 	for iter != nil {
 		select {
@@ -314,6 +344,42 @@ func (c *capture) readShard(
 		// Advance for the next round. A nil NextShardIterator from the GetRecords response
 		// indicates that the shard is closed and will yield no additional records.
 		iter = recs.NextShardIterator
+
+		if isOpen && iter != nil {
+			if len(recs.Records) == 0 {
+				consecutiveEmpties++
+				backoff = idleBackoff(consecutiveEmpties, backoff, c.idleBackoffMax)
+			} else {
+				if backoff > 0 {
+					// The age of the first record distinguishes a fresh write to an idle shard
+					// from a stretch of the shard that had to be stepped through to reach
+					// older records.
+					var firstRecordAge time.Duration
+					if ts := recs.Records[0].Dynamodb.ApproximateCreationDateTime; ts != nil {
+						firstRecordAge = time.Since(*ts)
+					}
+					log.WithFields(log.Fields{
+						"table":              t.tableName,
+						"shardId":            *shard.ShardId,
+						"consecutiveEmpties": consecutiveEmpties,
+						"backoff":            backoff.String(),
+						"firstRecordAge":     firstRecordAge.String(),
+					}).Debug("open shard returned records after idle backoff")
+				}
+				consecutiveEmpties = 0
+				backoff = 0
+			}
+
+			if backoff > 0 {
+				select {
+				case <-time.After(backoff):
+				case <-workersStop:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}
 	}
 
 	log.WithFields(log.Fields{

--- a/source-dynamodb/stream_test.go
+++ b/source-dynamodb/stream_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleBackoff(t *testing.T) {
+	// The default maximum of one second means no extra wait, before or after the grace period.
+	require.Equal(t, time.Duration(0), idleBackoff(1, 0, defaultIdleBackoffMax))
+	require.Equal(t, time.Duration(0), idleBackoff(idleGraceEmpties+100, 0, defaultIdleBackoffMax))
+
+	// With a raised maximum there is still no extra wait during the grace period.
+	require.Equal(t, time.Duration(0), idleBackoff(1, 0, time.Minute))
+	require.Equal(t, time.Duration(0), idleBackoff(idleGraceEmpties, 0, time.Minute))
+
+	// Then doubling from the minimum up to the cap, where it stays.
+	var backoff time.Duration
+	var got []time.Duration
+	for n := idleGraceEmpties + 1; n <= idleGraceEmpties+7; n++ {
+		backoff = idleBackoff(n, backoff, time.Minute)
+		got = append(got, backoff)
+	}
+	require.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		32 * time.Second,
+		time.Minute,
+		time.Minute,
+	}, got)
+
+	// A configured maximum clamps the ramp.
+	backoff = 0
+	got = nil
+	for n := idleGraceEmpties + 1; n <= idleGraceEmpties+4; n++ {
+		backoff = idleBackoff(n, backoff, 5*time.Second)
+		got = append(got, backoff)
+	}
+	require.Equal(t, []time.Duration{
+		2 * time.Second,
+		4 * time.Second,
+		5 * time.Second,
+		5 * time.Second,
+	}, got)
+}


### PR DESCRIPTION
**Description:**

DynamoDB Streams bills per `GetRecords` request regardless of payload, and open shards are polled at a fixed 1/s whether or not anything comes back.

The new advanced `idleBackoffMax` option caps a growing wait applied once an open shard has returned nothing for 60 consecutive reads. Each further empty read doubles the wait from 2s up to the cap, any read returning records resets it, and the wait is interruptible by shard-topology restarts. Closed shards are always read at full speed. At the default of 1s no wait is applied and polling is unchanged. At 1m an idle shard costs about 60 requests an hour instead of 3,600.

The grace period exists because an empty read of an open shard does not mean it is caught up: stepping through an empty portion of a shard can take several reads. Holding 1/s for the first minute of empties is intended to keep traversal through empty portions fast.

Closes #5135

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1787795629330659)

**Notes for reviewers:**

The new `idleBackoffMax` option allows users to trade latency for cost. I'm not 100% sure `'1s'` should be the default max backoff value, but it preserves existing behavior and is in line with most of our technical captures' methodology of "keep latency as low as possible by default", so I'm alright with it for now.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
