### PR TITLE
source-{various-that-request-acknowledgements}: require acknowledge counts to be non-zero, positive integers

### DIFF
--- a/estuary-cdk/estuary_cdk/capture/request.py
+++ b/estuary-cdk/estuary_cdk/capture/request.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, NonNegativeInt
+from pydantic import BaseModel, NonNegativeInt, PositiveInt
 from typing import Generic, Any
 
 from ..flow import (
@@ -63,4 +63,4 @@ class Open(GenericModel, Generic[EndpointConfig, ResourceConfig, ConnectorState]
 
 
 class Acknowledge(BaseModel):
-    checkpoints: NonNegativeInt
+    checkpoints: PositiveInt

--- a/sqlcapture/capture.go
+++ b/sqlcapture/capture.go
@@ -1164,12 +1164,8 @@ func (c *Capture) acknowledgeWorker(ctx context.Context, stream *boilerplate.Pul
 func (c *Capture) handleAcknowledgement(ctx context.Context, count int, replStream ReplicationStream) error {
 	c.pending.Lock()
 	defer c.pending.Unlock()
-	if count == 0 {
-		// Originally the Acknowledge message implicitly meant acknowledging one checkpoint,
-		// so in the absence of a count we will continue to interpret it that way.
-		count = 1
-	}
-	if count > len(c.pending.cursors) {
+
+	if count <= 0 || count > len(c.pending.cursors) {
 		return fmt.Errorf("invalid acknowledgement count %d, only %d pending checkpoints", count, len(c.pending.cursors))
 	}
 


### PR DESCRIPTION
**Description:**

There are a few capture connectors that request explicit acknowledgements from the runtime, and they are ok with `Request.Acknowledge` requests that contain a `checkpoints` count that's less than 1. It looks like before commit https://github.com/estuary/flow/commit/cc04073ff99bb3fe6e9eead2356644d89d9ab0e9 that connectors could receive a zero `checkpoints` count and that was probably why `sqlcapture` handled the zero count case, but we're well past April 4, 2023 when that commit was merged & all extant runtimes should now be sending `Request.Acknowledge` messages with [`checkpoints` counts that are 1 or more](https://github.com/estuary/flow/blob/e888e2b9d77f2fd1d9b6f56bc4ae0528f151f030/go/protocols/capture/capture.proto#L245-L248). We can safely assume that if any runtime tells us that zero or fewer checkpoints have been acknowledged, something wrong is happening on the runtime's end & the capture connector should fail loudly.

I updated the CDK to have slightly tighter handling too.

**Notes for reviewers:**

I'm drafting up a document for captures that mirrors this [one](https://github.com/estuary/connectors/blob/main/docs/materialize/README.md) for materializations, and digging deeper into Flow's capture protocol surfaced some slight inconsistencies in various connectors like the one addressed in this PR. I'm tidying up the easy-to-fix ones to make the code base slightly more consistent, especially for new contributors that won't have any context of why things are the ways they are.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
