### PR TITLE
source-hubspot-native-migrate-oauth

### DIFF
--- a/source-hubspot-native/CHANGELOG.md
+++ b/source-hubspot-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-09-10
+### Changed
+- OAuth token exchanges now use HubSpot's date-based `2026-03` OAuth API instead of the
+  deprecated v1 API, which HubSpot sunsets on February 16, 2027. Without this, OAuth
+  captures would fail at their first access token refresh after the sunset. Existing
+  captures keep working and do not need to re-authorize; refresh tokens remain valid.
+
 ## 2026-09-02
 ### Fixed
 - CRM object bindings no longer fail when the HubSpot Search API returns records out

--- a/source-hubspot-native/source_hubspot_native/models.py
+++ b/source-hubspot-native/source_hubspot_native/models.py
@@ -73,7 +73,7 @@ OAUTH2_SPEC = OAuth2Spec(
         + r"&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}"
         r"&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}"
     ),
-    accessTokenUrlTemplate="https://api.hubapi.com/oauth/v1/token",
+    accessTokenUrlTemplate="https://api.hubapi.com/oauth/2026-03/token",
     accessTokenHeaders={"content-type": "application/x-www-form-urlencoded"},
     accessTokenBody=(
         "grant_type=authorization_code"

--- a/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
+++ b/source-hubspot-native/tests/snapshots/snapshots__spec__stdout.json
@@ -143,7 +143,7 @@
     "oauth2": {
       "provider": "hubspot",
       "authUrlTemplate": "https://app.hubspot.com/oauth/authorize?client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&scope=crm.lists.read%20crm.objects.companies.read%20crm.objects.contacts.read%20crm.objects.deals.read%20crm.objects.owners.read%20crm.schemas.companies.read%20crm.schemas.contacts.read%20crm.schemas.deals.read%20e-commerce%20forms%20tickets&optional_scope=automation%20content%20crm.objects.custom.read%20crm.objects.feedback_submissions.read%20crm.objects.goals.read%20crm.objects.leads.read%20crm.objects.marketing_events.read%20crm.objects.orders.read%20crm.schemas.custom.read%20marketing.campaigns.read&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&response_type=code&state={{#urlencode}}{{{ state }}}{{/urlencode}}",
-      "accessTokenUrlTemplate": "https://api.hubapi.com/oauth/v1/token",
+      "accessTokenUrlTemplate": "https://api.hubapi.com/oauth/2026-03/token",
       "accessTokenBody": "grant_type=authorization_code&client_id={{#urlencode}}{{{ client_id }}}{{/urlencode}}&client_secret={{#urlencode}}{{{ client_secret }}}{{/urlencode}}&redirect_uri={{#urlencode}}{{{ redirect_uri }}}{{/urlencode}}&code={{#urlencode}}{{{ code }}}{{/urlencode}}",
       "accessTokenHeaders": {
         "content-type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
Refs #4620.

HubSpot sunsets the v1 OAuth API on **February 16, 2027** ([announcement](https://developers.hubspot.com/changelog/v1-oauth-api-deprecation), [migration guide](https://developers.hubspot.com/docs/api-reference/legacy/authentication/oauth-tokens/v1/migration-guide)). This points `source-hubspot-native` at the replacement token endpoint.

`https://api.hubapi.com/oauth/v1/token` → `https://api.hubapi.com/oauth/2026-09/token`

The replacement is a *date-based* version, not `v3` — HubSpot's changelog is titled "OAuth v3" but every path is dated. `2026-09` is the version the migration guide names, and it's what `materialize-hubspot` already uses (`materialize-hubspot/client.go:90`), so this keeps our HubSpot connectors on one version.

### Why the one-line change covers both OAuth flows

`accessTokenUrlTemplate` has two consumers:

- **Initial `authorization_code` exchange** — the control plane, not the connector. `supabase/functions/oauth/access-token.ts` reads `oauth2_spec.accessTokenUrlTemplate` off the `connectors` table, which is populated from the connector's spec response. So this only takes effect once the connector is published.
- **Ongoing `refresh_token` exchange** — the connector at runtime, via `estuary-cdk/estuary_cdk/http.py:441`.

The 2026-09 token endpoint accepts the same form-encoded body and returns the same fields, so `accessTokenBody`, `accessTokenHeaders`, and `accessTokenResponseMap` are unchanged.
