### PR TITLE
source-mysql: add support for GCP IAM auth

### DIFF
--- a/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/MySQL.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Set up Estuary's MySQL capture connector with CDC, binlog configuration, and time zone settings using self-hosted and cloud platform guides.
+description: Set up Estuary's MySQL capture connector with CDC, binlog configuration, IAM authentication, and time zone settings using self-hosted and cloud platform guides.
 ---
 
 # MySQL
@@ -174,13 +174,13 @@ GRANT SELECT ON *.* TO 'flow_capture';
 
 ### IAM Authentication
 
-On Amazon Aurora and Azure Database for MySQL you can authenticate with a cloud IAM identity instead of a password. IAM authentication always connects over TLS and never falls back to an unencrypted connection.
+On Amazon Aurora, Google Cloud SQL, and Azure Database for MySQL you can authenticate with a cloud IAM identity instead of a password. IAM authentication always connects over TLS and never falls back to an unencrypted connection.
 
 #### AWS IAM
 
 For Amazon Aurora MySQL clusters, you can authenticate with an AWS IAM role instead of a password.
 
-Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Flow to assume, and make note of its ARN and your cluster's region to use when configuring the connector's authentication options.
+Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Estuary to assume, and make note of its ARN and your cluster's region to use when configuring the connector's authentication options.
 
 [Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html) on the cluster, then run the following commands to create a database user which authenticates through the RDS plugin, granting it the same permissions as the `flow_capture` user in the [Amazon Aurora](#amazon-aurora) setup instructions above:
 
@@ -208,6 +208,21 @@ Finally, [attach a policy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuid
 }
 ```
 
+#### Google Cloud IAM
+
+For Google Cloud SQL for MySQL instances, you can authenticate with a Google Cloud service account instead of a password.
+
+Follow the steps in the [GCP IAM guide][gcp-iam] to set up a workload identity pool for Estuary, and make note of the pool audience and the service account email to use when configuring the connector's authentication options.
+
+Set the instance's `cloudsql_iam_authentication` flag to `on`, then [add the service account as an IAM database user](https://cloud.google.com/sql/docs/mysql/add-manage-iam-users#creating-database-user) and grant it the `roles/cloudsql.instanceUser` role. Cloud SQL logs the service account in under its email address with the `@PROJECT_ID.iam.gserviceaccount.com` suffix removed, and MySQL usernames are limited to 32 characters, so pick a service account name that fits. Grant that user the same permissions as the `flow_capture` user in the [Google Cloud SQL](./google-cloud-sql-mysql/) setup instructions:
+
+```sql
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow-capture';
+GRANT SELECT ON *.* TO 'flow-capture';
+```
+
+Use the same truncated name as the connector's `user` property.
+
 #### Azure IAM
 
 For Azure Database for MySQL flexible servers, you can authenticate with an Azure App Registration instead of a password.
@@ -226,6 +241,7 @@ GRANT SELECT ON *.* TO 'flow_capture';
 Use the name given in the `CREATE AADUSER` statement as the connector's `user` property.
 
 [aws-iam]: /guides/iam-auth/aws/
+[gcp-iam]: /guides/iam-auth/gcp/
 [azure-iam]: /guides/iam-auth/azure/
 
 ## Capturing from Read Replicas
@@ -305,10 +321,12 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword`, `AWSIAM`, or `AzureIAM`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword`, `AWSIAM`, `GCPIAM`, or `AzureIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
 | `/credentials/aws_region` | AWS Region | AWS region of your resource. | string | Required for `AWSIAM` auth |
 | `/credentials/aws_role_arn` | AWS Role ARN | AWS role for Estuary to use that has access to the resource. | string | Required for `AWSIAM` auth |
+| `/credentials/gcp_service_account_to_impersonate` | Service Account | GCP service account email for Cloud SQL IAM authentication. | string | Required for `GCPIAM` auth |
+| `/credentials/gcp_workload_identity_pool_audience` | Workload Identity Pool Audience | GCP workload identity pool audience. The format should be similar to: `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider`. | string | Required for `GCPIAM` auth |
 | `/credentials/azure_client_id` | Azure Client ID | Application (client) ID of the App Registration. | string | Required for `AzureIAM` auth |
 | `/credentials/azure_tenant_id` | Azure Tenant ID | Directory (tenant) ID of the App Registration. | string | Required for `AzureIAM` auth |
 
@@ -372,6 +390,15 @@ To authenticate to an Amazon Aurora MySQL cluster with [AWS IAM](#aws-iam) inste
             auth_type: AWSIAM
             aws_region: "us-east-1"
             aws_role_arn: "arn:aws:iam::123456789012:role/flow-capture"
+```
+
+To authenticate to a Google Cloud SQL for MySQL instance with [Google Cloud IAM](#google-cloud-iam) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: GCPIAM
+            gcp_service_account_to_impersonate: "flow-capture@example-project.iam.gserviceaccount.com"
+            gcp_workload_identity_pool_audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
 ```
 
 To authenticate to an Azure Database for MySQL flexible server with [Azure IAM](#azure-iam) instead, replace the credentials block:

--- a/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/amazon-rds-mysql.md
@@ -75,7 +75,7 @@ CALL mysql.rds_set_configuration('binlog retention hours', 168);
 
 Instead of a password, you can authenticate to your instance with an AWS IAM role.
 
-Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Flow to assume, and make note of its ARN and your instance's region to use when configuring the connector's authentication options.
+Follow the steps in the [AWS IAM guide][aws-iam] to create a role for Estuary to assume, and make note of its ARN and your instance's region to use when configuring the connector's authentication options.
 
 [Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html) on the instance, then switch to your MySQL client and run the following commands to create a database user which authenticates through the RDS plugin, granting it the same permissions as the `flow_capture` user in the [setup instructions](#setup) above:
 

--- a/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
+++ b/docs/reference/Connectors/capture-connectors/MySQL/google-cloud-sql-mysql.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Capture MySQL changes from Google Cloud SQL instances with Estuary’s CDC connector. Setup guide includes binlog handling, read replicas, and backfills.
+description: Capture MySQL changes from Google Cloud SQL instances with Estuary’s CDC connector. Setup guide includes binlog handling, IAM authentication, read replicas, and backfills.
 ---
 
 # Google Cloud SQL for MySQL
@@ -21,6 +21,7 @@ To use this connector, you'll need a MySQL database setup with the following.
   - Permission to read from `information_schema` tables, if automatic discovery is used.
 - If the table(s) to be captured include columns of type `DATETIME`, the `time_zone` system variable
   must be set to an IANA zone name or numerical offset or the capture configured with a `timezone` to use by default.
+- When using [IAM authentication](#iam-authentication), the `cloudsql_iam_authentication` flag enabled on the instance and the service account added as an IAM database user.
 
 ## Setup
 
@@ -53,6 +54,27 @@ GRANT SELECT ON *.* TO 'flow_capture';
 
 5. In the Cloud Console, note the instance's host under Public IP Address. Its port will always be `3306`.
    Together, you'll use the host:port as the `address` property when you configure the connector.
+
+### IAM Authentication
+
+Instead of a password, you can authenticate to your instance with a Google Cloud service account.
+
+Follow the steps in the [GCP IAM guide][gcp-iam] to set up a workload identity pool for Estuary, and make note of the pool audience and the service account email to use when configuring the connector's authentication options.
+
+[Enable IAM database authentication](https://cloud.google.com/sql/docs/mysql/create-edit-iam-instances) on the instance by setting the `cloudsql_iam_authentication` flag to `on`, then [add the service account as an IAM database user](https://cloud.google.com/sql/docs/mysql/add-manage-iam-users#creating-database-user) and grant it the `roles/cloudsql.instanceUser` role.
+
+Cloud SQL for MySQL logs the service account in under its email address with the `@PROJECT_ID.iam.gserviceaccount.com` suffix removed, and MySQL usernames are limited to 32 characters, so pick a service account name that fits. Using [Google Cloud Shell](https://cloud.google.com/sql/docs/mysql/connect-instance-cloud-shell) or your preferred client, grant that user the same permissions as the `flow_capture` user in the [setup instructions](#setup) above:
+
+```sql
+GRANT REPLICATION CLIENT, REPLICATION SLAVE ON *.* TO 'flow-capture';
+GRANT SELECT ON *.* TO 'flow-capture';
+```
+
+Use the same truncated name as the connector's `user` property.
+
+IAM authentication always connects over TLS and never falls back to an unencrypted connection.
+
+[gcp-iam]: /guides/iam-auth/gcp/
 
 ## Capturing from Read Replicas
 
@@ -130,8 +152,10 @@ See [connectors](/concepts/connectors.md#using-connectors) to learn more about u
 | Property | Title | Description | Type | Required/Default |
 | --- | --- | --- | --- | --- |
 | **`/credentials`** | Authentication | Authentication method and credentials that provide access to the database. | object | Required |
-| `/credentials/auth_type` | Auth Type | The authentication method to use. Google Cloud SQL for MySQL supports `UserPassword`. | string |  |
+| `/credentials/auth_type` | Auth Type | The authentication method to use. One of `UserPassword` or `GCPIAM`. | string |  |
 | `/credentials/password` | Password | Password for the specified database user. | string | Required for `UserPassword` auth |
+| `/credentials/gcp_service_account_to_impersonate` | Service Account | GCP service account email for Cloud SQL IAM authentication. | string | Required for `GCPIAM` auth |
+| `/credentials/gcp_workload_identity_pool_audience` | Workload Identity Pool Audience | GCP workload identity pool audience. The format should be similar to: `//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider`. | string | Required for `GCPIAM` auth |
 
 ##### Discovery Filters
 
@@ -184,6 +208,15 @@ captures:
           namespace: ${TABLE_NAMESPACE}
           stream: ${TABLE_NAME}
         target: ${PREFIX}/${COLLECTION_NAME}
+```
+
+To authenticate with [Google Cloud IAM](#iam-authentication) instead, replace the credentials block:
+
+```yaml
+          credentials:
+            auth_type: GCPIAM
+            gcp_service_account_to_impersonate: "flow-capture@example-project.iam.gserviceaccount.com"
+            gcp_workload_identity_pool_audience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
 ```
 
 Your capture definition will likely be more complex, with additional bindings for each table in the source database.

--- a/source-mysql/.snapshots/TestGeneric-SpecResponse
+++ b/source-mysql/.snapshots/TestGeneric-SpecResponse
@@ -73,6 +73,34 @@
           },
           {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://github.com/estuary/connectors/go/auth/iam/gcp-config",
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "GCPIAM",
+                "default": "GCPIAM",
+                "order": 0
+              },
+              "gcp_service_account_to_impersonate": {
+                "type": "string",
+                "title": "Service Account",
+                "description": "GCP Service Account email for Cloud SQL IAM authentication"
+              },
+              "gcp_workload_identity_pool_audience": {
+                "type": "string",
+                "title": "Workload Identity Pool Audience",
+                "description": "GCP Workload Identity Pool Audience in the format //iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+              }
+            },
+            "type": "object",
+            "required": [
+              "gcp_service_account_to_impersonate",
+              "gcp_workload_identity_pool_audience"
+            ],
+            "title": "Google Cloud IAM"
+          },
+          {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://github.com/estuary/connectors/go/auth/iam/azure-config",
             "properties": {
               "auth_type": {

--- a/source-mysql/CHANGELOG.md
+++ b/source-mysql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # source-mysql
 
+## 2026-09-03
+
+### Added
+- The `credentials` configuration union now also supports Google Cloud IAM
+  authentication, for Cloud SQL for MySQL instances with the
+  `cloudsql_iam_authentication` flag enabled. The access token obtained through
+  the workload identity pool is presented as the database password.
+
 ## 2026-09-01
 
 ### Added

--- a/source-mysql/config_test.go
+++ b/source-mysql/config_test.go
@@ -132,6 +132,31 @@ func TestConfigValidate(t *testing.T) {
 		require.ErrorContains(t, cfg.Validate(), "missing 'azure_client_id'")
 	})
 
+	t.Run("GCPIAMValid", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: GCPIAM}
+		cfg.Credentials.GCPServiceAccount = "flow-capture@example-project.iam.gserviceaccount.com"
+		cfg.Credentials.GCPWorkloadAudience = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("GCPIAMMissingServiceAccount", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: GCPIAM}
+		cfg.Credentials.GCPWorkloadAudience = "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'gcp_service_account_to_impersonate'")
+	})
+
+	t.Run("GCPIAMMissingWorkloadAudience", func(t *testing.T) {
+		var cfg = valid()
+		cfg.Credentials = &CredentialsConfig{AuthType: GCPIAM}
+		cfg.Credentials.GCPServiceAccount = "flow-capture@example-project.iam.gserviceaccount.com"
+
+		require.ErrorContains(t, cfg.Validate(), "missing 'gcp_workload_identity_pool_audience'")
+	})
+
 	t.Run("UnknownAuthType", func(t *testing.T) {
 		var cfg = valid()
 		cfg.Credentials = &CredentialsConfig{AuthType: "Bogus"}
@@ -230,6 +255,44 @@ func TestEffectivePassword(t *testing.T) {
 		require.Equal(t, unionPassword, legacyPassword)
 	})
 
+	t.Run("GCPIAMToken", func(t *testing.T) {
+		// Cloud SQL login tokens are far longer than 32 characters, which is fine:
+		// the replication password length limit only applies to password auth.
+		var token = strings.Repeat("token", 200)
+		var cfg = Config{
+			Address: "203.0.113.10:3306",
+			User:    "flow-capture",
+			Credentials: &CredentialsConfig{
+				AuthType: GCPIAM,
+				IAMConfig: iam.IAMConfig{
+					GCPConfig: iam.GCPConfig{
+						GCPServiceAccount:   "flow-capture@example-project.iam.gserviceaccount.com",
+						GCPWorkloadAudience: "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/test-pool/providers/test-provider",
+					},
+					IAMTokens: iam.IAMTokens{GCPTokens: iam.GCPTokens{GCPAccessToken: token}},
+				},
+			},
+		}
+		cfg.normalizeCredentials()
+
+		require.NoError(t, cfg.Validate())
+		password, err := cfg.EffectivePassword(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, token, password)
+	})
+
+	t.Run("GCPIAMMissingToken", func(t *testing.T) {
+		var cfg = Config{
+			Address:     "203.0.113.10:3306",
+			User:        "flow-capture",
+			Credentials: &CredentialsConfig{AuthType: GCPIAM},
+		}
+		cfg.normalizeCredentials()
+
+		_, err := cfg.EffectivePassword(context.Background())
+		require.ErrorContains(t, err, "missing 'gcp_access_token'")
+	})
+
 	t.Run("AzureIAMToken", func(t *testing.T) {
 		// Entra access tokens are far longer than 32 characters, which is fine:
 		// the replication password length limit only applies to password auth.
@@ -289,8 +352,8 @@ func TestRequiresTLS(t *testing.T) {
 	}{
 		{UserPassword, false},
 		{AWSIAM, true},
+		{GCPIAM, true},
 		{AzureIAM, true},
-		{AuthType(iam.GCPIAM), true},
 		{AuthType("Bogus"), true},
 	} {
 		t.Run(string(tc.authType), func(t *testing.T) {

--- a/source-mysql/main.go
+++ b/source-mysql/main.go
@@ -152,6 +152,7 @@ type AuthType string
 const (
 	UserPassword AuthType = "UserPassword"
 	AWSIAM       AuthType = "AWSIAM"
+	GCPIAM       AuthType = "GCPIAM"
 	AzureIAM     AuthType = "AzureIAM"
 )
 
@@ -173,6 +174,7 @@ func (CredentialsConfig) JSONSchema() *jsonschema.Schema {
 	return schemagen.OneOfSchema("Authentication", "", "auth_type", string(UserPassword),
 		schemagen.OneOfSubSchema("Password", UserPasswordConfig{}, string(UserPassword)),
 		schemagen.OneOfSubSchema("AWS IAM", iam.AWSConfig{}, string(AWSIAM)),
+		schemagen.OneOfSubSchema("Google Cloud IAM", iam.GCPConfig{}, string(GCPIAM)),
 		schemagen.OneOfSubSchema("Azure IAM", iam.AzureConfig{}, string(AzureIAM)),
 	)
 }
@@ -184,7 +186,7 @@ func (c *CredentialsConfig) Validate() error {
 			return errors.New("missing 'password'")
 		}
 		return nil
-	case AWSIAM, AzureIAM:
+	case AWSIAM, GCPIAM, AzureIAM:
 		// The embedded IAMConfig has its own auth_type field which JSON decoding
 		// leaves empty (the outer field shadows it), so sync it before ValidateIAM
 		// switches on it.
@@ -335,9 +337,9 @@ func (c *Config) normalizeCredentials() {
 // and only reads the credentials union. For AWS IAM the password is an RDS auth
 // token minted here from the session credentials the control plane injects, valid
 // for fifteen minutes, so callers should invoke this per connection attempt rather
-// than caching the result. For Azure IAM the password is the Entra access token
-// injected into the config by the control plane, which restarts the connector with
-// a fresh token before expiry.
+// than caching the result. For Google Cloud and Azure IAM the password is an access
+// token injected into the config by the control plane, which restarts the connector
+// with a fresh token before expiry.
 func (c *Config) EffectivePassword(ctx context.Context) (string, error) {
 	switch c.Credentials.AuthType {
 	case UserPassword:
@@ -352,6 +354,14 @@ func (c *Config) EffectivePassword(ctx context.Context) (string, error) {
 		token, err := auth.BuildAuthToken(ctx, c.Address, c.Credentials.AWSRegion, c.User, credProvider)
 		if err != nil {
 			return "", fmt.Errorf("building AWS IAM auth token: %w", err)
+		}
+		return token, nil
+	case GCPIAM:
+		// Cloud SQL IAM database authentication presents this token via the
+		// 'mysql_clear_password' plugin, which the server only allows over TLS.
+		var token = c.Credentials.GoogleToken()
+		if token == "" {
+			return "", errors.New("missing 'gcp_access_token'")
 		}
 		return token, nil
 	case AzureIAM:


### PR DESCRIPTION
**Description:**

Sibling PR to #5165 and #5177 

**Workflow steps:**

(How does one use this feature, and how has it changed)

**Notes for reviewers:**

(anything that might help someone review this PR)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
