### PR TITLE
source-boilerplate: Enlarge the stdout pipe and shrink the write buffer

### DIFF
--- a/source-boilerplate/boilerplate.go
+++ b/source-boilerplate/boilerplate.go
@@ -31,7 +31,15 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const outputWriteBuffer = 1 * 1024 * 1024 // 1MiB output buffer to amortize write syscall overhead
+const (
+	// requestedOutputPipeSize is the kernel pipe capacity we ask for on stdout.
+	requestedOutputPipeSize = 1 * 1024 * 1024
+
+	// outputWriteBuffer amortizes the cost of a write syscall across multiple documents.
+	// It needs to be smaller than the output pipe so that flushes only block due to
+	// runtime backpressure.
+	outputWriteBuffer = 64 * 1024
+)
 
 // StateKey is used to key binding-specific state a connector's driver checkpoint. It's just a type
 // alias for a string to help differentiate any old string from where a specific state key from the
@@ -92,6 +100,10 @@ func RunMain(connector Connector) {
 // It omits portions of setup which are only appropriate for a standalone binary.
 func InnerMain(ctx context.Context, connector Connector, r io.Reader, w io.Writer) error {
 	log.WithField("eventType", "connectorStatus").Info("Initializing connector")
+
+	if f, ok := w.(*os.File); ok {
+		enlargeOutputPipe(f, requestedOutputPipeSize)
+	}
 
 	var stream streamCodec
 	switch codec := getEnvDefault("FLOW_RUNTIME_CODEC", "proto"); codec {

--- a/source-boilerplate/pipe_linux.go
+++ b/source-boilerplate/pipe_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package boilerplate
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// enlargeOutputPipe grows the kernel buffer of the pipe behind f to at least
+// targetSize bytes. It does nothing if f is not a pipe, and logs a warning
+// if the pipe can't be enlarged.
+func enlargeOutputPipe(f *os.File, targetSize int) {
+	var fd = uintptr(f.Fd())
+	var current, err = unix.FcntlInt(fd, unix.F_GETPIPE_SZ, 0)
+	if err != nil || current >= targetSize {
+		return
+	}
+	if _, err := unix.FcntlInt(fd, unix.F_SETPIPE_SZ, targetSize); err != nil {
+		log.WithFields(log.Fields{
+			"err":       err,
+			"current":   current,
+			"requested": targetSize,
+		}).Warn("failed to enlarge output pipe buffer")
+	}
+}

--- a/source-boilerplate/pipe_other.go
+++ b/source-boilerplate/pipe_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package boilerplate
+
+import "os"
+
+// enlargeOutputPipe is a no-op on platforms without F_SETPIPE_SZ.
+func enlargeOutputPipe(f *os.File, targetSize int) {}


### PR DESCRIPTION
**Description:**

We buffer up to 1MiB of output before flushing it to stdout, but the pipe on the other side of stdout only holds 64KiB by default. So the runtime sits idle while we fill our buffer, and then we sit blocked in write() while the runtime slowly drains it. The two never actually run in parallel, and the ping-pong between those states costs us throughput.

The fix is to make the pipe bigger than our buffer. We ask the kernel for a 1MiB pipe at startup and shrink our write buffer to 64kB since it's only there to amortize syscall overhead on small documents. That way there's always data in the pipe for the runtime to read while we're filling the next buffer, and a flush only blocks when there's real backpressure.

The pipe resizing only works on Linux for obvious reasons, but shouldn't cause problems on other platforms.

**Workflow steps:**

No action required.

**Notes for reviewers:**

This is the quick-and-dirty fix for the idle/backpressure ping-pong we've seen in production. I believe it should help to prevent stalls _during_ a backfill cycle but as noted by Johnny on Slack the 1MiB pipe buffer will not necessarily be enough decoupling to prevent stalls while waiting for a backfill query to begin returning data, depending on target throughput and database RTT and query execution latency.

We may want to either raise the pipe buffer size even higher (which AFAIK requires adjusting some kernel parameter to allow) or put additional concurrent ring-buffering inside the connector (probably as a replacement for the existing bufio.Writer buffering) to address that, but that's a larger piece of work.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
