### PR TITLE
product name: use "Estuary" instead of "Estuary Flow"

### DIFF
--- a/estuary-cdk/importing_airbyte_source_connectors.md
+++ b/estuary-cdk/importing_airbyte_source_connectors.md
@@ -1,17 +1,17 @@
 # Importing Airbyte Source Connectors
 
-The Estuary CDK supports adapting Airbyte connectors to run on Estuary Flow. These are the
+The Estuary CDK supports adapting Airbyte connectors to run on Estuary. These are the
 requirements for importing Airbyte connectors into this repository to run using the Estuary CDK. It
 is intended as a reference for developers working on importing these connectors, and reviewers of
 the connector import pull requests.
 
 ### A Note on Pre-existing Connectors
 
-For the time being, all imported connectors will have already been running as Estuary Flow
+For the time being, all imported connectors will have already been running as Estuary
 connectors using a separate mechanism which is referred to as airbyte-to-flow, also known as ATF.
 These connectors reside in the [estuary/airbyte repository](https://github.com/estuary/airbyte), and
 you can see the list of pre-existing connectors there. ATF is a binary which wraps a specific Docker
-image of an Airbyte connector and adapts its inputs and outputs to be compatible with Estuary Flow.
+image of an Airbyte connector and adapts its inputs and outputs to be compatible with Estuary.
 
 Since these imported connectors already exist in a different form, it is necessary to preserve
 compatibility with them when the connectors are imported. Ideally, both versions of the connector
@@ -19,7 +19,7 @@ will have exactly the same outputs for their specification, discovered bindings,
 documents, but this is often not the case, especially when importing an Airbyte connector version
 that is more recent than the version used by ATF. The requirements listed here assume that there is
 a pre-existing connector, and the process for importing a connector from Airbyte that did not
-previously exist as a connector in Estuary Flow will be different and are TBD.
+previously exist as a connector in Estuary will be different and are TBD.
 
 ## Requirements
 

--- a/go/dbt/trigger.go
+++ b/go/dbt/trigger.go
@@ -17,7 +17,7 @@ type JobConfig struct {
 	AccessURL     string `json:"access_url,omitempty" jsonschema:"title=Access URL,description=dbt access URL can be found in your Account Settings. See go.estuary.dev/dbt-cloud-trigger" jsonschema_extras:"pattern=^https://.+$"`
 	AccountPrefix string `json:"account_prefix" jsonschema:"-"`
 	APIKey        string `json:"api_key" jsonschema:"title=API Key,description=dbt API Key" jsonschema_extras:"secret=true"`
-	Cause         string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."`
+	Cause         string `json:"cause,omitempty" jsonschema:"title=Cause Message,description=You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."`
 	Mode          string `json:"mode,omitempty" jsonschema:"title=Job Trigger Mode,description=Specifies how should already-running jobs be treated. Defaults to 'skip' which skips the trigger if a job is already running; 'replace' cancels the running job and runs a new one; while 'ignore' triggers a new job regardless of existing jobs.,enum=skip,enum=replace,enum=ignore,default=skip" jsonschema_extras:"nonsensitive=true"`
 	Interval      string `json:"interval,omitempty" jsonschema:"title=Minimum Run Interval,description=Minimum time between dbt job triggers. This interval is only triggered if data has been materialized by your task.,default=30m" jsonschema_extras:"nonsensitive=true"`
 }
@@ -114,7 +114,7 @@ func JobTrigger(config JobConfig) error {
 
 	var cause = config.Cause
 	if cause == "" {
-		cause = "Estuary Flow"
+		cause = "Estuary"
 	}
 	var url = fmt.Sprintf("%s/api/v2/accounts/%s/jobs/%s/run", config.accessURL(), config.AccountID, config.JobID)
 	var reqBodyJson = fmt.Sprintf(`{"cause": "%s"}`, cause)

--- a/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
+++ b/materialize-azure-fabric-warehouse/.snapshots/TestSpecification
@@ -152,7 +152,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-bigquery/.snapshots/TestSpecification
+++ b/materialize-bigquery/.snapshots/TestSpecification
@@ -199,7 +199,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-clickhouse/CHANGELOG.md
+++ b/materialize-clickhouse/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-04
+
+### Changed
+- The client name the connector reports to ClickHouse is now `Estuary`, was
+  `EstuaryFlow`. This is the value shown in `system.query_log`,
+  `system.processes`, and similar tables. If you filter or group on that name,
+  update the value you match on. Historical rows keep the old name.
+
 ## 2026-08-26
 
 ### Fixed

--- a/materialize-clickhouse/driver.go
+++ b/materialize-clickhouse/driver.go
@@ -143,12 +143,12 @@ func (c config) newClickhouseOptions() *clickhouse.Options {
 	}
 	return &clickhouse.Options{
 		Addr: []string{c.resolvedAddress()},
-		// Identify Estuary Flow in the client name reported to ClickHouse
+		// Identify Estuary in the client name reported to ClickHouse
 		// (system.query_log, system.processes, etc.), which otherwise only
 		// shows the generic clickhouse-go driver.
 		ClientInfo: clickhouse.ClientInfo{
 			Products: []struct{ Name, Version string }{
-				{Name: "EstuaryFlow", Version: strings.TrimSpace(connectorVersion)},
+				{Name: "Estuary", Version: strings.TrimSpace(connectorVersion)},
 			},
 			Comment: []string{"materialize-clickhouse"},
 		},

--- a/materialize-databricks/.snapshots/TestSpecification
+++ b/materialize-databricks/.snapshots/TestSpecification
@@ -181,7 +181,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-iceberg/.snapshots/TestSpec
+++ b/materialize-iceberg/.snapshots/TestSpec
@@ -367,7 +367,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-mysql/.snapshots/TestSpecification
+++ b/materialize-mysql/.snapshots/TestSpecification
@@ -70,7 +70,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-postgres/.snapshots/TestSpecification
+++ b/materialize-postgres/.snapshots/TestSpecification
@@ -185,7 +185,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-redshift/.snapshots/TestSpecification
+++ b/materialize-redshift/.snapshots/TestSpecification
@@ -159,7 +159,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-snowflake/.snapshots/TestSpecification
+++ b/materialize-snowflake/.snapshots/TestSpecification
@@ -215,7 +215,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/materialize-sql/README.md
+++ b/materialize-sql/README.md
@@ -1,6 +1,6 @@
 # materialize-sql
 
-A shared library for building SQL-based materialization connectors for Estuary Flow.
+A shared library for building SQL-based materialization connectors for Estuary.
 
 ## What it does
 

--- a/materialize-sqlserver/.snapshots/TestSpecification
+++ b/materialize-sqlserver/.snapshots/TestSpecification
@@ -157,7 +157,7 @@
           "cause": {
             "type": "string",
             "title": "Cause Message",
-            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary Flow'."
+            "description": "You can set a custom 'cause' message for the job trigger. Defaults to 'Estuary'."
           },
           "mode": {
             "type": "string",

--- a/source-kafka/README.md
+++ b/source-kafka/README.md
@@ -4,7 +4,7 @@ This is a flow connector that reads from Kafka topics/partitions.
 
 ## Getting Started
 
-To get started using this connector with Estuary Flow, run `flowctl-go discover --image ghcr.io/estuary/source-kafka:TAG`.
+To get started using this connector with Estuary, run `flowctl-go discover --image ghcr.io/estuary/source-kafka:TAG`.
 
 The remainder of this README is geared toward developers who wish to contribute or integrate the connector in other projects.
 


### PR DESCRIPTION
**Description:**

The product is "Estuary", not "Estuary Flow" ([context](https://estuaryworkspace.slack.com/archives/C012S5U0WP2/p1788452319856409)). Mostly READMEs and CDK docs, which agents read and imitate when drafting connector documentation.

Two values customers see in their own systems also change:

- dbt Cloud trigger `cause` default. It is a free-text label on the run; the job is selected by the URL path, and nothing reads the value back, so jobs trigger and run exactly as before. Only the label in dbt's run history changes.
- materialize-clickhouse client name, reported in `system.query_log` and `system.processes`.

**Notes for reviewers:**

CHANGELOG entry for ClickHouse only. I weighed one for the dbt `cause` and left it out: the dbt config is shared across nine connectors, so it would reach every user of all nine to describe a label almost nobody matches on, and their jobs behave identically.

The nine spec snapshots are a mechanical consequence of the `jsonschema` description change in `go/dbt/trigger.go` (`UPDATE_SNAPSHOTS=true go test ./<connector>/... -run TestSpec`), one line each.

Left alone as identifiers, not the product name: `LICENSE-BSL`, `estuary-flow-google`, `estuary-flow-poc`, `estuary-flow-web`.

Companion PR: estuary/flow#3463

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: n/a
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated — ClickHouse only, dbt omitted per above
- [x] If there are user-facing behavior changes, documentation has been updated, or the docs PR is linked here: docs PR for the dbt default follows
