### PR TITLE
materialize-iceberg: add spark job property overrides

### DIFF
--- a/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-iceberg/apache-iceberg.md
@@ -647,9 +647,10 @@ See below for a full list of configuration options.
 | **`/compute/credentials`**           | EMR Authentication     | Authentication method for EMR.                                                                                       | [EMR Credentials](#emr-credentials) | Required     |
 |   `/compute/bucket_path`             | Bucket Path            | Optional prefix used to store staged data files.                                                                     | string           |                                 |
 |   `/compute/systems_manager_prefix`  | System Manager Prefix  | Prefix for parameters in Systems Manager as an absolute directory path (must start and end with `/`).                | string           | `/estuary/`                     |
+|   `/compute/spark_job_properties`    | Spark Job Properties   | Override Spark Job Properties.  Reference the default [Spark Job Properties][spark-job-properties].                  | array            |                                 |
 |   `/advanced/table_identifier_case`  | Table Identifier Case  | Casing for namespace and table names: 'lowercase' (default), 'uppercase', or 'preserve'.                             | string           |                                 |
 |   `/advanced/field_name_case`        | Field Name Case        | Casing for column names: 'preserve' (default), 'lowercase', or 'uppercase'.                                          | string           |                                 |
-|   `/glue_optimizers`                 | Glue Table Optimizers  | Configure AWS Glue managed table optimizers for compaction. See [configuration details](#glue-table-optimizers).    | object           |                                 |
+|   `/glue_optimizers`                 | Glue Table Optimizers  | Configure AWS Glue managed table optimizers for compaction. See [configuration details](#glue-table-optimizers).     | object           |                                 |
 
 #### Credentials
 
@@ -776,3 +777,5 @@ to enable automatic maintenance on your tables, including data file compaction, 
 If you do not use Glue for your catalog or otherwise do not configure automatic optimization through the connector,
 you should conduct [regular maintenance](https://iceberg.apache.org/docs/latest/maintenance/)
 for your materialized tables to ensure optimal query performance.
+
+[spark-job-properties]: https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/jobs-spark.html#spark-defaults

--- a/materialize-iceberg/.snapshots/TestSpec
+++ b/materialize-iceberg/.snapshots/TestSpec
@@ -260,6 +260,42 @@
                   "propertyName": "auth_type"
                 },
                 "order": 9
+              },
+              "spark_job_properties": {
+                "items": {
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "enum": [
+                        "spark.dynamicAllocation.initialExecutors",
+                        "spark.dynamicAllocation.maxExecutors",
+                        "spark.executor.instances"
+                      ],
+                      "title": "Key",
+                      "description": "Spark Job Property Key.",
+                      "nonsensitive": true,
+                      "order": 1
+                    },
+                    "value": {
+                      "type": "string",
+                      "pattern": "^[0-9A-Za-z]+$",
+                      "title": "Value",
+                      "description": "Spark Job Property Value.",
+                      "nonsensitive": true,
+                      "order": 2
+                    }
+                  },
+                  "type": "object",
+                  "required": [
+                    "key",
+                    "value"
+                  ]
+                },
+                "type": "array",
+                "title": "Spark Job Properties",
+                "description": "Override Spark Job Properties",
+                "nonsensitive": true,
+                "order": 10
               }
             },
             "type": "object",

--- a/materialize-iceberg/CHANGELOG.md
+++ b/materialize-iceberg/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-09-09
+
+### Added
+- Add support for overriding Spark executor defaults for jobs started by
+  EMR.
+
 ## 2026-09-03
 
 ### Changed

--- a/materialize-iceberg/config.go
+++ b/materialize-iceberg/config.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,6 +24,7 @@ import (
 	"github.com/estuary/connectors/materialize-iceberg/catalog"
 	"github.com/invopop/jsonschema"
 	"github.com/segmentio/encoding/json"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 var featureFlagDefaults = map[string]bool{
@@ -32,6 +35,16 @@ var featureFlagDefaults = map[string]bool{
 	//   <base_location>/<namespace>/<table>.<hash>
 	"nested_dot_hash_location_style": false,
 }
+
+var (
+	sparkJobPropertyRegex = regexp.MustCompile(`^[0-9A-Za-z]+$`)
+
+	validSparkJobPropertyKeys = []string{
+		"spark.dynamicAllocation.initialExecutors",
+		"spark.dynamicAllocation.maxExecutors",
+		"spark.executor.instances",
+	}
+)
 
 // TODO(whb): It would be nice to have a configuration for making the table use
 // "Merge on Read" when performing DML, but that is broken in the latest version
@@ -528,16 +541,64 @@ func (emrCredentials) JSONSchema() *jsonschema.Schema {
 	)
 }
 
+type sparkJobProperty struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (sparkJobProperty) JSONSchema() *jsonschema.Schema {
+	properties := make([]any, 0, len(validSparkJobPropertyKeys))
+	for _, key := range validSparkJobPropertyKeys {
+		properties = append(properties, key)
+	}
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData[string, *jsonschema.Schema](
+			orderedmap.Pair[string, *jsonschema.Schema]{
+				Key: "key",
+				Value: &jsonschema.Schema{
+					Type:        "string",
+					Title:       "Key",
+					Description: "Spark Job Property Key.",
+					Enum:        properties,
+					Extras: map[string]any{
+						"order":        1,
+						"nonsensitive": true,
+					},
+				},
+			},
+			orderedmap.Pair[string, *jsonschema.Schema]{
+				Key: "value",
+				Value: &jsonschema.Schema{
+					Type:        "string",
+					Title:       "Value",
+					Description: "Spark Job Property Value.",
+					Pattern:     "^[0-9A-Za-z]+$",
+					Extras: map[string]any{
+						"order":        2,
+						"nonsensitive": true,
+					},
+				},
+			},
+		)),
+		Required: []string{
+			"key",
+			"value",
+		},
+	}
+}
+
 type emrConfig struct {
-	AWSAccessKeyID       string          `json:"aws_access_key_id" jsonschema:"-"`
-	AWSSecretAccessKey   string          `json:"aws_secret_access_key" jsonschema:"-" jsonschema_extras:"secret=true"`
-	Region               string          `json:"region" jsonschema:"title=Region,description=Region of the EMR application and staging bucket." jsonschema_extras:"order=3"`
-	ApplicationId        string          `json:"application_id" jsonschema:"title=Application ID,description=ID of the EMR serverless application." jsonschema_extras:"order=4"`
-	ExecutionRoleArn     string          `json:"execution_role_arn" jsonschema:"title=Execution Role ARN,description=ARN of the EMR serverless execution role used to run jobs." jsonschema_extras:"order=5"`
-	Bucket               string          `json:"bucket" jsonschema:"title=Bucket,description=Bucket to store staged data files." jsonschema_extras:"order=6"`
-	BucketPath           string          `json:"bucket_path,omitempty" jsonschema:"title=Bucket Path,description=Optional prefix that will be used to store staged data files." jsonschema_extras:"order=7"`
-	SystemsManagerPrefix string          `json:"systems_manager_prefix,omitempty" jsonschema:"title=System Manager Prefix,description=Prefix for parameters in Systems Manager as an absolute directory path (must start and end with /). This is required when using Client Credentials for catalog authentication." jsonschema_extras:"pattern=^/.+/$,order=8"`
-	Credentials          *emrCredentials `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=9"`
+	AWSAccessKeyID       string             `json:"aws_access_key_id" jsonschema:"-"`
+	AWSSecretAccessKey   string             `json:"aws_secret_access_key" jsonschema:"-" jsonschema_extras:"secret=true"`
+	Region               string             `json:"region" jsonschema:"title=Region,description=Region of the EMR application and staging bucket." jsonschema_extras:"order=3"`
+	ApplicationId        string             `json:"application_id" jsonschema:"title=Application ID,description=ID of the EMR serverless application." jsonschema_extras:"order=4"`
+	ExecutionRoleArn     string             `json:"execution_role_arn" jsonschema:"title=Execution Role ARN,description=ARN of the EMR serverless execution role used to run jobs." jsonschema_extras:"order=5"`
+	Bucket               string             `json:"bucket" jsonschema:"title=Bucket,description=Bucket to store staged data files." jsonschema_extras:"order=6"`
+	BucketPath           string             `json:"bucket_path,omitempty" jsonschema:"title=Bucket Path,description=Optional prefix that will be used to store staged data files." jsonschema_extras:"order=7"`
+	SystemsManagerPrefix string             `json:"systems_manager_prefix,omitempty" jsonschema:"title=System Manager Prefix,description=Prefix for parameters in Systems Manager as an absolute directory path (must start and end with /). This is required when using Client Credentials for catalog authentication." jsonschema_extras:"pattern=^/.+/$,order=8"`
+	Credentials          *emrCredentials    `json:"credentials" jsonschema:"title=Authentication" jsonschema_extras:"order=9"`
+	SparkJobProperties   []sparkJobProperty `json:"spark_job_properties,omitempty" jsonschema:"title=Spark Job Properties,description=Override Spark Job Properties" jsonschema_extras:"order=10,nonsensitive=true"`
 }
 
 func (c emrConfig) Validate() error {
@@ -573,6 +634,15 @@ func (c emrConfig) Validate() error {
 	if c.SystemsManagerPrefix != "" {
 		if !strings.HasPrefix(c.SystemsManagerPrefix, "/") || !strings.HasSuffix(c.SystemsManagerPrefix, "/") {
 			return fmt.Errorf("systems manager prefix %q must start and end with /", c.SystemsManagerPrefix)
+		}
+	}
+
+	for _, property := range c.SparkJobProperties {
+		if !slices.Contains(validSparkJobPropertyKeys, property.Key) {
+			return fmt.Errorf("spark job property key %q is not supported", property.Key)
+		}
+		if !sparkJobPropertyRegex.MatchString(property.Value) {
+			return fmt.Errorf("spark job property value %q is invalid", property.Value)
 		}
 	}
 

--- a/materialize-iceberg/driver.go
+++ b/materialize-iceberg/driver.go
@@ -66,7 +66,8 @@ type computeJob struct {
 	// This is a resource saving device, it cannot be relied on for
 	// correctness.  The token has a limited lifetime, and after it expires a
 	// new job would be created even with the same token.
-	IdempotencyToken string
+	IdempotencyToken   string
+	SparkJobProperties []sparkJobProperty
 }
 
 // computeRunner abstracts the execution backend that runs the materialization's

--- a/materialize-iceberg/emr.go
+++ b/materialize-iceberg/emr.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -184,13 +185,22 @@ func (e *emrClient) runJob(ctx context.Context, job computeJob) error {
 		clientToken = uuid.NewString()
 	}
 
+	sparkParameters := []string{
+		"--py-files", job.PyFilesCommonURI,
+		"--conf", "spark.driver.maxResultSize=0",
+		"--conf", "spark.sql.iceberg.vectorization.enabled=false",
+	}
+	for _, property := range job.SparkJobProperties {
+		sparkParameters = append(sparkParameters, "--conf", fmt.Sprintf("%s=%s", property.Key, property.Value))
+	}
+
 	startInput := &emr.StartJobRunInput{
 		ApplicationId:    aws.String(e.cfg.ApplicationId),
 		ClientToken:      aws.String(clientToken),
 		ExecutionRoleArn: aws.String(e.cfg.ExecutionRoleArn),
 		JobDriver: &emrTypes.JobDriverMemberSparkSubmit{
 			Value: emrTypes.SparkSubmit{
-				SparkSubmitParameters: aws.String(fmt.Sprintf("--py-files %s --conf spark.driver.maxResultSize=0 --conf spark.sql.iceberg.vectorization.enabled=false", job.PyFilesCommonURI)),
+				SparkSubmitParameters: aws.String(strings.Join(sparkParameters, " ")),
 				EntryPoint:            aws.String(job.EntryPointURI),
 				EntryPointArguments:   args,
 			},

--- a/materialize-iceberg/transactor.go
+++ b/materialize-iceberg/transactor.go
@@ -153,11 +153,12 @@ func (t *transactor) Load(it *m.LoadIterator, loaded func(binding int, doc json.
 
 	t.be.StartedEvaluatingLoads()
 	if err := t.compute.runJob(ctx, computeJob{
-		Input:            loadInput,
-		EntryPointURI:    t.pyFiles.load,
-		PyFilesCommonURI: t.pyFiles.common,
-		Name:             fmt.Sprintf("load for: %s", t.materializationName),
-		WorkingPrefix:    outputPrefix,
+		Input:              loadInput,
+		EntryPointURI:      t.pyFiles.load,
+		PyFilesCommonURI:   t.pyFiles.common,
+		Name:               fmt.Sprintf("load for: %s", t.materializationName),
+		WorkingPrefix:      outputPrefix,
+		SparkJobProperties: t.cfg.Compute.SparkJobProperties,
 	}); err != nil {
 		return fmt.Errorf("load job failed: %w", err)
 	} else if err := t.loadFiles.CleanupCurrentTransaction(ctx); err != nil {
@@ -301,12 +302,13 @@ func (t *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 		defer cleanupStatus()
 
 		if err := t.compute.runJob(ctx, computeJob{
-			Input:            mergeInput,
-			EntryPointURI:    t.pyFiles.merge,
-			PyFilesCommonURI: t.pyFiles.common,
-			Name:             fmt.Sprintf("store for: %s", t.materializationName),
-			WorkingPrefix:    outputPrefix,
-			IdempotencyToken: token,
+			Input:              mergeInput,
+			EntryPointURI:      t.pyFiles.merge,
+			PyFilesCommonURI:   t.pyFiles.common,
+			Name:               fmt.Sprintf("store for: %s", t.materializationName),
+			WorkingPrefix:      outputPrefix,
+			IdempotencyToken:   token,
+			SparkJobProperties: t.cfg.Compute.SparkJobProperties,
 		}); err != nil {
 			return nil, fmt.Errorf("store merge job failed: %w", err)
 		} else if err := cleanupStatus(); err != nil {


### PR DESCRIPTION
**Description:**

When using a EMR App shared between multiple tasks, it can be difficult to balance EMR use between tasks.  EMR sets many Spark properties for each job that the user may need to override.

This change adds 3 Spark Job Properties:
- spark.executor.instances
- spark.dynamicAllocation.initialExecutors
- spark.dynamicAllocation.maxExecutors

These properties take effect for both the load and store jobs.

I tried to add this in a way that could allow other properties to be added later on if it ends up we need to do this.

**Workflow steps:**

Set values as needed in the EMR compute section.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
