### PR TITLE
source-hubspot-native: don't skip form submissions that land mid-sweep

### DIFF
--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-09-02
+### Fixed
+- The `form_submissions` binding could permanently skip submissions that arrived on a
+  form while a sweep was still checking other forms. Each sweep now only emits
+  submissions made at least five minutes before it started and checkpoints the newest
+  one emitted, so anything newer is read by a later sweep.
+
 ## 2026-08-27
 ### Added
 - New `leads` binding for the HubSpot Leads object. Leads requires a Sales Hub

--- a/source-hubspot-native/source_hubspot_native/api/form_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/form_submissions.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from logging import Logger
 from typing import (
     AsyncGenerator,
@@ -17,6 +18,7 @@ from ..models import (
 )
 from .shared import (
     HUB,
+    dt_to_ms,
 )
 
 
@@ -25,13 +27,17 @@ from .shared import (
 # FORM_TYPE_NOT_ALLOWED.
 FORM_TYPES_WITHOUT_SUBMISSIONS = frozenset({"blog_comment"})
 
+FORM_SUBMISSIONS_LAG = timedelta(minutes=5)
 
-async def _fetch_form_submissions_since(
+
+async def _fetch_form_submissions_between(
     http: HTTPSession,
     log: Logger,
     form_id: str,
-    last_submitted_at: int,
+    since: int,
+    until: int,
 ) -> AsyncGenerator[FormSubmission, None]:
+    """Yield the form's submissions with `since < submittedAt <= until`."""
     url = f"{HUB}/form-integrations/v1/submissions/forms/{form_id}"
     after: str | None = None
     params: dict[str, str | int] = {
@@ -50,9 +56,12 @@ async def _fetch_form_submissions_since(
 
         for form_submission in result.results:
             # Form submissions are returned in reverse chronological order.
-            # We can safely stop paginating once we see a submission with
-            # a timestamp before the previous sweep.
-            if form_submission.submittedAt > last_submitted_at:
+            # Submissions newer than `until` are skipped over, and we can
+            # safely stop paginating once we see a submission with a
+            # timestamp at or before `since`.
+            if form_submission.submittedAt > until:
+                continue
+            elif form_submission.submittedAt > since:
                 yield form_submission
             else:
                 return
@@ -68,7 +77,17 @@ async def fetch_form_submissions(
     log: Logger,
     log_cursor: LogCursor,
 ) -> AsyncGenerator[FormSubmission | LogCursor, None]:
+    """
+    Emit every form's submissions in (cursor, horizon], where the horizon is
+    the sweep's start less FORM_SUBMISSIONS_LAG, then checkpoint the newest
+    submittedAt emitted.
+    """
     assert isinstance(log_cursor, int)
+
+    horizon = dt_to_ms(datetime.now(tz=UTC) - FORM_SUBMISSIONS_LAG)
+    if horizon <= log_cursor:
+        return
+
     form_ids: list[str] = []
 
     async for form in fetch_forms(http, log):
@@ -80,8 +99,8 @@ async def fetch_form_submissions(
     latest_submitted_at = log_cursor
 
     for id in form_ids:
-        async for submission in _fetch_form_submissions_since(
-            http, log, id, log_cursor
+        async for submission in _fetch_form_submissions_between(
+            http, log, id, log_cursor, horizon
         ):
             if submission.submittedAt > latest_submitted_at:
                 latest_submitted_at = submission.submittedAt


### PR DESCRIPTION
**Description:**

`fetch_form_submissions` walked every form in series and checkpointed the newest `submittedAt` seen across all of them. A submission landing on an already-walked form while a later form produced a newer one was left behind the cursor and never captured. Sweeps on accounts with a large number of forms can run an hour or more, so the the window of opportunity for this bug to occur can be pretty wide.

Each sweep now emits only submissions in `(cursor, sweep start - 5 min]` and checkpoints the newest one emitted, so anything newer is read by a later sweep.

Fixes #5170.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1788348729468039)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
