### PR TITLE
source-hubspot-native: backfill `form_submissions` per form

### DIFF
--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -7,6 +7,11 @@
   submissions made at least five minutes before it started and checkpoints the newest
   one emitted, so anything newer is read by a later sweep.
 
+### Changed
+- The `form_submissions` binding now reads historical submissions through a dedicated
+  backfill task that checkpoints after each form, so a restart resumes from the last
+  completed form instead of re-reading every form's history in a single sweep.
+
 ## 2026-08-27
 ### Added
 - New `leads` binding for the HubSpot Leads object. Leads requires a Sales Hub

--- a/source-hubspot-native/source_hubspot_native/api/__init__.py
+++ b/source-hubspot-native/source_hubspot_native/api/__init__.py
@@ -2,6 +2,7 @@ from .shared import (
     DELAYED_LAG,
     FetchDelayedFn,
     FetchRecentFn,
+    dt_to_ms,
     fetch_delayed_changes,
     fetch_realtime_changes,
 )
@@ -51,7 +52,12 @@ from .feedback_submissions import (
     fetch_delayed_feedback_submissions,
     fetch_recent_feedback_submissions,
 )
-from .form_submissions import fetch_form_submissions
+from .form_submissions import (
+    FORM_SUBMISSIONS_LAG,
+    FormIdCache,
+    fetch_form_submissions,
+    fetch_form_submissions_page,
+)
 from .forms import fetch_forms
 from .goals import (
     fetch_delayed_goals,
@@ -99,9 +105,12 @@ __all__ = [
     "DELAYED_LAG",
     "FetchDelayedFn",
     "FetchRecentFn",
+    "FORM_SUBMISSIONS_LAG",
+    "FormIdCache",
     "check_campaigns_access",
     "check_contact_list_memberships_access",
     "check_contact_lists_access",
+    "dt_to_ms",
     "fetch_campaigns",
     "fetch_campaigns_page",
     "fetch_contact_list_memberships",
@@ -126,6 +135,7 @@ __all__ = [
     "fetch_delayed_workflows",
     "fetch_email_events_page",
     "fetch_form_submissions",
+    "fetch_form_submissions_page",
     "fetch_forms",
     "fetch_marketing_emails_page",
     "fetch_marketing_event_participants",

--- a/source-hubspot-native/source_hubspot_native/api/form_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/form_submissions.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from logging import Logger
 from typing import (
@@ -6,8 +7,9 @@ from typing import (
 
 from estuary_cdk.capture.common import (
     LogCursor,
+    PageCursor,
 )
-from estuary_cdk.http import HTTPSession
+from estuary_cdk.http import HTTPError, HTTPSession
 
 from .forms import fetch_forms
 
@@ -28,6 +30,28 @@ from .shared import (
 FORM_TYPES_WITHOUT_SUBMISSIONS = frozenset({"blog_comment"})
 
 FORM_SUBMISSIONS_LAG = timedelta(minutes=5)
+
+
+@dataclass
+class FormIdCache:
+    """
+    Sorted ids of the forms whose submissions HubSpot will export, listed once
+    per connector process and shared by every backfill invocation in it.
+    """
+
+    form_ids: list[str] | None = None
+
+    async def get(self, http: HTTPSession, log: Logger) -> list[str]:
+        if self.form_ids is None:
+            self.form_ids = sorted(
+                [
+                    form.id
+                    async for form in fetch_forms(http, log)
+                    if form.formType not in FORM_TYPES_WITHOUT_SUBMISSIONS
+                ]
+            )
+
+        return self.form_ids
 
 
 async def _fetch_form_submissions_between(
@@ -109,3 +133,46 @@ async def fetch_form_submissions(
 
     if latest_submitted_at != log_cursor:
         yield latest_submitted_at
+
+
+async def fetch_form_submissions_page(
+    http: HTTPSession,
+    cache: FormIdCache,
+    log: Logger,
+    page: PageCursor,
+    cutoff: LogCursor,
+) -> AsyncGenerator[FormSubmission | PageCursor, None]:
+    """
+    Emit one form's submissions with `submittedAt <= cutoff`, then checkpoint
+    that form's id. Forms are walked in ascending id order and `page` is the id
+    of the last form completed, so a resumed backfill continues with the next
+    form.
+    """
+    assert page is None or isinstance(page, str)
+    assert isinstance(cutoff, int)
+
+    form_ids = await cache.get(http, log)
+    form_id = next(
+        (form_id for form_id in form_ids if page is None or form_id > page),
+        None,
+    )
+    if form_id is None:
+        return
+
+    try:
+        async for submission in _fetch_form_submissions_between(
+            http, log, form_id, 0, cutoff
+        ):
+            yield submission
+    except HTTPError as err:
+        # A form deleted after this process listed it has nothing left to
+        # export. Skip it rather than stall the backfill on it.
+        if err.code != 404:
+            raise
+
+        log.warning(
+            "form no longer exists, skipping its submissions backfill",
+            {"formId": form_id},
+        )
+
+    yield form_id

--- a/source-hubspot-native/source_hubspot_native/resources.py
+++ b/source-hubspot-native/source_hubspot_native/resources.py
@@ -18,8 +18,10 @@ from estuary_cdk.http import HTTPError, HTTPMixin, HTTPSession, TokenSource
 
 from .api import (
     DELAYED_LAG,
+    FORM_SUBMISSIONS_LAG,
     FetchDelayedFn,
     FetchRecentFn,
+    FormIdCache,
     check_campaigns_access,
     fetch_campaigns,
     fetch_campaigns_page,
@@ -27,6 +29,7 @@ from .api import (
     fetch_contact_lists_page,
     check_contact_list_memberships_access,
     check_contact_lists_access,
+    dt_to_ms,
     fetch_contact_list_memberships_page,
     fetch_contact_lists,
     fetch_deal_pipelines,
@@ -48,6 +51,7 @@ from .api import (
     fetch_delayed_workflows,
     fetch_email_events_page,
     fetch_form_submissions,
+    fetch_form_submissions_page,
     fetch_forms,
     fetch_marketing_emails_page,
     fetch_marketing_event_participants,
@@ -738,7 +742,14 @@ def form_submissions(http: HTTPSession) -> Resource:
                 fetch_form_submissions,
                 http,
             ),
+            fetch_page=functools.partial(
+                fetch_form_submissions_page,
+                http,
+                FormIdCache(),
+            ),
         )
+
+    cutoff = dt_to_ms(datetime.now(tz=UTC) - FORM_SUBMISSIONS_LAG)
 
     return Resource(
         name=Names.form_submissions,
@@ -746,7 +757,8 @@ def form_submissions(http: HTTPSession) -> Resource:
         model=FormSubmission,
         open=open,
         initial_state=ResourceState(
-            inc=ResourceState.Incremental(cursor=0),
+            inc=ResourceState.Incremental(cursor=cutoff),
+            backfill=ResourceState.Backfill(next_page=None, cutoff=cutoff),
         ),
         initial_config=ResourceConfig(
             name=Names.form_submissions, interval=timedelta(minutes=5)


### PR DESCRIPTION
**Description:**

`form_submissions` was incremental-only, so a binding with a cursor of 0 had to read every form's full history in a single sweep before it could checkpoint anything. For accounts with many forms that have many submissions, this initial sweep can take a long time and is succeptible to interruptions from capture restarts.

History at or below a `cutoff` is now read by a dedicated backfill task that walks forms in ascending id order and checkpoints after each one, so a restart resumes from the last completed form. The incremental task is seeded at the same `cutoff` and only ever covers time after it. Forms are listed once per connector process and reused by every backfill invocation.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
