### PR TITLE
source-snowflake: Scope dynamic table listing to the capture database

### DIFF
--- a/source-snowflake/CHANGELOG.md
+++ b/source-snowflake/CHANGELOG.md
@@ -1,5 +1,12 @@
 # source-snowflake
 
+## 2026-09-02
+
+### Fixed
+- Dynamic table discovery is now scoped to the capture database. Previously a
+  same-named dynamic table in another database could cause a captured table to
+  disappear from discovery.
+
 ## 2026-07-30
 
 ### Changed

--- a/source-snowflake/database.go
+++ b/source-snowflake/database.go
@@ -158,13 +158,17 @@ type snowflakeDynamicTable struct {
 func listDynamicTables(ctx context.Context, cfg *config, db *sql.DB) (map[snowflakeObject]*snowflakeDynamicTable, error) {
 	var xdb = sqlx.NewDb(db, "snowflake").Unsafe()
 	var tables []*snowflakeDynamicTable
-	if err := xdb.SelectContext(ctx, &tables, "SHOW DYNAMIC TABLES IN ACCOUNT;"); err != nil {
-		return nil, fmt.Errorf("error listing tables: %w", err)
+	var query = fmt.Sprintf("SHOW DYNAMIC TABLES IN DATABASE %s;", quoteSnowflakeIdentifier(cfg.Database))
+	if err := xdb.SelectContext(ctx, &tables, query); err != nil {
+		return nil, fmt.Errorf("error listing dynamic tables: %w", err)
 	}
 
 	var result = make(map[snowflakeObject]*snowflakeDynamicTable)
 	for _, table := range tables {
-		var tableID = snowflakeObject{cfg.Database, table.Schema, table.Name}
+		if table.Database != cfg.Database {
+			return nil, fmt.Errorf("internal error: dynamic table %q.%q.%q is not in database %q", table.Database, table.Schema, table.Name, cfg.Database)
+		}
+		var tableID = snowflakeObject{table.Database, table.Schema, table.Name}
 		result[tableID] = table
 	}
 	return result, nil


### PR DESCRIPTION
**Description:**

The dynamic table listing used `SHOW DYNAMIC TABLES IN ACCOUNT` and then keyed every result under the configured capture database, discarding the database name each row actually came from. A dynamic table in some other database of the same account, with the same schema and table name as a captured table, was therefore mistaken for that table. When the impostor had a full refresh mode the real table was filtered out of discovery, and Flow's auto-discover then removed the binding as though the table had been dropped.

The account-wide scope dates from before snowflakeObject carried a database component, and the cfg.Database stamping was added mechanically when that component was introduced. Every other discovery query is already scoped to the capture database, so this brings the dynamic table listing in line with them and adds the same sanity check the other queries have against results from unexpected databases.

**Workflow steps:**

No user action required.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: N/A
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
