### PR TITLE
materialize-snowflake: drop every orphaned channel from one sweep

### DIFF
--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -330,6 +330,7 @@ func newTransactor(
 		sv2.listChannels = func(ctx context.Context, database, schema, table string) ([]string, error) {
 			return streamV2ListChannels(ctx, db, ep.Dialect, database, schema, table)
 		}
+		sv2.dropStreamingChannel = sm.dropChannel
 	}
 
 	var d = &transactor{
@@ -393,11 +394,7 @@ type binding struct {
 
 	streaming   bool
 	streamingV2 bool
-	// dropStreamingChannel marks a streaming v2 binding whose snowpipe_streaming
-	// channel still has blobs to register, so the channel is dropped once
-	// Acknowledge has drained them rather than at Open.
-	dropStreamingChannel bool
-	pipeName             string
+	pipeName    string
 	// clusteringExpr is the parenthesized CLUSTER BY expression for this
 	// binding, or empty if clustering is not configured.
 	clusteringExpr string
@@ -463,19 +460,6 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table, streaming
 		var loc = d.ep.Dialect.TableLocator(b.target.Path)
 		d.snowpipeStreamingV2.addBinding(d.cfg.Database, loc.TableSchema, d.ep.Identifier(loc.TableName), target, d.priorStreamV2(target.StateKey))
 		b.streamingV2 = true
-
-		// A binding this shard has no streaming v2 items for is arriving on the
-		// path, and the snowpipe_streaming path may hold its channel. Nothing else
-		// drops that channel, so this binding does, once the blobs the channel
-		// still has to register are drained.
-		if held == nil && d.snowpipeStreaming != nil {
-			if pending := d.cp[target.StateKey]; pending != nil && len(pending.StreamBlobs) > 0 {
-				b.dropStreamingChannel = true
-			} else if err := d.snowpipeStreaming.dropChannel(ctx, loc.TableSchema, d.ep.Identifier(loc.TableName), target.Binding); err != nil {
-				return fmt.Errorf("dropping the snowpipe_streaming channel of %s: %w", target.Identifier, err)
-			}
-		}
-
 		d.bindings = append(d.bindings, b)
 		return nil
 	}
@@ -503,13 +487,9 @@ func (d *transactor) addBinding(ctx context.Context, target sql.Table, streaming
 		} else {
 			if downgrade {
 				// Drop this shard's streaming v2 channels as it leaves the path, so a
-				// return to streaming v2 cannot read their committed offset tokens as
-				// documents to skip that this path never appended — which would drop
-				// them for good. The return starts clean once the first Acknowledge on
-				// this path has deleted the binding's state key; a return before that
-				// finds counters for channels holding no token, which reconciliation
-				// rejects.
-				if err := d.snowpipeStreamingV2.dropBindingChannels(ctx, d.cfg.Database, loc.TableSchema, d.ep.Identifier(loc.TableName), prior, d._range); err != nil {
+				// return to it cannot read their committed offset tokens as documents
+				// to skip.
+				if err := d.snowpipeStreamingV2.sweep(ctx, d.cfg.Database, loc.TableSchema, d.ep.Identifier(loc.TableName), target.StateKey, nil); err != nil {
 					return fmt.Errorf("dropping the snowpipe_streaming_v2 channels of %s as it downgrades to snowpipe_streaming: %w", target.Identifier, err)
 				}
 				log.WithFields(log.Fields{
@@ -1135,17 +1115,6 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 
 	if err := group.Wait(); err != nil {
 		return nil, fmt.Errorf("executing concurrent store query: %w", err)
-	}
-
-	for _, b := range d.bindings {
-		if !b.dropStreamingChannel || !slices.Contains(drained, b.target.StateKey) {
-			continue
-		}
-		var loc = d.ep.Dialect.TableLocator(b.target.Path)
-		if err := d.snowpipeStreaming.dropChannel(ctx, loc.TableSchema, d.ep.Identifier(loc.TableName), b.target.Binding); err != nil {
-			return nil, fmt.Errorf("dropping the snowpipe_streaming channel of %s after draining its blobs: %w", b.target.Identifier, err)
-		}
-		b.dropStreamingChannel = false
 	}
 
 	// Keep asking for a report on the files that have been submitted for processing

--- a/materialize-snowflake/stream.go
+++ b/materialize-snowflake/stream.go
@@ -119,21 +119,18 @@ func (sm *streamManager) addBinding(ctx context.Context, schema string, table st
 	return nil
 }
 
-// dropChannel drops this shard's channel on a table and forgets any stream the
-// manager held for the binding, so that no blob can be registered against a
-// channel which is gone.
-func (sm *streamManager) dropChannel(ctx context.Context, schema, table string, binding int) error {
-	if err := sm.c.dropChannel(ctx, schema, table, sm.channelName); err != nil {
+// dropChannel drops a channel of a table, unless this manager holds it open.
+// Snowflake holds channel names case-insensitively, so the match ignores case.
+func (sm *streamManager) dropChannel(ctx context.Context, schema, table, name string) error {
+	for _, ts := range sm.tableStreams {
+		if strings.EqualFold(ts.channel.Channel, name) {
+			return nil
+		}
+	}
+	if err := sm.c.dropChannel(ctx, schema, table, name); err != nil {
 		return fmt.Errorf("dropChannel: %w", err)
 	}
-	delete(sm.tableStreams, binding)
-
-	log.WithFields(log.Fields{
-		"schema":  schema,
-		"table":   table,
-		"channel": sm.channelName,
-	}).Info("dropped streaming channel")
-
+	log.WithFields(log.Fields{"schema": schema, "table": table, "channel": name}).Info("dropped streaming channel")
 	return nil
 }
 

--- a/materialize-snowflake/streamv2.go
+++ b/materialize-snowflake/streamv2.go
@@ -292,57 +292,59 @@ const streamV2DefaultPipeSuffix = "-STREAMING"
 // does not tell the two apart.
 const streamV2ErrObjectNotExistOrAuthorized = 2003
 
-// streamV2ListChannels reports, sorted by name, the channels Snowflake holds on
-// the default pipe of a table. A table that has never been streamed into has no
-// default pipe, and reports no channels rather than an error.
+// streamV2ListChannels reports, sorted, the channels on a table and on its default
+// pipe. A table nothing has streamed into has no default pipe and lists no channels
+// for it.
 //
 // database, schema, and table are the unquoted names Snowflake stores.
 func streamV2ListChannels(ctx context.Context, db *stdsql.DB, dialect sql.Dialect, database, schema, table string) ([]string, error) {
-	var pipe = dialect.Identifier(database, schema, table+streamV2DefaultPipeSuffix)
-
-	rows, err := db.QueryContext(ctx, fmt.Sprintf("SHOW CHANNELS IN PIPE %s;", pipe))
-	if err != nil {
-		// A table that has never been streamed into has no default pipe. Snowflake
-		// reports an absent pipe with the same error as one the role may not see,
-		// so the miss is logged for the case where it is a permissions mistake.
-		var sfErr *sf.SnowflakeError
-		if errors.As(err, &sfErr) && sfErr.Number == streamV2ErrObjectNotExistOrAuthorized {
-			log.WithFields(log.Fields{"pipe": pipe, "error": err.Error()}).Info("the table has no default pipe visible to this role")
-			return nil, nil
-		}
-		return nil, fmt.Errorf("listing channels of pipe %s: %w", pipe, err)
-	}
-	defer rows.Close()
-
-	// SHOW reports many columns; only "name" is read, and the rest are scanned
-	// into a sink, so the column order Snowflake chooses does not matter.
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, fmt.Errorf("reading columns of the channel listing of pipe %s: %w", pipe, err)
-	}
-	var nameAt = slices.Index(columns, "name")
-	if nameAt < 0 {
-		return nil, fmt.Errorf("the channel listing of pipe %s reports no \"name\" column", pipe)
-	}
-
 	var names []string
-	for rows.Next() {
-		var name string
-		var dest = make([]any, len(columns))
-		for i := range dest {
-			dest[i] = new(any)
+	for _, in := range []string{
+		"TABLE " + dialect.Identifier(database, schema, table),
+		"PIPE " + dialect.Identifier(database, schema, table+streamV2DefaultPipeSuffix),
+	} {
+		rows, err := db.QueryContext(ctx, fmt.Sprintf("SHOW CHANNELS IN %s;", in))
+		if err != nil {
+			// Snowflake reports an absent pipe with the same error as one the role
+			// may not see, so the miss is logged.
+			var sfErr *sf.SnowflakeError
+			if errors.As(err, &sfErr) && sfErr.Number == streamV2ErrObjectNotExistOrAuthorized {
+				log.WithFields(log.Fields{"in": in, "error": err.Error()}).Info("no channels are visible to this role")
+				continue
+			}
+			return nil, fmt.Errorf("listing channels in %s: %w", in, err)
 		}
-		dest[nameAt] = &name
-		if err := rows.Scan(dest...); err != nil {
-			return nil, fmt.Errorf("scanning the channel listing of pipe %s: %w", pipe, err)
+		defer rows.Close()
+
+		// SHOW reports many columns; only "name" is read, and the rest are scanned
+		// into a sink, so the column order Snowflake chooses does not matter.
+		columns, err := rows.Columns()
+		if err != nil {
+			return nil, fmt.Errorf("reading columns of the channel listing in %s: %w", in, err)
 		}
-		names = append(names, name)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating the channel listing of pipe %s: %w", pipe, err)
+		var nameAt = slices.Index(columns, "name")
+		if nameAt < 0 {
+			return nil, fmt.Errorf("the channel listing in %s reports no \"name\" column", in)
+		}
+
+		for rows.Next() {
+			var name string
+			var dest = make([]any, len(columns))
+			for i := range dest {
+				dest[i] = new(any)
+			}
+			dest[nameAt] = &name
+			if err := rows.Scan(dest...); err != nil {
+				return nil, fmt.Errorf("scanning the channel listing in %s: %w", in, err)
+			}
+			names = append(names, name)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterating the channel listing in %s: %w", in, err)
+		}
 	}
 	slices.Sort(names)
-	return names, nil
+	return slices.Compact(names), nil
 }
 
 // streamV2Channel is one channel of a binding: the key range of the key-hash space it
@@ -526,13 +528,12 @@ type streamV2Manager struct {
 	keyBegin        uint32
 	keyEnd          uint32
 
-	// listChannels reports the channels standing on a table's default pipe. The
-	// transactor supplies it over its own connection. It is what reveals another
-	// task's channels on a table this one is about to stream into, and what the sweep
-	// reads to drop the channels a layout has left behind. It is nil when no
-	// connection backs the manager, and the manager then reasons from the checkpoint
-	// alone.
+	// listChannels reports the channels on a table and its default pipe. It is nil
+	// when no connection backs the manager.
 	listChannels func(ctx context.Context, database, schema, table string) ([]string, error)
+	// dropStreamingChannel drops a snowpipe_streaming channel. It is nil when that
+	// path is unavailable.
+	dropStreamingChannel func(ctx context.Context, schema, table, name string) error
 
 	// procCtx bounds the lifetime of the sidecar process to the transactor session.
 	procCtx    context.Context
@@ -643,23 +644,17 @@ func (m *streamV2Manager) ensureOpened(ctx context.Context, b *streamV2Binding) 
 		return nil
 	}
 
-	// The channels standing on the table's pipe, read once and before this shard opens
-	// any channel of its own: a table another task already streams into is rejected
-	// here, before this shard has created anything the other task could see, and the
-	// same listing is what the sweep at the end reads. A name of the v2 shape derived
-	// for another task is that task's; a name of no v2 shape is some other
-	// high-performance client's, which the connector cannot attribute and leaves alone.
-	var standing []string
+	// A table another task streams into is rejected before this shard creates any
+	// channel of its own. A name of no v2 shape is another client's and is left alone.
 	if m.listChannels != nil {
 		names, err := m.listChannels(ctx, b.database, b.schema, unquotedIdentifier(b.table))
 		if err != nil {
 			return err
 		}
-		standing = names
 
 		var own = sanitizeAndAppendHash(m.materialization)
 		var foreign = make(map[string][]string)
-		for _, name := range standing {
+		for _, name := range names {
 			var task, ok = streamV2ChannelTask(name)
 			if !ok {
 				log.WithFields(log.Fields{"table": b.table, "channel": name}).Info("a channel of no snowpipe streaming v2 shape stands on the table's pipe")
@@ -966,31 +961,12 @@ func (m *streamV2Manager) ensureOpened(ctx context.Context, b *streamV2Binding) 
 		"abandoned":  b.abandoned,
 	}).Info("opened snowpipe streaming v2 channels")
 
-	// Drop the channels this layout stands past — the ones just abandoned, and any a
-	// prior session or another write path left on the pipe — before the first append.
-	return m.sweep(ctx, b, standing)
+	// Drop the channels this layout leaves behind before the first append.
+	return m.sweep(ctx, b.database, b.schema, b.table, b.stateKey, m.layoutNames(b))
 }
 
-// sweep drops the channels standing on the binding's pipe that its current layout has
-// left behind: the ones nested in this shard's range, derived for this binding, that
-// neither the active layout nor the declared target layout names. A fresh epoch keeps
-// an abandoned channel's name out of every live layout, so the drop only reclaims the
-// pipe's channel budget and races no shard that still routes to one. It reads the
-// channel listing the caller passes, which is empty when no connection backs the
-// manager, and then does nothing.
-//
-// A channel whose range this shard does not wholly contain is a sibling's or a
-// parent's, never this shard's to drop, so it is left alone.
-//
-// It also drops the channels this task derived for the binding under a state key a
-// backfill has since rotated away, because a backfill truncates the table and so
-// leaves them standing. No shard routes to one of those, whatever its range, so the
-// shard whose range holds the channel's first key drops it, and exactly one does.
-func (m *streamV2Manager) sweep(ctx context.Context, b *streamV2Binding, names []string) error {
-	if len(names) == 0 {
-		return nil
-	}
-
+// layoutNames is the set of channel names the binding's active and target layouts hold.
+func (m *streamV2Manager) layoutNames(b *streamV2Binding) map[string]bool {
 	var keep = make(map[string]bool, len(b.channels)+len(b.targets))
 	for _, c := range b.channels {
 		keep[c.name] = true
@@ -998,26 +974,54 @@ func (m *streamV2Manager) sweep(ctx context.Context, b *streamV2Binding, names [
 	for _, r := range b.targets {
 		keep[streamV2ChannelName(m.materialization, b.targetEpoch, r, b.stateKey)] = true
 	}
+	return keep
+}
 
-	var shard = m.shardRange()
-	client, err := m.ensureStarted(ctx)
+// sweep drops the channels this task derived for the binding that it no longer uses:
+// the snowpipe_streaming_v2 channels of stateKey not in keep, those of a state key a
+// backfill rotated away, and the snowpipe_streaming channel of this shard. Only
+// channels within this shard's range are its to drop. Without a listing it does
+// nothing.
+func (m *streamV2Manager) sweep(ctx context.Context, database, schema, table, stateKey string, keep map[string]bool) error {
+	if m.listChannels == nil {
+		return nil
+	}
+	names, err := m.listChannels(ctx, database, schema, unquotedIdentifier(table))
 	if err != nil {
 		return err
 	}
+
+	var shard = m.shardRange()
+	var client *sidecarClient
 	for _, name := range names {
 		if keep[name] {
 			continue
 		}
-		if _, r, ok := streamV2ParseChannel(name, m.materialization, b.stateKey); ok {
+		if keyBegin, ok := streamingChannelKeyBegin(name, m.materialization); ok {
+			if keyBegin < shard.keyBegin || keyBegin > shard.keyEnd || m.dropStreamingChannel == nil {
+				continue
+			}
+			if err := m.dropStreamingChannel(ctx, schema, table, name); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, r, ok := streamV2ParseChannel(name, m.materialization, stateKey); ok {
 			if r.keyBegin < shard.keyBegin || r.keyEnd > shard.keyEnd {
 				continue
 			}
-		} else if r, ok := streamV2ParseBackfilledChannel(name, m.materialization, b.stateKey); ok {
+		} else if r, ok := streamV2ParseBackfilledChannel(name, m.materialization, stateKey); ok {
 			if r.keyBegin < shard.keyBegin || r.keyBegin > shard.keyEnd {
 				continue
 			}
 		} else {
 			continue
+		}
+
+		if client == nil {
+			if client, err = m.ensureStarted(ctx); err != nil {
+				return err
+			}
 		}
 
 		// The drop needs an open handle. A channel this session opened — one a
@@ -1026,7 +1030,7 @@ func (m *streamV2Manager) sweep(ctx context.Context, b *streamV2Binding, names [
 		// prior session's orphan, is opened only when the drop reports none.
 		var err = dropChannel(ctx, client, name)
 		if unknownChannel(err) {
-			if _, err = client.OpenChannel(ctx, b.database, b.schema, b.table, name); err != nil {
+			if _, err = client.OpenChannel(ctx, database, schema, table, name); err != nil {
 				return fmt.Errorf("opening channel %q to drop it: %w", name, err)
 			}
 			err = dropChannel(ctx, client, name)
@@ -1034,34 +1038,23 @@ func (m *streamV2Manager) sweep(ctx context.Context, b *streamV2Binding, names [
 		if err != nil {
 			return err
 		}
-		log.WithFields(log.Fields{"table": b.table, "channel": name}).Info("swept a snowpipe streaming v2 channel a layout left behind")
+		log.WithFields(log.Fields{"table": table, "channel": name}).Info("swept a snowpipe streaming v2 channel a layout left behind")
 	}
 	return nil
 }
 
-// dropBindingChannels drops the streaming v2 channels this shard holds for a binding
-// that is leaving the write path, so a later return to it starts from channels with
-// no committed offset token to misread as documents to skip. It opens each channel to
-// obtain the handle the drop needs; a channel Snowflake no longer holds is re-created
-// empty by the open and then dropped, so a repeated call is idempotent. Only channels
-// nested in this shard's range are its to drop; the rest are a sibling's.
-func (m *streamV2Manager) dropBindingChannels(ctx context.Context, database, schema, table string, prior map[string]*streamV2Item, shard *pf.RangeSpec) error {
-	client, err := m.ensureStarted(ctx)
+// streamingChannelKeyBegin reads the key-begin of a snowpipe_streaming channel this
+// task derived. Snowflake lists those names upper-cased, so the match ignores case.
+func streamingChannelKeyBegin(name, materialization string) (uint32, bool) {
+	var prefix = sanitizeAndAppendHash(materialization) + "_"
+	if len(name) != len(prefix)+8 || !strings.EqualFold(name[:len(prefix)], prefix) {
+		return 0, false
+	}
+	keyBegin, err := strconv.ParseUint(name[len(prefix):], 16, 32)
 	if err != nil {
-		return err
+		return 0, false
 	}
-	for _, item := range prior {
-		if item == nil || item.KeyBegin < shard.KeyBegin || item.KeyEnd > shard.KeyEnd {
-			continue
-		}
-		if _, err := client.OpenChannel(ctx, database, schema, table, item.Channel); err != nil {
-			return fmt.Errorf("opening channel %q to drop it: %w", item.Channel, err)
-		}
-		if err := dropChannel(ctx, client, item.Channel); err != nil {
-			return err
-		}
-	}
-	return nil
+	return uint32(keyBegin), true
 }
 
 // rejectedRowsError rejects a channel when Snowflake rejected any row on it. It
@@ -1224,7 +1217,7 @@ func streamV2ChannelNames(items map[string]*streamV2Item) []string {
 // streamV2PathOrphaned rejects a binding that materialized through this write path
 // and no longer does, unless the departure is the one exit this connector supports:
 // the escape-hatch downgrade to the snowpipe_streaming path, which streamV2Downgrade
-// recognizes and streamV2ChannelDrop carries out. The error names the channels that
+// recognizes and sweep carries out. The error names the channels that
 // the binding otherwise leaves behind.
 //
 // The prior parameter holds the checkpoint items of the binding, one for each channel
@@ -1639,15 +1632,8 @@ func (m *streamV2Manager) acknowledged(ctx context.Context) error {
 		}).Info("snowpipe streaming v2: converged the channel layout to the target layout")
 
 		// The inherited channels are out of the layout now; drop them from the pipe.
-		// The listing is fresh, since the layout changed since the binding opened.
-		if m.listChannels != nil {
-			names, err := m.listChannels(ctx, b.database, b.schema, unquotedIdentifier(b.table))
-			if err != nil {
-				return err
-			}
-			if err := m.sweep(ctx, b, names); err != nil {
-				return err
-			}
+		if err := m.sweep(ctx, b.database, b.schema, b.table, b.stateKey, m.layoutNames(b)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/materialize-snowflake/streamv2_switch_test.go
+++ b/materialize-snowflake/streamv2_switch_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -260,8 +261,8 @@ func TestStreamV2SwitchOffTheWritePathIsRejected(t *testing.T) {
 			d.cfg.Advanced.FeatureFlags = "snowpipe_streaming"
 			d.snowpipeStreaming = openChannelServer(t, 0)
 
-			// The binding leaves for the snowpipe_streaming path; its streaming v2
-			// channels are left standing for a later return to sweep.
+			// The binding leaves for the snowpipe_streaming path. With no listing
+			// here, the sweep drops nothing.
 			require.NoError(t, d.addBinding(ctx, target(stateKey, true), true, false))
 			require.True(t, d.bindings[len(d.bindings)-1].streaming)
 		})
@@ -537,10 +538,10 @@ func TestStreamV2WritePathSwitch(t *testing.T) {
 		// with nothing under that name, so a later open starts from no token.
 		sm, err := newStreamManager(&cfg, testMaterialization, accountName, 0)
 		require.NoError(t, err)
-		require.NoError(t, sm.dropChannel(ctx, cfg.Schema, tableName, 0))
+		require.NoError(t, sm.dropChannel(ctx, cfg.Schema, tableName, sm.channelName))
 
 		// Dropping what is already gone is not an error.
-		require.NoError(t, sm.dropChannel(ctx, cfg.Schema, tableName, 0))
+		require.NoError(t, sm.dropChannel(ctx, cfg.Schema, tableName, sm.channelName))
 
 		reopened, err := sm.c.openChannel(ctx, cfg.Schema, tableName, sm.channelName)
 		require.NoError(t, err)
@@ -715,127 +716,56 @@ func TestStreamV2SwitchOntoTheWritePathWithPendingWorkIsRejected(t *testing.T) {
 	})
 }
 
-// TestStreamV2SwitchOntoTheWritePathDropsTheStreamingChannel covers what a binding
-// arriving on streaming v2 does with the channel the snowpipe_streaming path holds
-// for it: one deterministic channel per shard, which nothing else would ever drop.
-func TestStreamV2SwitchOntoTheWritePathDropsTheStreamingChannel(t *testing.T) {
+// TestStreamV2SweepDropsTheStreamingChannel covers the sweep of the snowpipe_streaming
+// channel on a table whose binding moved to streaming v2: it stands while that path
+// holds it open, and is dropped once it does not.
+func TestStreamV2SweepDropsTheStreamingChannel(t *testing.T) {
 	var ctx = context.Background()
 
-	var target = func(stateKey string) sql.Table {
-		return sql.Table{
-			TableShape: sql.TableShape{Binding: 0, DeltaUpdates: true, Path: []string{"SCH", "TBL"}},
-			Identifier: "TBL",
-			Keys:       []sql.Column{{Identifier: `KEY`}},
-			Values:     []sql.Column{{Identifier: `VAL`}},
-			StateKey:   stateKey,
+	var drops []string
+	var mux = http.NewServeMux()
+	mux.HandleFunc("POST /v1/streaming/channels/drop", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Channel string `json:"channel"`
 		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		drops = append(drops, req.Channel)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"Success","status_code":0}`)
+	})
+	var ts = httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	pkey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+	var sm = &streamManager{
+		c: &streamClient{
+			r:        resty.New().SetBaseURL(ts.URL + "/v1/streaming").SetDisableWarn(true),
+			key:      pkey,
+			user:     "TEST_USER",
+			database: "DB",
+			account:  "TEST_ACCOUNT",
+		},
+		tableStreams: map[int]*tableStream{},
+		channelName:  channelName("test/onto", 0),
 	}
 
-	type dropRequest struct {
-		Schema  string `json:"schema"`
-		Table   string `json:"table"`
-		Channel string `json:"channel"`
+	// The lower shard of two. Snowflake lists the names upper-cased. Only the first
+	// channel is this shard's to drop.
+	var m = newStreamV2Manager(ctx, &config{Credentials: &snowflake_auth.CredentialConfig{}}, "test/onto", "acct",
+		&pf.RangeSpec{KeyEnd: 0x7fffffff, RClockEnd: math.MaxUint32})
+	m.dropStreamingChannel = sm.dropChannel
+	var listed = strings.ToUpper(sm.channelName)
+	m.listChannels = func(context.Context, string, string, string) ([]string, error) {
+		return []string{listed, strings.ToUpper(channelName("test/onto", 0x80000000)), strings.ToUpper(channelName("other/task", 0))}, nil
 	}
 
-	// newTransactor serves the snowpipe_streaming REST API from a fake which
-	// records every channel drop and answers everything else with a bare success.
-	var newTransactor = func(t *testing.T, item *checkpointItem) (*transactor, *[]dropRequest) {
-		t.Helper()
-		var drops []dropRequest
-		var mux = http.NewServeMux()
-		mux.HandleFunc("POST /v1/streaming/channels/drop", func(w http.ResponseWriter, r *http.Request) {
-			var req dropRequest
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			drops = append(drops, req)
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"message":"Success","status_code":0}`)
-		})
-		mux.HandleFunc("POST /v1/streaming/channels/open", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"message":"Success","status_code":0,"table_columns":[]}`)
-		})
-		var ts = httptest.NewServer(mux)
-		t.Cleanup(ts.Close)
+	// Held open, to register blobs through: it stands.
+	sm.tableStreams[0] = &tableStream{channel: &channel{Channel: sm.channelName}}
+	require.NoError(t, m.sweep(ctx, "DB", "SCH", "TBL", "sk.v1", nil))
+	require.Empty(t, drops)
 
-		pkey, err := rsa.GenerateKey(rand.Reader, 1024)
-		require.NoError(t, err)
-		var role = "TEST_ROLE"
-
-		var cfg = config{
-			Database:    "DB",
-			Schema:      "SCH",
-			Credentials: &snowflake_auth.CredentialConfig{AuthType: snowflake_auth.JWT},
-		}
-		var rng = &pf.RangeSpec{KeyEnd: math.MaxUint32, RClockEnd: math.MaxUint32}
-		var d = &transactor{
-			cfg:    cfg,
-			ep:     &sql.Endpoint[config]{Dialect: snowflakeDialect("SCH", timestampTypeLTZ, nil)},
-			_range: rng,
-			cp:     checkpoint{},
-			snowpipeStreaming: &streamManager{
-				c: &streamClient{
-					r:        resty.New().SetBaseURL(ts.URL + "/v1/streaming").SetDisableWarn(true),
-					key:      pkey,
-					user:     "TEST_USER",
-					database: "DB",
-					account:  "TEST_ACCOUNT",
-					role:     &role,
-				},
-				tableStreams: map[int]*tableStream{},
-				channelName:  channelName("test/onto", 0),
-				lastBinding:  -1,
-				blobStats:    map[int][]*blobStatsTracker{},
-				counter:      -1,
-			},
-			snowpipeStreamingV2: newStreamV2Manager(ctx, &cfg, "test/onto", "acct", rng),
-		}
-		if item != nil {
-			d.cp["sk.v1"] = item
-		}
-		t.Cleanup(d.snowpipeStreamingV2.stop)
-		return d, &drops
-	}
-
-	t.Run("a binding arriving on this write path drops the channel at Open", func(t *testing.T) {
-		var d, drops = newTransactor(t, nil)
-		require.NoError(t, d.addBinding(ctx, target("sk.v1"), true, true))
-		require.Equal(t, []dropRequest{{Schema: "SCH", Table: "TBL", Channel: channelName("test/onto", 0)}}, *drops)
-		require.False(t, d.bindings[0].dropStreamingChannel)
-	})
-
-	t.Run("a binding with blobs still to drain drops the channel after the drain instead", func(t *testing.T) {
-		var d, drops = newTransactor(t, &checkpointItem{
-			Table:       "TBL",
-			StreamBlobs: []*blobMetadata{{Path: "one.bdec"}},
-		})
-		require.NoError(t, d.addBinding(ctx, target("sk.v1"), true, true))
-		require.Empty(t, *drops)
-		require.True(t, d.bindings[0].dropStreamingChannel)
-	})
-
-	t.Run("a binding already on this write path leaves the channel alone", func(t *testing.T) {
-		var d, drops = newTransactor(t, &checkpointItem{StreamV2: map[string]*streamV2Item{
-			"00000000-ffffffff": {Channel: "task_00000000_sk_v1", Counter: 7, KeyEnd: math.MaxUint32},
-		}})
-		require.NoError(t, d.addBinding(ctx, target("sk.v1"), true, true))
-		require.Empty(t, *drops)
-		require.False(t, d.bindings[0].dropStreamingChannel)
-	})
-
-	t.Run("a channel Snowflake no longer holds counts as dropped", func(t *testing.T) {
-		var d, drops = newTransactor(t, nil)
-		d.snowpipeStreaming.c.r.SetBaseURL(func() string {
-			var mux = http.NewServeMux()
-			mux.HandleFunc("POST /v1/streaming/channels/drop", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				fmt.Fprint(w, `{"message":"The requested channel no longer exists.","status_code":19}`)
-			})
-			var ts = httptest.NewServer(mux)
-			t.Cleanup(ts.Close)
-			return ts.URL + "/v1/streaming"
-		}())
-		require.NoError(t, d.addBinding(ctx, target("sk.v1"), true, true))
-		require.Empty(t, *drops)
-	})
+	// Let go of: it is dropped, and nothing else is.
+	delete(sm.tableStreams, 0)
+	require.NoError(t, m.sweep(ctx, "DB", "SCH", "TBL", "sk.v1", nil))
+	require.Equal(t, []string{listed}, drops)
 }

--- a/materialize-snowflake/streamv2_test.go
+++ b/materialize-snowflake/streamv2_test.go
@@ -1257,4 +1257,24 @@ func TestStreamV2ListChannels(t *testing.T) {
 	}, 3*time.Minute, 5*time.Second)
 	require.NoError(t, err)
 	require.Contains(t, names, opened)
+
+	// The table's snowpipe_streaming channel is listed too, upper-cased as Snowflake
+	// holds it, and the drop accepts the listed name.
+	sm, err := newStreamManager(&cfg, "test/streamV2List", accountName, 0)
+	require.NoError(t, err)
+	_, err = sm.c.openChannel(ctx, cfg.Schema, tableName, sm.channelName)
+	require.NoError(t, err)
+	names, err = streamV2ListChannels(ctx, db, testDialect, cfg.Database, cfg.Schema, tableName)
+	require.NoError(t, err)
+	require.Contains(t, names, opened)
+	var listed = slices.IndexFunc(names, func(n string) bool { return strings.EqualFold(n, sm.channelName) })
+	require.GreaterOrEqual(t, listed, 0, "%v does not list %s", names, sm.channelName)
+	keyBegin, ok := streamingChannelKeyBegin(names[listed], "test/streamV2List")
+	require.True(t, ok)
+	require.Zero(t, keyBegin)
+
+	require.NoError(t, sm.dropChannel(ctx, cfg.Schema, tableName, names[listed]))
+	names, err = streamV2ListChannels(ctx, db, testDialect, cfg.Database, cfg.Schema, tableName)
+	require.NoError(t, err)
+	require.Equal(t, []string{opened}, names)
 }


### PR DESCRIPTION
Proposal on top of #5160: every channel a binding leaves behind is dropped by a single function, `streamV2Manager.sweep`.

## What it does

`sweep` lists the channels standing on the table and its default pipe, and drops every one this task derived, within this shard's range, that the binding no longer uses:

- a `snowpipe_streaming_v2` channel of the binding's state key that the live or target layout doesn't name,
- a v2 channel of a state key a backfill rotated away,
- the `snowpipe_streaming` channel of this shard, once that path has let go of it.

It runs at the moments a binding's set of channels shrinks: the end of `ensureOpened`, after the switch in `acknowledged`, and from `addBinding` with nothing to keep when a binding leaves v2 for `snowpipe_streaming`.

## How the two paths meet in one listing

`streamV2ListChannels` unions `SHOW CHANNELS IN TABLE` (the `snowpipe_streaming` channel on the table) with `SHOW CHANNELS IN PIPE` (the v2 channels on the default pipe). v2 names are dropped through the sidecar as before. A `snowpipe_streaming` name is handed to that path's manager through a hook, and the manager declines to drop a channel it still holds open — one it streams rows to, or one it is still registering blobs through. That is what keeps a channel standing while a pending drain still needs it, and what protects the classic path's own channel during a downgrade. The channel of a drained binding is dropped by the next session's sweep.

Snowflake holds `snowpipe_streaming` channel names case-insensitively and lists them upper-cased, so the name match and the held-open check are case-insensitive. The live listing test opens a classic channel, finds it in the listing, drops it by the listed name, and confirms it is gone.

## Diff shape

- `snowflake.go`: no drop logic left in `addBinding` or `Acknowledge` beyond the one downgrade call; the `dropStreamingChannel` flag on `binding` is gone.
- `stream.go`: `streamManager.dropChannel` takes a name and skips channels it holds.
- `streamv2.go`: `sweep` takes `keep`; `dropBindingChannels` removed; listing covers both paths.
- Tests: the arrival test is replaced by a sweep test against the fake REST server; the live listing test covers the classic channel.

Net −58 lines against the PR head. Short suite passes; `TestStreamV2ListChannels` and `TestStreamV2WritePathSwitch` pass against live Snowflake.
