### PR TITLE
source-postgres-batch: demote per-chunk progress logging to debug

### DIFF
--- a/source-postgres-batch/driver.go
+++ b/source-postgres-batch/driver.go
@@ -873,6 +873,8 @@ func (c *capture) pollIncremental(ctx context.Context, binding *bindingInfo) err
 	}
 
 	// Iterate over CTID range chunks until we reach the maximum possible CTID page for this table
+	var chunkCount int
+	var sweepResultCount int64
 	for int64(afterCTID.BlockNumber) < maximumPageID {
 		var untilCTID = pgtype.TID{BlockNumber: afterCTID.BlockNumber + pagesPerChunk, Valid: true}
 		var resultCount, err = c.pollIncrementalChunk(ctx, &incrementalChunkDescription{
@@ -895,10 +897,24 @@ func (c *capture) pollIncremental(ctx context.Context, binding *bindingInfo) err
 		afterCTID = untilCTID
 		state.ScanTID = fmt.Sprintf("(%d,%d)", afterCTID.BlockNumber, afterCTID.OffsetNumber)
 		state.DocumentCount += resultCount
+		chunkCount++
+		sweepResultCount += resultCount
 		if err := c.streamStateCheckpoint(stateKey, state); err != nil {
 			return err
 		}
 	}
+
+	// Summarize the polling operation.
+	var summaryEntry = log.WithFields(log.Fields{
+		"name":   res.Name,
+		"chunks": chunkCount,
+		"count":  sweepResultCount,
+		"total":  state.DocumentCount,
+	})
+	if state.BaseXID != 0 {
+		summaryEntry = summaryEntry.WithField("txids", fmt.Sprintf("%d to %d", state.BaseXID, state.NextXID))
+	}
+	summaryEntry.Info("incremental polling complete")
 
 	// Reset scanning state for the next incremental table update
 	state.ScanTID = ""
@@ -951,7 +967,7 @@ func (c *capture) pollIncrementalChunk(ctx context.Context, chunk *incrementalCh
 	if chunk.BaseXID != 0 {
 		logEntry = logEntry.WithField("txids", fmt.Sprintf("%d to %d", chunk.BaseXID, chunk.NextXID))
 	}
-	logEntry.Info("polling incremental chunk")
+	logEntry.Debug("polling incremental chunk")
 
 	// Set up a watchdog timeout which will terminate the capture task if no data is
 	// received after a long period of time. The deferred stop ensures that the timeout
@@ -1085,7 +1101,7 @@ func (c *capture) pollIncrementalChunk(ctx context.Context, chunk *incrementalCh
 		"query": query,
 		"count": queryResultsCount,
 		"total": chunk.DocumentCount + queryResultsCount,
-	}).Info("chunk query complete")
+	}).Debug("chunk query complete")
 
 	return queryResultsCount, nil
 }


### PR DESCRIPTION
**Description:**

These per-chunk progress logs can be a little excessive for large tables. I'm demoting them to debug & logging out a summary once the incremental poll is complete instead. That reduces logging frequency at INFO level at the cost of some observability into which chunk a capture is processing - I think that's acceptable & we can always turn on debug logging if we need those details.

Motivating Slack thread: [link](https://estuaryworkspace.slack.com/archives/C03DYBS4J3E/p1788543820374789?thread_ts=1788538727.189209&cid=C03DYBS4J3E)

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [ ] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
