### PR TITLE
source-mysql: add support for AWS IAM auth

### DIFF
--- a/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
+++ b/docs/reference/Connectors/capture-connectors/MariaDB/amazon-rds-mariadb.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-description: Set up Estuary's Amazon RDS for MariaDB capture connector with CDC, binlog configuration, replication permissions, and backfill and time zone settings.
+description: Set up Estuary's Amazon RDS for MariaDB capture connector with CDC, binlog configuration, replication permissions, IAM authentication, and backfill and time zone settings.
 ---
 
 # Amazon RDS for MariaDB
@@ -26,6 +26,7 @@ To use this connector, you'll need a MariaDB database setup with the following.
   - Permission to read from `information_schema` tables, if automatic discovery is used.
 - If the table(s) to be captured include columns of type `DATETIME`, the `time_zone` system variable
   must be set to an IANA zone name or numerical offset or the capture configured with a `timezone` to use by default.
+- When using [IAM authentication](#iam-authentication), IAM database authentication enabled on the instance and a database user which authenticates through the RDS plugin.
 
 ### Setup
 
@@ -78,6 +79,42 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 ```
 
 5. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+
+### IAM Authentication
+
+Instead of a password, you can authenticate to your instance with an AWS IAM role.
+
+Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Flow to assume, and make note of its ARN and your instance's region to use when configuring the connector's authentication options.
+
+[Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html) on the instance, then switch to your MariaDB client and run the following commands to create a database user which authenticates through the RDS plugin, granting it the same permissions as the `flow_capture` user in the [setup instructions](#setup) above:
+
+```sql
+CREATE USER IF NOT EXISTS flow_capture
+  IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'
+  REQUIRE SSL
+  COMMENT 'User account for Estuary MySQL data capture';
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
+GRANT SELECT ON *.* TO 'flow_capture';
+```
+
+Finally, [attach a policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) to the role granting it `rds-db:connect` on that user, substituting your own region, account ID, and the instance's resource ID:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["rds-db:connect"],
+      "Resource": ["arn:aws:rds-db:us-east-1:123456789012:dbuser:db-ABCDEFGHIJKL01234/flow_capture"]
+    }
+  ]
+}
+```
+
+IAM authentication always connects over TLS and never falls back to an unencrypted connection.
+
+[aws-iam]: /guides/iam-auth/aws/
 
 ## Capturing from Read Replicas
 
@@ -136,8 +173,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. Amazon RDS for MariaDB supports `UserPassword`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AWSIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
+| `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
 
 #### Bindings
 
@@ -177,6 +216,15 @@ captures:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate with [AWS IAM](#iam-authentication) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AWSIAM
+            aws_region: "us-east-1"
+            aws_role_arn: "arn:aws:iam::123456789012:role/flow-capture"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -174,6 +174,42 @@ GRANT SELECT ON *.* TO 'flow_capture';
 
 ### IAM Authentication
 
+On Amazon Aurora and Azure Database for MySQL you can authenticate with a cloud IAM identity instead of a password. IAM authentication always connects over TLS and never falls back to an unencrypted connection.
+
+#### AWS IAM
+
+For Amazon Aurora MySQL clusters, you can authenticate with an AWS IAM role instead of a password.
+
+Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Flow to assume, and make note of its ARN and your cluster's region to use when configuring the connector's authentication options.
+
+[Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html) on the cluster, then run the following commands to create a database user which authenticates through the RDS plugin, granting it the same permissions as the `flow_capture` user in the [Amazon Aurora](#amazon-aurora) setup instructions above:
+
+```sql
+CREATE USER IF NOT EXISTS flow_capture
+  IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'
+  REQUIRE SSL
+  COMMENT 'User account for Estuary MySQL data capture';
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
+GRANT SELECT ON *.* TO 'flow_capture';
+```
+
+Finally, [attach a policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) to the role granting it `rds-db:connect` on that user, substituting your own region, account ID, and the cluster's resource ID:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["rds-db:connect"],
+      "Resource": ["arn:aws:rds-db:us-east-1:123456789012:dbuser:cluster-ABCDEFGHIJKL01234/flow_capture"]
+    }
+  ]
+}
+```
+
+#### Azure IAM
+
 For Azure Database for MySQL flexible servers, you can authenticate with an Azure App Registration instead of a password.
 
 Follow the steps in the [Azure IAM guide][azure-iam] to create an App Registration and make note of the Application ID and Tenant ID to use when configuring the connector's authentication options.
@@ -189,6 +225,7 @@ GRANT SELECT ON *.* TO 'flow_capture';
 
 Use the name given in the `CREATE AADUSER` statement as the connector's `user` property.
 
+[aws-iam]: /guides/iam-auth/aws/
 [azure-iam]: /guides/iam-auth/azure/
 
 ## Capturing from Read Replicas
@@ -268,8 +305,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AzureIAM`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword`, `AWSIAM`, or `AzureIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
+| `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
 | `/credentials/azure_client_id` | Azure Client ID | Application (client) ID of the App Registration. | string | Required for `AzureIAM` auth |
 | `/credentials/azure_tenant_id` | Azure Tenant ID | Directory (tenant) ID of the App Registration. | string | Required for `AzureIAM` auth |
 
@@ -326,7 +365,16 @@ captures:
         target: ${PREFIX}/${COLLECTION_NAME}
 ```
 
-To authenticate to an Azure Database for MySQL flexible server with [Azure IAM](#iam-authentication) instead, replace the credentials block:
+To authenticate to an Amazon Aurora MySQL cluster with [AWS IAM](#aws-iam) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AWSIAM
+            aws_region: "us-east-1"
+            aws_role_arn: "arn:aws:iam::123456789012:role/flow-capture"
+```
+
+To authenticate to an Azure Database for MySQL flexible server with [Azure IAM](#azure-iam) instead, replace the credentials block:
 
 ```yaml
           credentials:

--- a/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Capture Amazon RDS MySQL changes with Estuary’s CDC connector. Guide includes binlog setup, capturing from read replicas, and backfill considerations.
+description: Capture Amazon RDS MySQL changes with Estuary’s CDC connector. Guide includes binlog setup, IAM authentication, capturing from read replicas, and backfill considerations.
 ---
 
 # Amazon RDS for MySQL
@@ -22,6 +22,7 @@ To use this connector, you'll need a MySQL database setup with the following.
   - Permission to read from `information_schema` tables, if automatic discovery is used.
 - If the table(s) to be captured include columns of type `DATETIME`, the `time_zone` system variable
   must be set to an IANA zone name or numerical offset or the capture configured with a `timezone` to use by default.
+- When using [IAM authentication](#iam-authentication), IAM database authentication enabled on the instance and a database user which authenticates through the RDS plugin.
 
 ## Setup
 
@@ -69,6 +70,42 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 ```
 
 5. In the [RDS console](https://console.aws.amazon.com/rds/), note the instance's Endpoint and Port. You'll need these for the `address` property when you configure the connector.
+
+### IAM Authentication
+
+Instead of a password, you can authenticate to your instance with an AWS IAM role.
+
+Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Flow to assume, and make note of its ARN and your instance's region to use when configuring the connector's authentication options.
+
+[Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html) on the instance, then switch to your MySQL client and run the following commands to create a database user which authenticates through the RDS plugin, granting it the same permissions as the `flow_capture` user in the [setup instructions](#setup) above:
+
+```sql
+CREATE USER IF NOT EXISTS flow_capture
+  IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'
+  REQUIRE SSL
+  COMMENT 'User account for Estuary MySQL data capture';
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow_capture';
+GRANT SELECT ON *.* TO 'flow_capture';
+```
+
+Finally, [attach a policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) to the role granting it `rds-db:connect` on that user, substituting your own region, account ID, and the instance's resource ID:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["rds-db:connect"],
+      "Resource": ["arn:aws:rds-db:us-east-1:123456789012:dbuser:db-ABCDEFGHIJKL01234/flow_capture"]
+    }
+  ]
+}
+```
+
+IAM authentication always connects over TLS and never falls back to an unencrypted connection.
+
+[aws-iam]: /guides/iam-auth/aws/
 
 ## Capturing from Read Replicas
 
@@ -155,8 +192,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. Amazon RDS for MySQL supports `UserPassword`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `AWSIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
+| `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
 
 ##### Discovery Filters
 
@@ -209,6 +248,15 @@ captures:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate with [AWS IAM](#iam-authentication) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: AWSIAM
+            aws_region: "us-east-1"
+            aws_role_arn: "arn:aws:iam::123456789012:role/flow-capture"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -45,6 +45,34 @@
           },
           {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/aws-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "AWSIAM",
+                "default": "AWSIAM",
+                "order": 0
+              },
+              "aws_region": {
+                "type": "string",
+                "title": "AWS Region",
+                "description": "AWS Region of your resource"
+              },
+              "aws_role_arn": {
+                "type": "string",
+                "title": "AWS Role ARN",
+                "description": "AWS Role which has access to the resource which will be assumed by Flow"
+              }
+            },
+            "type": "object",
+            "required": [
+              "aws_region",
+              "aws_role_arn"
+            ],
+            "title": "AWS IAM"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/go/auth/iam/azure-config",
             "properties": {
               "auth_type": {

--- a/source-mysql/CHANGELOG.md
+++ b/source-mysql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # source-mysql
 
+## 2026-09-01
+
+### Added
+- The `credentials` configuration union now also supports AWS IAM
+  authentication, for Amazon RDS and Aurora instances with IAM database
+  authentication enabled. A fresh RDS auth token is minted from the assumed
+  role's session credentials for each connection attempt.
+
 ## 2026-08-28
 
 ### Added

--- a/source-mysql/config_test.go
+++ b/source-mysql/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -89,6 +90,31 @@ func TestConfigValidate(t *testing.T) {
 		require.ErrorContains(t, cfg.Validate(), "cannot exceed 32 characters")
 	})
 
+	t.Run("AWSIAMValid", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AWSIAM}
+		cfg.Credentials.AWSRegion = "us-east-1"
+		cfg.Credentials.AWSRole = "arn:aws:iam::123456789012:role/flow-capture"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("AWSIAMMissingRegion", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AWSIAM}
+		cfg.Credentials.AWSRole = "arn:aws:iam::123456789012:role/flow-capture"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'aws_region'")
+	})
+
+	t.Run("AWSIAMMissingRoleARN", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: AWSIAM}
+		cfg.Credentials.AWSRegion = "us-east-1"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'aws_role_arn'")
+	})
+
 	t.Run("AzureIAMValid", func(t *testing.T) {
 		var cfg = valid()
 		cfg.Credentials = &CredentialsConfig{AuthType: AzureIAM}
@@ -114,14 +140,94 @@ func TestConfigValidate(t *testing.T) {
 	})
 }
 
+// awsIAMConfig is a config authenticating with AWS IAM, with the session credentials
+// the control plane would have injected alongside the user's region and role.
+func awsIAMConfig() Config {
+	return Config{
+		Address: "example.abcdefg.us-east-1.rds.amazonaws.com:3306",
+		User:    "flow_capture",
+		Credentials: &CredentialsConfig{
+			AuthType: AWSIAM,
+			IAMConfig: iam.IAMConfig{
+				AWSConfig: iam.AWSConfig{
+					AWSRegion: "us-east-1",
+					AWSRole:   "arn:aws:iam::123456789012:role/flow-capture",
+				},
+				IAMTokens: iam.IAMTokens{AWSTokens: iam.AWSTokens{
+					AWSAccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+					AWSSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+					AWSSessionToken:    "FwoGZXIvYXdzEXAMPLESESSIONTOKEN",
+				}},
+			},
+		},
+	}
+}
+
 func TestEffectivePassword(t *testing.T) {
 	t.Run("UserPassword", func(t *testing.T) {
 		var cfg = Config{Address: "example.com:3306", User: "flow_capture", Password: "secret1234"}
 		cfg.normalizeCredentials()
 
-		password, err := cfg.EffectivePassword()
+		password, err := cfg.EffectivePassword(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, "secret1234", password)
+	})
+
+	t.Run("AWSIAMToken", func(t *testing.T) {
+		var cfg = awsIAMConfig()
+		cfg.normalizeCredentials()
+
+		require.NoError(t, cfg.Validate())
+		password, err := cfg.EffectivePassword(context.Background())
+		require.NoError(t, err)
+		// The RDS auth token is a presigned request against the configured endpoint,
+		// and is far longer than the 32 characters allowed for a real password.
+		require.Greater(t, len(password), 32)
+		require.Contains(t, password, "example.abcdefg.us-east-1.rds.amazonaws.com:3306")
+		require.Contains(t, password, "X-Amz-Signature=")
+		require.Contains(t, password, "DBUser=flow_capture")
+	})
+
+	t.Run("AWSIAMTokenIsFreshlyMinted", func(t *testing.T) {
+		// Tokens expire fifteen minutes after they are built, so every call must mint
+		// a new one rather than hand back a value cached at startup.
+		var cfg = awsIAMConfig()
+		cfg.normalizeCredentials()
+		cfg.Credentials.AWSRegion = "us-west-2"
+
+		password, err := cfg.EffectivePassword(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, password, "us-west-2%2Frds-db%2Faws4_request")
+	})
+
+	t.Run("AWSIAMMissingSessionCredentials", func(t *testing.T) {
+		var cfg = awsIAMConfig()
+		cfg.Credentials.AWSAccessKeyID = ""
+		cfg.normalizeCredentials()
+
+		_, err := cfg.EffectivePassword(context.Background())
+		require.ErrorContains(t, err, "missing iam session 'aws_access_key_id'")
+	})
+
+	t.Run("NormalizedShapeMatchesLegacy", func(t *testing.T) {
+		var legacy = Config{Address: "example.com:3306", User: "flow_capture", Password: "secret1234"}
+		var union = Config{
+			Address: "example.com:3306",
+			User:    "flow_capture",
+			Credentials: &CredentialsConfig{
+				AuthType:           UserPassword,
+				UserPasswordConfig: UserPasswordConfig{Password: "secret1234"},
+			},
+		}
+
+		legacy.normalizeCredentials()
+		union.normalizeCredentials()
+
+		legacyPassword, err := legacy.EffectivePassword(context.Background())
+		require.NoError(t, err)
+		unionPassword, err := union.EffectivePassword(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, unionPassword, legacyPassword)
 	})
 
 	t.Run("AzureIAMToken", func(t *testing.T) {
@@ -145,7 +251,7 @@ func TestEffectivePassword(t *testing.T) {
 		cfg.normalizeCredentials()
 
 		require.NoError(t, cfg.Validate())
-		password, err := cfg.EffectivePassword()
+		password, err := cfg.EffectivePassword(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, token, password)
 	})
@@ -158,7 +264,7 @@ func TestEffectivePassword(t *testing.T) {
 		}
 		cfg.normalizeCredentials()
 
-		_, err := cfg.EffectivePassword()
+		_, err := cfg.EffectivePassword(context.Background())
 		require.ErrorContains(t, err, "missing 'azure_access_token'")
 	})
 
@@ -169,7 +275,7 @@ func TestEffectivePassword(t *testing.T) {
 			Credentials: &CredentialsConfig{AuthType: "Bogus"},
 		}
 
-		_, err := cfg.EffectivePassword()
+		_, err := cfg.EffectivePassword(context.Background())
 		require.ErrorContains(t, err, `unsupported 'auth_type' "Bogus"`)
 	})
 }
@@ -182,8 +288,8 @@ func TestRequiresTLS(t *testing.T) {
 		expect   bool
 	}{
 		{UserPassword, false},
+		{AWSIAM, true},
 		{AzureIAM, true},
-		{AuthType(iam.AWSIAM), true},
 		{AuthType(iam.GCPIAM), true},
 		{AuthType("Bogus"), true},
 	} {

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/estuary/connectors/go/auth/iam"
 	"github.com/estuary/connectors/go/common"
 	cerrors "github.com/estuary/connectors/go/connector-errors"
@@ -150,6 +151,7 @@ type AuthType string
 
 const (
 	UserPassword AuthType = "UserPassword"
+	AWSIAM       AuthType = "AWSIAM"
 	AzureIAM     AuthType = "AzureIAM"
 )
 
@@ -170,6 +172,7 @@ type CredentialsConfig struct {
 func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
 	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword),
 		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
+		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)),
 		schemagen.OneOfSubSchema("Azure IAM", iam.AzureConfig{}, string(AzureIAM)),
 	)
 }
@@ -181,7 +184,7 @@ func (c *CredentialsConfig) Validate() error {
 			return errors.New("missing 'password'")
 		}
 		return nil
-	case AzureIAM:
+	case AWSIAM, AzureIAM:
 		// The embedded IAMConfig has its own auth_type field which JSON decoding
 		// leaves empty (the outer field shadows it), so sync it before ValidateIAM
 		// switches on it.
@@ -329,13 +332,28 @@ func (c *Config) normalizeCredentials() {
 
 // EffectivePassword returns the secret to present as the MySQL password for the
 // configured authentication method. It requires normalizeCredentials to have run,
-// and only reads the credentials union. For Azure IAM the password is the Entra
-// access token injected into the config by the control plane, which restarts the
-// connector with a fresh token before expiry.
-func (c *Config) EffectivePassword() (string, error) {
+// and only reads the credentials union. For AWS IAM the password is an RDS auth
+// token minted here from the session credentials the control plane injects, valid
+// for fifteen minutes, so callers should invoke this per connection attempt rather
+// than caching the result. For Azure IAM the password is the Entra access token
+// injected into the config by the control plane, which restarts the connector with
+// a fresh token before expiry.
+func (c *Config) EffectivePassword(ctx context.Context) (string, error) {
 	switch c.Credentials.AuthType {
 	case UserPassword:
 		return c.Credentials.Password, nil
+	case AWSIAM:
+		credProvider, err := c.Credentials.AWSCredentialsProvider()
+		if err != nil {
+			return "", err
+		}
+		// The token is bound to the endpoint it will be presented to, so it's built
+		// from the configured address rather than the network tunnel's local address.
+		token, err := auth.BuildAuthToken(ctx, c.Address, c.Credentials.AWSRegion, c.User, credProvider)
+		if err != nil {
+			return "", fmt.Errorf("building AWS IAM auth token: %w", err)
+		}
+		return token, nil
 	case AzureIAM:
 		var token = c.Credentials.AzureToken()
 		if token == "" {
@@ -423,7 +441,7 @@ func (db *mysqlDatabase) connectPreferringTLS(address, password string) (*client
 	}
 }
 
-func (db *mysqlDatabase) connect(_ context.Context) error {
+func (db *mysqlDatabase) connect(ctx context.Context) error {
 	logrus.WithFields(logrus.Fields{
 		"addr":     db.config.Address,
 		"dbName":   db.config.Advanced.DBName,
@@ -448,7 +466,7 @@ func (db *mysqlDatabase) connect(_ context.Context) error {
 	})
 	defer connectionTimer.Stop()
 
-	var password, err = db.config.EffectivePassword()
+	var password, err = db.config.EffectivePassword(ctx)
 	if err != nil {
 		return err
 	}

--- a/source-mysql/main_test.go
+++ b/source-mysql/main_test.go
@@ -85,9 +85,12 @@ func mysqlTestBackend(t testing.TB) *testBackend {
 
 	// Construct the capture config
 	var captureConfig = Config{
-		Address:  *dbCaptureAddress,
-		User:     *dbCaptureUser,
-		Password: *dbCapturePass,
+		Address: *dbCaptureAddress,
+		User:    *dbCaptureUser,
+		Credentials: &CredentialsConfig{
+			AuthType:           UserPassword,
+			UserPasswordConfig: UserPasswordConfig{Password: *dbCapturePass},
+		},
 		Advanced: advancedConfig{
 			DBName:                   *dbName,
 			SkipBinlogRetentionCheck: *skipBinlogRetentionCheck,

--- a/source-mysql/replication.go
+++ b/source-mysql/replication.go
@@ -119,7 +119,10 @@ func (db *mysqlDatabase) ReplicationStream(ctx context.Context, startCursorJSON 
 		flavor = mysql.MariaDBFlavor
 	}
 
-	password, err := db.config.EffectivePassword()
+	// The syncer keeps this password for its entire lifetime, so under AWS IAM auth an
+	// internal reconnect attempted more than fifteen minutes from now will be denied.
+	// That failure terminates the capture and the restarted connector mints a fresh token.
+	password, err := db.config.EffectivePassword(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:**

Mirrors #5165 for AWS.

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
