### PR TITLE
source-hubspot-native: limit search chunks to below 10,000 results

### DIFF
--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2026-09-02
 ### Fixed
+- CRM object bindings no longer fail when the HubSpot Search API returns records out
+  of order. Search windows holding more than 10,000 records are split by time into
+  chunks HubSpot can return completely, so result order is never relied on. Records
+  HubSpot returns for a window are now always captured, even when their reported
+  last-modified time falls outside it.
 - The `form_submissions` binding could permanently skip submissions that arrived on a
   form while a sweep was still checking other forms. Each sweep now only emits
   submissions made at least five minutes before it started and checkpoints the newest

--- a/source-hubspot-native/source_hubspot_native/api/companies.py
+++ b/source-hubspot-native/source_hubspot_native/api/companies.py
@@ -77,5 +77,5 @@ def fetch_delayed_companies(
         )
 
     return fetch_chunked_changes_with_associations(
-        Names.companies, Company, do_fetch, log, http, with_history, since, until
+        Names.companies, Company, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/contacts.py
+++ b/source-hubspot-native/source_hubspot_native/api/contacts.py
@@ -82,5 +82,5 @@ def fetch_delayed_contacts(
         )
 
     return fetch_chunked_changes_with_associations(
-        Names.contacts, Contact, do_fetch, log, http, with_history, since, until
+        Names.contacts, Contact, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -57,7 +57,7 @@ def fetch_delayed_custom_objects(
         return await fetch_search_objects(object_name, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        object_name, CustomObject, do_fetch, log, http, with_history, since, until
+        object_name, CustomObject, do_fetch, log, http, with_history
     )
 
 async def list_custom_objects(

--- a/source-hubspot-native/source_hubspot_native/api/custom_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/custom_objects.py
@@ -35,10 +35,7 @@ def fetch_recent_custom_objects(
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
-        return await fetch_search_objects(
-            object_name, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
-        )
+        return await fetch_search_objects(object_name, log, http, since, until, page)
 
     return fetch_changes_with_associations(
         object_name, CustomObject, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/deals.py
+++ b/source-hubspot-native/source_hubspot_native/api/deals.py
@@ -76,5 +76,5 @@ def fetch_delayed_deals(
         return await fetch_search_objects(Names.deals, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.deals, Deal, do_fetch, log, http, with_history, since, until
+        Names.deals, Deal, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -33,8 +33,7 @@ def fetch_recent_feedback_submissions(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
-            Names.feedback_submissions, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
+            Names.feedback_submissions, log, http, since, until, page
         )
 
     return fetch_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
+++ b/source-hubspot-native/source_hubspot_native/api/feedback_submissions.py
@@ -66,6 +66,4 @@ def fetch_delayed_feedback_submissions(
         log,
         http,
         with_history,
-        since,
-        until,
     )

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -49,5 +49,5 @@ def fetch_delayed_goals(
         return await fetch_search_objects(Names.goals, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.goals, Goals, do_fetch, log, http, with_history, since, until
+        Names.goals, Goals, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/goals.py
+++ b/source-hubspot-native/source_hubspot_native/api/goals.py
@@ -32,10 +32,7 @@ def fetch_recent_goals(
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
-        return await fetch_search_objects(
-            Names.goals, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
-        )
+        return await fetch_search_objects(Names.goals, log, http, since, until, page)
 
     return fetch_changes_with_associations(
         Names.goals, Goals, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/leads.py
+++ b/source-hubspot-native/source_hubspot_native/api/leads.py
@@ -32,10 +32,7 @@ def fetch_recent_leads(
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
-        return await fetch_search_objects(
-            Names.leads, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
-        )
+        return await fetch_search_objects(Names.leads, log, http, since, until, page)
 
     return fetch_changes_with_associations(
         Names.leads, Lead, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/leads.py
+++ b/source-hubspot-native/source_hubspot_native/api/leads.py
@@ -49,5 +49,5 @@ def fetch_delayed_leads(
         return await fetch_search_objects(Names.leads, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.leads, Lead, do_fetch, log, http, with_history, since, until
+        Names.leads, Lead, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -53,5 +53,5 @@ def fetch_delayed_line_items(
         )
 
     return fetch_chunked_changes_with_associations(
-        Names.line_items, LineItem, do_fetch, log, http, with_history, since, until
+        Names.line_items, LineItem, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/line_items.py
+++ b/source-hubspot-native/source_hubspot_native/api/line_items.py
@@ -33,8 +33,7 @@ def fetch_recent_line_items(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
         return await fetch_search_objects(
-            Names.line_items, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
+            Names.line_items, log, http, since, until, page
         )
 
     return fetch_changes_with_associations(

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -369,8 +369,6 @@ async def fetch_chunked_changes_with_associations(
     log: Logger,
     http: HTTPSession,
     with_history: bool,
-    since: datetime,
-    until: datetime | None,
 ) -> AsyncGenerator[TimestampedObject[CRMObject] | datetime, None]:
     """
     Like fetch_changes_with_associations, but emits each fetcher page's documents

--- a/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
+++ b/source-hubspot-native/source_hubspot_native/api/object_with_associations.py
@@ -1,6 +1,6 @@
 import asyncio
 import itertools
-from datetime import datetime
+from datetime import datetime, timedelta
 from logging import Logger
 from typing import (
     Any,
@@ -30,6 +30,7 @@ from .properties import fetch_properties
 from .shared import (
     chunk_props,
     HUB,
+    str_to_dt,
 )
 
 
@@ -55,10 +56,13 @@ fetchers do so when their window is exhausted.
 # relies on. They are not enforced, so it's on each fetcher to honor it.
 _OrderedFetchIdsFn = _FetchIdsFn
 """
-A _FetchIdsFn whose pages never leave gaps: every record at or before a page's
-newest timestamp is in that page or an earlier one, and successive pages advance
-in time. This is what lets fetch_chunked_changes_with_associations treat each
-page's newest timestamp as a safe intermediate checkpoint.
+A _FetchIdsFn whose next_page, when present, is a timestamp string naming the
+first millisecond its pages so far do not cover: every record the fetcher's
+window holds before that instant is in this page or an earlier one, and
+successive pages advance in time. This is what lets
+fetch_chunked_changes_with_associations treat the millisecond before next_page
+as a safe intermediate checkpoint. Order within a page is not part of the
+contract.
 """
 
 
@@ -237,34 +241,19 @@ async def fetch_batch_with_associations(
 
 async def _fetch_id_chunks(
     fetcher: _FetchIdsFn,
-    since: datetime,
-    until: datetime | None,
 ) -> AsyncGenerator[IdChunk, None]:
     # Walk pages of IDs until the fetcher reports no more pages remain via a falsy
-    # next_page. Each fetcher page is yielded as its own chunk, along with
-    # whether more pages remain.
+    # next_page. Each fetcher page is yielded as its own chunk, along with the
+    # cursor for the page after it. Consumers apply their own window filtering.
     next_page: PageCursor = None
     count = 0
 
     while True:
         ids, next_page = await fetcher(next_page, count)
+        chunk = list(ids)
+        count += len(chunk)
 
-        chunk: list[TimestampedId] = []
-        for entry in ids:
-            count += 1
-            if until and entry.ts > until:
-                continue
-            elif entry.ts > since:
-                # TODO(whb): It may be worth consulting the emitted changes
-                # cache here to see if we have already emitted a more recent
-                # change event before we do all the associations fetching work.
-                # Before implementing that I'd like to make sure that the
-                # top-level filtering works in production. Since the delayed
-                # changes stream only runs every 5 minutes or so it shouldn't be
-                # a huge load on the connector.
-                chunk.append(entry)
-
-        yield IdChunk(chunk, bool(next_page))
+        yield IdChunk(chunk, next_page)
 
         if not next_page:
             break
@@ -351,9 +340,23 @@ async def fetch_changes_with_associations(
     until: datetime | None,
 ) -> AsyncGenerator[TimestampedObject[CRMObject], None]:
 
+    # The realtime fetchers can't all bound their results server-side: the
+    # legacy "recents" endpoints page newest-first and overrun `since` on their
+    # last page, so the window is applied here.
     recent: list[TimestampedId] = []
-    async for chunk in _fetch_id_chunks(fetcher, since, until):
-        recent.extend(chunk.ids)
+    async for chunk in _fetch_id_chunks(fetcher):
+        for entry in chunk.ids:
+            if until and entry.ts > until:
+                continue
+            elif entry.ts > since:
+                # TODO(whb): It may be worth consulting the emitted changes
+                # cache here to see if we have already emitted a more recent
+                # change event before we do all the associations fetching work.
+                # Before implementing that I'd like to make sure that the
+                # top-level filtering works in production. Since the delayed
+                # changes stream only runs every 5 minutes or so it shouldn't be
+                # a huge load on the connector.
+                recent.append(entry)
 
     async for res in _emit_batches(log, cls, http, with_history, object_name, recent):
         yield res
@@ -371,11 +374,16 @@ async def fetch_chunked_changes_with_associations(
 ) -> AsyncGenerator[TimestampedObject[CRMObject] | datetime, None]:
     """
     Like fetch_changes_with_associations, but emits each fetcher page's documents
-    as its own chunk and then yields the chunk's newest timestamp as an intermediate
-    checkpoint boundary. This lets a delayed stream checkpoint progress within a
-    large window instead of processing the whole window as one atomic, un-checkpointed unit.
+    as its own chunk and then yields the page's resume boundary as an intermediate
+    checkpoint. This lets a delayed stream checkpoint progress within a large
+    window instead of processing the whole window as one atomic, un-checkpointed unit.
+
+    Every id the fetcher returns is emitted, whatever timestamp it carries: the
+    fetcher's server-side window decides membership. The checkpoint after a page
+    is the millisecond before its next_page cursor, which the _OrderedFetchIdsFn
+    contract makes the newest instant the pages so far fully cover.
     """
-    async for chunk in _fetch_id_chunks(fetcher, since, until):
+    async for chunk in _fetch_id_chunks(fetcher):
         async for res in _emit_batches(
             log, cls, http, with_history, object_name, chunk.ids
         ):
@@ -383,5 +391,6 @@ async def fetch_chunked_changes_with_associations(
 
         # Emit an intermediate checkpoint. fetch_delayed_changes handles emitting
         # the final checkpoint once all chunks have been read.
-        if chunk.has_more and chunk.ids:
-            yield max(entry.ts for entry in chunk.ids)
+        if chunk.next_page:
+            assert isinstance(chunk.next_page, str)
+            yield str_to_dt(chunk.next_page) - timedelta(milliseconds=1)

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -32,10 +32,7 @@ def fetch_recent_orders(
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
-        return await fetch_search_objects(
-            Names.orders, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
-        )
+        return await fetch_search_objects(Names.orders, log, http, since, until, page)
 
     return fetch_changes_with_associations(
         Names.orders, Order, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/orders.py
+++ b/source-hubspot-native/source_hubspot_native/api/orders.py
@@ -49,5 +49,5 @@ def fetch_delayed_orders(
         return await fetch_search_objects(Names.orders, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.orders, Order, do_fetch, log, http, with_history, since, until
+        Names.orders, Order, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -49,5 +49,5 @@ def fetch_delayed_products(
         return await fetch_search_objects(Names.products, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.products, Product, do_fetch, log, http, with_history, since, until
+        Names.products, Product, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/api/products.py
+++ b/source-hubspot-native/source_hubspot_native/api/products.py
@@ -32,10 +32,7 @@ def fetch_recent_products(
     async def do_fetch(
         page: PageCursor, count: int
     ) -> tuple[Iterable[TimestampedId], PageCursor]:
-        return await fetch_search_objects(
-            Names.products, log, http, since, until, page,
-            should_crash_on_unordered_results=False,
-        )
+        return await fetch_search_objects(Names.products, log, http, since, until, page)
 
     return fetch_changes_with_associations(
         Names.products, Product, do_fetch, log, http, with_history, since, until

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum, auto
 from logging import Logger
 from typing import (
     Any,
@@ -23,6 +24,62 @@ from .shared import (
 # past it returns a 400.
 SEARCH_RESULT_CAP = 10_000
 SEARCH_PAGE_LIMIT = 200
+# Offset of the last page a query can serve. Its records show where the cap
+# falls in time.
+PEEK_OFFSET = SEARCH_RESULT_CAP - SEARCH_PAGE_LIMIT
+
+ONE_MS = timedelta(milliseconds=1)
+
+
+class _CapReached(Exception):
+    """Paging a chunk would cross the offset cap despite its reported total."""
+
+
+class _SplitMethod(StrEnum):
+    """How a chunk's end was chosen from the page at the cap."""
+
+    # The earliest in-window timestamp at the cap, less one millisecond.
+    PEEK = auto()
+    # Fewer than SEARCH_PAGE_LIMIT records sit at the cap, so the rest of the
+    # window fits in one search.
+    FITS = auto()
+    # The peek offered no usable timestamp, or a peeked chunk still overflowed,
+    # so the range is halved.
+    HALVE = auto()
+    # Every record at the cap shares the window's first millisecond; drain it.
+    CYCLE = auto()
+
+
+def _floor_to_ms(dt: datetime) -> datetime:
+    """`dt` with its sub-millisecond part removed. HubSpot compares timestamps
+    at millisecond resolution and ignores the microseconds in a request's
+    bounds, so flooring ours keeps every comparison here consistent with what
+    the search actually returns."""
+    return dt - timedelta(microseconds=dt.microsecond % 1000)
+
+
+def _midpoint(start: datetime, end: datetime) -> datetime:
+    """The whole millisecond halfway from `start` to `end`; `start` itself when
+    they are a millisecond or less apart."""
+    return start + ONE_MS * ((end - start) // ONE_MS // 2)
+
+
+def _choose_chunk_end(
+    start: datetime, end: datetime, peeked_timestamps: list[datetime]
+) -> tuple[_SplitMethod, datetime]:
+    """Decide where a chunk ends from the last-modified timestamps HubSpot
+    reports for the records at the cap. A short page means fewer than the cap
+    remain, so the whole window fits. Otherwise only a timestamp inside the
+    window can end a chunk. For CYCLE the returned end is the window's start."""
+    if len(peeked_timestamps) < SEARCH_PAGE_LIMIT:
+        return _SplitMethod.FITS, end
+
+    in_window_timestamps = [ts for ts in peeked_timestamps if start < ts <= end]
+    if in_window_timestamps:
+        return _SplitMethod.PEEK, min(in_window_timestamps) - ONE_MS
+    if all(ts <= start for ts in peeked_timestamps):
+        return _SplitMethod.CYCLE, start
+    return _SplitMethod.HALVE, _midpoint(start, end)
 
 
 async def _request_search_page(
@@ -71,63 +128,34 @@ async def _request_search_page(
     return result, input
 
 
-async def fetch_search_objects(
-    object_name: str,
+async def _fetch_all_ids_between(
     log: Logger,
     http: HTTPSession,
-    since: datetime,
-    until: datetime | None,
-    page: PageCursor,
-    last_modified_property_name: str = "hs_lastmodifieddate",
-    should_crash_on_unordered_results: bool = True,
-) -> tuple[Iterable[TimestampedId], PageCursor]:
-    """
-    Retrieve a single chunk of records modified at or after 'since' and at or
-    before 'until' if provided, in ascending order of last-modified time.
-
-    The HubSpot Search API has an undocumented maximum offset of 10,000 items.
-    Rather than enumerate the whole window in one call, this returns one chunk
-    that ends at the offset boundary, along with a resume PageCursor (a
-    last-modified timestamp string) to continue from on the next call. When the
-    whole window has been read, the returned PageCursor is None.
-
-    Chunks never leave gaps. A chunk contains every record in the window
-    modified at or before the chunk's newest timestamp, except records already
-    returned by an earlier chunk. The returned cursor is the first millisecond the
-    chunk does NOT cover. Records the search read at that millisecond are
-    withheld from the chunk, since the offset cap may have cut that millisecond
-    off partway. Passing the cursor back as 'page' starts a fresh search at
-    that millisecond, which re-reads it in full and continues on.
-
-    Multiple records can have the same "last modified" property value, and
-    indeed large runs of these may have the same value. When more than 10,000
-    records share a single millisecond (a "cycle"), the whole instant is drained
-    via fetch_search_objects_modified_at and the resume cursor steps forward by
-    one millisecond.
-    """
-
-    if isinstance(page, str):
-        since = str_to_dt(page)
-
+    object_name: str,
+    last_modified_property_name: str,
+    start: datetime,
+    end: datetime | None,
+    first_page: tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]],
+    should_crash_on_unordered_results: bool,
+) -> tuple[list[TimestampedId], int]:
+    """Fetch the id and last-modified timestamp of the records HubSpot returns
+    for [start, end], paging until it reports no more. The caller has already
+    requested `first_page` to check the range's total, so reading continues
+    from it. The range must hold at most SEARCH_RESULT_CAP records: if paging
+    would cross the cap, raise _CapReached so the caller can narrow it. Returns
+    the records sorted by timestamp and the number of pages read."""
     output_items: set[TimestampedId] = set()
-    cursor: int | None = None
-    max_updated: datetime = since
-    original_total: int | None = None
+    max_updated = start
+    pages = 0
+    result, input = first_page
 
     while True:
-        result, input = await _request_search_page(
-            log, http, object_name, last_modified_property_name, since, until, cursor
-        )
-
-        if not original_total:
-            # Record the total from the original entire request range for
-            # logging.
-            original_total = result.total
+        pages += 1
 
         for r in result.results:
             this_mod_time = r.properties.hs_lastmodifieddate
 
-            if this_mod_time < since:
+            if this_mod_time < start:
                 # The search API will return records with a modification time
                 # before the requested "since" (the start of the window) if
                 # their updatedAt timestamp is within the same millisecond,
@@ -138,14 +166,14 @@ async def fetch_search_objects(
                 # time window, but some smaller fraction of a second earlier.
                 log.info(
                     "ignoring search result with record modification time that is earlier than minimum search window",
-                    {"id": r.id, "this_mod_time": this_mod_time, "since": since},
+                    {"id": r.id, "this_mod_time": this_mod_time, "since": start},
                 )
                 continue
 
-            if until and this_mod_time > until:
+            if end and this_mod_time > end:
                 log.info(
                     "ignoring search result with record modification time that is later than maximum search window",
-                    {"id": r.id, "this_mod_time": this_mod_time, "until": until},
+                    {"id": r.id, "this_mod_time": this_mod_time, "until": end},
                 )
                 continue
 
@@ -165,60 +193,169 @@ async def fetch_search_objects(
             output_items.add(TimestampedId(this_mod_time, str(r.id)))
 
         if not result.paging:
-            # The whole window has been read and no more chunks remain.
-            return sorted(output_items), None
+            return sorted(output_items), pages
 
-        cursor = int(result.paging.next.after)
-        if cursor + SEARCH_PAGE_LIMIT <= SEARCH_RESULT_CAP:
-            # Still within the offset cap; keep paginating this same search.
-            continue
+        after = int(result.paging.next.after)
+        # The caller should have already bounded the search so there are
+        # at most SEARCH_RESULT_CAP results returned by the search, but this
+        # sanity check covers the case where HubSpot's `total` under-reported
+        # the range or where records joined the result set while we paged: a
+        # record indexed late, or one modified during an open-ended realtime
+        # search. Requesting an offset at or past the cap gets a 400, so raise
+        # instead and let the caller narrow the range.
+        if after + SEARCH_PAGE_LIMIT > SEARCH_RESULT_CAP:
+            raise _CapReached()
 
-        # Hit the 10,000-offset cap. End this chunk here and return a resume
-        # cursor so the caller can continue with a fresh search.
-        if since == max_updated:
-            # More than 10,000 records share a single millisecond, so paginating
-            # by time can't make progress. Drain every record at that instant
-            # and step the resume cursor forward by the minimum (1ms) amount.
-            log.info(
-                "cycle detected for lastmodifieddate, fetching all ids for records modified at that instant",
-                {"object_name": object_name, "instant": since},
-            )
-            output_items.update(
-                await fetch_search_objects_modified_at(
-                    object_name, log, http, max_updated, last_modified_property_name
-                )
-            )
-
-            # HubSpot APIs use millisecond resolution, so move the time cursor
-            # forward by that minimum amount now that we know we have all of the
-            # records modified at the common `max_updated` time.
-            max_updated = max_updated + timedelta(milliseconds=1)
-
-            chunk = sorted(output_items)
-
-            if until and max_updated > until:
-                # Unlikely edge case, but resuming past `until` would otherwise
-                # result in an error from the API. The window is fully read.
-                return chunk, None
-        else:
-            # Withhold the in-progress `max_updated` millisecond from the chunk;
-            # the offset cap may have cut it off partway, so the next call
-            # re-reads it.
-            chunk = sorted(item for item in output_items if item.ts < max_updated)
-
-        log.info(
-            "search window chunk complete; resuming with a new search",
-            {
-                "object_name": object_name,
-                "since": since,
-                "until": until,
-                "max_updated": dt_to_str(max_updated),
-                "count": len(output_items),
-                "total": original_total,
-            },
+        result, input = await _request_search_page(
+            log, http, object_name, last_modified_property_name, start, end, after
         )
 
-        return chunk, dt_to_str(max_updated)
+
+async def fetch_search_objects(
+    object_name: str,
+    log: Logger,
+    http: HTTPSession,
+    since: datetime,
+    until: datetime | None,
+    page: PageCursor,
+    last_modified_property_name: str = "hs_lastmodifieddate",
+    should_crash_on_unordered_results: bool = True,
+) -> tuple[Iterable[TimestampedId], PageCursor]:
+    """
+    Retrieve one chunk of the records modified in [since, until] (or from
+    `since` onward when `until` is None), plus a resume PageCursor for the rest
+    of the window, or None once the window has been read.
+
+    HubSpot's Search API serves at most 10,000 results per query. Rather than
+    page up to that cap and rely on result order to know what was covered, a
+    window holding more records is split by time into chunks the API can return
+    completely, and every record in a chunk is read in whatever order it comes.
+
+                 start          chunk_end          until
+    ───────────────┼────────────────┼────────────────┼──▶ time (1 ms ticks)
+                   │                │                │
+    emitted ───────[════════════════]                │
+    resume ────────┼────────────────(════════════════]
+                   │                └─ chosen so the chunk holds at most
+                   │                   10,000 records; equals until when
+                   │                   the whole window fits
+                   └─ inclusive; page replaces since when resuming
+
+    `emitted` is what this call returns: the records HubSpot's filter
+    matches in [start, chunk_end], inclusive at both ends at its millisecond
+    resolution. `resume` is what the next call covers: its cursor is
+    chunk_end + 1 ms, the first millisecond this chunk did not cover, and is
+    None once the chunk reaches until.
+
+    A chunk end is found by peeking at the last page the cap allows (offset
+    9,800): the earliest timestamp there that lies inside the window, less one
+    millisecond, bounds a chunk of at most 9,800 records. A fresh search then
+    confirms the chunk's total before it is read, so the peek only sizes the
+    chunk and never decides completeness. When the peek offers no usable
+    timestamp the window is halved instead, and a chunk that is a single
+    millisecond yet still exceeds the cap is drained with
+    fetch_search_objects_modified_at.
+    """
+    start = _floor_to_ms(str_to_dt(page) if isinstance(page, str) else since)
+    until = _floor_to_ms(until) if until is not None else None
+    # Realtime callers pass no `until`. The present bounds any splitting they need.
+    end = until if until is not None else _floor_to_ms(datetime.now(tz=UTC))
+
+    async def request_page(chunk_end: datetime | None, after: int | None):
+        return await _request_search_page(
+            log, http, object_name, last_modified_property_name, start, chunk_end, after
+        )
+
+    async def fetch_all_ids(
+        chunk_end: datetime | None,
+        first_page: tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]],
+    ) -> tuple[list[TimestampedId], int]:
+        return await _fetch_all_ids_between(
+            log, http, object_name, last_modified_property_name, start, chunk_end,
+            first_page, should_crash_on_unordered_results,
+        )
+
+    def resume_after(chunk_end: datetime) -> PageCursor:
+        resume = chunk_end + ONE_MS
+        return dt_to_str(resume) if resume <= end else None
+
+    async def drain_instant() -> tuple[Iterable[TimestampedId], PageCursor]:
+        # More than 10,000 records share a single millisecond, so splitting by
+        # time can't make progress. Drain every record at that instant and step
+        # the resume cursor forward by the minimum (1ms) amount.
+        log.info(
+            "cycle detected for lastmodifieddate, fetching all ids for records modified at that instant",
+            {"object_name": object_name, "instant": start},
+        )
+        items = await fetch_search_objects_modified_at(
+            object_name, log, http, start, last_modified_property_name
+        )
+        return sorted(items), resume_after(start)
+
+    if page is None:
+        # A fresh window. Its first page is needed regardless and carries the
+        # window's total.
+        first_page = await request_page(until, None)
+        if first_page[0].total <= SEARCH_RESULT_CAP:
+            try:
+                items, _ = await fetch_all_ids(until, first_page)
+                return items, None
+            except _CapReached:
+                log.warning(
+                    "search paged past the cap despite its total; splitting the window",
+                    {"object_name": object_name, "start": start, "total": first_page[0].total},
+                )
+
+    # The window contains over SEARCH_RESULT_CAP records or we're resuming
+    # inside one that was. Peek at the last page the cap allows to see
+    # where the cap falls in time.
+    peek, _ = await request_page(until, PEEK_OFFSET)
+    method, chunk_end = _choose_chunk_end(
+        start, end, [r.properties.hs_lastmodifieddate for r in peek.results]
+    )
+    if method is _SplitMethod.CYCLE:
+        return await drain_instant()
+
+    while True:
+        if chunk_end < end:
+            log.info(
+                "search window split",
+                {
+                    "object_name": object_name,
+                    "start": start,
+                    "end": end,
+                    "chunk_end": chunk_end,
+                    "method": method,
+                },
+            )
+
+        first_page = await request_page(chunk_end, None)
+        if first_page[0].total <= SEARCH_RESULT_CAP:
+            try:
+                items, pages = await fetch_all_ids(chunk_end, first_page)
+            except _CapReached:
+                # The chunk held more than the cap after all, so it needs
+                # narrowing just as if its total had said so. Fall through to
+                # the same halving (or drain) below.
+                pass
+            else:
+                log.info(
+                    "search window chunk complete",
+                    {
+                        "object_name": object_name,
+                        "start": start,
+                        "chunk_end": chunk_end,
+                        "count": len(items),
+                        "pages": pages,
+                        "total": first_page[0].total,
+                    },
+                )
+                return items, resume_after(chunk_end)
+
+        if chunk_end <= start:
+            return await drain_instant()
+
+        chunk_end, method = _midpoint(start, chunk_end), _SplitMethod.HALVE
 
 
 async def fetch_search_objects_modified_at(

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -90,12 +90,11 @@ async def _request_search_page(
     start: datetime,
     end: datetime | None,
     after: int | None,
-) -> tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]]:
+) -> SearchPageResult[CustomObjectSearchResult]:
     """Request one page of Search API results for records whose last-modified
     property is in [start, end], or at or after `start` when `end` is None,
     sorted ascending, SEARCH_PAGE_LIMIT per page. `after` is HubSpot's offset
-    for the page; None requests the first. Also returns the request body, which
-    the ordering check logs when it fails."""
+    for the page; None requests the first."""
     filter = (
         {
             "propertyName": last_modified_property_name,
@@ -122,10 +121,9 @@ async def _request_search_page(
         input["after"] = after
 
     url = f"{HUB}/crm/v3/objects/{object_name}/search"
-    result = SearchPageResult[CustomObjectSearchResult].model_validate_json(
+    return SearchPageResult[CustomObjectSearchResult].model_validate_json(
         await http.request(log, url, method="POST", json=input)
     )
-    return result, input
 
 
 async def _fetch_all_ids_between(
@@ -135,19 +133,17 @@ async def _fetch_all_ids_between(
     last_modified_property_name: str,
     start: datetime,
     end: datetime | None,
-    first_page: tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]],
-    should_crash_on_unordered_results: bool,
+    first_page: SearchPageResult[CustomObjectSearchResult],
 ) -> tuple[list[TimestampedId], int]:
-    """Fetch the id and last-modified timestamp of the records HubSpot returns
+    """Fetch the id and last-modified timestamp of every record HubSpot returns
     for [start, end], paging until it reports no more. The caller has already
     requested `first_page` to check the range's total, so reading continues
     from it. The range must hold at most SEARCH_RESULT_CAP records: if paging
     would cross the cap, raise _CapReached so the caller can narrow it. Returns
     the records sorted by timestamp and the number of pages read."""
     output_items: set[TimestampedId] = set()
-    max_updated = start
     pages = 0
-    result, input = first_page
+    result = first_page
 
     while True:
         pages += 1
@@ -155,41 +151,24 @@ async def _fetch_all_ids_between(
         for r in result.results:
             this_mod_time = r.properties.hs_lastmodifieddate
 
-            if this_mod_time < start:
-                # The search API will return records with a modification time
-                # before the requested "since" (the start of the window) if
-                # their updatedAt timestamp is within the same millisecond,
-                # effectively ignoring the microseconds part of the range
-                # criteria. These spurious results can be safely ignored in the
-                # rare case that there is a record with a modification time
-                # within the same millisecond as requested at the start of the
-                # time window, but some smaller fraction of a second earlier.
+            if this_mod_time < start or (end and this_mod_time > end):
+                # HubSpot's filter placed this record in the window although the
+                # timestamp it reports lies outside it. The filter decides
+                # membership, so the record is kept and its timestamp treated
+                # as payload. One cause is HubSpot matching at millisecond
+                # resolution while the reported value carries microseconds;
+                # another is the filter and the reported property disagreeing
+                # about when the record changed.
                 log.info(
-                    "ignoring search result with record modification time that is earlier than minimum search window",
-                    {"id": r.id, "this_mod_time": this_mod_time, "since": start},
+                    "search result reports a modification time outside its search window",
+                    {
+                        "id": r.id,
+                        "this_mod_time": this_mod_time,
+                        "start": start,
+                        "end": end,
+                    },
                 )
-                continue
 
-            if end and this_mod_time > end:
-                log.info(
-                    "ignoring search result with record modification time that is later than maximum search window",
-                    {"id": r.id, "this_mod_time": this_mod_time, "until": end},
-                )
-                continue
-
-            if this_mod_time < max_updated:
-                if should_crash_on_unordered_results:
-                    log.error("search query input", input)
-                    raise Exception(
-                        f"search query returned records out of order for {r.id} with {this_mod_time} < {max_updated}"
-                    )
-                # The realtime stream is best-effort and allowed to be
-                # incomplete, so an out-of-order result is skipped rather
-                # than treated as fatal. The delayed stream will capture
-                # any records the realtime stream skips.
-                continue
-
-            max_updated = this_mod_time
             output_items.add(TimestampedId(this_mod_time, str(r.id)))
 
         if not result.paging:
@@ -206,7 +185,7 @@ async def _fetch_all_ids_between(
         if after + SEARCH_PAGE_LIMIT > SEARCH_RESULT_CAP:
             raise _CapReached()
 
-        result, input = await _request_search_page(
+        result = await _request_search_page(
             log, http, object_name, last_modified_property_name, start, end, after
         )
 
@@ -219,7 +198,6 @@ async def fetch_search_objects(
     until: datetime | None,
     page: PageCursor,
     last_modified_property_name: str = "hs_lastmodifieddate",
-    should_crash_on_unordered_results: bool = True,
 ) -> tuple[Iterable[TimestampedId], PageCursor]:
     """
     Retrieve one chunk of the records modified in [since, until] (or from
@@ -230,6 +208,8 @@ async def fetch_search_objects(
     page up to that cap and rely on result order to know what was covered, a
     window holding more records is split by time into chunks the API can return
     completely, and every record in a chunk is read in whatever order it comes.
+    HubSpot's filter decides which records a chunk holds: a record is returned
+    even when the timestamp it reports falls outside the chunk.
 
                  start          chunk_end          until
     ───────────────┼────────────────┼────────────────┼──▶ time (1 ms ticks)
@@ -268,11 +248,10 @@ async def fetch_search_objects(
 
     async def fetch_all_ids(
         chunk_end: datetime | None,
-        first_page: tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]],
+        first_page: SearchPageResult[CustomObjectSearchResult],
     ) -> tuple[list[TimestampedId], int]:
         return await _fetch_all_ids_between(
-            log, http, object_name, last_modified_property_name, start, chunk_end,
-            first_page, should_crash_on_unordered_results,
+            log, http, object_name, last_modified_property_name, start, chunk_end, first_page
         )
 
     def resume_after(chunk_end: datetime) -> PageCursor:
@@ -296,20 +275,20 @@ async def fetch_search_objects(
         # A fresh window. Its first page is needed regardless and carries the
         # window's total.
         first_page = await request_page(until, None)
-        if first_page[0].total <= SEARCH_RESULT_CAP:
+        if first_page.total <= SEARCH_RESULT_CAP:
             try:
                 items, _ = await fetch_all_ids(until, first_page)
                 return items, None
             except _CapReached:
                 log.warning(
                     "search paged past the cap despite its total; splitting the window",
-                    {"object_name": object_name, "start": start, "total": first_page[0].total},
+                    {"object_name": object_name, "start": start, "total": first_page.total},
                 )
 
     # The window contains over SEARCH_RESULT_CAP records or we're resuming
     # inside one that was. Peek at the last page the cap allows to see
     # where the cap falls in time.
-    peek, _ = await request_page(until, PEEK_OFFSET)
+    peek = await request_page(until, PEEK_OFFSET)
     method, chunk_end = _choose_chunk_end(
         start, end, [r.properties.hs_lastmodifieddate for r in peek.results]
     )
@@ -330,7 +309,7 @@ async def fetch_search_objects(
             )
 
         first_page = await request_page(chunk_end, None)
-        if first_page[0].total <= SEARCH_RESULT_CAP:
+        if first_page.total <= SEARCH_RESULT_CAP:
             try:
                 items, pages = await fetch_all_ids(chunk_end, first_page)
             except _CapReached:
@@ -347,7 +326,7 @@ async def fetch_search_objects(
                         "chunk_end": chunk_end,
                         "count": len(items),
                         "pages": pages,
-                        "total": first_page[0].total,
+                        "total": first_page.total,
                     },
                 )
                 return items, resume_after(chunk_end)

--- a/source-hubspot-native/source_hubspot_native/api/search_objects.py
+++ b/source-hubspot-native/source_hubspot_native/api/search_objects.py
@@ -19,6 +19,57 @@ from .shared import (
     HUB,
 )
 
+# HubSpot's Search API serves at most this many results for one query; paging
+# past it returns a 400.
+SEARCH_RESULT_CAP = 10_000
+SEARCH_PAGE_LIMIT = 200
+
+
+async def _request_search_page(
+    log: Logger,
+    http: HTTPSession,
+    object_name: str,
+    last_modified_property_name: str,
+    start: datetime,
+    end: datetime | None,
+    after: int | None,
+) -> tuple[SearchPageResult[CustomObjectSearchResult], dict[str, Any]]:
+    """Request one page of Search API results for records whose last-modified
+    property is in [start, end], or at or after `start` when `end` is None,
+    sorted ascending, SEARCH_PAGE_LIMIT per page. `after` is HubSpot's offset
+    for the page; None requests the first. Also returns the request body, which
+    the ordering check logs when it fails."""
+    filter = (
+        {
+            "propertyName": last_modified_property_name,
+            "operator": "BETWEEN",
+            "value": dt_to_str(start),
+            "highValue": dt_to_str(end),
+        }
+        if end
+        else {
+            "propertyName": last_modified_property_name,
+            "operator": "GTE",
+            "value": dt_to_str(start),
+        }
+    )
+
+    input: dict[str, Any] = {
+        "filters": [filter],
+        "sorts": [
+            {"propertyName": last_modified_property_name, "direction": "ASCENDING"}
+        ],
+        "limit": SEARCH_PAGE_LIMIT,
+    }
+    if after is not None:
+        input["after"] = after
+
+    url = f"{HUB}/crm/v3/objects/{object_name}/search"
+    result = SearchPageResult[CustomObjectSearchResult].model_validate_json(
+        await http.request(log, url, method="POST", json=input)
+    )
+    return result, input
+
 
 async def fetch_search_objects(
     object_name: str,
@@ -58,42 +109,15 @@ async def fetch_search_objects(
     if isinstance(page, str):
         since = str_to_dt(page)
 
-    url = f"{HUB}/crm/v3/objects/{object_name}/search"
-    limit = 200
     output_items: set[TimestampedId] = set()
     cursor: int | None = None
     max_updated: datetime = since
     original_total: int | None = None
 
     while True:
-        filter = (
-            {
-                "propertyName": last_modified_property_name,
-                "operator": "BETWEEN",
-                "value": dt_to_str(since),
-                "highValue": dt_to_str(until),
-            }
-            if until
-            else {
-                "propertyName": last_modified_property_name,
-                "operator": "GTE",
-                "value": dt_to_str(since),
-            }
+        result, input = await _request_search_page(
+            log, http, object_name, last_modified_property_name, since, until, cursor
         )
-
-        input = {
-            "filters": [filter],
-            "sorts": [
-                {"propertyName": last_modified_property_name, "direction": "ASCENDING"}
-            ],
-            "limit": limit,
-        }
-        if cursor:
-            input["after"] = cursor
-
-        result: SearchPageResult[CustomObjectSearchResult] = SearchPageResult[
-            CustomObjectSearchResult
-        ].model_validate_json(await http.request(log, url, method="POST", json=input))
 
         if not original_total:
             # Record the total from the original entire request range for
@@ -145,7 +169,7 @@ async def fetch_search_objects(
             return sorted(output_items), None
 
         cursor = int(result.paging.next.after)
-        if cursor + limit <= 10_000:
+        if cursor + SEARCH_PAGE_LIMIT <= SEARCH_RESULT_CAP:
             # Still within the offset cap; keep paginating this same search.
             continue
 

--- a/source-hubspot-native/source_hubspot_native/api/shared.py
+++ b/source-hubspot-native/source_hubspot_native/api/shared.py
@@ -60,15 +60,18 @@ stream of not-so-recent documents. The key is used for seeing if a more recent
 change event document has already been emitted by the FetchRecentFn.
 
 A bare datetime may be interleaved between tuples to mark an intermediate
-checkpoint boundary: every document at or before that timestamp has already
-been yielded, so fetch_delayed_changes can safely checkpoint there. Chunked
-delayed fetchers use this to checkpoint progress within a large window.
+checkpoint boundary: every document the window holds at or before that
+timestamp has already been yielded, so fetch_delayed_changes can safely
+checkpoint there. Chunked delayed fetchers use this to checkpoint progress
+within a large window.
 
-Similar to FetchRecentFn, documents may be returned in any order and iteration
-stops when seeing an entry that's as-old or older than the "since" datetime
-cursor, which is the first datetime parameter. The second datetime parameter
-represents an "until" value, and documents more recent than this are discarded
-and should usually not even be retrieved if possible.
+Documents may be returned in any order, and a document's timestamp may fall
+outside the requested window when the provider's own notion of the document's
+modification time disagrees with the timestamp it reports. Every document is
+emitted regardless; fetch_delayed_changes checkpoints on the window's bounds,
+not on document timestamps. The first datetime parameter is the "since" value
+and the second is the "until" value; documents outside them should not be
+retrieved where the API allows it.
 """
 
 
@@ -173,6 +176,11 @@ async def fetch_delayed_changes(
     This function uses consistent APIs to ensure all documents are
     captured. It uses cache.should_yield() to skip documents that were already
     emitted by the REALTIME subtask with the same or newer timestamp.
+
+    Every document the FetchDelayedFn yields is emitted, whatever timestamp it
+    carries. Checkpoints come from the window's bounds, never from a document:
+    the datetimes the fetcher interleaves mark intermediate progress, and the
+    window's upper bound is the final checkpoint.
     """
     assert isinstance(log_cursor, datetime)
 
@@ -195,8 +203,8 @@ async def fetch_delayed_changes(
     if lower_bound >= upper_bound:
         return
 
-    max_ts = lower_bound
     last_checkpoint = lower_bound
+    saw_anything = False
     cache_hits = 0
     emitted = 0
 
@@ -222,6 +230,8 @@ async def fetch_delayed_changes(
         lower_bound,
         upper_bound,
     ):
+        saw_anything = True
+
         if isinstance(item, datetime):
             # An intermediate checkpoint boundary yielded by a chunked
             # fetcher. Every document at or before this timestamp has
@@ -233,23 +243,18 @@ async def fetch_delayed_changes(
             continue
 
         ts, key, obj = item
-        if ts > upper_bound:
-            # In case the FetchDelayedFn is unable to filter based on upper_bound.
-            continue
-        elif ts > lower_bound:
-            max_ts = max(max_ts, ts)
-            if cache.should_yield(object_name, key, ts):
-                emitted += 1
-                yield obj
-            else:
-                cache_hits += 1
+        if cache.should_yield(object_name, key, ts):
+            emitted += 1
+            yield obj
         else:
-            break
+            cache_hits += 1
 
-    # If we limited the window, advance cursor to upper_bound.
-    if upper_bound < horizon:
-        max_ts = upper_bound
+    is_catching_up = upper_bound < horizon
 
-    if max_ts > last_checkpoint:
-        _log_progress(max_ts)
-        yield max_ts
+    # A catch-up window always checkpoints so progress is made even through
+    # an empty hour. A caught-up window that returned nothing leaves the
+    # cursor where it is so idle streams don't checkpoint on every poll;
+    # the next poll just reads a slightly wider window.
+    if (saw_anything or is_catching_up) and upper_bound > last_checkpoint:
+        _log_progress(upper_bound)
+        yield upper_bound

--- a/source-hubspot-native/source_hubspot_native/api/tickets.py
+++ b/source-hubspot-native/source_hubspot_native/api/tickets.py
@@ -66,5 +66,5 @@ def fetch_delayed_tickets(
         return await fetch_search_objects(Names.tickets, log, http, since, until, page)
 
     return fetch_chunked_changes_with_associations(
-        Names.tickets, Ticket, do_fetch, log, http, with_history, since, until
+        Names.tickets, Ticket, do_fetch, log, http, with_history
     )

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -20,6 +20,7 @@ from estuary_cdk.capture.common import (
     BaseOAuth2Credentials,
     CRON_REGEX,
     OAuth2Spec,
+    PageCursor,
     ReductionStrategy,
     ResourceConfigWithSchedule,
     ResourceState,
@@ -438,11 +439,11 @@ class TimestampedId(NamedTuple):
 
 
 class IdChunk(NamedTuple):
-    """One page of TimestampedIds yielded by _fetch_id_chunks, plus whether the
-    underlying fetcher reports more pages remain."""
+    """One page of TimestampedIds yielded by _fetch_id_chunks, plus the
+    underlying fetcher's cursor for the page after it, falsy when none remains."""
 
     ids: list[TimestampedId]
-    has_more: bool
+    next_page: PageCursor
 
 
 # The document type carried by a TimestampedObject. Its bound is intentionally

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -2,8 +2,9 @@
 
 These cover the pieces that make delayed streams checkpoint progress within a
 large window:
-  - fetch_search_objects returning a fully-read chunk plus a resume cursor at the
-    Search API's 10k offset boundary,
+  - fetch_search_objects splitting a window that exceeds the Search API's 10k
+    result cap into time chunks the API can return completely, resuming at
+    each chunk's end,
   - fetch_chunked_changes_with_associations yielding the millisecond before
     each page's resume cursor as the intermediate checkpoint, and
   - fetch_delayed_changes treating an interleaved bare datetime as an
@@ -23,7 +24,11 @@ from source_hubspot_native.api.object_with_associations import (
     fetch_chunked_changes_with_associations,
 )
 from source_hubspot_native.api.properties import properties_cache
-from source_hubspot_native.api.search_objects import fetch_search_objects
+from source_hubspot_native.api.search_objects import (
+    PEEK_OFFSET,
+    SEARCH_PAGE_LIMIT,
+    fetch_search_objects,
+)
 from source_hubspot_native.api.shared import (
     MAX_DELAYED_WINDOW,
     dt_to_str,
@@ -49,10 +54,16 @@ class FakeHTTP:
         return self._responses.pop(0)
 
 
-def _search_page(items: list[tuple[datetime, int]], next_after: str | None) -> bytes:
-    """Build a SearchPageResult[CustomObjectSearchResult] JSON body."""
+def _search_page(
+    items: list[tuple[datetime, int]],
+    next_after: str | None,
+    total: int | None = None,
+) -> bytes:
+    """Build a SearchPageResult[CustomObjectSearchResult] JSON body. `total` is
+    the window's match count as HubSpot reports it, defaulting to the page's
+    own size."""
     body: dict[str, Any] = {
-        "total": len(items),
+        "total": len(items) if total is None else total,
         "results": [
             {"id": id, "properties": {"hs_lastmodifieddate": ts.isoformat()}}
             for ts, id in items
@@ -63,56 +74,333 @@ def _search_page(items: list[tuple[datetime, int]], next_after: str | None) -> b
     return json.dumps(body).encode()
 
 
-@pytest.mark.asyncio
-async def test_fetch_search_objects_fully_read_chunk_and_inclusive_resume():
-    base = datetime(2026, 1, 1, tzinfo=UTC)
-    t1, t2, t3 = base, base + timedelta(seconds=1), base + timedelta(seconds=2)
-    since = base - timedelta(seconds=10)
+MS = timedelta(milliseconds=1)
+SINCE = datetime(2026, 1, 1, tzinfo=UTC)
+UNTIL = SINCE + timedelta(hours=1)
 
+
+def _filter(request: dict[str, Any]) -> dict[str, Any]:
+    return request["json"]["filters"][0]
+
+
+def _afters(http: FakeHTTP) -> list[Any]:
+    return [r["json"].get("after") for r in http.requests]
+
+
+def _full_peek_page(
+    items: list[tuple[datetime, int]], filler: datetime, total: int = 25_000
+) -> bytes:
+    """A page at the cap offset holding exactly SEARCH_PAGE_LIMIT records:
+    `items` plus filler records stamped `filler`, so the page reads as the cap
+    having been reached."""
+    padding = [(filler, 20_000 + i) for i in range(SEARCH_PAGE_LIMIT - len(items))]
+    return _search_page(items + padding, next_after="10000", total=total)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_reads_a_window_that_fits_in_one_search():
+    t1, t2, t3 = (SINCE + timedelta(minutes=i) for i in (1, 2, 3))
     http = FakeHTTP(
         [
-            # First page hits the offset cap (after=10000). t3 is the in-progress
-            # millisecond and may have more records past the cap, so it's
-            # withheld; the chunk covers only up to t2.
-            _search_page([(t1, 1), (t2, 2), (t3, 3)], next_after="10000"),
-            # Resuming from the cursor re-searches GTE t3 and finds the rest.
-            _search_page([(t3, 3), (t3 + timedelta(seconds=1), 4)], next_after=None),
+            _search_page([(t1, 1), (t2, 2)], next_after="200", total=3),
+            _search_page([(t3, 3)], next_after=None, total=3),
         ]
     )
 
-    items, page = await fetch_search_objects("deals", log, http, since, None, None)
-    assert items == [(t1, "1"), (t2, "2")]  # ascending, t3 dropped
-    assert page == dt_to_str(t3)
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
 
-    items2, page2 = await fetch_search_objects("deals", log, http, since, None, page)
-    # The resume search starts at the cursor inclusively, re-reading the
-    # withheld t3 instant.
-    assert http.requests[1]["json"]["filters"][0]["value"] == dt_to_str(t3)
-    assert page2 is None
-    assert set(items2) == {(t3, "3"), (t3 + timedelta(seconds=1), "4")}
+    assert items == [(t1, "1"), (t2, "2"), (t3, "3")]
+    assert page is None
+    assert _afters(http) == [None, 200]
+    f = _filter(http.requests[0])
+    assert (f["operator"], f["value"], f["highValue"]) == (
+        "BETWEEN", dt_to_str(SINCE), dt_to_str(UNTIL),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_open_ended_window_searches_forward_from_since():
+    http = FakeHTTP([_search_page([(SINCE + MS, 1)], next_after=None)])
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, None, None)
+
+    assert items == [(SINCE + MS, "1")]
+    assert page is None
+    f = _filter(http.requests[0])
+    assert f["operator"] == "GTE"
+    assert "highValue" not in f
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_splits_an_oversized_window_at_the_peeked_boundary():
+    boundary = SINCE + timedelta(minutes=30)
+    http = FakeHTTP(
+        [
+            # The window holds far more than the cap. This page's records are
+            # discarded; only its total matters.
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            # The last page the cap allows. Its earliest in-window timestamp is
+            # where the cap falls, whatever order the page is in.
+            _full_peek_page(
+                [(boundary + MS, 9801), (boundary, 9800), (boundary + 2 * MS, 9802)],
+                filler=boundary + 3 * MS,
+            ),
+            # A fresh search bounded just below it fits, and is read in full.
+            _search_page([(SINCE + MS, 1), (SINCE + 2 * MS, 2)], next_after=None, total=2),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert items == [(SINCE + MS, "1"), (SINCE + 2 * MS, "2")]
+    # The chunk ends the millisecond before the boundary and resumes on it.
+    assert page == dt_to_str(boundary)
+    assert _afters(http) == [None, PEEK_OFFSET, None]
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(boundary - MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_ignores_peeked_timestamps_outside_the_window():
+    boundary = SINCE + timedelta(minutes=30)
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            # A stale timestamp below the window start and an inflated one past
+            # its end are both on the peek page. Neither can bound the chunk.
+            _full_peek_page(
+                [(SINCE - timedelta(days=1), 9800), (boundary, 9801), (UNTIL + MS, 9802)],
+                filler=boundary + MS,
+            ),
+            _search_page([(SINCE + MS, 1)], next_after=None, total=1),
+        ]
+    )
+
+    _, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert page == dt_to_str(boundary)
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(boundary - MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_halves_when_the_peek_offers_no_boundary():
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            # Every peeked timestamp is past the window's end.
+            _full_peek_page([(UNTIL + MS, 9800), (UNTIL + 2 * MS, 9801)], filler=UNTIL + 3 * MS),
+            _search_page([(SINCE + MS, 1)], next_after=None, total=1),
+        ]
+    )
+
+    _, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    midpoint = SINCE + timedelta(minutes=30)
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(midpoint)
+    assert page == dt_to_str(midpoint + MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_halves_again_when_verification_overflows():
+    boundary = SINCE + timedelta(minutes=40)
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            _full_peek_page([(boundary, 9800)], filler=boundary + MS),
+            # Disorder at the boundary: the peeked chunk still exceeds the cap.
+            _search_page([(SINCE + MS, 1)], next_after="200", total=12_000),
+            # Halving from the failed chunk end fits.
+            _search_page([(SINCE + MS, 1)], next_after=None, total=1),
+        ]
+    )
+
+    _, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    first_end = boundary - MS
+    # Halving lands on a whole millisecond.
+    second_end = SINCE + MS * ((first_end - SINCE) // MS // 2)
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(first_end)
+    assert _filter(http.requests[3])["highValue"] == dt_to_str(second_end)
+    assert page == dt_to_str(second_end + MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_reads_the_window_when_the_peek_is_empty():
+    http = FakeHTTP(
+        [
+            # The total says oversized, but nothing sits at the peek offset.
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            _search_page([], next_after=None, total=25_000),
+            _search_page([(SINCE + MS, 1), (SINCE + 2 * MS, 2)], next_after=None, total=2),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert items == [(SINCE + MS, "1"), (SINCE + 2 * MS, "2")]
+    assert page is None
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(UNTIL)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_resumes_by_peeking_first():
+    resume_at = SINCE + timedelta(minutes=30)
+    boundary = SINCE + timedelta(minutes=45)
+    http = FakeHTTP(
+        [
+            # No leading probe page: the remainder of a split window is
+            # probably still oversized, so measure it straight away.
+            _full_peek_page([(boundary, 9800)], filler=boundary + MS, total=12_000),
+            _search_page([(resume_at, 5)], next_after=None, total=1),
+        ]
+    )
+
+    items, page = await fetch_search_objects(
+        "deals", log, http, SINCE, UNTIL, dt_to_str(resume_at)
+    )
+
+    assert items == [(resume_at, "5")]
+    assert page == dt_to_str(boundary)
+    assert _afters(http) == [PEEK_OFFSET, None]
+    assert _filter(http.requests[0])["value"] == dt_to_str(resume_at)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_splits_when_paging_would_cross_the_cap_anyway():
+    boundary = SINCE + timedelta(minutes=30)
+    http = FakeHTTP(
+        [
+            # The total says the window fits, but the page after this one would
+            # cross the cap. Don't trust the total; split.
+            _search_page([(SINCE + MS, 1)], next_after="9900", total=100),
+            _full_peek_page([(boundary, 9800)], filler=boundary + MS, total=100),
+            _search_page([(SINCE + MS, 1)], next_after=None, total=1),
+        ]
+    )
+
+    _, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert page == dt_to_str(boundary)
+    assert _afters(http) == [None, PEEK_OFFSET, None]
 
 
 @pytest.mark.asyncio
 async def test_fetch_search_objects_drains_dense_millisecond_cycle():
-    instant = datetime(2026, 1, 1, tzinfo=UTC)
-    since = instant  # every record shares `since`'s millisecond
-
+    instant = SINCE  # every record shares `since`'s millisecond
     http = FakeHTTP(
         [
-            # The whole capped page sits at a single instant, so advancing by
+            _search_page([(instant, i) for i in range(1, 6)], next_after="200", total=25_000),
+            # The whole peek page sits at the window start, so advancing by
             # timestamp can't make progress: a cycle.
-            _search_page([(instant, i) for i in range(1, 6)], next_after="10000"),
+            _search_page([(instant, i) for i in range(9801, 10001)], next_after="10000", total=25_000),
             # The modified-at drain returns every record at that instant, in
             # ascending hs_object_id order, with no further pages.
             _search_page([(instant, i) for i in range(1, 9)], next_after=None),
         ]
     )
 
-    items, page = await fetch_search_objects("deals", log, http, since, None, None)
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
 
     # All ids at the instant are returned, and the cursor steps one ms past it.
     assert {id for _, id in items} == {str(i) for i in range(1, 9)}
-    assert page == dt_to_str(instant + timedelta(milliseconds=1))
+    assert page == dt_to_str(instant + MS)
+    assert _filter(http.requests[2])["operator"] == "EQ"
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_reads_the_window_when_fewer_than_the_cap_remain():
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            # Only 50 records sit at the cap offset, so the window holds at
+            # most 9,850 and is read whole rather than split.
+            _search_page(
+                [(SINCE + timedelta(minutes=i), 9800 + i) for i in range(50)],
+                next_after=None,
+                total=25_000,
+            ),
+            _search_page([(SINCE + MS, 1), (SINCE + 2 * MS, 2)], next_after=None, total=2),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert items == [(SINCE + MS, "1"), (SINCE + 2 * MS, "2")]
+    assert page is None
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(UNTIL)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_floors_window_bounds_to_whole_milliseconds():
+    # Delayed windows carry microseconds; HubSpot timestamps don't.
+    since = SINCE + timedelta(microseconds=456)
+    until = UNTIL + timedelta(microseconds=789)
+    boundary = SINCE + MS  # the first record at the cap is in the next millisecond
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE, 1)], next_after="200", total=25_000),
+            _full_peek_page([(boundary, 9800)], filler=boundary + MS),
+            # The chunk end can't fall below the floored start, so the
+            # verification covers exactly the start's millisecond.
+            _search_page([(SINCE, 1)], next_after=None, total=1),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, since, until, None)
+
+    assert items == [(SINCE, "1")]
+    assert page == dt_to_str(SINCE + MS)
+    first, verify = _filter(http.requests[0]), _filter(http.requests[2])
+    assert (first["value"], first["highValue"]) == (dt_to_str(SINCE), dt_to_str(UNTIL))
+    assert (verify["value"], verify["highValue"]) == (dt_to_str(SINCE), dt_to_str(SINCE))
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_halves_when_a_verified_chunk_pages_past_the_cap():
+    boundary = SINCE + timedelta(minutes=40)
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE + MS, 1)], next_after="200", total=25_000),
+            _full_peek_page([(boundary, 9800)], filler=boundary + MS),
+            # The total says the chunk fits, but its paging would cross the cap.
+            _search_page([(SINCE + MS, 1)], next_after="9900", total=100),
+            _search_page([(SINCE + MS, 1)], next_after=None, total=1),
+        ]
+    )
+
+    _, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    first_end = boundary - MS
+    second_end = SINCE + MS * ((first_end - SINCE) // MS // 2)
+    assert _filter(http.requests[2])["highValue"] == dt_to_str(first_end)
+    assert _filter(http.requests[3])["highValue"] == dt_to_str(second_end)
+    assert page == dt_to_str(second_end + MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_drains_when_halving_reaches_a_single_millisecond():
+    until = SINCE + 3 * MS
+    http = FakeHTTP(
+        [
+            _search_page([(SINCE, 1)], next_after="200", total=25_000),
+            # Every peeked timestamp is past the window, so halving is the only
+            # tool, and the window is too narrow for it to find a chunk that fits.
+            _full_peek_page([(until + MS, 9800)], filler=until + 2 * MS),
+            _search_page([(SINCE, 1)], next_after="200", total=25_000),
+            _search_page([(SINCE, 1)], next_after="200", total=25_000),
+            # The single-millisecond drain, in ascending id order.
+            _search_page([(SINCE, i) for i in range(1, 4)], next_after=None),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, until, None)
+
+    assert [_filter(r)["highValue"] for r in http.requests[2:4]] == [
+        dt_to_str(SINCE + MS),
+        dt_to_str(SINCE),
+    ]
+    assert _filter(http.requests[4])["operator"] == "EQ"
+    assert {id for _, id in items} == {"1", "2", "3"}
+    assert page == dt_to_str(SINCE + MS)
 
 
 def _properties_page(names: list[str]) -> bytes:

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -102,7 +102,9 @@ async def test_fetch_search_objects_reads_a_window_that_fits_in_one_search():
     t1, t2, t3 = (SINCE + timedelta(minutes=i) for i in (1, 2, 3))
     http = FakeHTTP(
         [
-            _search_page([(t1, 1), (t2, 2)], next_after="200", total=3),
+            # Out of order within the page; the reader sorts and never
+            # depends on the order HubSpot chose.
+            _search_page([(t2, 2), (t1, 1)], next_after="200", total=3),
             _search_page([(t3, 3)], next_after=None, total=3),
         ]
     )
@@ -146,7 +148,7 @@ async def test_fetch_search_objects_splits_an_oversized_window_at_the_peeked_bou
                 filler=boundary + 3 * MS,
             ),
             # A fresh search bounded just below it fits, and is read in full.
-            _search_page([(SINCE + MS, 1), (SINCE + 2 * MS, 2)], next_after=None, total=2),
+            _search_page([(SINCE + 2 * MS, 2), (SINCE + MS, 1)], next_after=None, total=2),
         ]
     )
 
@@ -281,6 +283,28 @@ async def test_fetch_search_objects_splits_when_paging_would_cross_the_cap_anywa
 
     assert page == dt_to_str(boundary)
     assert _afters(http) == [None, PEEK_OFFSET, None]
+
+
+@pytest.mark.asyncio
+async def test_fetch_search_objects_returns_records_reported_outside_the_window():
+    inside = SINCE + timedelta(minutes=1)
+    http = FakeHTTP(
+        [
+            # HubSpot's filter placed all three in the window; two report a
+            # timestamp outside it. All are returned, since the filter decides
+            # membership, and none moves the resume cursor.
+            _search_page(
+                [(SINCE - timedelta(hours=1), 1), (inside, 2), (UNTIL + timedelta(hours=1), 3)],
+                next_after=None,
+                total=3,
+            ),
+        ]
+    )
+
+    items, page = await fetch_search_objects("deals", log, http, SINCE, UNTIL, None)
+
+    assert [id for _, id in items] == ["1", "2", "3"]
+    assert page is None
 
 
 @pytest.mark.asyncio

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -23,7 +23,11 @@ from source_hubspot_native.api.object_with_associations import (
 )
 from source_hubspot_native.api.properties import properties_cache
 from source_hubspot_native.api.search_objects import fetch_search_objects
-from source_hubspot_native.api.shared import dt_to_str, fetch_delayed_changes
+from source_hubspot_native.api.shared import (
+    MAX_DELAYED_WINDOW,
+    dt_to_str,
+    fetch_delayed_changes,
+)
 from source_hubspot_native.models import Product, TimestampedId
 
 log = getLogger("test_search_objects")
@@ -259,3 +263,73 @@ async def test_fetch_delayed_changes_ignores_duplicate_and_regressing_datetimes(
 
     assert cursors.count(c1) == 1
     assert all(b > a for a, b in zip(cursors, cursors[1:]))  # strictly increasing
+
+
+@pytest.mark.asyncio
+async def test_fetch_delayed_changes_emits_out_of_window_documents_and_checkpoints_at_bound():
+    object_name = "test_delayed_out_of_window"
+    cache.emitted_cache.pop(object_name, None)
+
+    # lower_bound is two hours back, so the stream is catching up and the
+    # window is capped at [lower_bound, lower_bound + MAX_DELAYED_WINDOW].
+    lower_bound = datetime.now(UTC) - timedelta(hours=2)
+    upper_bound = lower_bound + MAX_DELAYED_WINDOW
+    below = lower_bound - timedelta(minutes=30)
+    inside = lower_bound + timedelta(minutes=30)
+    above = upper_bound + timedelta(minutes=30)
+
+    fake_delayed = _make_delayed(
+        [(below, "k1", "doc_below"), (inside, "k2", "doc_inside"), (above, "k3", "doc_above")]
+    )
+
+    out = []
+    async for item in fetch_delayed_changes(
+        object_name, fake_delayed, None, False, log, lower_bound
+    ):
+        out.append(item)
+
+    docs = [x for x in out if isinstance(x, str)]
+    cursors = [x for x in out if isinstance(x, datetime)]
+
+    # Documents outside the window are emitted rather than dropped, and one
+    # below the window does not end the stream early.
+    assert docs == ["doc_below", "doc_inside", "doc_above"]
+    # The checkpoint is the window's bound, unaffected by any document's timestamp.
+    assert cursors == [upper_bound]
+
+
+@pytest.mark.asyncio
+async def test_fetch_delayed_changes_leaves_an_empty_caught_up_window_open():
+    object_name = "test_delayed_empty_window"
+    cache.emitted_cache.pop(object_name, None)
+
+    # Ten minutes of unread time: wide enough to poll, and within an hour of
+    # the horizon, so the stream is caught up and the window reaches it.
+    lower_bound = datetime.now(UTC) - timedelta(hours=1, minutes=10)
+
+    out = []
+    async for item in fetch_delayed_changes(
+        object_name, _make_delayed([]), None, False, log, lower_bound
+    ):
+        out.append(item)
+
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_delayed_changes_checkpoints_an_empty_catch_up_window_at_its_bound():
+    object_name = "test_delayed_empty_catch_up"
+    cache.emitted_cache.pop(object_name, None)
+
+    # Three hours behind: the stream is catching up and the window is capped at
+    # MAX_DELAYED_WINDOW. Nothing is in it, but the cursor still moves so an
+    # empty hour doesn't stall the catch-up.
+    lower_bound = datetime.now(UTC) - timedelta(hours=3)
+
+    out = []
+    async for item in fetch_delayed_changes(
+        object_name, _make_delayed([]), None, False, log, lower_bound
+    ):
+        out.append(item)
+
+    assert out == [lower_bound + MAX_DELAYED_WINDOW]

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -486,7 +486,7 @@ async def test_fetch_chunked_changes_checkpoints_at_the_page_resume_boundary():
 
     out = []
     async for item in fetch_chunked_changes_with_associations(
-        "products", Product, fake_fetcher, log, http, False, since, None
+        "products", Product, fake_fetcher, log, http, False
     ):
         out.append(item)
 
@@ -527,7 +527,7 @@ async def test_fetch_chunked_changes_emits_every_id_the_fetcher_returns():
 
     docs = []
     async for item in fetch_chunked_changes_with_associations(
-        "products", Product, fake_fetcher, log, http, False, since, until
+        "products", Product, fake_fetcher, log, http, False
     ):
         if not isinstance(item, datetime):
             docs.append((item[0], item[1]))

--- a/source-hubspot-native/tests/test_delayed_stream_chunking.py
+++ b/source-hubspot-native/tests/test_delayed_stream_chunking.py
@@ -4,8 +4,8 @@ These cover the pieces that make delayed streams checkpoint progress within a
 large window:
   - fetch_search_objects returning a fully-read chunk plus a resume cursor at the
     Search API's 10k offset boundary,
-  - fetch_chunked_changes_with_associations yielding each chunk's maximum
-    timestamp as the intermediate checkpoint, and
+  - fetch_chunked_changes_with_associations yielding the millisecond before
+    each page's resume cursor as the intermediate checkpoint, and
   - fetch_delayed_changes treating an interleaved bare datetime as an
     intermediate, strictly-increasing checkpoint.
 """
@@ -19,6 +19,7 @@ import pytest
 
 import estuary_cdk.emitted_changes_cache as cache
 from source_hubspot_native.api.object_with_associations import (
+    fetch_changes_with_associations,
     fetch_chunked_changes_with_associations,
 )
 from source_hubspot_native.api.properties import properties_cache
@@ -143,16 +144,17 @@ def _batch_page(items: list[tuple[datetime, int]]) -> bytes:
 
 
 @pytest.mark.asyncio
-async def test_fetch_chunked_changes_yields_max_ts_as_checkpoint():
+async def test_fetch_chunked_changes_checkpoints_at_the_page_resume_boundary():
     since = datetime(2026, 1, 1, tzinfo=UTC)
     t1, t2, t3 = (since + timedelta(minutes=i) for i in (1, 2, 3))
+    ms = timedelta(milliseconds=1)
 
-    # The fetcher's cursor is opaque to the chunked layer; only its presence
-    # (more pages remain) matters. IDs are deliberately out of order within the
-    # chunk since the chunked layer is order-agnostic.
+    # A page's cursor is the first millisecond it does not cover. IDs are
+    # deliberately out of order within the chunk since the chunked layer is
+    # order-agnostic.
     pages = [
-        ([TimestampedId(t2, "2"), TimestampedId(t1, "1")], "opaque-resume-cursor-1"),
-        ([], "opaque-resume-cursor-2"),  # empty non-final chunk
+        ([TimestampedId(t2, "2"), TimestampedId(t1, "1")], dt_to_str(t2 + ms)),
+        ([], dt_to_str(t2 + 2 * ms)),  # empty non-final chunk
         ([TimestampedId(t3, "3")], None),  # final page
     ]
 
@@ -181,12 +183,79 @@ async def test_fetch_chunked_changes_yields_max_ts_as_checkpoint():
 
     # Documents are emitted oldest-first within each chunk.
     assert docs == [(t1, "1"), (t2, "2"), (t3, "3")]
-    # Only the first chunk checkpoints, at its newest timestamp: the empty
-    # chunk has no safe checkpoint of its own, and the final page's checkpoint
-    # is the window edge emitted by fetch_delayed_changes instead.
-    assert checkpoints == [t2]
-    # The checkpoint lands between the first chunk's documents and the rest.
+    # Each non-final page checkpoints at the millisecond before its cursor,
+    # including the empty one, since the cursor alone says what has been
+    # covered. The final page's checkpoint is the window edge emitted by
+    # fetch_delayed_changes instead.
+    assert checkpoints == [t2, t2 + ms]
+    # The first checkpoint lands between the first chunk's documents and the rest.
     assert out.index(t2) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_chunked_changes_emits_every_id_the_fetcher_returns():
+    since = datetime(2026, 1, 1, tzinfo=UTC)
+    until = since + timedelta(hours=1)
+    below, inside, above = since - timedelta(minutes=1), since + timedelta(minutes=1), until + timedelta(minutes=1)
+
+    pages = [
+        ([TimestampedId(below, "0"), TimestampedId(inside, "1"), TimestampedId(above, "9")], None),
+    ]
+
+    async def fake_fetcher(page: Any, count: int) -> Any:
+        return pages.pop(0)
+
+    properties_cache.pop("products", None)
+    http = FakeHTTP(
+        [
+            _properties_page(["hs_lastmodifieddate"]),
+            _batch_page([(below, 0), (inside, 1), (above, 9)]),
+        ]
+    )
+
+    docs = []
+    async for item in fetch_chunked_changes_with_associations(
+        "products", Product, fake_fetcher, log, http, False, since, until
+    ):
+        if not isinstance(item, datetime):
+            docs.append((item[0], item[1]))
+
+    # The fetcher's window decides membership; timestamps outside it are payload.
+    assert docs == [(below, "0"), (inside, "1"), (above, "9")]
+
+
+@pytest.mark.asyncio
+async def test_fetch_changes_with_associations_filters_to_the_window():
+    since = datetime(2026, 1, 1, tzinfo=UTC)
+    until = since + timedelta(hours=1)
+    below, inside, above = since, since + timedelta(minutes=1), until + timedelta(minutes=1)
+
+    # A legacy recents-style fetcher overruns `since` on its last page and has
+    # no server-side `until`.
+    pages = [
+        ([TimestampedId(above, "9"), TimestampedId(inside, "1"), TimestampedId(below, "0")], None),
+    ]
+
+    async def fake_fetcher(page: Any, count: int) -> Any:
+        return pages.pop(0)
+
+    properties_cache.pop("products", None)
+    http = FakeHTTP(
+        [
+            _properties_page(["hs_lastmodifieddate"]),
+            _batch_page([(inside, 1)]),
+        ]
+    )
+
+    docs = []
+    async for ts, id, _ in fetch_changes_with_associations(
+        "products", Product, fake_fetcher, log, http, False, since, until
+    ):
+        docs.append((ts, id))
+
+    assert docs == [(inside, "1")]
+    # Only the in-window id was batch-read.
+    assert http.requests[1]["json"]["inputs"] == [{"id": "1"}]
 
 
 def _make_delayed(items: list[Any]):


### PR DESCRIPTION
**Description:**

### Problem
The delayed streams for CRM objects read changes through HubSpot's Search API, sorted ascending by last-modified time. HubSpot does not consistently honor that sort. Records come back out of order, sometimes by seconds and sometimes by close to an hour, even in windows that are already an hour old.

The connector relies on HubSpot's sorting to determine when a checkpoint is safe to emit. A search can serve at most 10,000 results, so a window with more records than that was cut into chunks at the 10,000 offset cap, and the resume cursor for the next chunk was the newest timestamp seen so far. That is only correct if every record below that timestamp has already been returned, which is exactly what the sort was supposed to guarantee. Because a misordered record could mean records below the cursor were about to be skipped, the delayed stream treated any out-of-order result as fatal and crashed the task. A record HubSpot persistently misorders turns that into a crash loop for the whole capture.

### Solution
This PR addresses that problem by making it so searches never reach the 10,000 cap anymore and the connector no longer needs HubSpot's sorting to be correct. A window that holds more than 10,000 records is split by time into chunks that each hold fewer than 10,000, and every chunk is read completely. Within a completely read chunk, the order of the records is irrelevant. There is nothing left unread that the sort could have hidden, and the chunk's end time is a checkpoint that stands on its own. The out-of-order exception is gone, along with the client-side filters that dropped records whose reported timestamp fell outside the window they were returned in. HubSpot's own filter now decides which records belong to a window, and every record it returns is captured.

As for how a window is read now, the connector relies on the `total` HubSpot includes on the first page of a search to determine how many results are in the search's window. If it is at most 10,000, the window is read to the end like before this PR. If it is larger than 10,000, the connector peeks at the last page the cap allows, at offset 9,800. The earliest timestamp on that page bounds a chunk of at most 9,800 records. A fresh search bounded there confirms the chunk's total is under the cap before it is read in full, and the next chunk resumes one millisecond after where this one ended. The peek only sizes the chunk. Completeness comes from the verified total and the full read, so a misordered or stale timestamp on the peek page can only make a chunk smaller than necessary, never incomplete. When the peek offers no usable timestamp the window is halved instead, and a single millisecond holding more than 10,000 records is drained with the existing id-paged cycle path. Each chunk's end is checkpointed as it completes, so large windows still make incremental progress.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03Q2NRFKDL/p1788361643803779?thread_ts=1788348729.468039&cid=C03Q2NRFKDL)

**Notes for reviewers:**

Best reviewed commit-by-commit. The change is conceptually simple - keep searches below the 10,000 cap so we don't have to worry about HubSpot's loose definition of "sorted" between separate searches - but a fair amount of code had to be touched to do that, and I tried to break those changes into atomic commits to they're easier to review.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
