### PR TITLE
source-shopify-native: capture media on product variants

### DIFF
--- a/source-shopify-native/CHANGELOG.md
+++ b/source-shopify-native/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-09-01
+
+### Added
+- `product_variants` variants now include `media`, the media attached to each
+  variant, with each entry's `id`, `alt` and `mediaContentType`, plus `image`
+  (`url`, `width`, `height`) for image media. Shopify offers no media type
+  filter at the variant level, so videos and 3D models appear here too,
+  carrying no `image`.
+
 ## 2026-08-27
 
 ### Added

--- a/source-shopify-native/source_shopify_native/graphql/products/variants.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/variants.py
@@ -31,6 +31,22 @@ class ProductVariants(ShopifyGraphQLResource):
                 image {
                     id
                 }
+                media {
+                    edges {
+                        node {
+                            id
+                            alt
+                            mediaContentType
+                            ... on MediaImage {
+                                image {
+                                    url
+                                    width
+                                    height
+                                }
+                            }
+                        }
+                    }
+                }
                 selectedOptions {
                     name
                     value
@@ -69,12 +85,17 @@ class ProductVariants(ShopifyGraphQLResource):
         log: Logger, lines: AsyncGenerator[bytes, None]
     ) -> AsyncGenerator[dict, None]:
         VARIANTS_KEY = "variants"
+        MEDIA_KEY = "media"
         current_product = None
-        current_variant = None
+        # Variants of the current product, keyed by id, so media lines can be attached to the
+        # variant named by their __parentId. Shopify only guarantees a child appears somewhere
+        # after its parent, not immediately after, so media can't be attached positionally.
+        current_variants_by_id: dict[str, dict[str, Any]] = {}
 
         async for line in lines:
             record: dict[str, Any] = json.loads(line)
             id: str = record.get("id", "")
+            parent_id: str = record.get("__parentId", "")
 
             if "gid://shopify/Product/" in id:
                 if current_product:
@@ -83,24 +104,33 @@ class ProductVariants(ShopifyGraphQLResource):
                 current_product = record
 
                 current_product[VARIANTS_KEY] = []
+                current_variants_by_id = {}
 
             elif "gid://shopify/ProductVariant/" in id:
                 if not current_product:
                     log.error("Found a variant before finding a product.")
                     raise RuntimeError()
-                elif record.get("__parentId", "") != current_product.get("id", ""):
+                elif parent_id != current_product.get("id", ""):
                     log.error(
                         "Variant's parent id does not match the current product's id. Check if the JSONL response from Shopify is not ordered correctly.",
                         {
                             "variant.id": id,
-                            "variant.__parentId": record.get("__parentId"),
+                            "variant.__parentId": parent_id,
                             "current_product.id": current_product.get("id"),
                         },
                     )
                     raise RuntimeError()
 
-                current_variant = record
-                current_product[VARIANTS_KEY].append(current_variant)
+                record[MEDIA_KEY] = []
+                current_product[VARIANTS_KEY].append(record)
+                current_variants_by_id[id] = record
+
+            elif parent_id in current_variants_by_id:
+                # Any other line parented to one of this product's variants is one of that
+                # variant's media nodes. Media is matched on __parentId rather than on a gid
+                # prefix because ProductVariant.media takes no media_type filter, so a node can
+                # be a MediaImage, Video, ExternalVideo or Model3d.
+                current_variants_by_id[parent_id][MEDIA_KEY].append(record)
 
             else:
                 log.error("Unidentified line in JSONL response.", record)

--- a/source-shopify-native/source_shopify_native/graphql/products/variants.py
+++ b/source-shopify-native/source_shopify_native/graphql/products/variants.py
@@ -5,6 +5,16 @@ from typing import Any, AsyncGenerator
 
 from source_shopify_native.models import ShopifyGraphQLResource, SortKey, StoreCapabilities
 
+# Every type implementing Shopify's `Media` interface, one per `MediaContentType` value
+# (IMAGE, VIDEO, EXTERNAL_VIDEO, MODEL_3D). `ProductVariant.media` takes no media_type
+# filter, so a variant's media line can be any of these.
+MEDIA_GID_PREFIXES = (
+    "gid://shopify/MediaImage/",
+    "gid://shopify/Video/",
+    "gid://shopify/ExternalVideo/",
+    "gid://shopify/Model3d/",
+)
+
 
 class ProductVariants(ShopifyGraphQLResource):
     NAME = "product_variants"
@@ -125,11 +135,23 @@ class ProductVariants(ShopifyGraphQLResource):
                 current_product[VARIANTS_KEY].append(record)
                 current_variants_by_id[id] = record
 
-            elif parent_id in current_variants_by_id:
-                # Any other line parented to one of this product's variants is one of that
-                # variant's media nodes. Media is matched on __parentId rather than on a gid
-                # prefix because ProductVariant.media takes no media_type filter, so a node can
-                # be a MediaImage, Video, ExternalVideo or Model3d.
+            elif id.startswith(MEDIA_GID_PREFIXES):
+                # Classify on the gid prefix rather than "parented to a variant", so a
+                # connection added under variants later without updating this function falls
+                # through to the unidentified-line error instead of landing in `media`.
+                if parent_id not in current_variants_by_id:
+                    log.error(
+                        "Media's parent is not a variant of the current product. Check if the JSONL response from Shopify is not ordered correctly.",
+                        {
+                            "media.id": id,
+                            "media.__parentId": parent_id,
+                            "current_product.id": current_product.get("id")
+                            if current_product
+                            else None,
+                        },
+                    )
+                    raise RuntimeError()
+
                 current_variants_by_id[parent_id][MEDIA_KEY].append(record)
 
             else:

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -162,133 +162,133 @@
         "uuid": "DocUUIDPlaceholder-329Bb50aa48EAa9ef"
       },
       "createdAt": "2025-01-14T15:10:14Z",
-      "id": "gid://shopify/Product/8086707830829",
-      "legacyResourceId": "8086707830829",
+      "id": "gid://shopify/Product/8086708027437",
+      "legacyResourceId": "8086708027437",
       "updatedAt": "redacted",
       "variants": [
         {
-          "__parentId": "gid://shopify/Product/8086707830829",
-          "barcode": "",
+          "__parentId": "gid://shopify/Product/8086708027437",
+          "barcode": null,
           "compareAtPrice": null,
           "createdAt": "2025-01-14T15:10:14Z",
-          "id": "gid://shopify/ProductVariant/43217823334445",
-          "image": null,
+          "id": "gid://shopify/ProductVariant/43217823924269",
+          "image": {
+            "id": "gid://shopify/ProductImage/34440549072941"
+          },
           "inventoryItem": {
-            "id": "gid://shopify/InventoryItem/45258934976557",
-            "legacyResourceId": "45258934976557"
+            "id": "gid://shopify/InventoryItem/45258935566381",
+            "legacyResourceId": "45258935566381"
           },
           "inventoryPolicy": "DENY",
-          "inventoryQuantity": 0,
-          "legacyResourceId": "43217823334445",
+          "inventoryQuantity": 10000,
+          "legacyResourceId": "43217823924269",
+          "media": [
+            {
+              "__parentId": "gid://shopify/ProductVariant/43217823924269",
+              "alt": "A bar of golden yellow wax",
+              "id": "gid://shopify/MediaImage/26890923638829",
+              "image": {
+                "height": 2881,
+                "url": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/snowboard_wax.png?v=1736867416",
+                "width": 2881
+              },
+              "mediaContentType": "IMAGE"
+            }
+          ],
           "position": 1,
-          "price": "10.00",
+          "price": "24.95",
           "selectedOptions": [
             {
-              "name": "Denominations",
+              "name": "Title",
               "optionValue": {
-                "id": "gid://shopify/ProductOptionValue/4829205987373",
-                "name": "$10"
+                "id": "gid://shopify/ProductOptionValue/4829206577197",
+                "name": "Selling Plans Ski Wax"
               },
-              "value": "$10"
+              "value": "Selling Plans Ski Wax"
             }
           ],
           "sku": null,
-          "taxable": false,
-          "title": "$10",
-          "updatedAt": "2025-08-29T12:12:00Z"
+          "taxable": true,
+          "title": "Selling Plans Ski Wax",
+          "updatedAt": "2026-09-01T13:05:16Z"
         },
         {
-          "__parentId": "gid://shopify/Product/8086707830829",
+          "__parentId": "gid://shopify/Product/8086708027437",
           "barcode": null,
           "compareAtPrice": null,
           "createdAt": "2025-01-14T15:10:14Z",
-          "id": "gid://shopify/ProductVariant/43217823367213",
-          "image": null,
+          "id": "gid://shopify/ProductVariant/43217823957037",
+          "image": {
+            "id": "gid://shopify/ProductImage/34440548974637"
+          },
           "inventoryItem": {
-            "id": "gid://shopify/InventoryItem/45258935009325",
-            "legacyResourceId": "45258935009325"
+            "id": "gid://shopify/InventoryItem/45258935599149",
+            "legacyResourceId": "45258935599149"
           },
           "inventoryPolicy": "DENY",
-          "inventoryQuantity": -1,
-          "legacyResourceId": "43217823367213",
+          "inventoryQuantity": 10000,
+          "legacyResourceId": "43217823957037",
+          "media": [
+            {
+              "__parentId": "gid://shopify/ProductVariant/43217823957037",
+              "alt": "A bar of purple wax",
+              "id": "gid://shopify/MediaImage/26890923835437",
+              "image": {
+                "height": 2881,
+                "url": "https://cdn.shopify.com/s/files/1/0663/4006/1229/files/wax-special.png?v=1736867416",
+                "width": 2881
+              },
+              "mediaContentType": "IMAGE"
+            }
+          ],
           "position": 2,
-          "price": "25.00",
+          "price": "49.95",
           "selectedOptions": [
             {
-              "name": "Denominations",
+              "name": "Title",
               "optionValue": {
-                "id": "gid://shopify/ProductOptionValue/4829206020141",
-                "name": "$25"
+                "id": "gid://shopify/ProductOptionValue/4829206609965",
+                "name": "Special Selling Plans Ski Wax"
               },
-              "value": "$25"
+              "value": "Special Selling Plans Ski Wax"
             }
           ],
           "sku": null,
-          "taxable": false,
-          "title": "$25",
-          "updatedAt": "2025-04-10T17:43:00Z"
+          "taxable": true,
+          "title": "Special Selling Plans Ski Wax",
+          "updatedAt": "2026-09-01T13:05:16Z"
         },
         {
-          "__parentId": "gid://shopify/Product/8086707830829",
+          "__parentId": "gid://shopify/Product/8086708027437",
           "barcode": null,
           "compareAtPrice": null,
           "createdAt": "2025-01-14T15:10:14Z",
-          "id": "gid://shopify/ProductVariant/43217823399981",
+          "id": "gid://shopify/ProductVariant/43217823989805",
           "image": null,
           "inventoryItem": {
-            "id": "gid://shopify/InventoryItem/45258935042093",
-            "legacyResourceId": "45258935042093"
+            "id": "gid://shopify/InventoryItem/45258935631917",
+            "legacyResourceId": "45258935631917"
           },
           "inventoryPolicy": "DENY",
-          "inventoryQuantity": -1,
-          "legacyResourceId": "43217823399981",
+          "inventoryQuantity": 10000,
+          "legacyResourceId": "43217823989805",
+          "media": [],
           "position": 3,
-          "price": "50.00",
+          "price": "9.95",
           "selectedOptions": [
             {
-              "name": "Denominations",
+              "name": "Title",
               "optionValue": {
-                "id": "gid://shopify/ProductOptionValue/4829206052909",
-                "name": "$50"
+                "id": "gid://shopify/ProductOptionValue/4829206642733",
+                "name": "Sample Selling Plans Ski Wax"
               },
-              "value": "$50"
+              "value": "Sample Selling Plans Ski Wax"
             }
           ],
           "sku": null,
-          "taxable": false,
-          "title": "$50",
-          "updatedAt": "2025-04-10T17:43:00Z"
-        },
-        {
-          "__parentId": "gid://shopify/Product/8086707830829",
-          "barcode": null,
-          "compareAtPrice": null,
-          "createdAt": "2025-01-14T15:10:14Z",
-          "id": "gid://shopify/ProductVariant/43217823432749",
-          "image": null,
-          "inventoryItem": {
-            "id": "gid://shopify/InventoryItem/45258935074861",
-            "legacyResourceId": "45258935074861"
-          },
-          "inventoryPolicy": "DENY",
-          "inventoryQuantity": 0,
-          "legacyResourceId": "43217823432749",
-          "position": 4,
-          "price": "100.00",
-          "selectedOptions": [
-            {
-              "name": "Denominations",
-              "optionValue": {
-                "id": "gid://shopify/ProductOptionValue/4829206085677",
-                "name": "$100"
-              },
-              "value": "$100"
-            }
-          ],
-          "sku": null,
-          "taxable": false,
-          "title": "$100",
-          "updatedAt": "2025-01-14T15:10:14Z"
+          "taxable": true,
+          "title": "Sample Selling Plans Ski Wax",
+          "updatedAt": "2026-06-11T17:29:31Z"
         }
       ]
     }

--- a/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
+++ b/source-shopify-native/tests/snapshots/snapshots__capture__capture.stdout.json
@@ -261,7 +261,7 @@
         {
           "__parentId": "gid://shopify/Product/8086708027437",
           "barcode": null,
-          "compareAtPrice": null,
+          "compareAtPrice": "14.95",
           "createdAt": "2025-01-14T15:10:14Z",
           "id": "gid://shopify/ProductVariant/43217823989805",
           "image": null,
@@ -288,7 +288,7 @@
           "sku": null,
           "taxable": true,
           "title": "Sample Selling Plans Ski Wax",
-          "updatedAt": "2026-06-11T17:29:31Z"
+          "updatedAt": "2026-09-02T09:42:19Z"
         }
       ]
     }

--- a/source-shopify-native/tests/test_snapshots.py
+++ b/source-shopify-native/tests/test_snapshots.py
@@ -46,8 +46,12 @@ def test_capture(request, snapshot):
 
     # Keep one representative document per stream, preserving first-appearance order.
     RETURNS_STREAM = "acmeCo/order_returns"
+    VARIANTS_STREAM = "acmeCo/product_variants"
     chosen: dict[str, list] = {}
     order: list[str] = []
+
+    def has_variant_media(record) -> bool:
+        return any(variant.get("media") for variant in record.get("variants", []))
 
     for line in lines:
         stream, record = line[0], line[1]
@@ -61,6 +65,15 @@ def test_capture(request, snapshot):
         ):
             # Prefer the first order that actually has returns so the snapshot
             # covers the nested return reassembly.
+            chosen[stream] = line
+        elif (
+            stream == VARIANTS_STREAM
+            and not has_variant_media(chosen[stream][1])
+            and has_variant_media(record)
+        ):
+            # Prefer the first product whose variants carry media. Most products have
+            # none, and media is nested two connections deep, so this is the only
+            # document that covers attaching it to the right variant by __parentId.
             chosen[stream] = line
 
     unique_stream_lines = []

--- a/source-shopify-native/tests/test_variant_media_parsing.py
+++ b/source-shopify-native/tests/test_variant_media_parsing.py
@@ -1,0 +1,120 @@
+"""Tests for `ProductVariants.process_result`, which reassembles the bulk JSONL result.
+
+`product_variants` is the connector's only bulk stream nested two connections deep
+(`products` -> `variants` -> `media`), so a variant's media arrives on its own line
+carrying the variant's id in `__parentId`. Shopify guarantees only that a child appears
+somewhere after its parent, so these tests pin the reassembly to `__parentId` lookup
+rather than to line adjacency.
+"""
+
+import json
+from contextlib import aclosing
+from logging import Logger
+from typing import Any, AsyncGenerator
+from unittest.mock import MagicMock
+
+import pytest
+
+from source_shopify_native.graphql.products.variants import ProductVariants
+
+PRODUCT_1 = "gid://shopify/Product/1"
+PRODUCT_2 = "gid://shopify/Product/2"
+VARIANT_1 = "gid://shopify/ProductVariant/11"
+VARIANT_2 = "gid://shopify/ProductVariant/12"
+VARIANT_3 = "gid://shopify/ProductVariant/21"
+IMAGE_1 = "gid://shopify/MediaImage/101"
+VIDEO_1 = "gid://shopify/Video/102"
+IMAGE_2 = "gid://shopify/MediaImage/103"
+
+
+async def _lines(records: list[dict[str, Any]]) -> AsyncGenerator[bytes, None]:
+    for record in records:
+        yield json.dumps(record).encode()
+
+
+async def _process(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    log: Logger = MagicMock()
+    # Closed explicitly so the tests that assert a RuntimeError don't leave the generators
+    # suspended mid-iteration.
+    async with aclosing(_lines(records)) as lines:
+        async with aclosing(ProductVariants.process_result(log, lines)) as documents:
+            return [document async for document in documents]
+
+
+@pytest.mark.asyncio
+async def test_media_attaches_to_its_variant_across_non_adjacent_lines():
+    # VARIANT_1's media is emitted after VARIANT_2's line, which Shopify permits: children
+    # are ordered after their parent, but not necessarily immediately after it.
+    documents = await _process(
+        [
+            {"id": PRODUCT_1},
+            {"id": VARIANT_1, "__parentId": PRODUCT_1},
+            {"id": VARIANT_2, "__parentId": PRODUCT_1},
+            {"id": IMAGE_1, "mediaContentType": "IMAGE", "__parentId": VARIANT_1},
+            {"id": VIDEO_1, "mediaContentType": "VIDEO", "__parentId": VARIANT_1},
+            {"id": IMAGE_2, "mediaContentType": "IMAGE", "__parentId": VARIANT_2},
+        ]
+    )
+
+    assert len(documents) == 1
+    variants = documents[0]["variants"]
+    assert [variant["id"] for variant in variants] == [VARIANT_1, VARIANT_2]
+    # Non-image media has no `image`, so it is identified by mediaContentType alone.
+    assert [media["id"] for media in variants[0]["media"]] == [IMAGE_1, VIDEO_1]
+    assert [media["id"] for media in variants[1]["media"]] == [IMAGE_2]
+
+
+@pytest.mark.asyncio
+async def test_variant_without_media_still_carries_an_empty_list():
+    documents = await _process(
+        [
+            {"id": PRODUCT_1},
+            {"id": VARIANT_1, "__parentId": PRODUCT_1},
+        ]
+    )
+
+    assert documents[0]["variants"][0]["media"] == []
+
+
+@pytest.mark.asyncio
+async def test_media_is_scoped_to_the_product_that_owns_the_variant():
+    documents = await _process(
+        [
+            {"id": PRODUCT_1},
+            {"id": VARIANT_1, "__parentId": PRODUCT_1},
+            {"id": IMAGE_1, "__parentId": VARIANT_1},
+            {"id": PRODUCT_2},
+            {"id": VARIANT_3, "__parentId": PRODUCT_2},
+            {"id": IMAGE_2, "__parentId": VARIANT_3},
+        ]
+    )
+
+    assert len(documents) == 2
+    assert [media["id"] for media in documents[0]["variants"][0]["media"]] == [IMAGE_1]
+    assert [media["id"] for media in documents[1]["variants"][0]["media"]] == [IMAGE_2]
+
+
+@pytest.mark.asyncio
+async def test_media_for_a_previous_product_variant_is_rejected():
+    # Media parented to a variant of an already-yielded product means the JSONL arrived out of
+    # order. Silently dropping it would lose media, so the stream fails loudly instead.
+    with pytest.raises(RuntimeError):
+        await _process(
+            [
+                {"id": PRODUCT_1},
+                {"id": VARIANT_1, "__parentId": PRODUCT_1},
+                {"id": PRODUCT_2},
+                {"id": IMAGE_1, "__parentId": VARIANT_1},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_unidentified_line_is_still_rejected():
+    with pytest.raises(RuntimeError):
+        await _process(
+            [
+                {"id": PRODUCT_1},
+                {"id": "gid://shopify/Customer/9", "__parentId": "gid://shopify/Order/9"},
+            ]
+        )

--- a/source-shopify-native/tests/test_variant_media_parsing.py
+++ b/source-shopify-native/tests/test_variant_media_parsing.py
@@ -110,6 +110,49 @@ async def test_media_for_a_previous_product_variant_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_non_media_line_parented_to_a_variant_is_rejected():
+    # A connection added under variants later, without updating process_result, must not be
+    # silently stitched into `media` — it falls through to the unidentified-line error.
+    with pytest.raises(RuntimeError):
+        await _process(
+            [
+                {"id": PRODUCT_1},
+                {"id": VARIANT_1, "__parentId": PRODUCT_1},
+                {"id": "gid://shopify/Metafield/77", "__parentId": VARIANT_1},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_media_parented_to_an_unknown_variant_is_rejected():
+    with pytest.raises(RuntimeError):
+        await _process(
+            [
+                {"id": PRODUCT_1},
+                {"id": VARIANT_1, "__parentId": PRODUCT_1},
+                {"id": IMAGE_1, "__parentId": "gid://shopify/ProductVariant/999"},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_media_type_is_captured():
+    # ProductVariant.media takes no media_type filter, so all four Media types can arrive.
+    media_ids = [
+        "gid://shopify/MediaImage/1",
+        "gid://shopify/Video/2",
+        "gid://shopify/ExternalVideo/3",
+        "gid://shopify/Model3d/4",
+    ]
+    documents = await _process(
+        [{"id": PRODUCT_1}, {"id": VARIANT_1, "__parentId": PRODUCT_1}]
+        + [{"id": m, "__parentId": VARIANT_1} for m in media_ids]
+    )
+
+    assert [m["id"] for m in documents[0]["variants"][0]["media"]] == media_ids
+
+
+@pytest.mark.asyncio
 async def test_unidentified_line_is_still_rejected():
     with pytest.raises(RuntimeError):
         await _process(


### PR DESCRIPTION
**Description:**

Adds `ProductVariant.media` to the `product_variants` bulk query, so each variant carries its attached media — `id`, `alt`, `mediaContentType`, and `image` for image media. A customer needs at variant level what `product_media` already gives at product level.

**Workflow steps:**

Query change in `graphql/products/variants.py` plus its `process_result`. `media` is a connection, so bulk JSONL puts each node on its own line carrying the variant's id in `__parentId`; media attaches by that id rather than positionally, since Shopify only guarantees a child follows its parent somewhere. `products → variants → media` sits at Shopify's two-connection nesting ceiling, so nothing can nest beneath `media`.

No access scope beyond the `read_products` the stream already requires. Verified with the capture snapshot test, after seeding two Ski Wax variants with media and a third without. `test_snapshots.py` now prefers a product whose variants carry media, which accounts for most of the snapshot diff.

Existing captures won't backfill — media appears on products whose `updatedAt` advances after deploy.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: N/A
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated: N/A — no config/schema changes, discovery/schema is inferred

Closes #5163
