### PR TITLE
source-salesforce-native: remove support for date window paginated backfills

### DIFF
--- a/source-salesforce-native/CHANGELOG.md
+++ b/source-salesforce-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-09-08
+
+### Changed
+- The date window strategy that drove backfills started before 2026-07-22 to completion has
+  been removed, and the `advanced.window_size` setting now only applies to incremental
+  catch-up sweeps.
+
 ## 2026-08-04
 
 ### Fixed

--- a/source-salesforce-native/source_salesforce_native/api.py
+++ b/source-salesforce-native/source_salesforce_native/api.py
@@ -15,7 +15,7 @@ from .bulk_job_manager import (
     MAX_BULK_QUERY_SET_SIZE,
 )
 from .rest_query_manager import MAX_REST_RESPONSE_SIZE, RestQueryManager, chunk_fields
-from .shared import build_date_window_query, build_id_page_query, build_snapshot_query, dt_to_str, is_salesforce_id, str_to_dt, now, should_retry, VERSION
+from .shared import build_date_window_query, build_id_page_query, build_snapshot_query, str_to_dt, now, should_retry, VERSION
 from .models import (
     MIN_INCREMENTAL_WINDOW_SIZE,
     FieldDetails,
@@ -243,7 +243,6 @@ async def backfill_incremental_resources(
     name: str,
     fields: FieldDetailsDict,
     model_cls: type[SalesforceRecord],
-    window_size: timedelta,
     start_date: datetime,
     log: Logger,
     page: PageCursor | None,
@@ -271,40 +270,21 @@ async def backfill_incremental_resources(
     if page is not None:
         assert isinstance(page, str)
 
-    # Backfills that started before Id-based pagination existed persisted a datetime page cursor
-    # and are driven to completion with the original date window strategy.
-    # TODO(bair): Remove the backwards-compatible date window logic once we're sure all on-going
-    # backfills have completed.
-    if isinstance(page, str) and not is_salesforce_id(page):
-        gen = _backfill_with_date_windows(
-            is_supported_by_bulk_api,
-            bulk_job_manager,
-            rest_query_manager,
-            name,
-            fields,
-            model_cls,
-            cursor_field,
-            window_size,
-            log,
-            str_to_dt(page),
-            cutoff,
-        )
-    else:
-        gen = _backfill_with_id_pages(
-            http,
-            is_supported_by_bulk_api,
-            bulk_job_manager,
-            rest_query_manager,
-            instance_url,
-            name,
-            fields,
-            model_cls,
-            cursor_field,
-            start_date,
-            log,
-            page,
-            cutoff,
-        )
+    gen = _backfill_with_id_pages(
+        http,
+        is_supported_by_bulk_api,
+        bulk_job_manager,
+        rest_query_manager,
+        instance_url,
+        name,
+        fields,
+        model_cls,
+        cursor_field,
+        start_date,
+        log,
+        page,
+        cutoff,
+    )
 
     async for record_or_cursor in gen:
         yield record_or_cursor
@@ -372,75 +352,6 @@ async def _backfill_with_id_pages(
         if _should_fallback_to_rest_api(err, name, log):
             async for record_or_id in _execute_rest():
                 yield record_or_id
-        else:
-            raise
-
-
-async def _backfill_with_date_windows(
-    is_supported_by_bulk_api: bool,
-    bulk_job_manager: BulkJobManager,
-    rest_query_manager: RestQueryManager,
-    name: str,
-    fields: FieldDetailsDict,
-    model_cls: type[SalesforceRecord],
-    cursor_field: CursorFields,
-    window_size: timedelta,
-    log: Logger,
-    start: datetime,
-    cutoff: datetime,
-) -> AsyncGenerator[SalesforceRecord | str, None]:
-    if start >= cutoff:
-        log.debug("Page cursor is after cutoff, indicating backfill is complete.", {
-            "start": start,
-            "cutoff": cutoff,
-        })
-        return
-
-    max_window_size = min(window_size, cutoff - start)
-    end = min(cutoff, start + max_window_size)
-
-    async def _execute(
-        gen: AsyncGenerator[SalesforceRecord, None],
-        checkpoint_interval: int
-    ) -> AsyncGenerator[SalesforceRecord | str, None]:
-        async for record_or_dt in _datetime_execution_wrapper(gen, cursor_field, start, end, max_window_size, checkpoint_interval):
-            if isinstance(record_or_dt, datetime):
-                yield dt_to_str(record_or_dt)
-            else:
-                yield record_or_dt
-
-    def _execute_bulk() -> AsyncGenerator[SalesforceRecord | str, None]:
-        gen = bulk_job_manager.execute(
-            name,
-            build_date_window_query(name, list(fields.keys()), cursor_field, start, end),
-            model_cls,
-        )
-
-        return _execute(gen, BULK_CHECKPOINT_INTERVAL)
-
-    def _execute_rest() -> AsyncGenerator[SalesforceRecord | str, None]:
-        queries = [
-            build_date_window_query(name, chunk, cursor_field, start, end)
-            for chunk in chunk_fields(fields, cursor_field)
-        ]
-        gen = rest_query_manager.execute(name, queries, model_cls, cursor_field, end)
-
-        return _execute(gen, REST_CHECKPOINT_INTERVAL)
-
-    log.debug("Executing backfill.", {
-        "start": start,
-        "end": end,
-        "is_support_by_bulk_api": is_supported_by_bulk_api,
-    })
-
-    try:
-        gen = _execute_bulk() if is_supported_by_bulk_api else _execute_rest()
-        async for doc_or_str in gen:
-            yield doc_or_str
-    except BulkJobError as err:
-        if _should_fallback_to_rest_api(err, name, log):
-            async for doc_or_str in _execute_rest():
-                yield doc_or_str
         else:
             raise
 

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -128,7 +128,7 @@ class EndpointConfig(BaseModel):
 
     class Advanced(BaseModel):
         window_size: WindowSizeAsInterval | WindowSizeInDays = Field(
-            description="Date window size for Bulk API 2.0 queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+            description="Date window size for incremental queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
             title="Window size",
             default_factory=lambda: WindowSizeInDays(days=18250),
             discriminator="window_type",

--- a/source-salesforce-native/source_salesforce_native/resources.py
+++ b/source-salesforce-native/source_salesforce_native/resources.py
@@ -168,7 +168,6 @@ def incremental_resource(
                 name,
                 fields,
                 model_cls,
-                config.advanced.window_size.as_timedelta,
                 config.start_date,
             ),
             fetch_changes=functools.partial(

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,7 +6,7 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "description": "Date window size for Bulk API 2.0 queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+              "description": "Date window size for incremental queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
               "discriminator": {
                 "mapping": {
                   "days": "#/$defs/WindowSizeInDays",

--- a/source-salesforce-native/tests/test_id_backfill.py
+++ b/source-salesforce-native/tests/test_id_backfill.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 
 import pytest
 
@@ -25,7 +25,6 @@ _LOG = logging.getLogger(__name__)
 
 START_DATE = datetime(1999, 2, 3, tzinfo=UTC)
 CUTOFF = datetime(2026, 7, 1, tzinfo=UTC)
-WINDOW_SIZE = timedelta(days=18250)
 MODSTAMP = "2026-06-01T00:00:00.000Z"
 INSTANCE_URL = "https://instance.example.com"
 
@@ -196,7 +195,6 @@ def _backfill(http, is_supported_by_bulk_api, bulk_manager, rest_manager, page):
         "Account",
         FIELDS,
         MODEL,
-        WINDOW_SIZE,
         START_DATE,
         _LOG,
         page,
@@ -233,22 +231,6 @@ async def test_backfill_id_page_cursor_resumes_id_pagination():
     assert len(manager.queries) == 1
     assert f"AND Id > '{_id(1)}'" in manager.queries[0]
     assert "ORDER BY Id ASC" in manager.queries[0]
-
-
-@pytest.mark.asyncio
-async def test_backfill_datetime_page_cursor_uses_date_windows():
-    manager = FakeBulkManager([_record(1), _record(2)])
-    page = dt_to_str(datetime(2026, 1, 1, tzinfo=UTC))
-
-    items = await _collect(_bulk_backfill(manager, page=page))
-
-    assert manager.queries == [
-        "SELECT Id,SystemModstamp,Name FROM Account"
-        " WHERE SystemModstamp > 2026-01-01T00:00:00.000Z AND SystemModstamp <= 2026-07-01T00:00:00.000Z"
-        " ORDER BY SystemModstamp ASC"
-    ]
-    # The legacy strategy checkpoints datetime cursors.
-    assert items[-1] == MODSTAMP
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Description:**

After https://github.com/estuary/connectors/pull/4875 went live ~7 weeks ago, the connector retained support for in-progress backfills that still used date windows to paginate through results. I did not find any captures still working on a backfill that started >7 weeks ago, so it's safe to remove this backwards compatible support & only support Id-paginated backfills from now on. (If I missed a capture that is indeed still working on a backfill that started over 7 weeks ago, then I'd argue it's not going to complete any time soon anyway & we want it to fail loudly so we can re-backfill it using the newer and more efficient Id-keyset pagination strategy).

With the removal of support for date window paginated backfills, `advanced.window_size` now applies only to incremental catch-up sweeps via the REST API, so its description no longer claims to govern Bulk API 2.0 queries.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
