### PR TITLE
source-zendesk-support-native: add eventual consistency lag to incremental streams

### DIFF
--- a/source-zendesk-support-native/CHANGELOG.md
+++ b/source-zendesk-support-native/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-09-10
+
+### Changed
+- Incremental streams now trail roughly 5 minutes behind the present to combat the Zendesk Support API's eventually consistent behavior. Records still arrive on each binding's normal polling interval, with up to 5 minutes of additional delay.
+
 ## 2026-08-05
 
 ### Fixed

--- a/source-zendesk-support-native/source_zendesk_support_native/api.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/api.py
@@ -45,6 +45,13 @@ MAX_SATISFACTION_RATINGS_WINDOW_SIZE = timedelta(days=30)
 MIN_PAGE_SIZE = 1
 # Zendesk errors out if a start or end time parameter is 60 seconds or less in the past. 
 TIME_PARAMETER_DELAY = timedelta(seconds=61)
+# Zendesk's API is eventually consistent: a record can become queryable seconds or
+# minutes after its timestamp, after we've already seen records with later timestamps.
+# Since incremental cursors are high-water marks, anything that surfaces below one
+# would be filtered out and lost forever. To avoid that, we never advance a cursor
+# over records younger than INCREMENTAL_LAG, giving late arrivals time to appear
+# before the cursor moves past their timestamp.
+INCREMENTAL_LAG = timedelta(minutes=5)
 
 DATETIME_STRING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 INCREMENTAL_TIME_EXPORT_REQ_PER_MIN_LIMIT = 10
@@ -180,6 +187,10 @@ async def fetch_client_side_incremental_offset_paginated_resources(
     }
 
     last_seen = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
+
+    if horizon <= log_cursor:
+        return
 
     while True:
         response = response_model.model_validate_json(
@@ -187,6 +198,10 @@ async def fetch_client_side_incremental_offset_paginated_resources(
         )
 
         for resource in response.resources:
+            # Skip records Zendesk may not have finished making visible.
+            if resource.updated_at >= horizon:
+                continue
+
             if resource.updated_at > log_cursor:
                 yield resource
 
@@ -224,6 +239,10 @@ async def fetch_client_side_incremental_cursor_paginated_resources(
         params.update(additional_query_params)
 
     last_seen = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
+
+    if horizon <= log_cursor:
+        return
 
     while True:
         response = response_model.model_validate_json(
@@ -231,6 +250,10 @@ async def fetch_client_side_incremental_cursor_paginated_resources(
         )
 
         for resource in response.resources:
+            # Skip records Zendesk may not have finished making visible.
+            if resource.updated_at >= horizon:
+                continue
+
             if resource.updated_at > log_cursor:
                 yield resource
 
@@ -280,6 +303,11 @@ async def fetch_incremental_cursor_paginated_resources(
     }
 
     last_seen_dt = log_cursor
+    last_checkpointed = log_cursor
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
+
+    if horizon <= log_cursor:
+        return
 
     while True:
         response = response_model.model_validate_json(
@@ -287,15 +315,20 @@ async def fetch_incremental_cursor_paginated_resources(
         )
 
         if (
-            last_seen_dt > log_cursor
+            last_seen_dt > last_checkpointed
             and response.resources
             and _str_to_dt(getattr(response.resources[0], cursor_field)) > last_seen_dt
         ):
             yield last_seen_dt
+            last_checkpointed = last_seen_dt
 
 
         for resource in response.resources:
             resource_dt = _str_to_dt(getattr(resource, cursor_field))
+            # Skip records Zendesk may not have finished making visible.
+            if resource_dt >= horizon:
+                continue
+
             if resource_dt > last_seen_dt:
                 last_seen_dt = resource_dt
 
@@ -303,7 +336,7 @@ async def fetch_incremental_cursor_paginated_resources(
                 yield resource
 
         if not response.meta.has_more:
-            if last_seen_dt > log_cursor:
+            if last_seen_dt > last_checkpointed:
                 yield last_seen_dt
             break
 
@@ -392,7 +425,13 @@ async def fetch_satisfaction_ratings(
 ) -> AsyncGenerator[ZendeskResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    end = min(datetime.now(tz=UTC) - TIME_PARAMETER_DELAY, log_cursor + MAX_SATISFACTION_RATINGS_WINDOW_SIZE)
+    end = min(
+        datetime.now(tz=UTC) - INCREMENTAL_LAG,
+        log_cursor + MAX_SATISFACTION_RATINGS_WINDOW_SIZE,
+    )
+
+    if end <= log_cursor:
+        return
 
     generator = _fetch_satisfaction_ratings_between(
         http=http,
@@ -452,6 +491,7 @@ async def _fetch_incremental_time_export_resources(
     response_model: type[IncrementalTimeExportResponse],
     start_date: datetime,
     log: Logger,
+    horizon: datetime | None = None,
 ) -> AsyncGenerator[TimestampedResource | datetime, None]:
     # Docs: https://developer.zendesk.com/documentation/ticketing/managing-tickets/using-the-incremental-export-api/#time-based-incremental-exports
     # Incremental time export streams use timestamps for pagination that correlate to the updated_at timestamp for each record.
@@ -477,6 +517,16 @@ async def _fetch_incremental_time_export_resources(
             )
 
             async for resource in processor:
+                # Stop at the first record Zendesk may not have finished making visible.
+                # Results are ordered ascending by updated_at, so every later record is
+                # unsettled too. This stops rather than skips because the loop advances
+                # start_time to fetch the next page — skipping would just walk further
+                # into the unsettled window.
+                if horizon is not None and resource.updated_at >= horizon:
+                    if last_seen_dt > start_date:
+                        yield last_seen_dt
+                    return
+
                 # Ignore duplicate results that were yielded on the previous sweep.
                 if resource.updated_at <= start_date:
                     continue
@@ -532,7 +582,10 @@ async def fetch_incremental_time_export_resources(
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    generator = _fetch_incremental_time_export_resources(http, subdomain, name, path, response_model, log_cursor, log)
+    generator = _fetch_incremental_time_export_resources(
+        http, subdomain, name, path, response_model, log_cursor, log,
+        datetime.now(tz=UTC) - INCREMENTAL_LAG,
+    )
 
     async for result in generator:
         yield result
@@ -582,6 +635,7 @@ async def _fetch_talk_incremental_export_resources(
     response_model: type[TalkIncrementalExportResponse],
     start_date: datetime,
     log: Logger,
+    horizon: datetime | None = None,
 ) -> AsyncGenerator[TimestampedResource | datetime, None]:
     # Talk API incremental exports use timestamps for pagination similar to other time-based exports.
     # The end_time returned in the response is the updated_at timestamp of the last record.
@@ -606,6 +660,16 @@ async def _fetch_talk_incremental_export_resources(
             )
 
             async for resource in processor:
+                # Stop at the first record Zendesk may not have finished making visible.
+                # Results are ordered ascending by updated_at, so every later record is
+                # unsettled too. This stops rather than skips because the loop advances
+                # start_time to fetch the next page — skipping would just walk further
+                # into the unsettled window.
+                if horizon is not None and resource.updated_at >= horizon:
+                    if last_seen_dt > start_date:
+                        yield last_seen_dt
+                    return
+
                 # Ignore duplicate results that were yielded on the previous sweep.
                 if resource.updated_at <= start_date:
                     continue
@@ -661,7 +725,10 @@ async def fetch_talk_incremental_export_resources(
 ) -> AsyncGenerator[TimestampedResource | LogCursor, None]:
     assert isinstance(log_cursor, datetime)
 
-    generator = _fetch_talk_incremental_export_resources(http, subdomain, name, path, response_model, log_cursor, log)
+    generator = _fetch_talk_incremental_export_resources(
+        http, subdomain, name, path, response_model, log_cursor, log,
+        datetime.now(tz=UTC) - INCREMENTAL_LAG,
+    )
 
     async for result in generator:
         yield result
@@ -1115,8 +1182,13 @@ async def fetch_audit_logs(
 
     url = f"{url_base(subdomain)}/audit_logs"
 
+    horizon = datetime.now(tz=UTC) - INCREMENTAL_LAG
+
+    if horizon <= log_cursor:
+        return
+
     start = _dt_to_str(log_cursor)
-    end = _dt_to_str(datetime.now(tz=UTC))
+    end = _dt_to_str(horizon)
 
     params = {
         "page[size]": CURSOR_PAGINATION_PAGE_SIZE,

--- a/source-zendesk-support-native/source_zendesk_support_native/resources.py
+++ b/source-zendesk-support-native/source_zendesk_support_native/resources.py
@@ -70,6 +70,7 @@ from .api import (
     snapshot_cursor_paginated_resources,
     url_base,
     _dt_to_s,
+    INCREMENTAL_LAG,
     TIME_PARAMETER_DELAY,
 )
 
@@ -203,7 +204,7 @@ def audit_logs(
             )
         )
 
-    cutoff = datetime.now(tz=UTC)
+    cutoff = datetime.now(tz=UTC) - INCREMENTAL_LAG
 
     return common.Resource(
         name="audit_logs",
@@ -529,7 +530,7 @@ def satisfaction_ratings(
             )
         )
 
-    cutoff = datetime.now(tz=UTC) - TIME_PARAMETER_DELAY
+    cutoff = datetime.now(tz=UTC) - max(INCREMENTAL_LAG, TIME_PARAMETER_DELAY)
 
     return common.Resource(
         name="satisfaction_ratings",
@@ -588,7 +589,7 @@ def incremental_cursor_paginated_resources(
             )
         )
 
-    cutoff = datetime.now(tz=UTC)
+    cutoff = datetime.now(tz=UTC) - max(INCREMENTAL_LAG, TIME_PARAMETER_DELAY)
 
     resources = [
             common.Resource(
@@ -649,7 +650,7 @@ def incremental_time_export_resources(
             )
         )
 
-    cutoff = datetime.now(tz=UTC) - TIME_PARAMETER_DELAY
+    cutoff = datetime.now(tz=UTC) - max(INCREMENTAL_LAG, TIME_PARAMETER_DELAY)
 
     resources = [
             common.Resource(
@@ -710,7 +711,7 @@ def talk_incremental_export_resources(
             )
         )
 
-    cutoff = datetime.now(tz=UTC) - TIME_PARAMETER_DELAY
+    cutoff = datetime.now(tz=UTC) - max(INCREMENTAL_LAG, TIME_PARAMETER_DELAY)
 
     resources = [
             common.Resource(


### PR DESCRIPTION
**Description:**

We've observed the Zendesk's API exhibit eventually consistent behavior: a record can become queryable seconds or minutes after its own timestamp, and after we've already seen records with later timestamps. Since incremental cursors are high-water marks, anything surfacing below one was filtered out and lost for good.

Incremental streams now ignore records younger than `INCREMENTAL_LAG`, and the backfill/incremental cutoffs are held back the same amount so a new binding's backfill doesn't drain into the same unsettled window.

**Notes for reviewers:**

I didn't implement eventual consistency handling for our streams based off of Zendesk's cursor-based incremental export endpoints (AKA our `users`, `tickets`, etc. streams). These are more difficult to implement a lag for - the cursor we persist is the next page cursor from the API response, not a timestamp derived from individual records, so we can't incrementally process a response's results any longer if we have to hold back emitting and checkpointing them until we know they're all below the eventual consistency horizon. Zendesk explicitly states these incremental cursor export endpoints are for capturing new changes, so optimistically I'm hoping they aren't as susceptible to eventually consistent behavior. Plus we haven't seen these endpoints exhibit eventually consistent behavior yet, so I'm opting to not add eventual consistency handling for those streams yet due to the performance & complexity costs it would entail.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
