### PR TITLE
materialize-databricks: nest checkpoint entries by state key, then range

### DIFF
--- a/docs/materialize/README.md
+++ b/docs/materialize/README.md
@@ -662,6 +662,13 @@ these use cases, delta updates do the "right thing" by trivially replacing
 each document with its most recent version.
 This matches the behavior of Kafka Connect, for example.
 
+# Consistency testing
+
+See the [materialize-consistency suite][materialize-consistency] in the [flow] repo.
+
+[materialize-consistency]: https://github.com/estuary/flow/tree/master/crates/materialize-consistency
+[flow]: https://github.com/estuary/flow
+
 [connectors]: https://docs.estuary.dev/concepts/connectors/
 [collections]: https://docs.estuary.dev/concepts/collections/
 [protobuf]: https://github.com/estuary/flow/blob/master/go/protocols/materialize/materialize.proto

--- a/materialize-databricks/CHANGELOG.md
+++ b/materialize-databricks/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-09-02
+
+### Changed
+- The connector checkpoint now groups each table's pending work under its
+  binding first and the staging shard's key range second, so a task can find
+  everything staged for a table across all of its shards in one place.
+  Checkpoints written by earlier versions are still recovered and cleared.
+  Note for downgrades: versions predating this change refuse to parse the new
+  layout — drain the task (let it idle at an acknowledged commit) before
+  pinning an older image.
+
 ## 2026-08-26
 
 ### Fixed

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -136,6 +136,7 @@ type transactor struct {
 	// Pending entries in the layouts of earlier connector versions: range-first
 	// buckets, and flat items under legacyRangeKey. Only the primary shard
 	// tracks and executes these.
+	// TODO: remove after checkpoints have all migrated
 	peerShardsCheckpoints rangeCheckpoints
 	cpRecovery            bool // is this checkpoint a recovered checkpoint?
 	primary               bool // does this shard's range begin at key 0?
@@ -171,6 +172,7 @@ func (d *transactor) UnmarshalState(state json.RawMessage) error {
 	return nil
 }
 
+// TODO: remove after checkpoints have all migrated
 func (d *transactor) legacyBucket(rangeKey string) checkpoint {
 	if d.peerShardsCheckpoints[rangeKey] == nil {
 		d.peerShardsCheckpoints[rangeKey] = make(checkpoint)
@@ -195,6 +197,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 			return fmt.Errorf("parsing checkpoint entry %q: %w", key, err)
 		}
 
+		// TODO: remove after checkpoints have all migrated
 		if rangeKeyRe.MatchString(key) {
 			for stateKey, itemRaw := range bucket {
 				if item, err := parseCheckpointItem(itemRaw); err != nil {
@@ -208,6 +211,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 
 		var flat = make(map[string]json.RawMessage)
 		for rangeKey, itemRaw := range bucket {
+			// TODO: remove after checkpoints have all migrated
 			if !rangeKeyRe.MatchString(rangeKey) {
 				flat[rangeKey] = itemRaw
 			} else if skipOwnRange && rangeKey == d.rangeKey {
@@ -218,6 +222,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 				d.cp.add(key, rangeKey, item)
 			}
 		}
+		// TODO: remove after checkpoints have all migrated
 		if len(flat) > 0 {
 			var flatRaw, _ = json.Marshal(flat)
 			if item, err := parseCheckpointItem(flatRaw); err != nil {
@@ -550,13 +555,16 @@ func (s connectorState) add(stateKey, rangeKey string, item *checkpointItem) {
 }
 
 // rangeCheckpoints is the range-first layout of earlier connector versions.
+// TODO: remove after checkpoints have all migrated
 type rangeCheckpoints map[string]checkpoint
 
 // legacyRangeKey is the in-memory bucket of flat per-stateKey entries written
 // before range scoping. A current bucket may since have been merged onto the
 // same state key, so these clear by nulling the item's fields, not the key.
+// TODO: remove after checkpoints have all migrated
 const legacyRangeKey = ""
 
+// TODO: remove after checkpoints have all migrated
 var legacyItemClear = map[string]any{
 	"Query": nil, "Queries": nil, "ToDelete": nil,
 	"StagedFiles": nil, "Bounds": nil, "NeedsMerge": nil,
@@ -733,6 +741,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 		}
 		return clear[key].(map[string]any)
 	}
+	// TODO: remove after checkpoints have all migrated
 	var peerRangeKeys = slices.Sorted(maps.Keys(d.peerShardsCheckpoints))
 
 	// Everything else pending — entries of other state keys, and entries whose
@@ -750,6 +759,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 		for _, rk := range slices.Sorted(maps.Keys(d.cp[sk])) {
 			items = append(items, d.cp[sk][rk])
 		}
+		// TODO: remove after checkpoints have all migrated
 		for _, rk := range peerRangeKeys {
 			if item := d.peerShardsCheckpoints[rk][sk]; item != nil {
 				items = append(items, item)
@@ -767,6 +777,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 			clearAt(sk)[rk] = nil
 		}
 		delete(d.cp, sk)
+		// TODO: remove after checkpoints have all migrated
 		for rk, cp := range d.peerShardsCheckpoints {
 			if cp[sk] != nil {
 				delete(cp, sk)

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -6,8 +6,8 @@ import (
 	stdsql "database/sql"
 	"encoding/json"
 	"fmt"
-	"math"
 	"maps"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -132,10 +132,10 @@ var _ m.Transactor = (*transactor)(nil)
 type transactor struct {
 	runtimeCheckpoint m.RuntimeCheckpoint
 	cfg               config
-	cp                checkpoint
-	// Pending entries of other shards, of sessions predating the range-scoped
-	// checkpoint format (legacyRangeKey), and of stale ranges from previous
-	// shard topologies. Only the primary shard tracks and executes these.
+	cp                connectorState // every shard's pending entries; non-primary shards hold only their own
+	// Pending entries in the layouts of earlier connector versions: range-first
+	// buckets, and flat items under legacyRangeKey. Only the primary shard
+	// tracks and executes these.
 	peerShardsCheckpoints rangeCheckpoints
 	cpRecovery            bool // is this checkpoint a recovered checkpoint?
 	primary               bool // does this shard's range begin at key 0?
@@ -163,34 +163,72 @@ func (d *transactor) UnmarshalState(state json.RawMessage) error {
 		return nil
 	}
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(state, &raw); err != nil {
+	if err := d.absorbState(state, false); err != nil {
 		return err
-	}
-
-	for key, val := range raw {
-		if bucket, ok := parseRangeBucket(key, val); ok {
-			if key == d.rangeKey {
-				d.cp = bucket
-			} else {
-				d.peerShardsCheckpoints[key] = bucket
-			}
-		} else if item, err := parseCheckpointItem(val); err != nil {
-			return fmt.Errorf("parsing checkpoint entry %q: %w", key, err)
-		} else {
-			d.legacyBucket()[key] = item
-		}
 	}
 	d.cpRecovery = true
 
 	return nil
 }
 
-func (d *transactor) legacyBucket() checkpoint {
-	if d.peerShardsCheckpoints[legacyRangeKey] == nil {
-		d.peerShardsCheckpoints[legacyRangeKey] = make(checkpoint)
+func (d *transactor) legacyBucket(rangeKey string) checkpoint {
+	if d.peerShardsCheckpoints[rangeKey] == nil {
+		d.peerShardsCheckpoints[rangeKey] = make(checkpoint)
 	}
-	return d.peerShardsCheckpoints[legacyRangeKey]
+	return d.peerShardsCheckpoints[rangeKey]
+}
+
+// absorbState folds a state document into the pending entries. Earlier
+// connector versions wrote {rangeKey: {stateKey: item}}, and before that flat
+// {stateKey: item}, which can share a state key with a current bucket: the
+// bucket's non-range keys are then the flat item's fields. skipOwnRange drops
+// this shard's own entries, which the runtime echoes back in peer patches.
+func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &raw); err != nil {
+		return err
+	}
+
+	for key, val := range raw {
+		var bucket map[string]json.RawMessage
+		if err := json.Unmarshal(val, &bucket); err != nil {
+			return fmt.Errorf("parsing checkpoint entry %q: %w", key, err)
+		}
+
+		if rangeKeyRe.MatchString(key) {
+			for stateKey, itemRaw := range bucket {
+				if item, err := parseCheckpointItem(itemRaw); err != nil {
+					return fmt.Errorf("parsing checkpoint entry %q of %q: %w", stateKey, key, err)
+				} else {
+					d.legacyBucket(key)[stateKey] = item
+				}
+			}
+			continue
+		}
+
+		var flat = make(map[string]json.RawMessage)
+		for rangeKey, itemRaw := range bucket {
+			if !rangeKeyRe.MatchString(rangeKey) {
+				flat[rangeKey] = itemRaw
+			} else if skipOwnRange && rangeKey == d.rangeKey {
+				continue
+			} else if item, err := parseCheckpointItem(itemRaw); err != nil {
+				return fmt.Errorf("parsing checkpoint entry %q of %q: %w", rangeKey, key, err)
+			} else {
+				d.cp.add(key, rangeKey, item)
+			}
+		}
+		if len(flat) > 0 {
+			var flatRaw, _ = json.Marshal(flat)
+			if item, err := parseCheckpointItem(flatRaw); err != nil {
+				return fmt.Errorf("parsing checkpoint entry %q: %w", key, err)
+			} else {
+				d.legacyBucket(legacyRangeKey)[key] = item
+			}
+		}
+	}
+
+	return nil
 }
 
 // mergePeerStatePatches folds the aggregated StartedCommit state patches of
@@ -206,49 +244,14 @@ func (d *transactor) mergePeerStatePatches(patches []json.RawMessage) error {
 		if isJSONNull(patch) {
 			// The runtime encodes a full-replace (non-merge-patch) state
 			// update as a literal null reset patch followed by the new state
-			// document. No shard emits full replacements in the range-scoped
-			// checkpoint format, so a reset means a peer (e.g. one running an
-			// older connector image) just clobbered the consolidated state.
+			// document. No shard emits full replacements, so a reset means a
+			// peer (e.g. one running an older connector image) just clobbered
+			// the consolidated state.
 			return fmt.Errorf("unexpected state reset patch in aggregated shard state")
 		}
 
-		var raw map[string]json.RawMessage
-		if err := json.Unmarshal(patch, &raw); err != nil {
+		if err := d.absorbState(patch, true); err != nil {
 			return fmt.Errorf("parsing aggregated state patch: %w", err)
-		}
-
-		for key, val := range raw {
-			if key == d.rangeKey {
-				// Our own contribution, echoed back by the runtime. It's
-				// already tracked in d.cp.
-				continue
-			}
-
-			if !rangeKeyRe.MatchString(key) {
-				// Top-level stateKeys are never emitted by range-scoped peers,
-				// but route them as legacy entries rather than dropping them.
-				if item, err := parseCheckpointItem(val); err != nil {
-					return fmt.Errorf("parsing aggregated state patch entry %q: %w", key, err)
-				} else {
-					d.legacyBucket()[key] = item
-				}
-				continue
-			}
-
-			var bucket map[string]json.RawMessage
-			if err := json.Unmarshal(val, &bucket); err != nil {
-				return fmt.Errorf("parsing aggregated state patch bucket %q: %w", key, err)
-			}
-			for stateKey, itemRaw := range bucket {
-				if item, err := parseCheckpointItem(itemRaw); err != nil {
-					return fmt.Errorf("parsing aggregated state patch entry %q of %q: %w", stateKey, key, err)
-				} else {
-					if d.peerShardsCheckpoints[key] == nil {
-						d.peerShardsCheckpoints[key] = make(checkpoint)
-					}
-					d.peerShardsCheckpoints[key][stateKey] = item
-				}
-			}
 		}
 	}
 
@@ -286,7 +289,7 @@ func newTransactor(
 	var d = &transactor{
 		runtimeCheckpoint:     fence.Checkpoint,
 		cfg:                   cfg,
-		cp:                    make(checkpoint),
+		cp:                    make(connectorState),
 		peerShardsCheckpoints: make(rangeCheckpoints),
 		primary:               keyBegin == 0,
 		rangeKey:              fmt.Sprintf("%08x-%08x", keyBegin, keyEnd),
@@ -533,16 +536,31 @@ func (c *checkpoint) Validate() error {
 	return nil
 }
 
-// rangeCheckpoints maps shard range keys ("%08x-%08x" of key_begin-key_end)
-// to that shard's per-stateKey checkpoint. Range keys are disjoint across the
-// shards of a task, which is what lets each shard's StartedCommit merge patch
-// commute with its peers' when the runtime consolidates connector state.
+// connectorState is the persisted layout: entries by binding state key, then
+// by the range key ("%08x-%08x" of key_begin-key_end) of the shard that staged
+// them. Range keys are disjoint across shards, so their StartedCommit merge
+// patches commute when the runtime consolidates connector state.
+type connectorState map[string]checkpoint
+
+func (s connectorState) add(stateKey, rangeKey string, item *checkpointItem) {
+	if s[stateKey] == nil {
+		s[stateKey] = make(checkpoint)
+	}
+	s[stateKey][rangeKey] = item
+}
+
+// rangeCheckpoints is the range-first layout of earlier connector versions.
 type rangeCheckpoints map[string]checkpoint
 
-// legacyRangeKey is the in-memory bucket holding top-level per-stateKey
-// entries written by connector versions predating the range-scoped checkpoint
-// format. Its entries clear with top-level nulls rather than nested ones.
+// legacyRangeKey is the in-memory bucket of flat per-stateKey entries written
+// before range scoping. A current bucket may since have been merged onto the
+// same state key, so these clear by nulling the item's fields, not the key.
 const legacyRangeKey = ""
+
+var legacyItemClear = map[string]any{
+	"Query": nil, "Queries": nil, "ToDelete": nil,
+	"StagedFiles": nil, "Bounds": nil, "NeedsMerge": nil,
+}
 
 var rangeKeyRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{8}$`)
 
@@ -562,22 +580,6 @@ func parseCheckpointItem(data json.RawMessage) (*checkpointItem, error) {
 		return nil, err
 	}
 	return &item, nil
-}
-
-// parseRangeBucket decodes val as a per-stateKey checkpoint when key names a
-// shard key-range. A key matching the range pattern whose value doesn't
-// decode as a bucket falls through to legacy entry parsing, which fails
-// loudly. StateKeys cannot collide with range keys: they are URL-encoded
-// resource paths carrying a ".vN" backfill counter suffix.
-func parseRangeBucket(key string, val json.RawMessage) (checkpoint, bool) {
-	if !rangeKeyRe.MatchString(key) {
-		return nil, false
-	}
-	var bucket checkpoint
-	if err := unmarshalStrict(val, &bucket); err != nil {
-		return nil, false
-	}
-	return bucket, true
 }
 
 func (d *transactor) deleteFiles(ctx context.Context, files []string) {
@@ -642,12 +644,12 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 		// given that COPY INTO is idempotent by default: files that have already been loaded into a table will
 		// not be loaded again
 		// see https://docs.databricks.com/en/sql/language-manual/delta-copy-into.html
-		d.cp[b.target.StateKey] = &checkpointItem{
+		d.cp.add(b.target.StateKey, d.rangeKey, &checkpointItem{
 			ToDelete:    pathsWithRoot(b.rootStagingPath, toCopy),
 			StagedFiles: toCopy,
 			Bounds:      boundsLiterals(b.storeMergeBounds.Build()),
 			NeedsMerge:  !b.target.DeltaUpdates && b.needsMerge,
-		}
+		})
 		b.needsMerge = false // reset for next round
 	}
 
@@ -661,11 +663,18 @@ func (d *transactor) Store(it *m.StoreIterator) (_ m.StartCommitFunc, err error)
 }
 
 func (d *transactor) startCommitState() (*pf.ConnectorState, error) {
-	// Emit only this shard's range bucket as a merge patch: range keys are
+	// Emit only this shard's own entries as a merge patch: range keys are
 	// disjoint across shards, so concurrent patches never clobber when the
 	// runtime consolidates connector state. A single-shard task uses the same
-	// format, with one bucket covering the full key range.
-	var patch, err = json.Marshal(rangeCheckpoints{d.rangeKey: d.cp})
+	// format, with one entry covering the full key range.
+	var own = make(connectorState)
+	for stateKey, bucket := range d.cp {
+		if item := bucket[d.rangeKey]; item != nil {
+			own.add(stateKey, d.rangeKey, item)
+		}
+	}
+
+	var patch, err = json.Marshal(own)
 	if err != nil {
 		return nil, fmt.Errorf("creating checkpoint patch json: %w", err)
 	}
@@ -714,21 +723,15 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 // the time those per-shard queries take back to back.
 func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, shouldProcess func(string) bool) (*pf.ConnectorState, error) {
 	// The clearing state update, nulling each executed entry at the state-
-	// document path it occupies: nested under a range key, or top-level
-	// (legacyRangeKey) for entries predating the range-scoped checkpoint
-	// format. Clearing is a best-
-	// effort attempt to spare a restart from running the same queries again —
-	// there is no guarantee this checkpoint update can actually be committed.
-	var clear = make(map[string]interface{})
-	var clearEntry = func(rangeKey, stateKey string) {
-		if rangeKey == legacyRangeKey {
-			clear[stateKey] = nil
-		} else {
-			if clear[rangeKey] == nil {
-				clear[rangeKey] = make(map[string]interface{})
-			}
-			clear[rangeKey].(map[string]interface{})[stateKey] = nil
+	// document path it occupies. Clearing is a best-effort attempt to spare a
+	// restart from running the same queries again; there is no guarantee this
+	// checkpoint update can actually be committed.
+	var clear = make(map[string]any)
+	var clearAt = func(key string) map[string]any {
+		if clear[key] == nil {
+			clear[key] = make(map[string]any)
 		}
+		return clear[key].(map[string]any)
 	}
 	var peerRangeKeys = slices.Sorted(maps.Keys(d.peerShardsCheckpoints))
 
@@ -741,11 +744,11 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 			continue
 		}
 
-		// The binding's pending entries: this shard's own, then those of
-		// legacy sessions and peer shards.
+		// The binding's pending entries: every shard's, then those written by
+		// earlier connector versions.
 		var items []*checkpointItem
-		if item := d.cp[sk]; item != nil {
-			items = append(items, item)
+		for _, rk := range slices.Sorted(maps.Keys(d.cp[sk])) {
+			items = append(items, d.cp[sk][rk])
 		}
 		for _, rk := range peerRangeKeys {
 			if item := d.peerShardsCheckpoints[rk][sk]; item != nil {
@@ -760,14 +763,18 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 			return nil, err
 		}
 
-		if d.cp[sk] != nil {
-			delete(d.cp, sk)
-			clearEntry(d.rangeKey, sk)
+		for rk := range d.cp[sk] {
+			clearAt(sk)[rk] = nil
 		}
+		delete(d.cp, sk)
 		for rk, cp := range d.peerShardsCheckpoints {
 			if cp[sk] != nil {
 				delete(cp, sk)
-				clearEntry(rk, sk)
+				if rk == legacyRangeKey {
+					maps.Copy(clearAt(sk), legacyItemClear)
+				} else {
+					clearAt(rk)[sk] = nil
+				}
 			}
 			if len(cp) == 0 {
 				delete(d.peerShardsCheckpoints, rk)

--- a/materialize-databricks/driver.go
+++ b/materialize-databricks/driver.go
@@ -132,11 +132,12 @@ var _ m.Transactor = (*transactor)(nil)
 type transactor struct {
 	runtimeCheckpoint m.RuntimeCheckpoint
 	cfg               config
-	cp                connectorState // every shard's pending entries; non-primary shards hold only their own
+	// Every shard's pending entries; non-primary shards hold only their own.
+	cp connectorState
 	// Pending entries in the layouts of earlier connector versions: range-first
 	// buckets, and flat items under legacyRangeKey. Only the primary shard
 	// tracks and executes these.
-	// TODO: remove after checkpoints have all migrated
+	// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 	peerShardsCheckpoints rangeCheckpoints
 	cpRecovery            bool // is this checkpoint a recovered checkpoint?
 	primary               bool // does this shard's range begin at key 0?
@@ -172,7 +173,7 @@ func (d *transactor) UnmarshalState(state json.RawMessage) error {
 	return nil
 }
 
-// TODO: remove after checkpoints have all migrated
+// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 func (d *transactor) legacyBucket(rangeKey string) checkpoint {
 	if d.peerShardsCheckpoints[rangeKey] == nil {
 		d.peerShardsCheckpoints[rangeKey] = make(checkpoint)
@@ -197,7 +198,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 			return fmt.Errorf("parsing checkpoint entry %q: %w", key, err)
 		}
 
-		// TODO: remove after checkpoints have all migrated
+		// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 		if rangeKeyRe.MatchString(key) {
 			for stateKey, itemRaw := range bucket {
 				if item, err := parseCheckpointItem(itemRaw); err != nil {
@@ -211,7 +212,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 
 		var flat = make(map[string]json.RawMessage)
 		for rangeKey, itemRaw := range bucket {
-			// TODO: remove after checkpoints have all migrated
+			// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 			if !rangeKeyRe.MatchString(rangeKey) {
 				flat[rangeKey] = itemRaw
 			} else if skipOwnRange && rangeKey == d.rangeKey {
@@ -222,7 +223,7 @@ func (d *transactor) absorbState(doc json.RawMessage, skipOwnRange bool) error {
 				d.cp.add(key, rangeKey, item)
 			}
 		}
-		// TODO: remove after checkpoints have all migrated
+		// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 		if len(flat) > 0 {
 			var flatRaw, _ = json.Marshal(flat)
 			if item, err := parseCheckpointItem(flatRaw); err != nil {
@@ -555,16 +556,16 @@ func (s connectorState) add(stateKey, rangeKey string, item *checkpointItem) {
 }
 
 // rangeCheckpoints is the range-first layout of earlier connector versions.
-// TODO: remove after checkpoints have all migrated
+// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 type rangeCheckpoints map[string]checkpoint
 
 // legacyRangeKey is the in-memory bucket of flat per-stateKey entries written
 // before range scoping. A current bucket may since have been merged onto the
 // same state key, so these clear by nulling the item's fields, not the key.
-// TODO: remove after checkpoints have all migrated
+// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 const legacyRangeKey = ""
 
-// TODO: remove after checkpoints have all migrated
+// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 var legacyItemClear = map[string]any{
 	"Query": nil, "Queries": nil, "ToDelete": nil,
 	"StagedFiles": nil, "Bounds": nil, "NeedsMerge": nil,
@@ -741,7 +742,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 		}
 		return clear[key].(map[string]any)
 	}
-	// TODO: remove after checkpoints have all migrated
+	// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 	var peerRangeKeys = slices.Sorted(maps.Keys(d.peerShardsCheckpoints))
 
 	// Everything else pending — entries of other state keys, and entries whose
@@ -759,7 +760,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 		for _, rk := range slices.Sorted(maps.Keys(d.cp[sk])) {
 			items = append(items, d.cp[sk][rk])
 		}
-		// TODO: remove after checkpoints have all migrated
+		// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 		for _, rk := range peerRangeKeys {
 			if item := d.peerShardsCheckpoints[rk][sk]; item != nil {
 				items = append(items, item)
@@ -777,7 +778,7 @@ func (d *transactor) acknowledgeApply(ctx context.Context, db *stdsql.DB, should
 			clearAt(sk)[rk] = nil
 		}
 		delete(d.cp, sk)
-		// TODO: remove after checkpoints have all migrated
+		// TODO(#5176): remove in about January 2027, after checkpoints have all migrated
 		for rk, cp := range d.peerShardsCheckpoints {
 			if cp[sk] != nil {
 				delete(cp, sk)

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	m "github.com/estuary/connectors/go/materialize"
+	boilerplate "github.com/estuary/connectors/materialize-boilerplate"
 	sql "github.com/estuary/connectors/materialize-sql"
+	pf "github.com/estuary/flow/go/protocols/flow"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +25,7 @@ const (
 
 func testTransactor(rangeKey string, stateKeys ...string) *transactor {
 	var d = &transactor{
-		cp:                    make(checkpoint),
+		cp:                    make(connectorState),
 		peerShardsCheckpoints: make(rangeCheckpoints),
 		primary:               rangeKey == fullRangeKey || rangeKey == lowerRangeKey,
 		rangeKey:              rangeKey,
@@ -40,6 +42,21 @@ func testTransactor(rangeKey string, stateKeys ...string) *transactor {
 
 func item(query string, toDelete ...string) *checkpointItem {
 	return &checkpointItem{Queries: []string{query}, ToDelete: toDelete}
+}
+
+// reduce applies a state update to a JSON state document the way the runtime
+// consolidates connector state, returning the resulting document.
+func reduce(t *testing.T, doc string, update *pf.ConnectorState) string {
+	t.Helper()
+	var before, patch any
+	require.NoError(t, json.Unmarshal([]byte(doc), &before))
+	require.NoError(t, json.Unmarshal(update.UpdatedJson, &patch))
+	if !update.MergePatch {
+		before = nil
+	}
+	var out, err = json.Marshal(boilerplate.ApplyMergePatch(before, patch))
+	require.NoError(t, err)
+	return string(out)
 }
 
 // keys builds the non-nil restricted-processing predicate of Acknowledge's
@@ -101,45 +118,72 @@ func recordingDB(t *testing.T, failWith error) *stdsql.DB {
 }
 
 func TestUnmarshalStateRouting(t *testing.T) {
-	var legacyState = json.RawMessage(`{
+	var flatState = json.RawMessage(`{
 		"a_table.v1": {"Queries": ["Q1"], "ToDelete": ["f1"]},
 		"b_table.v1": {"Queries": ["Q2"], "ToDelete": []}
 	}`)
-	var mixedState = json.RawMessage(`{
+	var rangeFirstState = json.RawMessage(`{
 		"00000000-7fffffff": {"a_table.v1": {"Queries": ["QL"], "ToDelete": []}},
-		"80000000-ffffffff": {"a_table.v1": {"Queries": ["QU"], "ToDelete": []}},
-		"a_table.v1": {"Queries": ["Q0"], "ToDelete": []}
+		"80000000-ffffffff": {"a_table.v1": {"Queries": ["QU"], "ToDelete": []}}
+	}`)
+	var currentState = json.RawMessage(`{
+		"a_table.v1": {
+			"00000000-7fffffff": {"Queries": ["QL"], "ToDelete": []},
+			"80000000-ffffffff": {"Queries": ["QU"], "ToDelete": []}
+		}
+	}`)
+	// All three layouts under one state key: a flat item's fields merged with
+	// current range entries, plus a range-first bucket.
+	var mixedState = json.RawMessage(`{
+		"a_table.v1": {
+			"Queries": ["Q0"], "ToDelete": ["f0"],
+			"00000000-7fffffff": {"Queries": ["QL"], "ToDelete": []}
+		},
+		"80000000-ffffffff": {"a_table.v1": {"Queries": ["QU"], "ToDelete": []}}
 	}`)
 
-	t.Run("legacy top-level entries route to the legacy bucket", func(t *testing.T) {
+	t.Run("current layout", func(t *testing.T) {
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+		require.NoError(t, d.UnmarshalState(currentState))
+		require.True(t, d.cpRecovery)
+		require.Equal(t, []string{"QL"}, d.cp["a_table.v1"][lowerRangeKey].Queries)
+		require.Equal(t, []string{"QU"}, d.cp["a_table.v1"][upperRangeKey].Queries)
+		require.Empty(t, d.peerShardsCheckpoints)
+	})
+
+	t.Run("flat entries route to the legacy bucket", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1", "b_table.v1")
-		require.NoError(t, d.UnmarshalState(legacyState))
+		require.NoError(t, d.UnmarshalState(flatState))
 		require.True(t, d.cpRecovery)
 		require.Empty(t, d.cp)
 		require.Len(t, d.peerShardsCheckpoints[legacyRangeKey], 2)
 		require.Equal(t, []string{"Q1"}, d.peerShardsCheckpoints[legacyRangeKey]["a_table.v1"].Queries)
+		require.Equal(t, []string{"f1"}, d.peerShardsCheckpoints[legacyRangeKey]["a_table.v1"].ToDelete)
+		require.Equal(t, []string{"Q2"}, d.peerShardsCheckpoints[legacyRangeKey]["b_table.v1"].Queries)
 	})
 
-	t.Run("single shard routes own range to cp, others to peers", func(t *testing.T) {
-		var d = testTransactor(fullRangeKey, "a_table.v1")
-		require.NoError(t, d.UnmarshalState(json.RawMessage(`{
-			"00000000-ffffffff": {"a_table.v1": {"Queries": ["OWN"], "ToDelete": []}},
-			"00000000-7fffffff": {"a_table.v1": {"Queries": ["QL"], "ToDelete": []}},
-			"a_table.v1": {"Queries": ["Q0"], "ToDelete": []}
-		}`)))
-		require.True(t, d.cpRecovery)
-		require.Equal(t, []string{"OWN"}, d.cp["a_table.v1"].Queries)
+	t.Run("range-first entries route to their range bucket, own range included", func(t *testing.T) {
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+		require.NoError(t, d.UnmarshalState(rangeFirstState))
+		require.Empty(t, d.cp)
 		require.Equal(t, []string{"QL"}, d.peerShardsCheckpoints[lowerRangeKey]["a_table.v1"].Queries)
-		require.Equal(t, []string{"Q0"}, d.peerShardsCheckpoints[legacyRangeKey]["a_table.v1"].Queries)
+		require.Equal(t, []string{"QU"}, d.peerShardsCheckpoints[upperRangeKey]["a_table.v1"].Queries)
 	})
 
-	t.Run("multi-shard primary routes own range to cp", func(t *testing.T) {
+	t.Run("all layouts under one state key", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
 		require.NoError(t, d.UnmarshalState(mixedState))
-		require.True(t, d.cpRecovery)
-		require.Equal(t, []string{"QL"}, d.cp["a_table.v1"].Queries)
-		require.Equal(t, []string{"QU"}, d.peerShardsCheckpoints[upperRangeKey]["a_table.v1"].Queries)
+		require.Len(t, d.cp["a_table.v1"], 1)
+		require.Equal(t, []string{"QL"}, d.cp["a_table.v1"][lowerRangeKey].Queries)
 		require.Equal(t, []string{"Q0"}, d.peerShardsCheckpoints[legacyRangeKey]["a_table.v1"].Queries)
+		require.Equal(t, []string{"f0"}, d.peerShardsCheckpoints[legacyRangeKey]["a_table.v1"].ToDelete)
+		require.Equal(t, []string{"QU"}, d.peerShardsCheckpoints[upperRangeKey]["a_table.v1"].Queries)
+	})
+
+	t.Run("an emptied bucket holds nothing", func(t *testing.T) {
+		var d = testTransactor(fullRangeKey, "a_table.v1")
+		require.NoError(t, d.UnmarshalState(json.RawMessage(`{"a_table.v1": {}}`)))
+		require.Empty(t, d.cp)
 	})
 
 	t.Run("non-primary discards everything", func(t *testing.T) {
@@ -153,28 +197,45 @@ func TestUnmarshalStateRouting(t *testing.T) {
 	t.Run("unknown fields error", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1")
 		require.Error(t, d.UnmarshalState(json.RawMessage(`{"a_table.v1": {"Unknown": 1}}`)))
+		require.Error(t, d.UnmarshalState(json.RawMessage(`{"a_table.v1": {"00000000-ffffffff": {"Unknown": 1}}}`)))
+		require.Error(t, d.UnmarshalState(json.RawMessage(`{"00000000-ffffffff": {"a_table.v1": {"Unknown": 1}}}`)))
+	})
+
+	t.Run("non-object entries error", func(t *testing.T) {
+		var d = testTransactor(fullRangeKey, "a_table.v1")
+		require.Error(t, d.UnmarshalState(json.RawMessage(`{"a_table.v1": 1}`)))
+		require.Error(t, d.UnmarshalState(json.RawMessage(`{"00000000-ffffffff": 1}`)))
 	})
 }
 
 func TestStartCommitState(t *testing.T) {
 	t.Run("single shard emits a full-range merge patch", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1")
-		d.cp["a_table.v1"] = item("Q1", "f1")
+		d.cp.add("a_table.v1", fullRangeKey, item("Q1", "f1"))
 
 		state, err := d.startCommitState()
 		require.NoError(t, err)
 		require.True(t, state.MergePatch)
-		require.JSONEq(t, `{"00000000-ffffffff": {"a_table.v1": {"Queries": ["Q1"], "ToDelete": ["f1"]}}}`, string(state.UpdatedJson))
+		require.JSONEq(t, `{"a_table.v1": {"00000000-ffffffff": {"Queries": ["Q1"], "ToDelete": ["f1"]}}}`, string(state.UpdatedJson))
 	})
 
-	t.Run("multi-shard emits a range-scoped merge patch", func(t *testing.T) {
+	t.Run("multi-shard emits a range-scoped merge patch of only its own entries", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
-		d.cp["a_table.v1"] = item("Q1", "f1")
+		d.cp.add("a_table.v1", lowerRangeKey, item("Q1", "f1"))
+		d.cp.add("a_table.v1", upperRangeKey, item("PEER"))
 
 		state, err := d.startCommitState()
 		require.NoError(t, err)
 		require.True(t, state.MergePatch)
-		require.JSONEq(t, `{"00000000-7fffffff": {"a_table.v1": {"Queries": ["Q1"], "ToDelete": ["f1"]}}}`, string(state.UpdatedJson))
+		require.JSONEq(t, `{"a_table.v1": {"00000000-7fffffff": {"Queries": ["Q1"], "ToDelete": ["f1"]}}}`, string(state.UpdatedJson))
+	})
+
+	t.Run("nothing staged emits an empty patch", func(t *testing.T) {
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+
+		state, err := d.startCommitState()
+		require.NoError(t, err)
+		require.JSONEq(t, `{}`, string(state.UpdatedJson))
 	})
 }
 
@@ -189,18 +250,26 @@ func TestMergePeerStatePatches(t *testing.T) {
 
 	t.Run("no-op when non-primary", func(t *testing.T) {
 		var d = testTransactor(upperRangeKey)
-		require.NoError(t, d.mergePeerStatePatches(patches(`{"00000000-7fffffff": {"a_table.v1": {"Queries": ["Q"], "ToDelete": []}}}`)))
-		require.Empty(t, d.peerShardsCheckpoints)
+		require.NoError(t, d.mergePeerStatePatches(patches(`{"a_table.v1": {"00000000-7fffffff": {"Queries": ["Q"], "ToDelete": []}}}`)))
+		require.Empty(t, d.cp)
 	})
 
 	t.Run("own contribution is skipped, peers merged", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
 		require.NoError(t, d.mergePeerStatePatches(patches(
-			`{"00000000-7fffffff": {"a_table.v1": {"Queries": ["OWN"], "ToDelete": []}}}`,
-			`{"80000000-ffffffff": {"a_table.v1": {"Queries": ["PEER"], "ToDelete": ["pf1"]}}}`,
+			`{"a_table.v1": {"00000000-7fffffff": {"Queries": ["OWN"], "ToDelete": []}}}`,
+			`{"a_table.v1": {"80000000-ffffffff": {"Queries": ["PEER"], "ToDelete": ["pf1"]}}}`,
 		)))
-		require.Empty(t, d.cp) // own patch is not folded back
-		require.Len(t, d.peerShardsCheckpoints, 1)
+		require.Len(t, d.cp["a_table.v1"], 1) // own patch is not folded back
+		require.Equal(t, []string{"PEER"}, d.cp["a_table.v1"][upperRangeKey].Queries)
+	})
+
+	t.Run("range-first peer patches are accepted", func(t *testing.T) {
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+		require.NoError(t, d.mergePeerStatePatches(patches(
+			`{"80000000-ffffffff": {"a_table.v1": {"Queries": ["PEER"], "ToDelete": []}}}`,
+		)))
+		require.Empty(t, d.cp)
 		require.Equal(t, []string{"PEER"}, d.peerShardsCheckpoints[upperRangeKey]["a_table.v1"].Queries)
 	})
 
@@ -261,9 +330,9 @@ func TestExecQueriesRetriesRetriableErrors(t *testing.T) {
 }
 
 func TestAcknowledge(t *testing.T) {
-	t.Run("single shard clears own entries nested, legacy entries top-level", func(t *testing.T) {
+	t.Run("single shard clears own entries nested, legacy entries by field", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1", "b_table.v1")
-		d.cp["a_table.v1"] = item("Q1")
+		d.cp.add("a_table.v1", fullRangeKey, item("Q1"))
 		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"b_table.v1": item("Q2")}
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
@@ -271,8 +340,11 @@ func TestAcknowledge(t *testing.T) {
 		require.Equal(t, []string{"Q1", "Q2"}, recording.executed)
 		require.True(t, state.MergePatch)
 		require.JSONEq(t, `{
-			"00000000-ffffffff": {"a_table.v1": null},
-			"b_table.v1": null
+			"a_table.v1": {"00000000-ffffffff": null},
+			"b_table.v1": {
+				"Query": null, "Queries": null, "ToDelete": null,
+				"StagedFiles": null, "Bounds": null, "NeedsMerge": null
+			}
 		}`, string(state.UpdatedJson))
 		require.Empty(t, d.cp)
 		require.Empty(t, d.peerShardsCheckpoints)
@@ -280,84 +352,135 @@ func TestAcknowledge(t *testing.T) {
 
 	t.Run("primary executes own and peer entries", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
-		d.cp["a_table.v1"] = item("OWN")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{"a_table.v1": item("PEER")}
-		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("LEGACY")}
+		d.cp.add("a_table.v1", lowerRangeKey, item("OWN"))
+		d.cp.add("a_table.v1", upperRangeKey, item("PEER"))
+		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{"a_table.v1": item("OLD-PEER")}
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
-		require.Equal(t, []string{"OWN", "LEGACY", "PEER"}, recording.executed)
+		require.Equal(t, []string{"OWN", "PEER", "OLD-PEER"}, recording.executed)
 		require.True(t, state.MergePatch)
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
-			"80000000-ffffffff": {"a_table.v1": null},
-			"a_table.v1": null
+			"a_table.v1": {"00000000-7fffffff": null, "80000000-ffffffff": null},
+			"80000000-ffffffff": {"a_table.v1": null}
 		}`, string(state.UpdatedJson))
 		require.Empty(t, d.cp)
 		require.Empty(t, d.peerShardsCheckpoints)
 	})
 
+	t.Run("each layout clears at its own path", func(t *testing.T) {
+		var recovered = `{
+			"a_table.v1": {
+				"Queries": ["FLAT"], "ToDelete": [],
+				"00000000-7fffffff": {"Queries": ["OWN"], "ToDelete": []}
+			},
+			"80000000-ffffffff": {
+				"a_table.v1": {"Queries": ["OLD-PEER"], "ToDelete": []},
+				"b_table.v1": {"Queries": ["OLD-PEER-B"], "ToDelete": []}
+			}
+		}`
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+		require.NoError(t, d.UnmarshalState(json.RawMessage(recovered)))
+
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
+		require.NoError(t, err)
+		require.Equal(t, []string{"OWN", "FLAT", "OLD-PEER"}, recording.executed)
+		require.JSONEq(t, `{
+			"a_table.v1": {
+				"Query": null, "Queries": null, "ToDelete": null,
+				"StagedFiles": null, "Bounds": null, "NeedsMerge": null,
+				"00000000-7fffffff": null
+			},
+			"80000000-ffffffff": {"a_table.v1": null}
+		}`, string(state.UpdatedJson))
+		require.Empty(t, d.cp["a_table.v1"])
+
+		// Reduced into the recovered document, only the unbound b_table entry
+		// survives.
+		require.JSONEq(t, `{
+			"a_table.v1": {},
+			"80000000-ffffffff": {"b_table.v1": {"Queries": ["OLD-PEER-B"], "ToDelete": []}}
+		}`, reduce(t, recovered, state))
+	})
+
+	t.Run("clearing a flat entry spares a current entry merged onto it", func(t *testing.T) {
+		// The flat entry was recovered and executed on its own; a peer's
+		// current entry landed under the same state key in the meantime.
+		var d = testTransactor(lowerRangeKey, "a_table.v1")
+		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("FLAT")}
+
+		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"a_table.v1": {"80000000-ffffffff": {"Queries": ["PEER"], "ToDelete": []}}
+		}`, reduce(t, `{
+			"a_table.v1": {
+				"Queries": ["FLAT"], "ToDelete": [],
+				"80000000-ffffffff": {"Queries": ["PEER"], "ToDelete": []}
+			}
+		}`, state))
+	})
+
 	t.Run("removed binding entries are retained and not cleared", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1":       item("PEER"),
-			"removed_table.v1": item("REMOVED"),
-		}
+		d.cp.add("a_table.v1", upperRangeKey, item("PEER"))
+		d.cp.add("removed_table.v1", upperRangeKey, item("REMOVED"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
 		require.Equal(t, []string{"PEER"}, recording.executed)
 		require.JSONEq(t, `{
-			"80000000-ffffffff": {"a_table.v1": null}
+			"a_table.v1": {"80000000-ffffffff": null}
 		}`, string(state.UpdatedJson))
-		require.NotNil(t, d.peerShardsCheckpoints[upperRangeKey]["removed_table.v1"])
+		require.NotNil(t, d.cp["removed_table.v1"][upperRangeKey])
 	})
 
 	t.Run("subset drain executes only requested state keys", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1", "b_table.v1")
-		d.cp["a_table.v1"] = item("QA")
-		d.cp["b_table.v1"] = item("QB")
+		d.cp.add("a_table.v1", fullRangeKey, item("QA"))
+		d.cp.add("b_table.v1", fullRangeKey, item("QB"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
 		require.NoError(t, err)
 		require.Equal(t, []string{"QA"}, recording.executed)
-		require.JSONEq(t, `{"00000000-ffffffff": {"a_table.v1": null}}`, string(state.UpdatedJson))
-		require.NotNil(t, d.cp["b_table.v1"]) // untouched, still pending
+		require.JSONEq(t, `{"a_table.v1": {"00000000-ffffffff": null}}`, string(state.UpdatedJson))
+		require.NotNil(t, d.cp["b_table.v1"][fullRangeKey]) // untouched, still pending
 	})
 
 	t.Run("subset drain spans all range buckets", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1", "b_table.v1")
-		d.cp["a_table.v1"] = item("OWN-A")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": item("PEER-A"),
-			"b_table.v1": item("PEER-B"),
-		}
 		d.peerShardsCheckpoints[legacyRangeKey] = checkpoint{"a_table.v1": item("LEGACY-A")}
+		d.cp.add("a_table.v1", lowerRangeKey, item("OWN-A"))
+		d.cp.add("a_table.v1", upperRangeKey, item("PEER-A"))
+		d.cp.add("b_table.v1", upperRangeKey, item("PEER-B"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
 		require.NoError(t, err)
-		require.Equal(t, []string{"OWN-A", "LEGACY-A", "PEER-A"}, recording.executed)
+		require.Equal(t, []string{"OWN-A", "PEER-A", "LEGACY-A"}, recording.executed)
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
-			"a_table.v1": null,
-			"80000000-ffffffff": {"a_table.v1": null}
+			"a_table.v1": {
+				"Query": null, "Queries": null, "ToDelete": null,
+				"StagedFiles": null, "Bounds": null, "NeedsMerge": null,
+				"00000000-7fffffff": null,
+				"80000000-ffffffff": null
+			}
 		}`, string(state.UpdatedJson))
-		require.NotNil(t, d.peerShardsCheckpoints[upperRangeKey]["b_table.v1"])
+		require.NotNil(t, d.cp["b_table.v1"][upperRangeKey])
 	})
 
 	t.Run("nothing to drain returns nil state", func(t *testing.T) {
 		var d = testTransactor(fullRangeKey, "a_table.v1", "b_table.v1")
-		d.cp["b_table.v1"] = item("QB")
+		d.cp.add("b_table.v1", fullRangeKey, item("QB"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), keys("a_table.v1"))
 		require.NoError(t, err)
 		require.Nil(t, state)
-		require.NotNil(t, d.cp["b_table.v1"]) // untouched, still pending
+		require.NotNil(t, d.cp["b_table.v1"][fullRangeKey]) // untouched, still pending
 	})
 
 	t.Run("non-primary does no work", func(t *testing.T) {
 		var d = testTransactor(upperRangeKey, "a_table.v1")
-		d.cp["a_table.v1"] = item("SHOULD NOT RUN")
+		d.cp.add("a_table.v1", upperRangeKey, item("SHOULD NOT RUN"))
 		d.cpRecovery = true
 
 		// Acknowledge itself is callable here since the non-primary path
@@ -371,14 +494,14 @@ func TestAcknowledge(t *testing.T) {
 
 	t.Run("recovery tolerates deleted paths", func(t *testing.T) {
 		var d = testTransactor(lowerRangeKey, "a_table.v1")
-		d.cp["a_table.v1"] = item("Q1")
+		d.cp.add("a_table.v1", lowerRangeKey, item("Q1"))
 		d.cpRecovery = true
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
 		require.NoError(t, err)
 		require.False(t, d.cpRecovery)
 
-		d.cp["a_table.v1"] = item("Q1")
+		d.cp.add("a_table.v1", lowerRangeKey, item("Q1"))
 		_, err = d.acknowledgeApply(context.Background(), recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
 		require.Error(t, err) // no longer a recovery apply
 	})
@@ -436,14 +559,12 @@ func structuredItem(needsMerge bool, bounds []mergeBoundLiterals, files ...strin
 func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 	t.Run("entries of all shards coalesce into a single merge", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true,
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true,
 			[]mergeBoundLiterals{bound("1", "10"), bound("'2024-01-01T00:00:00Z'", "'2024-01-02T00:00:00Z'")},
-			"own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": structuredItem(false,
-				[]mergeBoundLiterals{bound("5", "50"), bound("'2024-01-01T12:00:00Z'", "'2024-01-03T00:00:00Z'")},
-				"peer.json"),
-		}
+			"own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, structuredItem(false,
+			[]mergeBoundLiterals{bound("5", "50"), bound("'2024-01-01T12:00:00Z'", "'2024-01-03T00:00:00Z'")},
+			"peer.json"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -459,19 +580,15 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 		require.Contains(t, query, "l.ts <= GREATEST('2024-01-02T00:00:00Z'::TIMESTAMP, '2024-01-03T00:00:00Z'::TIMESTAMP)")
 
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
-			"80000000-ffffffff": {"a_table.v1": null}
+			"a_table.v1": {"00000000-7fffffff": null, "80000000-ffffffff": null}
 		}`, string(state.UpdatedJson))
 		require.Empty(t, d.cp)
-		require.Empty(t, d.peerShardsCheckpoints)
 	})
 
 	t.Run("one merging entry is enough to merge the coalesced files", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(false, nil, "own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": structuredItem(true, nil, "peer.json"),
-		}
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(false, nil, "own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, structuredItem(true, nil, "peer.json"))
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -481,10 +598,8 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 
 	t.Run("entries with no merging coalesce into a single copy", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(false, nil, "own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": structuredItem(false, nil, "peer.json"),
-		}
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(false, nil, "own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, structuredItem(false, nil, "peer.json"))
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -496,10 +611,8 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 
 	t.Run("recovery coalesces exactly like steady state", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true, nil, "own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": structuredItem(true, nil, "peer.json"),
-		}
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true, nil, "own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, structuredItem(true, nil, "peer.json"))
 		d.cpRecovery = true
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
@@ -513,10 +626,8 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 
 	t.Run("recovery tolerates an already-applied group whose files are gone", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true, nil, "own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": structuredItem(true, nil, "peer.json"),
-		}
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true, nil, "own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, structuredItem(true, nil, "peer.json"))
 		d.cpRecovery = true
 
 		// The coalesced query fails on deleted staged files, which during
@@ -527,16 +638,14 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, recording.executed)
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
-			"80000000-ffffffff": {"a_table.v1": null}
+			"a_table.v1": {"00000000-7fffffff": null, "80000000-ffffffff": null}
 		}`, string(state.UpdatedJson))
 		require.Empty(t, d.cp)
-		require.Empty(t, d.peerShardsCheckpoints)
 	})
 
 	t.Run("non-recovery missing objects are fatal", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true, nil, "own.json")
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true, nil, "own.json"))
 
 		_, err := d.acknowledgeApply(context.Background(),
 			recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
@@ -545,10 +654,8 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 
 	t.Run("entries of older versions run pre-rendered alongside the coalesced query", func(t *testing.T) {
 		var d = renderingTransactor(lowerRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true, nil, "own.json")
-		d.peerShardsCheckpoints[upperRangeKey] = checkpoint{
-			"a_table.v1": item("OLD-PEER"),
-		}
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true, nil, "own.json"))
+		d.cp.add("a_table.v1", upperRangeKey, item("OLD-PEER"))
 
 		state, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -556,16 +663,15 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 		require.Equal(t, "OLD-PEER", recording.executed[0])
 		require.Contains(t, recording.executed[1], "MERGE INTO `schema`.`a_table`")
 		require.JSONEq(t, `{
-			"00000000-7fffffff": {"a_table.v1": null},
-			"80000000-ffffffff": {"a_table.v1": null}
+			"a_table.v1": {"00000000-7fffffff": null, "80000000-ffffffff": null}
 		}`, string(state.UpdatedJson))
 	})
 
 	t.Run("a single entry renders its bounds verbatim", func(t *testing.T) {
 		var d = renderingTransactor(fullRangeKey)
-		d.cp["a_table.v1"] = structuredItem(true,
+		d.cp.add("a_table.v1", fullRangeKey, structuredItem(true,
 			[]mergeBoundLiterals{bound("1", "10"), bound("'2024-01-01T00:00:00Z'", "'2024-01-02T00:00:00Z'")},
-			"own.json")
+			"own.json"))
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -580,7 +686,7 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 		for i := 0; i < queryBatchSize+1; i++ {
 			files = append(files, fmt.Sprintf("f%d.json", i))
 		}
-		d.cp["a_table.v1"] = structuredItem(true, nil, files...)
+		d.cp.add("a_table.v1", lowerRangeKey, structuredItem(true, nil, files...))
 
 		_, err := d.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
 		require.NoError(t, err)
@@ -636,4 +742,3 @@ func TestCombineBounds(t *testing.T) {
 		require.Equal(t, keys[0].Identifier, out[0].Identifier)
 	})
 }
-

--- a/materialize-databricks/driver_state_test.go
+++ b/materialize-databricks/driver_state_test.go
@@ -694,6 +694,71 @@ func TestAcknowledgeCoalescesShardEntries(t *testing.T) {
 	})
 }
 
+// TestFormatMigrationCrashRecovery proves that upgrading a task while it has
+// pending work staged in an earlier checkpoint layout survives a crash at
+// either risky point of the post-commit-apply cycle: after a StartedCommit
+// checkpoint is durable but before Acknowledge's clearing patch lands, and
+// again during the retry that follows. Each layout is the state exactly as
+// an older connector version, or an older scale-out topology, would have
+// left it mid-crash; the new binary must recover it, apply it at most once,
+// and converge to an empty checkpoint with no residue that could trigger a
+// phantom re-run.
+func TestFormatMigrationCrashRecovery(t *testing.T) {
+	var entry = `{"StagedFiles": ["f.json"], "NeedsMerge": true, "Bounds": [{"Lower":"1","Upper":"10"},{"Lower":"'2024-01-01T00:00:00Z'","Upper":"'2024-01-02T00:00:00Z'"}]}`
+
+	var layouts = []struct {
+		name string
+		doc  string
+	}{
+		{"flat, pre-range-scoping", fmt.Sprintf(`{"a_table.v1": %s}`, entry)},
+		{"range-first, pre-this-PR scale-out", fmt.Sprintf(`{%q: {"a_table.v1": %s}}`, fullRangeKey, entry)},
+		{"current", fmt.Sprintf(`{"a_table.v1": {%q: %s}}`, fullRangeKey, entry)},
+	}
+
+	for _, layout := range layouts {
+		t.Run(layout.name, func(t *testing.T) {
+			var doc = layout.doc
+
+			// Crash 1: a StartedCommit checkpoint in this layout is durable,
+			// then the process dies before Acknowledge's clearing patch is
+			// persisted. The new binary boots and recovers it.
+			var d1 = renderingTransactor(fullRangeKey)
+			require.NoError(t, d1.UnmarshalState(json.RawMessage(doc)))
+			require.True(t, d1.cpRecovery)
+
+			state1, err := d1.acknowledgeApply(context.Background(), recordingDB(t, nil), allKeys)
+			require.NoError(t, err)
+			require.Len(t, recording.executed, 1) // the one real side effect
+			require.Contains(t, recording.executed[0], "MERGE INTO `schema`.`a_table`")
+			require.NotNil(t, state1) // the clear patch the runtime failed to persist
+
+			// Crash 2: the process dies again before the retry's clearing
+			// patch persists either, so a second restart recovers the exact
+			// same pending entry from the still-unclearred `doc`. Its staged
+			// file was already deleted by crash 1's successful MERGE, so
+			// this retry's query hits a missing-file error, which recovery
+			// tolerates as "already applied" rather than re-running it.
+			var d2 = renderingTransactor(fullRangeKey)
+			require.NoError(t, d2.UnmarshalState(json.RawMessage(doc)))
+			require.True(t, d2.cpRecovery)
+
+			state2, err := d2.acknowledgeApply(context.Background(),
+				recordingDB(t, fmt.Errorf("some PATH_NOT_FOUND error")), allKeys)
+			require.NoError(t, err)
+			require.Empty(t, recording.executed) // no second real side effect
+			require.NotNil(t, state2)
+
+			// This time the clearing patch lands. The persisted document
+			// converges to nothing pending for a_table.v1, regardless of the
+			// layout it started in, so a third restart finds no work at all.
+			var d3 = renderingTransactor(fullRangeKey)
+			require.NoError(t, d3.UnmarshalState(json.RawMessage(reduce(t, doc, state2))))
+			require.Empty(t, d3.cp)
+			require.Empty(t, d3.peerShardsCheckpoints)
+		})
+	}
+}
+
 func TestCombineBounds(t *testing.T) {
 	var keys = renderableTable().Keys
 

--- a/materialize-databricks/driver_test.go
+++ b/materialize-databricks/driver_test.go
@@ -49,12 +49,15 @@ func TestIntegration(t *testing.T) {
 
 			seedPending := func(t *testing.T, appliedSpec *pf.MaterializationSpec) json.RawMessage {
 				// A staged transaction is a set of queries persisted in the
-				// connector state, keyed by the binding's state key.
+				// connector state under the binding's state key and the
+				// staging shard's key range.
 				query := sql.DrainSeedInsertQuery(t, NewDriver(), cfg, appliedSpec, "'{}'")
 				state, err := json.Marshal(map[string]any{
 					appliedSpec.Bindings[0].StateKey: map[string]any{
-						"Queries":  []string{query},
-						"ToDelete": []string{},
+						"00000000-ffffffff": map[string]any{
+							"Queries":  []string{query},
+							"ToDelete": []string{},
+						},
 					},
 				})
 				require.NoError(t, err)


### PR DESCRIPTION
**Description:**

- Switch checkpoint format from `{rangeKey: {stateKey}}` to `{stateKey: {rangeKey}}`

Downgrades: versions predating this change refuse to parse the new format; drain the task before pinning an older image.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
