### PR TITLE
source-salesforce-native: infer window_type for untagged window_size configs

### DIFF
--- a/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-native.md
+++ b/docs/reference/Connectors/capture-connectors/Salesforce/salesforce-native.md
@@ -158,7 +158,10 @@ See [connectors](../../../../concepts/connectors.md#using-connectors) to learn m
 | `/my_domain` | My Domain | Your Salesforce My Domain login host. Enter the full host ending in .my.salesforce.com to login with your My Domain host. e.g. mycompany.my.salesforce.com, acme--uat.sandbox.my.salesforce.com. Leave blank to log in via the standard login/test endpoint. Required when authenticating with Client Credentials. | string | `""` |
 | `/is_sandbox` | Sandbox | Whether you&#x27;re using a [Salesforce Sandbox](https://help.salesforce.com/s/articleView?id=sf.deploy_sandboxes_parent.htm&type=5). | boolean | `false` |
 | **`/credentials`** | Authentication | Credentials for the chosen [authentication method](#authentication). See the per-method credential properties below. | object | Required |
-| `/advanced/window_size` | Window size | The date window size in days to use when querying the Salesforce APIs. | integer | 18250 |
+| `/advanced/window_size` | Incremental Query Window Size | How much time a single incremental query covers when the connector sweeps for changes. Typically left as the default unless Estuary Support or the connector logs indicate otherwise. | object | `{"window_type": "days", "days": 18250}` |
+| `/advanced/window_size/window_type` | Window Type | Either `days` or `interval`. Selects which of the two properties below sets the window size. | string | `days` |
+| `/advanced/window_size/days` | Days | Size of the date window each incremental query covers, in whole days. Used when `window_type` is `days`. | integer | 18250 |
+| `/advanced/window_size/interval` | Duration | Size of the date window each incremental query covers, as an ISO 8601 duration, e.g. `PT1H` for one hour. Used when `window_type` is `interval`. | string | |
 
 ##### Credentials
 
@@ -216,7 +219,9 @@ captures:
           is_sandbox: false
           start_date: "2025-03-19T12:00:00Z"
           advanced:
-            window_size: 18250
+            window_size:
+              window_type: days
+              days: 18250
     bindings:
       - resource:
           name: Account

--- a/source-salesforce-native/CHANGELOG.md
+++ b/source-salesforce-native/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-09-09
+
+### Fixed
+- Setting `advanced.window_size` when first configuring a capture no longer fails with an
+  `Unable to extract tag using discriminator 'window_type'` error. A window size saved without
+  the window type selector is now resolved from the value that was provided.
+
+### Changed
+- The `advanced.window_size` setting is now labeled `Incremental Query Window Size`, and its
+  duration option is labeled `Duration`, to distinguish it from the per-binding sync schedule.
+
 ## 2026-09-08
 
 ### Changed

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -54,7 +54,7 @@ class WindowSizeInDays(BaseModel):
     )
     days: int = Field(
         title="Days",
-        description="Window size as a whole number of days.",
+        description="Size of the date window each incremental query covers, in whole days.",
         gt=0,
         json_schema_extra={"order": 1},
     )
@@ -65,15 +65,18 @@ class WindowSizeInDays(BaseModel):
 
 
 class WindowSizeAsInterval(BaseModel):
-    model_config = ConfigDict(title="Interval")
+    model_config = ConfigDict(title="Duration")
 
     window_type: Literal["interval"] = Field(
         default="interval",
         json_schema_extra={"nonsensitive": True, "type": "string", "order": 0},
     )
     interval: timedelta = Field(
-        title="Interval",
-        description="Window size as an ISO 8601 duration, e.g. PT1H for one hour.",
+        title="Duration",
+        description=(
+            "Size of the date window each incremental query covers, as an ISO 8601 duration, "
+            "e.g. PT1H for one hour."
+        ),
         gt=MIN_INCREMENTAL_WINDOW_SIZE,
         json_schema_extra={"nonsensitive": True, "order": 1},
     )
@@ -130,8 +133,12 @@ class EndpointConfig(BaseModel):
 
     class Advanced(BaseModel):
         window_size: WindowSizeAsInterval | WindowSizeInDays = Field(
-            description="Date window size for incremental queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
-            title="Window size",
+            description=(
+                "How much time a single incremental query covers when the connector sweeps for "
+                "changes. Typically left as the default unless Estuary Support or the connector "
+                "logs indicate otherwise."
+            ),
+            title="Incremental Query Window Size",
             default_factory=lambda: WindowSizeInDays(days=18250),
             discriminator="window_type",
             json_schema_extra={"nonsensitive": True},
@@ -139,15 +146,32 @@ class EndpointConfig(BaseModel):
 
         @model_validator(mode="before")
         @classmethod
-        def _coerce_legacy_window_size(cls, data: Any) -> Any:
+        def _coerce_untagged_window_size(cls, data: Any) -> Any:
             # Older configs stored window_size as a bare integer count of days, before it became a
             # discriminated union. Wrap that legacy form so running captures keep working without the
             # user re-saving their config.
-            if isinstance(data, dict) and isinstance(data.get("window_size"), int):
+            if not isinstance(data, dict):
+                return data
+
+            window_size = data.get("window_size")
+
+            if isinstance(window_size, int):
                 return {
                     **data,
-                    "window_size": {"window_type": "days", "days": data["window_size"]},
+                    "window_size": {"window_type": "days", "days": window_size},
                 }
+
+            # A window_size can also arrive untagged, since the UI only fills a union's hidden
+            # discriminator for required fields. Each variant's value key doubles as its
+            # window_type, so whichever key is present selects the tag.
+            if isinstance(window_size, dict) and "window_type" not in window_size:
+                for window_type in ("interval", "days"):
+                    if window_type in window_size:
+                        return {
+                            **data,
+                            "window_size": {**window_size, "window_type": window_type},
+                        }
+
             return data
 
     advanced: Advanced = Field(

--- a/source-salesforce-native/source_salesforce_native/models.py
+++ b/source-salesforce-native/source_salesforce_native/models.py
@@ -1,7 +1,16 @@
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Any, Iterator, ClassVar, Literal
+from typing import Any, ClassVar, Iterator, Literal
 
+from estuary_cdk.capture.common import (
+    CRON_REGEX,
+    BaseDocument,
+    ResourceConfigWithSchedule,
+    ResourceState,
+)
+from estuary_cdk.capture.common import (
+    ConnectorState as GenericConnectorState,
+)
 from pydantic import (
     AwareDatetime,
     BaseModel,
@@ -11,19 +20,9 @@ from pydantic import (
     create_model,
     model_validator,
 )
-from estuary_cdk.capture.common import (
-    BaseDocument,
-    ResourceConfigWithSchedule,
-    CRON_REGEX,
-    ResourceState,
-)
-from estuary_cdk.capture.common import (
-    ConnectorState as GenericConnectorState,
-)
 
 from .auth import OAuth2Credentials, SalesforceClientCredentials, UserPass
 from .shared import dt_to_str, str_to_dt
-
 
 EARLIEST_VALID_DATE_IN_SALESFORCE = datetime(1700, 1, 1, tzinfo=UTC)
 # Salesforce was founded on 03FEB1999. As long as cursor values aren't backdated before this date (which only seems possible
@@ -120,7 +119,10 @@ class EndpointConfig(BaseModel):
         # Salesforce's Client Credentials flow must hit the org's My Domain token endpoint since
         # login.salesforce.com doesn't support the client_credentials grant. The other auth
         # methods can work with the standard login/test host, so My Domain stays optional for them.
-        if isinstance(self.credentials, SalesforceClientCredentials) and not self.my_domain:
+        if (
+            isinstance(self.credentials, SalesforceClientCredentials)
+            and not self.my_domain
+        ):
             raise ValueError(
                 "The My Domain field is required when using Client Credentials authentication."
             )
@@ -142,7 +144,10 @@ class EndpointConfig(BaseModel):
             # discriminated union. Wrap that legacy form so running captures keep working without the
             # user re-saving their config.
             if isinstance(data, dict) and isinstance(data.get("window_size"), int):
-                return {**data, "window_size": {"window_type": "days", "days": data["window_size"]}}
+                return {
+                    **data,
+                    "window_size": {"window_type": "days", "days": data["window_size"]},
+                }
             return data
 
     advanced: Advanced = Field(
@@ -201,11 +206,12 @@ SOAP_TYPES_NOT_SUPPORTED_BY_BULK_API = [
     SoapTypes.SEARCH_LAYOUT_FIELDS_DISPLAYED,
 ]
 
+
 # BaseFieldDetails represents field metadata returned from Salesforce.
 class BaseFieldDetails(BaseModel, extra="allow"):
-    soapType: SoapTypes # Type of field
-    calculated: bool # Indicates whether or not this is a formula field.
-    custom: bool # Indicates whether or not this is a custom field.
+    soapType: SoapTypes  # Type of field
+    calculated: bool  # Indicates whether or not this is a formula field.
+    custom: bool  # Indicates whether or not this is a custom field.
 
 
 class SObject(PartialSObject):
@@ -268,7 +274,9 @@ class CursorFields(StrEnum):
     CREATED_DATE = "CreatedDate"
     LOGIN_TIME = "LoginTime"
 
+
 # REST API Related Models
+
 
 class QueryResponse(BaseModel, extra="forbid"):
     totalSize: int
@@ -276,7 +284,9 @@ class QueryResponse(BaseModel, extra="forbid"):
     records: list[dict[str, Any]]
     nextRecordsUrl: str | None = None
 
+
 # Bulk Job Related Models
+
 
 class BulkJobStates(StrEnum):
     UPLOAD_COMPLETE = "UploadComplete"
@@ -304,14 +314,15 @@ class BulkJobCheckStatusResponse(BulkJobSubmitResponse):
 
 class BulkJobError(RuntimeError):
     """Exception raised for errors when executing a bulk query job."""
-    def __init__(self, message: str, query: str | None = None, error: str | None = None):
+
+    def __init__(
+        self, message: str, query: str | None = None, error: str | None = None
+    ):
         self.message = message
         self.query = query
         self.errors = error
 
-        self.details: dict[str, Any] = {
-            "message": self.message
-        }
+        self.details: dict[str, Any] = {"message": self.message}
 
         if self.errors:
             self.details["errors"] = self.errors
@@ -324,11 +335,7 @@ class BulkJobError(RuntimeError):
         return f"BulkJobError: {self.message}"
 
     def __repr__(self):
-        return (
-            f"BulkJobError: {self.message},"
-            f"query: {self.query},"
-            f"errors: {self.errors}"
-        )
+        return f"BulkJobError: {self.message},query: {self.query},errors: {self.errors}"
 
 
 class SalesforceDataSource(StrEnum):
@@ -357,21 +364,27 @@ class SalesforceRecord(BaseDocument, extra="allow"):
     # regular model attributes. This override enables easy access to these
     # extra fields with `getattr``.
     def __getattr__(self, name: str) -> Any:
-        extra = getattr(self, '__pydantic_extra__', None)
+        extra = getattr(self, "__pydantic_extra__", None)
         if extra is not None and name in extra:
             return extra[name]
-        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
 
     @model_validator(mode="before")
     @classmethod
-    def _transform_fields(cls, values: dict[str, Any], info: ValidationInfo) -> dict[str, Any]:
-        if not hasattr(cls, 'field_details'):
+    def _transform_fields(
+        cls, values: dict[str, Any], info: ValidationInfo
+    ) -> dict[str, Any]:
+        if not hasattr(cls, "field_details"):
             raise RuntimeError(
                 "field_details must be set on the SalesforceRecord subclass before validation."
             )
 
         if not info.context or not isinstance(info.context, ValidationContext):
-            raise RuntimeError(f"Validation context must be of type ValidationContext: {info.context}")
+            raise RuntimeError(
+                f"Validation context must be of type ValidationContext: {info.context}"
+            )
 
         data_source = info.context.data_source
 
@@ -392,7 +405,7 @@ class SalesforceRecord(BaseDocument, extra="allow"):
                     # This metadata isn't present in the Bulk API response, so we remove it from records fetched
                     # via the REST API.
                     if field_name == "attributes":
-                            continue
+                        continue
 
                     transformed_value = cls._transform_rest_value(
                         cls.field_details[field_name],
@@ -425,7 +438,14 @@ class SalesforceRecord(BaseDocument, extra="allow"):
 
         # Transform standard fields to the correct type.
         match field_details.soapType:
-            case SoapTypes.ID | SoapTypes.STRING | SoapTypes.DATE | SoapTypes.DATETIME | SoapTypes.TIME | SoapTypes.BASE64:
+            case (
+                SoapTypes.ID
+                | SoapTypes.STRING
+                | SoapTypes.DATE
+                | SoapTypes.DATETIME
+                | SoapTypes.TIME
+                | SoapTypes.BASE64
+            ):
                 transformed_value = value
             case SoapTypes.BOOLEAN:
                 transformed_value = cls._bool_str_to_bool(value)
@@ -438,7 +458,9 @@ class SalesforceRecord(BaseDocument, extra="allow"):
             case SoapTypes.ANY_TYPE:
                 transformed_value = cls._str_to_anytype(value)
             case _:
-                raise BulkJobError(f"Unanticipated field type {field_details.soapType} for field {name}. Please reach out to Estuary support for help resolving this issue.")
+                raise BulkJobError(
+                    f"Unanticipated field type {field_details.soapType} for field {name}. Please reach out to Estuary support for help resolving this issue."
+                )
 
         return transformed_value
 
@@ -518,7 +540,7 @@ class SalesforceRecord(BaseDocument, extra="allow"):
     # always schematized as & cast to strings.
     @classmethod
     def sourced_schema(cls) -> dict[str, Any]:
-        if not hasattr(cls, 'field_details'):
+        if not hasattr(cls, "field_details"):
             raise RuntimeError(
                 "field_details must be set on the SalesforceRecord subclass before generating a sourced schema."
             )
@@ -629,7 +651,9 @@ class SalesforceRecord(BaseDocument, extra="allow"):
         return schema
 
 
-def create_salesforce_model(object_name: str, fields: FieldDetailsDict) -> type[SalesforceRecord]:
+def create_salesforce_model(
+    object_name: str, fields: FieldDetailsDict
+) -> type[SalesforceRecord]:
     field_defs = {}
 
     # No fields other than `Id` are included in the model by default since what fields should be included differ

--- a/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
+++ b/source-salesforce-native/tests/snapshots/snapshots__spec__capture.stdout.json
@@ -6,7 +6,7 @@
         "Advanced": {
           "properties": {
             "window_size": {
-              "description": "Date window size for incremental queries. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
+              "description": "How much time a single incremental query covers when the connector sweeps for changes. Typically left as the default unless Estuary Support or the connector logs indicate otherwise.",
               "discriminator": {
                 "mapping": {
                   "days": "#/$defs/WindowSizeInDays",
@@ -23,7 +23,7 @@
                   "$ref": "#/$defs/WindowSizeInDays"
                 }
               ],
-              "title": "Window size"
+              "title": "Incremental Query Window Size"
             }
           },
           "title": "Advanced",
@@ -106,18 +106,18 @@
               "type": "string"
             },
             "interval": {
-              "description": "Window size as an ISO 8601 duration, e.g. PT1H for one hour.",
+              "description": "Size of the date window each incremental query covers, as an ISO 8601 duration, e.g. PT1H for one hour.",
               "format": "duration",
               "nonsensitive": true,
               "order": 1,
-              "title": "Interval",
+              "title": "Duration",
               "type": "string"
             }
           },
           "required": [
             "interval"
           ],
-          "title": "Interval",
+          "title": "Duration",
           "type": "object"
         },
         "WindowSizeInDays": {
@@ -131,7 +131,7 @@
               "type": "string"
             },
             "days": {
-              "description": "Window size as a whole number of days.",
+              "description": "Size of the date window each incremental query covers, in whole days.",
               "exclusiveMinimum": 0,
               "order": 1,
               "title": "Days",

--- a/source-salesforce-native/tests/test_window_size.py
+++ b/source-salesforce-native/tests/test_window_size.py
@@ -1,0 +1,73 @@
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from source_salesforce_native.models import (
+    EndpointConfig,
+    WindowSizeAsInterval,
+    WindowSizeInDays,
+)
+
+
+def _endpoint_config(window_size: Any) -> EndpointConfig:
+    # Minimal valid endpoint config; only advanced.window_size matters here.
+    return EndpointConfig.model_validate(
+        {
+            "credentials": {
+                "credentials_title": "Username, Password, & Security Token",
+                "username": "svc@example.com",
+                "password": "pw",
+                "security_token": "tok",
+            },
+            "advanced": {"window_size": window_size},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "window_size, expected",
+    [
+        # The UI only sets a union's hidden discriminator for required fields,
+        # and window_size is optional, so a window set at capture creation time
+        # arrives untagged.
+        ({"interval": "PT12H"}, WindowSizeAsInterval(interval=timedelta(hours=12))),
+        ({"days": 30}, WindowSizeInDays(days=30)),
+        # Configs written before window_size became a union stored a bare count of days.
+        (30, WindowSizeInDays(days=30)),
+        # Fully tagged payloads keep working.
+        (
+            {"window_type": "interval", "interval": "PT12H"},
+            WindowSizeAsInterval(interval=timedelta(hours=12)),
+        ),
+        ({"window_type": "days", "days": 7}, WindowSizeInDays(days=7)),
+    ],
+)
+def test_window_size_accepts_untagged_and_tagged_payloads(
+    window_size: Any, expected: WindowSizeAsInterval | WindowSizeInDays
+) -> None:
+    assert _endpoint_config(window_size).advanced.window_size == expected
+
+
+def test_window_size_defaults_when_absent() -> None:
+    assert EndpointConfig.Advanced().window_size == WindowSizeInDays(days=18250)
+
+
+@pytest.mark.parametrize(
+    "window_size",
+    [
+        # Neither variant's value key is present, so there's nothing to infer a tag from and the
+        # config should be rejected rather than silently defaulted.
+        {},
+        {"bogus": 1},
+        # An explicit tag that doesn't match the payload stays an error.
+        {"window_type": "days", "interval": "PT12H"},
+        # Variant constraints still apply: intervals must exceed one minute, days must be positive.
+        {"interval": "PT30S"},
+        {"days": 0},
+    ],
+)
+def test_window_size_rejects_unresolvable_payloads(window_size: Any) -> None:
+    with pytest.raises(ValidationError):
+        _ = _endpoint_config(window_size)


### PR DESCRIPTION
**Description:**

`advanced.window_size` is a discriminated union tagged by `window_type`, and it is also optional (it carries a `default_factory`). The UI only fills a union's hidden discriminator for required fields, so a window size set while first configuring a capture is saved as bare `{"interval": "PT12H"}` or `{"days": 30}`, and discover fails:

```
Unable to extract tag using discriminator 'window_type' [type=union_tag_not_found, input_value={'interval': 'PT12H'}, input_type=dict]
```

Both variants fail the same way. This has been broken since #4682 turned the plain integer field into a union.

The before-validator that already normalises pre-union bare-integer configs now also infers `window_type` from an untagged payload's value key. Each variant's value key (`interval`, `days`) doubles as its tag, so whichever key is present selects the variant.

**Notes for reviewers:**

Tested using a local deployment and unit tests. Both are now green.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: #4682
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: `docs/reference/Connectors/capture-connectors/Salesforce/salesforce-native.md` is updated in this PR
