### PR TITLE
source-mysql: add support for Azure IAM auth

### DIFF
--- a/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/MariaDB.md
@@ -121,7 +121,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
 | **`/address`**                          | Server Address                     | The host or host:port at which the database can be reached.                                                                                                                                                                                                                                                                                                                             | string  | Required                   |
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
-| **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
@@ -133,6 +132,14 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
 | `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. Allowed values: `30s`, `1m`, `5m`, `30m`, or empty to disable. | string |  |
 | `/advanced/rediscovery_interval` | Rediscovery Interval | How often the connector re-runs discovery while a capture is running, in order to notice schema changes and newly added tables. Accepts duration strings like `15m` or `1h`, from `1m` up to `8760h`. | string | `"15m"` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. MariaDB supports `UserPassword`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 
 #### Bindings
 
@@ -164,7 +171,9 @@ captures:
         config:
           address: "127.0.0.1:3306"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           namespace: ${TABLE_NAMESPACE}

--- a/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -119,7 +119,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
 | **`/address`**                          | Server Address                     | The host or host:port at which the database can be reached.                                                                                                                                                                                                                                                                                                                             | string  | Required                   |
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
-| **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
@@ -131,6 +130,14 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
 | `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. Allowed values: `30s`, `1m`, `5m`, `30m`, or empty to disable. | string |  |
 | `/advanced/rediscovery_interval` | Rediscovery Interval | How often the connector re-runs discovery while a capture is running, in order to notice schema changes and newly added tables. Accepts duration strings like `15m` or `1h`, from `1m` up to `8760h`. | string | `"15m"` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. Amazon RDS for MariaDB supports `UserPassword`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 
 #### Bindings
 
@@ -162,7 +169,9 @@ captures:
         config:
           address: "127.0.0.1:3306"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           namespace: ${TABLE_NAMESPACE}

--- a/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -172,6 +172,25 @@ GRANT SELECT ON *.* TO 'flow_capture';
 4. Note the instance's host under Server name, and the port under Connection Strings (usually `3306`).
    Together, you'll use the host:port as the `address` property when you configure the connector.
 
+### IAM Authentication
+
+For Azure Database for MySQL flexible servers, you can authenticate with an Azure App Registration instead of a password.
+
+Follow the steps in the [Azure IAM guide][azure-iam] to create an App Registration and make note of the Application ID and Tenant ID to use when configuring the connector's authentication options.
+
+Ensure that the flexible server has [Microsoft Entra authentication](https://learn.microsoft.com/en-us/azure/mysql/flexible-server/how-to-azure-ad) enabled and connect to it as the Entra admin. Run the following commands to create a database user for the App Registration, granting it the same permissions as the `flow_capture` user in the [Azure Database for MySQL](#azure-database-for-mysql) setup instructions above:
+
+```sql
+SET aad_auth_validate_oids_in_tenant = OFF;
+CREATE AADUSER 'flow_capture' IDENTIFIED BY 'application-id-of-app-registration';
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
+GRANT SELECT ON *.* TO 'flow_capture';
+```
+
+Use the name given in the `CREATE AADUSER` statement as the connector's `user` property.
+
+[azure-iam]: /guides/iam-auth/azure/
+
 ## Capturing from Read Replicas
 
 This connector supports capturing from a read replica of your database, provided that
@@ -232,7 +251,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
 | **`/address`**                          | Server Address                     | The host or host:port at which the database can be reached.                                                                                                                                                                                                                                                                                                                             | string  | Required                   |
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
-| **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
 | `/advanced/dbname`                      | Database Name                      | The name of the database to connect to. In general this shouldn't matter. The connector can discover and capture from all databases it's authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
@@ -244,6 +262,16 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
 | `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. Allowed values: `30s`, `1m`, `5m`, `30m`, or empty to disable. | string |  |
 | `/advanced/rediscovery_interval` | Rediscovery Interval | How often the connector re-runs discovery while a capture is running, in order to notice schema changes and newly added tables. Accepts duration strings like `15m` or `1h`, from `1m` up to `8760h`. | string | `"15m"` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AzureIAM`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/azure_client_id` | Azure Client ID | Application (client) ID of the App Registration. | string | Required for `AzureIAM` auth |
+| `/credentials/azure_tenant_id` | Azure Tenant ID | Directory (tenant) ID of the App Registration. | string | Required for `AzureIAM` auth |
 
 ##### Discovery Filters
 
@@ -288,12 +316,23 @@ captures:
         config:
           address: "127.0.0.1:3306"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate to an Azure Database for MySQL flexible server with [Azure IAM](#iam-authentication) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AzureIAM
+            azure_client_id: "11111111-2222-3333-4444-555555555555"
+            azure_tenant_id: "66666666-7777-8888-9999-000000000000"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -138,7 +138,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
 | **`/address`**                          | Server Address                     | The host or host:port at which the database can be reached.                                                                                                                                                                                                                                                                                                                             | string  | Required                   |
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
-| **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
@@ -150,6 +149,14 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
 | `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. Allowed values: `30s`, `1m`, `5m`, `30m`, or empty to disable. | string |  |
 | `/advanced/rediscovery_interval` | Rediscovery Interval | How often the connector re-runs discovery while a capture is running, in order to notice schema changes and newly added tables. Accepts duration strings like `15m` or `1h`, from `1m` up to `8760h`. | string | `"15m"` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. Amazon RDS for MySQL supports `UserPassword`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 
 ##### Discovery Filters
 
@@ -194,7 +201,9 @@ captures:
         config:
           address: "127.0.0.1:3306"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           namespace: ${TABLE_NAMESPACE}

--- a/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -113,7 +113,6 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
 | **`/address`**                          | Server Address                     | The host or host:port at which the database can be reached.                                                                                                                                                                                                                                                                                                                             | string  | Required                   |
 | **`/user`**                             | Login User                         | The database user to authenticate as.                                                                                                                                                                                                                                                                                                                                                   | string  | Required, `"flow_capture"` |
-| **`/password`**                         | Login Password                     | Password for the specified database user.                                                                                                                                                                                                                                                                                                                                               | string  | Required                   |
 | `/timezone`                             | Timezone                           | Timezone to use when capturing datetime columns. Should normally be left blank to use the database's `'time_zone'` system variable. Only required if the `'time_zone'` system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the `'time_zone'` system variable if both are set. | string  |                            |
 | `/historyMode` | History Mode | Capture each change event, without merging. | boolean | `false` |
 | `/advanced/dbname`                      | Database Name                      | The name of database to connect to. In general this shouldn&#x27;t matter. The connector can discover and capture from all databases it&#x27;s authorized to access.                                                                                                                                                                                                                    | string  | `"mysql"`                  |
@@ -125,6 +124,14 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | `/advanced/source_tag` | Source Tag | This value is added as the property 'tag' in the source metadata of each document. | string |  |
 | `/advanced/statement_timeout` | Statement Timeout | Overrides the default statement timeout used by the connector. Allowed values: `30s`, `1m`, `5m`, `30m`, or empty to disable. | string |  |
 | `/advanced/rediscovery_interval` | Rediscovery Interval | How often the connector re-runs discovery while a capture is running, in order to notice schema changes and newly added tables. Accepts duration strings like `15m` or `1h`, from `1m` up to `8760h`. | string | `"15m"` |
+
+##### Authentication
+
+| Property | Title | Description | Type | Required/Default |
+| --- | --- | --- | --- | --- |
+| **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. Google Cloud SQL for MySQL supports `UserPassword`. | string |  |
+| `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 
 ##### Discovery Filters
 
@@ -169,7 +176,9 @@ captures:
         config:
           address: "127.0.0.1:3306"
           user: "flow_capture"
-          password: "secret"
+          credentials:
+            auth_type: UserPassword
+            password: "secret"
     bindings:
       - resource:
           namespace: ${TABLE_NAMESPACE}

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -17,12 +17,72 @@
         "default": "flow_capture",
         "order": 1
       },
-      "password": {
-        "type": "string",
-        "title": "Login Password",
-        "description": "Password for the specified database user.",
+      "credentials": {
+        "oneOf": [
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/source-mysql/user-password-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "UserPassword",
+                "default": "UserPassword",
+                "order": 0
+              },
+              "password": {
+                "type": "string",
+                "title": "Password",
+                "description": "Password for the specified database user.",
+                "order": 1,
+                "secret": true
+              }
+            },
+            "type": "object",
+            "required": [
+              "password"
+            ],
+            "title": "Password"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/azure-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AzureIAM",
+                "default": "AzureIAM",
+                "order": 0
+              },
+              "azure_client_id": {
+                "type": "string",
+                "title": "Azure Client ID",
+                "description": "Azure App Registration Client ID for Azure Active Directory authentication"
+              },
+              "azure_tenant_id": {
+                "type": "string",
+                "title": "Azure Tenant ID",
+                "description": "Azure Tenant ID for Azure Active Directory authentication"
+              }
+            },
+            "type": "object",
+            "required": [
+              "azure_client_id",
+              "azure_tenant_id"
+            ],
+            "title": "Azure IAM"
+          }
+        ],
+        "type": "object",
+        "title": "Authentication",
+        "default": {
+          "auth_type": "UserPassword"
+        },
+        "discriminator": {
+          "propertyName": "auth_type"
+        },
         "order": 2,
-        "secret": true
+        "x-iam-auth": true,
+        "x-iam-azure-scope": "https://ossrdbms-aad.database.windows.net/.default"
       },
       "timezone": {
         "type": "string",
@@ -206,7 +266,7 @@
     "required": [
       "address",
       "user",
-      "password",
+      "credentials",
       "historyMode"
     ],
     "title": "MySQL Connection"

--- a/source-mysql/CHANGELOG.md
+++ b/source-mysql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # source-mysql
 
+## 2026-08-28
+
+### Added
+- New `credentials` configuration union supporting username/password and Azure
+  IAM authentication, the latter using an Entra access token obtained through
+  an Azure App Registration. Existing configs with the legacy top-level
+  `password` field keep working and are folded into the new shape
+  automatically.
+
 ## 2026-08-18
 
 ### Added

--- a/source-mysql/config_test.go
+++ b/source-mysql/config_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/estuary/connectors/go/auth/iam"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeCredentials(t *testing.T) {
+	t.Run("LegacyPasswordPromotes", func(t *testing.T) {
+		var cfg = Config{Address: "example.com:3306", User: "flow_capture", Password: "secret1234"}
+
+		cfg.normalizeCredentials()
+
+		require.Empty(t, cfg.Password)
+		require.NotNil(t, cfg.Credentials)
+		require.Equal(t, UserPassword, cfg.Credentials.AuthType)
+		require.Equal(t, "secret1234", cfg.Credentials.Password)
+	})
+
+	t.Run("CredentialsWinOverLegacyPassword", func(t *testing.T) {
+		var cfg = Config{
+			Address:  "example.com:3306",
+			User:     "flow_capture",
+			Password: "stale-legacy-password",
+			Credentials: &CredentialsConfig{
+				AuthType:           UserPassword,
+				UserPasswordConfig: UserPasswordConfig{Password: "current-password"},
+			},
+		}
+
+		cfg.normalizeCredentials()
+
+		require.Empty(t, cfg.Password)
+		require.Equal(t, "current-password", cfg.Credentials.Password)
+	})
+}
+
+func TestConfigValidate(t *testing.T) {
+	var valid = func() Config {
+		return Config{Address: "example.com:3306", User: "flow_capture", Credentials: &CredentialsConfig{
+			AuthType:           UserPassword,
+			UserPasswordConfig: UserPasswordConfig{Password: "secret1234"},
+		}}
+	}
+
+	t.Run("UserPasswordCredentials", func(t *testing.T) {
+		var cfg = valid()
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("LegacyPasswordOnly", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = nil
+		cfg.Password = "secret1234"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("NoCredentialsAtAll", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = nil
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'credentials'")
+	})
+
+	t.Run("EmptyPasswordCredentials", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials.Password = ""
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'password'")
+	})
+
+	t.Run("OverlongPasswordCredentials", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials.Password = strings.Repeat("x", 33)
+
+		require.ErrorContains(t, cfg.Validate(), "cannot exceed 32 characters")
+	})
+
+	t.Run("OverlongLegacyPassword", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = nil
+		cfg.Password = strings.Repeat("x", 33)
+
+		require.ErrorContains(t, cfg.Validate(), "cannot exceed 32 characters")
+	})
+
+	t.Run("AzureIAMValid", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AzureIAM}
+		cfg.Credentials.AzureClientID = "11111111-2222-3333-4444-555555555555"
+		cfg.Credentials.AzureTenantID = "66666666-7777-8888-9999-000000000000"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("AzureIAMMissingClientID", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AzureIAM}
+		cfg.Credentials.AzureTenantID = "66666666-7777-8888-9999-000000000000"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'azure_client_id'")
+	})
+
+	t.Run("UnknownAuthType", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: "Bogus"}
+
+		require.ErrorContains(t, cfg.Validate(), "unknown 'auth_type'")
+	})
+}
+
+func TestEffectivePassword(t *testing.T) {
+	t.Run("UserPassword", func(t *testing.T) {
+		var cfg = Config{Address: "example.com:3306", User: "flow_capture", Password: "secret1234"}
+		cfg.normalizeCredentials()
+
+		password, err := cfg.EffectivePassword()
+		require.NoError(t, err)
+		require.Equal(t, "secret1234", password)
+	})
+
+	t.Run("AzureIAMToken", func(t *testing.T) {
+		// Entra access tokens are far longer than 32 characters, which is fine:
+		// the replication password length limit only applies to password auth.
+		var token = strings.Repeat("token", 400)
+		var cfg = Config{
+			Address: "example.mysql.database.azure.com:3306",
+			User:    "flow_capture",
+			Credentials: &CredentialsConfig{
+				AuthType: AzureIAM,
+				IAMConfig: iam.IAMConfig{
+					AzureConfig: iam.AzureConfig{
+						AzureClientID: "11111111-2222-3333-4444-555555555555",
+						AzureTenantID: "66666666-7777-8888-9999-000000000000",
+					},
+					IAMTokens: iam.IAMTokens{AzureTokens: iam.AzureTokens{AzureAccessToken: token}},
+				},
+			},
+		}
+		cfg.normalizeCredentials()
+
+		require.NoError(t, cfg.Validate())
+		password, err := cfg.EffectivePassword()
+		require.NoError(t, err)
+		require.Equal(t, token, password)
+	})
+
+	t.Run("AzureIAMMissingToken", func(t *testing.T) {
+		var cfg = Config{
+			Address:     "example.mysql.database.azure.com:3306",
+			User:        "flow_capture",
+			Credentials: &CredentialsConfig{AuthType: AzureIAM},
+		}
+		cfg.normalizeCredentials()
+
+		_, err := cfg.EffectivePassword()
+		require.ErrorContains(t, err, "missing 'azure_access_token'")
+	})
+
+	t.Run("UnsupportedAuthType", func(t *testing.T) {
+		var cfg = Config{
+			Address:     "example.com:3306",
+			User:        "flow_capture",
+			Credentials: &CredentialsConfig{AuthType: "Bogus"},
+		}
+
+		_, err := cfg.EffectivePassword()
+		require.ErrorContains(t, err, `unsupported 'auth_type' "Bogus"`)
+	})
+}
+
+func TestRequiresTLS(t *testing.T) {
+	// Pinned per auth type so that adding another IAM method cannot silently reopen
+	// the plaintext fallback. The unknown-type case pins the fail-closed default.
+	for _, tc := range []struct {
+		authType AuthType
+		expect   bool
+	}{
+		{UserPassword, false},
+		{AzureIAM, true},
+		{AuthType(iam.AWSIAM), true},
+		{AuthType(iam.GCPIAM), true},
+		{AuthType("Bogus"), true},
+	} {
+		t.Run(string(tc.authType), func(t *testing.T) {
+			var cfg = Config{Credentials: &CredentialsConfig{AuthType: tc.authType}}
+			require.Equal(t, tc.expect, cfg.requiresTLS())
+		})
+	}
+}

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
 	networkTunnel "github.com/estuary/connectors/go/network-tunnel"
@@ -85,6 +86,7 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 		return nil, fmt.Errorf("error parsing config json: %w", err)
 	}
 	config.SetDefaults(name)
+	config.normalizeCredentials()
 
 	// If SSH Endpoint is configured, then try to start a tunnel before establishing connections
 	if config.NetworkTunnel != nil && config.NetworkTunnel.SSHForwarding != nil && config.NetworkTunnel.SSHForwarding.SSHEndpoint != "" {
@@ -144,14 +146,60 @@ func connectMySQL(ctx context.Context, name string, cfg json.RawMessage) (sqlcap
 	return db, nil
 }
 
+type AuthType string
+
+const (
+	UserPassword AuthType = "UserPassword"
+	AzureIAM     AuthType = "AzureIAM"
+)
+
+type UserPasswordConfig struct {
+	Password string `json:"password" jsonschema:"title=Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=1"`
+}
+
+// CredentialsConfig is a flat union of the supported authentication methods,
+// discriminated by AuthType. The JSON Schema presents it as a oneOf with one
+// branch per method.
+type CredentialsConfig struct {
+	AuthType AuthType `json:"auth_type"`
+
+	UserPasswordConfig
+	iam.IAMConfig
+}
+
+func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
+	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword),
+		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
+		schemagen.OneOfSubSchema("Azure IAM", iam.AzureConfig{}, string(AzureIAM)),
+	)
+}
+
+func (c *CredentialsConfig) Validate() error {
+	switch c.AuthType {
+	case UserPassword:
+		if c.Password == "" {
+			return errors.New("missing 'password'")
+		}
+		return nil
+	case AzureIAM:
+		// The embedded IAMConfig has its own auth_type field which JSON decoding
+		// leaves empty (the outer field shadows it), so sync it before ValidateIAM
+		// switches on it.
+		c.IAMConfig.AuthType = iam.AuthType(c.AuthType)
+		return c.ValidateIAM()
+	}
+	return fmt.Errorf("unknown 'auth_type' %q", c.AuthType)
+}
+
 // Config tells the connector how to connect to the source database and
 // capture changes from it.
 type Config struct {
-	Address     string `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
-	User        string `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
-	Password    string `json:"password" jsonschema:"title=Login Password,description=Password for the specified database user." jsonschema_extras:"secret=true,order=2"`
-	Timezone    string `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3,nonsensitive=true"`
-	HistoryMode bool   `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4,nonsensitive=true"`
+	Address     string             `json:"address" jsonschema:"title=Server Address,description=The host or host:port at which the database can be reached." jsonschema_extras:"order=0"`
+	User        string             `json:"user" jsonschema:"title=Login Username,default=flow_capture,description=The database user to authenticate as." jsonschema_extras:"order=1"`
+	Password    string             `json:"password,omitempty" jsonschema:"-"`
+	Credentials *CredentialsConfig `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=2,x-iam-auth=true,x-iam-azure-scope=https://ossrdbms-aad.database.windows.net/.default"`
+	Timezone    string             `json:"timezone,omitempty" jsonschema:"title=Timezone,description=Timezone to use when capturing datetime columns. Should normally be left blank to use the database's 'time_zone' system variable. Only required if the 'time_zone' system variable cannot be read and columns with type datetime are being captured. Must be a valid IANA time zone name or +HH:MM offset. Takes precedence over the 'time_zone' system variable if both are set (go.estuary.dev/80J6rX)." jsonschema_extras:"order=3,nonsensitive=true"`
+	HistoryMode bool               `json:"historyMode" jsonschema:"default=false,description=Capture change events without reducing them to a final state." jsonschema_extras:"order=4,nonsensitive=true"`
 
 	DiscoveryFilters discoveryFilters `json:"discoveryFilters,omitempty" jsonschema:"title=Discovery Filters,description=Options that restrict which tables are visible to discovery."`
 	Advanced         advancedConfig   `json:"advanced,omitempty" jsonschema:"title=Advanced Options,description=Options for advanced users. You should not typically need to modify these." jsonschema_extras:"advanced=true"`
@@ -181,15 +229,29 @@ func (c *Config) Validate() error {
 	var requiredProperties = [][]string{
 		{"address", c.Address},
 		{"user", c.User},
-		{"password", c.Password},
 	}
 	for _, req := range requiredProperties {
 		if req[1] == "" {
 			return fmt.Errorf("missing '%s'", req[0])
 		}
 	}
-	if len(c.Password) > 32 {
-		return fmt.Errorf("passwords used as part of replication cannot exceed 32 characters in length due to an internal limitation in MySQL: password length of %d characters is too long, please use a shorter password", len(c.Password))
+
+	// Validation runs before normalizeCredentials, so both the legacy flat
+	// password and the credentials union must be accepted here.
+	var passwordInUse string
+	if c.Credentials == nil {
+		if c.Password == "" {
+			return errors.New("missing 'credentials'")
+		}
+		passwordInUse = c.Password
+	} else {
+		if err := c.Credentials.Validate(); err != nil {
+			return err
+		}
+		passwordInUse = c.Credentials.Password
+	}
+	if len(passwordInUse) > 32 {
+		return fmt.Errorf("passwords used as part of replication cannot exceed 32 characters in length due to an internal limitation in MySQL: password length of %d characters is too long, please use a shorter password", len(passwordInUse))
 	}
 	if c.Timezone != "" {
 		if _, err := schedule.ParseTimezone(c.Timezone); err != nil {
@@ -246,6 +308,55 @@ func (c *Config) SetDefaults(name string) {
 	}
 }
 
+// normalizeCredentials folds a legacy top-level password into c.Credentials as a
+// UserPassword credential, so that code downstream of it only ever reads one
+// credentials shape. When both are supplied the explicit credentials win.
+func (c *Config) normalizeCredentials() {
+	var legacyPassword = c.Password
+	c.Password = ""
+
+	if c.Credentials != nil {
+		if legacyPassword != "" {
+			logrus.Warn("both legacy 'password' and 'credentials' are set; the former will be ignored in favour of the latter")
+		}
+		return
+	}
+	c.Credentials = &CredentialsConfig{
+		AuthType:           UserPassword,
+		UserPasswordConfig: UserPasswordConfig{Password: legacyPassword},
+	}
+}
+
+// EffectivePassword returns the secret to present as the MySQL password for the
+// configured authentication method. It requires normalizeCredentials to have run,
+// and only reads the credentials union. For Azure IAM the password is the Entra
+// access token injected into the config by the control plane, which restarts the
+// connector with a fresh token before expiry.
+func (c *Config) EffectivePassword() (string, error) {
+	switch c.Credentials.AuthType {
+	case UserPassword:
+		return c.Credentials.Password, nil
+	case AzureIAM:
+		var token = c.Credentials.AzureToken()
+		if token == "" {
+			return "", errors.New("missing 'azure_access_token'")
+		}
+		return token, nil
+	}
+	return "", fmt.Errorf("unsupported 'auth_type' %q", c.Credentials.AuthType)
+}
+
+// requiresTLS reports whether the configured authentication method forbids falling
+// back to an unencrypted connection.
+func (c *Config) requiresTLS() bool {
+	switch c.Credentials.AuthType {
+	case UserPassword:
+		return false
+	default:
+		return true
+	}
+}
+
 func configSchema() json.RawMessage {
 	var schema = schemagen.GenerateSchema("MySQL Connection", &Config{})
 	var configSchema, err = schema.MarshalJSON()
@@ -253,6 +364,63 @@ func configSchema() json.RawMessage {
 		panic(err)
 	}
 	return json.RawMessage(configSchema)
+}
+
+// From https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html
+const mysqlErrorCodeSecureTransportRequired = 3159
+
+func withTLS(c *client.Conn) error {
+	c.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+	return nil
+}
+
+func withAttrs(c *client.Conn) error {
+	c.SetAttributes(map[string]string{"program_name": "Estuary source-mysql"})
+	return nil
+}
+
+// connectTLSOnly establishes a TLS connection and never falls back to an
+// unencrypted one. This is the IAM path.
+func (db *mysqlDatabase) connectTLSOnly(address, password string) (*client.Conn, error) {
+	var conn, err = client.Connect(address, db.config.User, password, db.config.Advanced.DBName, withTLS, withAttrs)
+	if err == nil {
+		logrus.WithField("addr", address).Info("connected with TLS")
+		return conn, nil
+	}
+	var mysqlErr *mysql.MyError
+	if errors.As(err, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
+		return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
+	}
+	return nil, fmt.Errorf("unable to connect to database with TLS: %w", err)
+}
+
+// connectPreferringTLS tries TLS first and falls back to an unencrypted connection,
+// which is acceptable for password authentication.
+func (db *mysqlDatabase) connectPreferringTLS(address, password string) (*client.Conn, error) {
+	// The following if-else chain looks somewhat complicated but it's really very simple.
+	// * We'd prefer to use TLS, so we first try to connect with TLS, and then if that fails
+	//   we try again without.
+	// * If either error is an incorrect username/password then we just report that.
+	// * Otherwise we report both errors because it's better to be clear what failed and how.
+	// * Except if the non-TLS connection specifically failed because TLS is required then
+	//   we don't need to mention that and just return the with-TLS error.
+	var mysqlErr *mysql.MyError
+	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, password, db.config.Advanced.DBName, withTLS, withAttrs); errWithTLS == nil {
+		logrus.WithField("addr", address).Info("connected with TLS")
+		return connWithTLS, nil
+	} else if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
+		return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
+	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, password, db.config.Advanced.DBName, withAttrs); errWithoutTLS == nil {
+		logrus.WithField("addr", address).Info("connected without TLS")
+		return connWithoutTLS, nil
+	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
+		logrus.WithFields(logrus.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
+		return nil, cerrors.NewUserError(mysqlErr, "incorrect username or password")
+	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysqlErrorCodeSecureTransportRequired {
+		return nil, fmt.Errorf("unable to connect to database: %w", errWithTLS)
+	} else {
+		return nil, fmt.Errorf("unable to connect to database: failed both with TLS (%w) and without TLS (%w)", errWithTLS, errWithoutTLS)
+	}
 }
 
 func (db *mysqlDatabase) connect(_ context.Context) error {
@@ -280,40 +448,21 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 	})
 	defer connectionTimer.Stop()
 
-	const mysqlErrorCodeSecureTransportRequired = 3159 // From https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html
-	var mysqlErr *mysql.MyError
-	var withTLS = func(c *client.Conn) error {
-		c.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
-		return nil
-	}
-	var withAttrs = func(c *client.Conn) error {
-		c.SetAttributes(map[string]string{"program_name": "Estuary source-mysql"})
-		return nil
+	var password, err = db.config.EffectivePassword()
+	if err != nil {
+		return err
 	}
 
-	// The following if-else chain looks somewhat complicated but it's really very simple.
-	// * We'd prefer to use TLS, so we first try to connect with TLS, and then if that fails
-	//   we try again without.
-	// * If either error is an incorrect username/password then we just report that.
-	// * Otherwise we report both errors because it's better to be clear what failed and how.
-	// * Except if the non-TLS connection specifically failed because TLS is required then
-	//   we don't need to mention that and just return the with-TLS error.
-	if connWithTLS, errWithTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withTLS, withAttrs); errWithTLS == nil {
-		logrus.WithField("addr", address).Info("connected with TLS")
-		db.conn = &mysqlConnection{inner: connWithTLS, queryTimeout: DefaultQueryTimeout}
-	} else if errors.As(errWithTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
-		return cerrors.NewUserError(mysqlErr, "incorrect username or password")
-	} else if connWithoutTLS, errWithoutTLS := client.Connect(address, db.config.User, db.config.Password, db.config.Advanced.DBName, withAttrs); errWithoutTLS == nil {
-		logrus.WithField("addr", address).Info("connected without TLS")
-		db.conn = &mysqlConnection{inner: connWithoutTLS, queryTimeout: DefaultQueryTimeout}
-	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysql.ER_ACCESS_DENIED_ERROR {
-		logrus.WithFields(logrus.Fields{"withTLS": errWithTLS, "nonTLS": errWithoutTLS}).Error("unable to connect to database")
-		return cerrors.NewUserError(mysqlErr, "incorrect username or password")
-	} else if errors.As(errWithoutTLS, &mysqlErr) && mysqlErr.Code == mysqlErrorCodeSecureTransportRequired {
-		return fmt.Errorf("unable to connect to database: %w", errWithTLS)
+	var conn *client.Conn
+	if db.config.requiresTLS() {
+		conn, err = db.connectTLSOnly(address, password)
 	} else {
-		return fmt.Errorf("unable to connect to database: failed both with TLS (%w) and without TLS (%w)", errWithTLS, errWithoutTLS)
+		conn, err = db.connectPreferringTLS(address, password)
 	}
+	if err != nil {
+		return err
+	}
+	db.conn = &mysqlConnection{inner: conn, queryTimeout: DefaultQueryTimeout}
 	connectionTimer.Stop() // Connection successful, cancel the timeout
 
 	// Debug logging hook so we can get the server config variables when needed

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -119,14 +119,20 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursorJSON 
 		flavor = mysql.MariaDBFlavor
 	}
 
+	password, err := db.config.EffectivePassword()
+	if err != nil {
+		return nil, err
+	}
+
 	var syncConfig = replication.BinlogSyncerConfig{
 		ServerID: uint32(db.config.Advanced.NodeID),
 		Flavor:   flavor,
 		Host:     host,
 		Port:     uint16(port),
 		User:     db.config.User,
-		Password: db.config.Password,
+		Password: password,
 		// TODO(wgd): Maybe add 'serverName' checking as described over in Connect()
+		// Must stay non-nil: under IAM auth the Password above is a bearer token.
 		TLSConfig: &tls.Config{InsecureSkipVerify: true},
 		// Request that timestamp values coming via replication be interpreted as UTC.
 		TimestampStringLocation: time.UTC,
@@ -156,19 +162,26 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursorJSON 
 	logrus.WithFields(logrus.Fields{"pos": pos}).Info("starting replication")
 	var streamer *replication.BinlogStreamer
 	var syncer = replication.NewBinlogSyncer(syncConfig)
-	if streamer, err = syncer.StartSync(pos); err == nil {
+	var errWithTLS error
+	if streamer, errWithTLS = syncer.StartSync(pos); errWithTLS == nil {
 		logrus.Debug("replication connected with TLS")
+	} else if db.config.requiresTLS() {
+		syncer.Close()
+		if userErr := wrapMySQLReplicationError(errWithTLS); userErr != nil {
+			return nil, userErr
+		}
+		return nil, fmt.Errorf("error starting binlog sync over TLS: %w", errWithTLS)
 	} else {
 		syncer.Close()
 		syncConfig.TLSConfig = nil
 		syncer = replication.NewBinlogSyncer(syncConfig)
 		if streamer, err = syncer.StartSync(pos); err == nil {
-			logrus.Info("replication connected without TLS")
+			logrus.WithField("errWithTLS", errWithTLS).Info("replication connected without TLS")
 		} else {
 			if userErr := wrapMySQLReplicationError(err); userErr != nil {
 				return nil, userErr
 			}
-			return nil, fmt.Errorf("error starting binlog sync: %w", err)
+			return nil, fmt.Errorf("error starting binlog sync: failed both with TLS (%w) and without TLS (%w)", errWithTLS, err)
 		}
 	}
 


### PR DESCRIPTION
**Description:**

Mirrors #5147 for `source-mysql`. Unlike with passwords, TLS is strictly required.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
