### PR TITLE
materialize-snowflake: freeze a private copy of the parquet writer for bdec

### DIFF
--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -48,7 +48,7 @@ const (
 
 	// For blobs we only write a single chunk and a chunk can only have a single
 	// row group, so this ends up being the size limit for the single row group
-	// written by the bdec bdecparquet.
+	// written by the bdec writer
 	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java#L64C62-L64C79
 	MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024
 )
@@ -197,7 +197,7 @@ func (bw *bdecWriter) writeRow(row []any) error {
 			// integer stats, and must parse it into an int128 here for that.
 			// The original value (a date string) is left as-is in the row, so
 			// we'll end up parsing it twice: Once here for stats, and once in
-			// the parquet bdecparquet.
+			// the parquet writer.
 			v, err := getDateInt(row[i])
 			if err != nil {
 				return fmt.Errorf("getDateInt for column %q: %w", col.Name, err)

--- a/materialize-snowflake/bdec.go
+++ b/materialize-snowflake/bdec.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
-	"github.com/estuary/connectors/go/writer"
+	"github.com/estuary/connectors/materialize-snowflake/bdecparquet"
 	sql "github.com/estuary/connectors/materialize-sql"
 )
 
@@ -48,13 +48,13 @@ const (
 
 	// For blobs we only write a single chunk and a chunk can only have a single
 	// row group, so this ends up being the size limit for the single row group
-	// written by the bdec writer.
+	// written by the bdec bdecparquet.
 	// Ref: https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java#L64C62-L64C79
 	MAX_CHUNK_SIZE_IN_BYTES_DEFAULT = 256 * 1024 * 1024
 )
 
 type bdecWriter struct {
-	pq        *writer.ParquetWriter
+	pq        *bdecparquet.ParquetWriter
 	blobStats *blobStatsTracker
 	cols      []tableColumn
 	done      bool
@@ -78,7 +78,7 @@ func newBdecWriter(
 	}
 
 	metadata := map[string]string{"primaryFileId": path.Base(string(fileName))}
-	sch := make(writer.ParquetSchema, 0, len(orderedCols))
+	sch := make(bdecparquet.ParquetSchema, 0, len(orderedCols))
 	for _, col := range orderedCols {
 		e, err := makeSchemaElement(col)
 		if err != nil {
@@ -122,14 +122,14 @@ func newBdecWriter(
 		})
 	}
 
-	pq, err := writer.NewParquetWriter(
+	pq, err := bdecparquet.NewParquetWriter(
 		blobStats,
 		sch,
-		writer.WithParquetCompression(writer.Snappy),
-		writer.WithDisableDictionaryEncoding(), // not only for performance, but also to support some column types (VARIANT)
-		writer.WithParquetMetadata(metadata),
-		writer.WithParquetRowGroupByteLimit(MAX_CHUNK_SIZE_IN_BYTES_DEFAULT),
-		writer.WithParquetRowGroupRowLimit(math.MaxInt64), // no specific limit on the number of rows in a bdec chunk
+		bdecparquet.WithParquetCompression(bdecparquet.Snappy),
+		bdecparquet.WithDisableDictionaryEncoding(), // not only for performance, but also to support some column types (VARIANT)
+		bdecparquet.WithParquetMetadata(metadata),
+		bdecparquet.WithParquetRowGroupByteLimit(MAX_CHUNK_SIZE_IN_BYTES_DEFAULT),
+		bdecparquet.WithParquetRowGroupRowLimit(math.MaxInt64), // no specific limit on the number of rows in a bdec chunk
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating parquet writer: %w", err)
@@ -197,7 +197,7 @@ func (bw *bdecWriter) writeRow(row []any) error {
 			// integer stats, and must parse it into an int128 here for that.
 			// The original value (a date string) is left as-is in the row, so
 			// we'll end up parsing it twice: Once here for stats, and once in
-			// the parquet writer.
+			// the parquet bdecparquet.
 			v, err := getDateInt(row[i])
 			if err != nil {
 				return fmt.Errorf("getDateInt for column %q: %w", col.Name, err)
@@ -598,9 +598,9 @@ func newUnhandledColError(format string, a ...any) error {
 
 // Loosely adapted from
 // https://github.com/snowflakedb/snowflake-ingest-java/blob/3cbaebfe26f59dc3a8b8e973649e3f1a1014438c/src/main/java/net/snowflake/ingest/streaming/internal/ParquetTypeGenerator.java#L77-L148
-func makeSchemaElement(col tableColumn) (writer.ParquetSchemaElement, error) {
+func makeSchemaElement(col tableColumn) (bdecparquet.ParquetSchemaElement, error) {
 	fieldId := int32(col.Ordinal)
-	e := writer.ParquetSchemaElement{
+	e := bdecparquet.ParquetSchemaElement{
 		Name:     col.Name,
 		Required: !col.Nullable,
 		FieldId:  &fieldId,
@@ -618,27 +618,27 @@ func makeSchemaElement(col tableColumn) (writer.ParquetSchemaElement, error) {
 		if col.PhysicalType == "SB16" && col.Scale == nil || *col.Scale == 0 {
 			// A decimal with 0 precision, like a DECIMAL(38,0) that we use for
 			// integer columns.
-			e.DataType = writer.LogicalTypeDecimal
+			e.DataType = bdecparquet.LogicalTypeDecimal
 			e.Scale = 0
 		} else {
 			return e, newUnhandledColError("fixed column with physical type %q and scale %s not supported", col.PhysicalType, nilOrScale(col.Scale))
 		}
 	case "text", "variant":
-		e.DataType = writer.LogicalTypeString
+		e.DataType = bdecparquet.LogicalTypeString
 	case "timestamp_ltz", "timestamp_ntz", "timestamp_tz":
 		if col.PhysicalType == "SB16" && col.Scale != nil && *col.Scale == 9 {
 			// A timestamp with nanosecond precision.
-			e.DataType = writer.LogicalTypeDecimal
+			e.DataType = bdecparquet.LogicalTypeDecimal
 			e.Scale = 9
 		} else {
 			return e, newUnhandledColError("%s column with physical type %q and scale %s not supported", col.LogicalType, col.PhysicalType, nilOrScale(col.Scale))
 		}
 	case "date":
-		e.DataType = writer.LogicalTypeDate
+		e.DataType = bdecparquet.LogicalTypeDate
 	case "boolean":
-		e.DataType = writer.PrimitiveTypeBoolean
+		e.DataType = bdecparquet.PrimitiveTypeBoolean
 	case "real":
-		e.DataType = writer.PrimitiveTypeNumber
+		e.DataType = bdecparquet.PrimitiveTypeNumber
 	default:
 		return e, newUnhandledColError("unhandled type %q", col.Type)
 	}

--- a/materialize-snowflake/bdecparquet/counting_write_closer.go
+++ b/materialize-snowflake/bdecparquet/counting_write_closer.go
@@ -1,0 +1,28 @@
+package bdecparquet
+
+import (
+	"fmt"
+	"io"
+)
+
+type countingWriteCloser struct {
+	written int
+	w       io.WriteCloser
+}
+
+func (c *countingWriteCloser) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	if err != nil {
+		return 0, fmt.Errorf("countingWriteCloser writing to w: %w", err)
+	}
+	c.written += n
+
+	return n, nil
+}
+
+func (c *countingWriteCloser) Close() error {
+	if err := c.w.Close(); err != nil {
+		return fmt.Errorf("countingWriteCloser closing w: %w", err)
+	}
+	return nil
+}

--- a/materialize-snowflake/bdecparquet/doc.go
+++ b/materialize-snowflake/bdecparquet/doc.go
@@ -1,0 +1,5 @@
+// Package bdecparquet is a frozen copy of the parquet writer from go/writer,
+// used only by the Snowflake bdec write path. Changes to the shared writer
+// have repeatedly broken bdec, so this copy is intentionally not updated.
+// Bug fixes and features go to go/writer; delete this package with bdec.
+package bdecparquet

--- a/materialize-snowflake/bdecparquet/parquet.go
+++ b/materialize-snowflake/bdecparquet/parquet.go
@@ -1,0 +1,1083 @@
+package bdecparquet
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/apache/arrow-go/v18/parquet/variant"
+	"github.com/google/uuid"
+	"github.com/segmentio/encoding/json"
+	iso8601 "github.com/senseyeio/duration"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// The default approximate limit on the number of document "rows" to buffer in memory before
+	// writing them out as a row group to the scratch file. A larger buffer will use more connector
+	// memory, and perhaps afford slightly less overhead when seeking through the scratch file to
+	// read columns from its individual row groups. A smaller buffer here means more row groups
+	// written to the scratch file, and this interacts with the maxScratchColumnChunkCount value as
+	// well in terms of how much metadata is written to the scratch file. Configurable via
+	// WithParquetBufferSize, which is useful to lower for schemas with very large individual values,
+	// since this is the only buffering stage sized in bytes rather than rows.
+	defaultBufferSize = 25 * 1024 * 1024
+
+	// Each row group that is written to the scratch file has a column chunk for each column it
+	// contains. In extreme cases of very large numbers of columns (1000+) where the values in the
+	// columns are small (example: all booleans), we can end up with a truly enormous amount of
+	// scratch file metadata and potentially run out of memory when trying to read the metadata to
+	// transfer the values out of the file. This value sets a limit on how much metadata is
+	// generated in the scratch file by only allowing this many column chunks to be written.
+	maxScratchColumnChunkCount = 5_000
+
+	// The default number of rows per row group in the generated parquet file. Configurable via
+	// WithRowGroupRowsLimit.
+	defaultRowGroupRowLimit = 1_000_000
+
+	// The default approximate upper limit for row group byte sizes, after compression. Configurable
+	// via WithRowGroupByteLimit.
+	defaultRowGroupByteLimit = 512 * 1024 * 1024
+)
+
+// rowSize is used to get a rough estimate of how much memory a row of values will take up when
+// buffered in the ParquetWriter's `buffer` slice. These estimates are used to bound how often a
+// buffer is written as a row group to the scratch file. The maximum allowed buffer size based on
+// these estimates should be << the connector limits since they are at best proportional wild
+// guesses.
+type rowSize struct {
+	// fixed is the constant component of a row's size as determined from a nominal number of bytes
+	// consumed by its scalar types and slice/string headers.
+	fixed int
+	// calcLen is the indices within a row where we should additionally consider the length of a
+	// byte slice or string in the memory estimate, on a per-row basis.
+	calcLen []int
+}
+
+func newRowSizing(sch ParquetSchema) rowSize {
+	rs := rowSize{
+		fixed: 24, // slice header for the row itself; it will use this much memory even for an empty row
+	}
+
+	for idx, e := range sch {
+		// Assume 16 bytes of overhead for any value due to the interface{} that contains it.
+		rs.fixed += 16
+
+		switch e.DataType {
+		case PrimitiveTypeInteger, PrimitiveTypeNumber:
+			rs.fixed += 8
+		case PrimitiveTypeBoolean:
+			rs.fixed += 1
+		case PrimitiveTypeBinary, LogicalTypeJson, LogicalTypeDecimal, LogicalTypeVariant:
+			rs.fixed += 24 // slice header
+			rs.calcLen = append(rs.calcLen, idx)
+		case LogicalTypeString, LogicalTypeUuid, LogicalTypeDate, LogicalTypeTime, LogicalTypeTimestamp, LogicalTypeTimestampNanos, LogicalTypeInterval:
+			rs.fixed += 16 // string header
+			rs.calcLen = append(rs.calcLen, idx)
+		default:
+			panic(fmt.Sprintf("newRowSizing unknown type: %d", e.DataType))
+		}
+	}
+
+	return rs
+}
+
+func (rs rowSize) estSize(row []any) int {
+	out := rs.fixed
+
+	for _, pos := range rs.calcLen {
+		switch v := row[pos].(type) {
+		case string:
+			out += len(v)
+		case []byte:
+			out += len(v)
+		case json.RawMessage:
+			out += len(v)
+		case nil:
+			// No additional overhead is assumed for nil values.
+		default:
+			// All other values are assumed to have a fixed overhead of 16
+			// bytes. This is applicable to fields which have multiple types
+			// where the Parquet type is a string or byte array but the field's
+			// value is some other scalar type.
+			out += 16
+		}
+	}
+
+	return out
+}
+
+type ParquetCompression int
+
+const (
+	Uncompressed ParquetCompression = iota
+	Snappy
+	Gzip
+)
+
+type parquetConfig struct {
+	compression               ParquetCompression
+	disableDictionaryEncoding bool
+	bufferSize                int
+	rowGroupRowLimit          int
+	rowGroupByteLimit         int
+	metadata                  map[string]string
+}
+
+type ParquetWriter struct {
+	cfg parquetConfig
+
+	schema         ParquetSchema
+	schemaRoot     *schema.GroupNode
+	sinkWriter     *file.Writer
+	cwc            *countingWriteCloser
+	rs             rowSize
+	rowGroupCount  int
+	numLeafColumns int
+
+	// Scratch values are re-initialized as scratch files are transposed into the output stream.
+	scratch struct {
+		file             *os.File
+		writer           *file.Writer
+		sizeBytes        int
+		rowCount         int
+		columnChunkCount int
+	}
+
+	// buffer contains rows of values that are pending to be written as a row group to the scratch
+	// file when bufferSizeBytes exceeds the threshold.
+	buffer          [][]any
+	bufferSizeBytes int
+}
+
+type ParquetOption func(*parquetConfig)
+
+func WithParquetCompression(c ParquetCompression) ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.compression = c
+	}
+}
+
+func WithDisableDictionaryEncoding() ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.disableDictionaryEncoding = true
+	}
+}
+
+func WithParquetBufferSize(n int) ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.bufferSize = n
+	}
+}
+
+func WithParquetRowGroupRowLimit(n int) ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.rowGroupRowLimit = n
+	}
+}
+
+func WithParquetRowGroupByteLimit(n int) ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.rowGroupByteLimit = n
+	}
+}
+
+func WithParquetMetadata(meta map[string]string) ParquetOption {
+	return func(cfg *parquetConfig) {
+		cfg.metadata = meta
+	}
+}
+
+func NewParquetWriter(w io.WriteCloser, sch ParquetSchema, opts ...ParquetOption) (*ParquetWriter, error) {
+	cfg := parquetConfig{
+		compression:       Uncompressed,
+		bufferSize:        defaultBufferSize,
+		rowGroupRowLimit:  defaultRowGroupRowLimit,
+		rowGroupByteLimit: defaultRowGroupByteLimit,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	fields := make(schema.FieldList, 0, len(sch))
+	for _, e := range sch {
+		fields = append(fields, makeNode(e))
+	}
+
+	schemaRoot := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1))
+
+	cwc := &countingWriteCloser{w: w}
+
+	// Use the non-panicking constructor: the sink here is typically one end of an io.Pipe
+	// streaming to a cloud-storage upload, and its very first write (the parquet magic header)
+	// can fail transiently (e.g. a broken pipe). The legacy file.NewParquetWriter panics in that
+	// case; returning the error instead lets the caller surface it as a normal, retryable failure.
+	sinkWriter, err := file.NewParquetWriterWithError(cwc, schemaRoot, writerOpts(cfg, sch)...)
+	if err != nil {
+		return nil, fmt.Errorf("initializing parquet sink writer: %w", err)
+	}
+
+	return &ParquetWriter{
+		cfg:            cfg,
+		schema:         sch,
+		schemaRoot:     schemaRoot,
+		sinkWriter:     sinkWriter,
+		cwc:            cwc,
+		rs:             newRowSizing(sch),
+		numLeafColumns: schema.NewSchema(schemaRoot).NumColumns(),
+	}, nil
+}
+
+func writerOpts(cfg parquetConfig, sch ParquetSchema) []file.WriteOption {
+	propOpts := []parquet.WriterProperty{}
+
+	switch cfg.compression {
+	case Uncompressed:
+		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Uncompressed))
+	case Snappy:
+		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Snappy))
+	case Gzip:
+		propOpts = append(propOpts, parquet.WithCompression(compress.Codecs.Gzip))
+	default:
+		panic(fmt.Sprintf("unknown compression setting: %d", cfg.compression))
+	}
+
+	if cfg.disableDictionaryEncoding {
+		propOpts = append(propOpts, parquet.WithDictionaryDefault(false))
+	}
+
+	// Byte-wise min/max values of the variant binary encoding are meaningless
+	// for readers and potentially very large, so statistics are disabled for
+	// the leaf columns of variant groups.
+	for _, e := range sch {
+		if e.DataType == LogicalTypeVariant {
+			propOpts = append(propOpts,
+				parquet.WithStatsPath(parquet.ColumnPath{e.Name, "metadata"}, false),
+				parquet.WithStatsPath(parquet.ColumnPath{e.Name, "value"}, false),
+			)
+		}
+	}
+
+	out := []file.WriteOption{file.WithWriterProps(parquet.NewWriterProperties(propOpts...))}
+	if len(cfg.metadata) > 0 {
+		meta := metadata.NewKeyValueMetadata()
+		for k, v := range cfg.metadata {
+			if err := meta.Append(k, v); err != nil {
+				panic(fmt.Sprintf("invalid metadata: %s", err)) // only possible if the metadata keys/values contain invalid UTF-8
+			}
+		}
+		out = append(out, file.WithWriteMetadata(meta))
+	}
+
+	return out
+}
+
+// Write a row of data by buffering it in the writers's buffer, and if thresholds are
+// exceed writing the buffer as a row group to the scratch file, and potentially flushing the row
+// groups from the scratch file collectively as a single row group to the output.
+func (w *ParquetWriter) Write(row []any) error {
+	if len(row) != len(w.schema) {
+		return fmt.Errorf("write: row length (%d) does not match schema length (%d)", len(row), len(w.schema))
+	}
+
+	w.buffer = append(w.buffer, row)
+	w.bufferSizeBytes += w.rs.estSize(row)
+	w.scratch.rowCount += 1
+
+	if w.bufferSizeBytes >= w.cfg.bufferSize {
+		// Write out the buffer as a single row group to the scratch file (see flushBuffer).
+		if err := w.flushBuffer(); err != nil {
+			return fmt.Errorf("write flushing buffer based on buffer size: %w", err)
+		}
+	}
+
+	if w.scratch.writer != nil && (w.scratch.sizeBytes >= w.cfg.rowGroupByteLimit ||
+		w.scratch.rowCount >= w.cfg.rowGroupRowLimit ||
+		w.scratch.columnChunkCount >= maxScratchColumnChunkCount) {
+		if w.scratch.columnChunkCount >= maxScratchColumnChunkCount {
+			log.WithFields(log.Fields{
+				"scratchSizeBytes":        w.scratch.sizeBytes,
+				"scratchRowCount":         w.scratch.rowCount,
+				"scratchColumnChunkCount": w.scratch.columnChunkCount,
+			}).Debug("flushing scratch file based on column chunk count")
+		}
+
+		if err := w.flushBuffer(); err != nil {
+			// Still might need to flush the buffer based on row count.
+			return fmt.Errorf("write flushing buffer based on scratch file size: %w", err)
+		} else if err := w.flushScratchFile(); err != nil {
+			return fmt.Errorf("write flushing scratch file based on scratch file size: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Written returns the number of bytes written to the output writer. This value increases only as
+// row groups from the scratch file are flushed to the output, which happens whenever there is
+// enough data (either by rows or bytes) in the scratch file to fill a complete row group.
+func (w *ParquetWriter) Written() int {
+	return w.cwc.written
+}
+
+// Close flushes the buffered rows and scratch file, and closes the output writer.
+func (w *ParquetWriter) Close() error {
+	if err := w.flushBuffer(); err != nil {
+		return fmt.Errorf("flushing buffer: %w", err)
+	} else if err := w.flushScratchFile(); err != nil {
+		return fmt.Errorf("flushing scratch file: %w", err)
+	} else if err := w.sinkWriter.Close(); err != nil { // also closes the underlying io.WriteCloser
+		return fmt.Errorf("closing sink: %w", err)
+	}
+	return nil
+}
+
+// FileMetadata returns the current state of the FileMetadata that would be
+// written if this file were to be closed. If the file has already been closed,
+// then this will return the FileMetaData which was written to the file. This is
+// a proxy for the parquet (*file).Writer.FileMetadata() method.
+func (w *ParquetWriter) FileMetadata() (*metadata.FileMetaData, error) {
+	return w.sinkWriter.FileMetadata()
+}
+
+// RowGroupsWritten returns the number of row groups that have been written to
+// the output so far, which is equivalent to how many times the scratch file has
+// been flushed.
+func (w *ParquetWriter) RowGroupsWritten() int {
+	return w.rowGroupCount
+}
+
+func (w *ParquetWriter) flushScratchFile() error {
+	if w.scratch.writer == nil {
+		return nil
+	}
+
+	if err := w.scratch.writer.Close(); err != nil { // also closes the underlying io.WriteCloser
+		return fmt.Errorf("closing scratch writer: %w", err)
+	}
+
+	sr, err := os.Open(w.scratch.file.Name())
+	if err != nil {
+		return fmt.Errorf("opening scratch file to transfer values: %w", err)
+	}
+
+	scratchReader, err := file.NewParquetReader(sr)
+	if err != nil {
+		return fmt.Errorf("creating scratch reader: %w", err)
+	}
+
+	if err := transferColumnValues(scratchReader, w.sinkWriter, sr); err != nil {
+		return fmt.Errorf("transferring column values: %w", err)
+	}
+
+	// The scratch file's page cache is charged against the process's cgroup memory limit like
+	// heap memory is, and the kernel won't necessarily reclaim it before it's needed elsewhere.
+	// Drop it explicitly now that its contents have been transferred to the sink writer and the
+	// file is about to be removed.
+	dropPageCache(sr)
+
+	if err := sr.Close(); err != nil {
+		return fmt.Errorf("closing scratch file after reading: %w", err)
+	} else if err := os.Remove(w.scratch.file.Name()); err != nil {
+		return fmt.Errorf("removing scratch file: %w", err)
+	}
+
+	w.scratch.file = nil
+	w.scratch.writer = nil
+	w.scratch.sizeBytes = 0
+	w.scratch.columnChunkCount = 0
+	w.scratch.rowCount = 0
+	w.rowGroupCount += 1
+
+	return nil
+}
+
+// flushBuffer writes the current buffered rows as a single row group to the scratch file.
+func (w *ParquetWriter) flushBuffer() error {
+	if len(w.buffer) == 0 {
+		return nil
+	}
+
+	if w.scratch.writer == nil {
+		// Either the very first buffered row group, or the first one after flushing the scratch
+		// file.
+		scratchFile, err := os.CreateTemp("", "parquet-scratch-*")
+		if err != nil {
+			return fmt.Errorf("flushing buffer creating scratch file: %w", err)
+		}
+
+		scratchOpts := []parquet.WriterProperty{
+			// Don't use dictionary encoding for the scratch file, since it is
+			// much slower to write than plain encoding with the small row
+			// groups of the scratch file.
+			parquet.WithDictionaryDefault(false),
+			// Turning off stats calculations helps too, but just a tiny bit.
+			parquet.WithStats(false),
+		}
+		scratchWriter, err := file.NewParquetWriterWithError(scratchFile, w.schemaRoot, file.WithWriterProps(parquet.NewWriterProperties(scratchOpts...)))
+		if err != nil {
+			return fmt.Errorf("flushing buffer creating scratch writer: %w", err)
+		}
+		w.scratch.file = scratchFile
+		w.scratch.writer = scratchWriter
+	}
+
+	rgWriter := w.scratch.writer.AppendRowGroup()
+
+	// Transpose the buffered rows into the scratch file row group by writing them column-by-column.
+	for colIdx, f := range w.schema {
+		// A variant element is a group of two leaf columns and so consumes two
+		// of the row group's columns, unlike every other element.
+		if f.DataType == LogicalTypeVariant {
+			if err := writeVariantColumn(f, colIdx, w.buffer, rgWriter); err != nil {
+				return fmt.Errorf("writing variant column '%s': %w", f.Name, err)
+			}
+			continue
+		}
+
+		cw, err := rgWriter.NextColumn()
+		if err != nil {
+			return fmt.Errorf("getting next column: %w", err)
+		}
+
+		switch f.DataType {
+		case PrimitiveTypeInteger:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getIntVal); err != nil {
+				return fmt.Errorf("writing integer column '%s': %w", f.Name, err)
+			}
+		case PrimitiveTypeNumber:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Float64ColumnChunkWriter), getNumberVal); err != nil {
+				return fmt.Errorf("writing number column '%s': %w", f.Name, err)
+			}
+		case PrimitiveTypeBoolean:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.BooleanColumnChunkWriter), getBooleanVal); err != nil {
+				return fmt.Errorf("writing boolean column '%s': %w", f.Name, err)
+			}
+		case PrimitiveTypeBinary:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getBinaryVal); err != nil {
+				return fmt.Errorf("writing byte array column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeJson:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getJsonVal); err != nil {
+				return fmt.Errorf("writing byte array (json) column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeString:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.ByteArrayColumnChunkWriter), getStringVal); err != nil {
+				return fmt.Errorf("writing byte array (string) column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeUuid:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getUuidVal); err != nil {
+				return fmt.Errorf("writing uuid column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeDate:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int32ColumnChunkWriter), getDateVal); err != nil {
+				return fmt.Errorf("writing date column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeTime:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimeVal); err != nil {
+				return fmt.Errorf("writing time column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeTimestamp:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampVal); err != nil {
+				return fmt.Errorf("writing timestamp column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeTimestampNanos:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.Int64ColumnChunkWriter), getTimestampNanosVal); err != nil {
+				return fmt.Errorf("writing timestamp (nanos) column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeDecimal:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getDecimalVal); err != nil {
+				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
+			}
+		case LogicalTypeInterval:
+			if err := writeColumn(colIdx, w.buffer, cw.(*file.FixedLenByteArrayColumnChunkWriter), getIntervalVal); err != nil {
+				return fmt.Errorf("writing interval column '%s': %w", f.Name, err)
+			}
+		default:
+			panic(fmt.Sprintf("attempted to write unknown type of column '%s': %d", f.Name, f.DataType))
+		}
+
+		if err := cw.Close(); err != nil {
+			return fmt.Errorf("closing column writer: %w", err)
+		}
+	}
+
+	if err := rgWriter.Close(); err != nil {
+		return fmt.Errorf("closing row group writer: %w", err)
+	}
+
+	w.scratch.sizeBytes += int(rgWriter.TotalBytesWritten())
+	w.scratch.columnChunkCount += w.numLeafColumns
+	w.buffer = w.buffer[:0]
+	w.bufferSizeBytes = 0
+
+	// Sync and drop the scratch file's page cache after each row group, so its resident (and
+	// cgroup-charged) page cache stays near one buffer's worth instead of growing to the full
+	// scratch file size. Nothing reads the scratch file until flushScratchFile, so dropping the
+	// whole file is safe.
+	flushAndDropPageCache(w.scratch.file)
+
+	return nil
+}
+
+type parquetValue interface {
+	int64 | int32 | float64 | bool | parquet.FixedLenByteArray | parquet.ByteArray
+}
+
+// columnBatchReader is a generic wrapper for reading a batch of values having type T from a column.
+// This interface is satisfied by any of the typed column readers from the Apache parquet package.
+type columnBatchReader[T parquetValue] interface {
+	// ReadBatch reads batchSize values from the column. values must be large enough to hold the
+	// number of values that will be read. defLvls and repLvls will be populated if not nil; they
+	// are not inputs to the operation but their populated values are necessary for interpreting the
+	// data read into values. total is the number of rows that were read; valuesRead is the actual
+	// number of physical values that were read excluding nulls.
+	ReadBatch(batchSize int64, values []T, defLvls []int16, repLvls []int16) (total int64, valuesRead int, err error)
+}
+
+// columnBatchWriter is a generic wrapper for writing a batch of values having type T to a column.
+// This interface is satisfied by any of the typed column writers from the Apache parquet package.
+type columnBatchWriter[T parquetValue] interface {
+	// WriteBatch writes a batch of repetition levels, definition levels, and values to the column.
+	// We don't currently support nested data structures (typed arrays being the only ones we
+	// reasonably could), so repLvls is always nil. The number of values in defLvls must equal the
+	// number of conceptual rows that are being written. The vals slice may contain a number of
+	// values less than or equal to the number of rows, as null values are omitted. Since we don't
+	// currently support nested data structures, a defLvl of 0 means the row at that corresponding
+	// position is null, and a defLvl of 1 means that value is not null and its value should be
+	// taken from the next value of vals. The returned valuesOffset indicates the number of physical
+	// values that were written, and it may be smaller than the number of conceptual rows written.
+	WriteBatch(vals []T, defLvls []int16, repLvls []int16) (valueOffset int64, err error)
+}
+
+type getValFn[T parquetValue] func(v any) (got T, err error)
+
+func writeColumn[T parquetValue](
+	colIdx int,
+	buf [][]any,
+	w columnBatchWriter[T],
+	getVal getValFn[T],
+) error {
+	var vals []T
+	var defLevels []int16
+
+	for _, row := range buf {
+		v := row[colIdx]
+		switch tv := v.(type) {
+		case nil:
+			defLevels = append(defLevels, 0)
+		default:
+			got, err := getVal(tv)
+			if err != nil {
+				return fmt.Errorf("getting typed value for value: %w (type %T)", err, tv)
+			}
+
+			vals = append(vals, got)
+			defLevels = append(defLevels, 1)
+		}
+	}
+
+	if valuesWritten, err := w.WriteBatch(vals, defLevels, nil); err != nil {
+		return fmt.Errorf("writing batch of values: %w", err)
+	} else if int(valuesWritten) != len(vals) {
+		return fmt.Errorf("written %d values vs. %d values in vals", valuesWritten, len(vals))
+	}
+
+	return nil
+}
+
+// encodeVariant encodes a value into the unshredded Variant V1 binary form.
+//
+// Scalars are appended to a variant builder directly rather than being marshaled to JSON that the
+// parse below would immediately undo — that round trip is what a multi-type field's scalar values
+// would otherwise pay for. Everything else is encoded from its JSON serialization, which is free
+// for the objects, arrays, and root documents that arrive as json.RawMessage, and is also the only
+// path that can represent a uint64 too large for the variant integer types.
+func encodeVariant(val any, stringType ParquetDataType) (variant.Value, error) {
+	var b variant.Builder
+	var err error
+	var scalar = true
+
+	switch v := val.(type) {
+	case string:
+		err = appendVariantString(&b, v, stringType)
+	case bool:
+		err = b.AppendBool(v)
+	case int64:
+		err = b.AppendInt(v)
+	case float64:
+		err = b.AppendFloat64(v)
+	case uint64:
+		if v <= math.MaxInt64 {
+			err = b.AppendInt(int64(v))
+		} else {
+			scalar = false
+		}
+	default:
+		scalar = false
+	}
+	if err != nil {
+		return variant.Value{}, err
+	} else if scalar {
+		return b.Build()
+	}
+
+	jsonVal, err := getJsonVal(val)
+	if err != nil {
+		return variant.Value{}, fmt.Errorf("getting JSON value: %w", err)
+	}
+
+	return variant.ParseJSONBytes(jsonVal, false)
+}
+
+// appendVariantString appends v as the variant type implied by its format
+// annotation, so that a formatted string is stored the same way it would be as
+// a column of its own.
+//
+// A string that does not parse is appended as a variant string. A variant holds
+// values of any type, so keeping the value costs nothing here, unlike the typed
+// columns whose converters have nowhere but an error to put it.
+func appendVariantString(b *variant.Builder, v string, stringType ParquetDataType) error {
+	switch stringType {
+	case LogicalTypeDate:
+		if d, err := getDateVal(v); err == nil {
+			return b.AppendDate(arrow.Date32(d))
+		}
+	case LogicalTypeTimestamp:
+		if ts, err := getTimestampVal(v); err == nil {
+			return b.AppendTimestamp(arrow.Timestamp(ts), true, true)
+		}
+	case LogicalTypeTimestampNanos:
+		if ts, err := getTimestampNanosVal(v); err == nil {
+			return b.AppendTimestamp(arrow.Timestamp(ts), false, true)
+		}
+	case LogicalTypeTime:
+		if t, err := getTimeVal(v); err == nil {
+			return b.AppendTimeMicro(arrow.Time64(t))
+		}
+	case LogicalTypeUuid:
+		if u, err := uuid.Parse(v); err == nil {
+			return b.AppendUUID(u)
+		}
+	case PrimitiveTypeBinary:
+		if bs, err := getBinaryVal(v); err == nil {
+			return b.AppendBinary(bs)
+		}
+	}
+
+	return b.AppendString(v)
+}
+
+// writeVariantColumn writes a variant schema element as its two leaf columns: each non-null value
+// is encoded from its JSON serialization to the unshredded Variant V1 binary form, and the
+// resulting metadata and value byte arrays are written as consecutive columns of the row group,
+// sharing the definition levels of the enclosing variant group.
+func writeVariantColumn(e ParquetSchemaElement, colIdx int, buf [][]any, rgWriter file.SerialRowGroupWriter) error {
+	var metaVals = make([]parquet.ByteArray, 0, len(buf))
+	var valueVals = make([]parquet.ByteArray, 0, len(buf))
+	var defLevels = make([]int16, 0, len(buf))
+
+	for _, row := range buf {
+		if row[colIdx] == nil {
+			defLevels = append(defLevels, 0)
+			continue
+		}
+
+		encoded, err := encodeVariant(row[colIdx], e.VariantStringType)
+		if err != nil {
+			return fmt.Errorf("encoding value as variant: %w (type %T)", err, row[colIdx])
+		}
+
+		metaVals = append(metaVals, parquet.ByteArray(encoded.Metadata().Bytes()))
+		valueVals = append(valueVals, parquet.ByteArray(encoded.Bytes()))
+		defLevels = append(defLevels, 1)
+	}
+
+	for _, vals := range [][]parquet.ByteArray{metaVals, valueVals} {
+		cw, err := rgWriter.NextColumn()
+		if err != nil {
+			return fmt.Errorf("getting next column: %w", err)
+		}
+
+		if valuesWritten, err := cw.(*file.ByteArrayColumnChunkWriter).WriteBatch(vals, defLevels, nil); err != nil {
+			return fmt.Errorf("writing batch of values: %w", err)
+		} else if int(valuesWritten) != len(vals) {
+			return fmt.Errorf("written %d values vs. %d values in vals", valuesWritten, len(vals))
+		}
+
+		if err := cw.Close(); err != nil {
+			return fmt.Errorf("closing column writer: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// transferColumnValues reads columns from the scratch file r and writes the values to w. The
+// scratch file may contain many row groups, and the corresponding column from each row group is
+// read and written in order to combine all of the row groups from the scratch file into a single
+// row group written to w.
+func transferColumnValues(r *file.Reader, w *file.Writer, scratchFile *os.File) error {
+	sch := r.MetaData().Schema
+	rgWriter := w.AppendRowGroup()
+
+	for c := 0; c < sch.NumColumns(); c++ {
+		cw, err := rgWriter.NextColumn()
+		if err != nil {
+			return fmt.Errorf("getting next column writer: %w", err)
+		}
+
+		for rgIdx := 0; rgIdx < r.NumRowGroups(); rgIdx++ {
+			rgReader := r.RowGroup(rgIdx)
+			n := int(rgReader.NumRows())
+
+			cr, err := rgReader.Column(c)
+			if err != nil {
+				return fmt.Errorf("getting next column reader: %w", err)
+			}
+
+			switch cw := cw.(type) {
+			case *file.FixedLenByteArrayColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.FixedLenByteArrayColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring fixed length byte array column: %w", err)
+				}
+			case *file.Float64ColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.Float64ColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring float64 column: %w", err)
+				}
+			case *file.ByteArrayColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.ByteArrayColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring byte array column: %w", err)
+				}
+			case *file.Int32ColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.Int32ColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring int32 column: %w", err)
+				}
+			case *file.Int64ColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.Int64ColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring int64 column: %w", err)
+				}
+			case *file.BooleanColumnChunkWriter:
+				if err := doTransfer(n, cr.(*file.BooleanColumnChunkReader), cw); err != nil {
+					return fmt.Errorf("transferring boolean column: %w", err)
+				}
+			default:
+				return fmt.Errorf("unhandled physical type %q (writer type %T)", sch.Column(c).PhysicalType(), cw)
+			}
+
+			// This chunk's byte range is never read again, and its pages are clean (the scratch
+			// file was synced as it was written), so drop it from the page cache immediately
+			// rather than letting the read-back re-accumulate the full scratch file size in
+			// cgroup-charged memory.
+			if scratchFile != nil {
+				if ccMeta, err := r.MetaData().RowGroup(rgIdx).ColumnChunk(c); err == nil {
+					off := ccMeta.DataPageOffset()
+					if dictOff := ccMeta.DictionaryPageOffset(); dictOff > 0 && dictOff < off {
+						off = dictOff
+					}
+					dropPageCacheRange(scratchFile, off, ccMeta.TotalCompressedSize())
+				}
+			}
+		}
+	}
+
+	if err := rgWriter.Close(); err != nil {
+		return fmt.Errorf("closing row group writer: %w", err)
+	}
+
+	return nil
+}
+
+func doTransfer[T parquetValue](numRows int, r columnBatchReader[T], w columnBatchWriter[T]) error {
+	vals := make([]T, numRows)
+	defLvls := make([]int16, numRows)
+	rowsRead, valuesRead, err := r.ReadBatch(int64(numRows), vals, defLvls, nil)
+	if err != nil {
+		return fmt.Errorf("reading batch: %w", err)
+	}
+
+	vals = vals[:valuesRead]
+
+	if int(rowsRead) != numRows {
+		return fmt.Errorf("read %d rows vs. expected %d", rowsRead, numRows)
+	} else if valuesWritten, err := w.WriteBatch(vals, defLvls, nil); err != nil {
+		return fmt.Errorf("writing batch of values: %w", err)
+	} else if int(valuesWritten) != len(vals) {
+		return fmt.Errorf("written %d values vs. %d values in vals", valuesWritten, len(vals))
+	}
+
+	return nil
+}
+
+// The remaining "getXVal" functions are for getting a specifically typed value from the provided
+// "any" values, as well as performing any processing necessary on that value to make it suitable
+// for storing in a parquet file.
+
+var (
+	// Used to verify no overflow when receiving integers encoded as 0
+	// fractional part floats.
+	minInt64 = big.NewFloat(float64(math.MinInt64))
+	maxInt64 = big.NewFloat(float64(math.MaxInt64))
+)
+
+func getIntVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case int64:
+		got = v
+	case int:
+		got = int64(v)
+	case string:
+		// Strings ending in a 0 decimal part like "1.0" or "3.00" are
+		// considered valid as integers per JSON specification so we must handle
+		// this possibility here. Anything after the decimal is discarded on the
+		// assumption that Flow has validated the data and verified that the
+		// decimal component is all 0's.
+		if idx := strings.Index(v, "."); idx != -1 {
+			v = v[:idx]
+		}
+
+		if p, parseErr := strconv.Atoi(v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as integer: %w", v, parseErr)
+		} else {
+			got = int64(p)
+		}
+	case float64:
+		if f := big.NewFloat(v); f.Cmp(minInt64) < 0 || f.Cmp(maxInt64) > 0 {
+			err = fmt.Errorf("float64 value %f is out of range for int64", v)
+		} else {
+			got, _ = f.Int64()
+		}
+	default:
+		err = fmt.Errorf("getIntVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getNumberVal(val any) (got float64, err error) {
+	switch v := val.(type) {
+	case float64:
+		got = v
+	case float32:
+		got = float64(v)
+	case int64:
+		got = float64(v)
+	case uint64:
+		got = float64(v)
+	case *big.Int:
+		got, _ = v.Float64()
+		if math.IsInf(got, 0) {
+			err = fmt.Errorf("big.Int value %q outside of float64 range", v.String())
+		}
+	case string:
+		if p, parseErr := strconv.ParseFloat(v, 64); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as float64: %w", v, parseErr)
+		} else {
+			got = p
+		}
+	default:
+		err = fmt.Errorf("getNumberVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getBooleanVal(val any) (got bool, err error) {
+	switch v := val.(type) {
+	case bool:
+		got = v
+	default:
+		err = fmt.Errorf("getBooleanVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getBinaryVal(val any) (got parquet.ByteArray, err error) {
+	switch v := val.(type) {
+	case string:
+		if got, err = base64.StdEncoding.DecodeString(v); err != nil {
+			err = fmt.Errorf("unable to parse string %q as binary: %w", v, err)
+		}
+	default:
+		err = fmt.Errorf("getBinaryVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getJsonVal(val any) (got parquet.ByteArray, err error) {
+	switch v := val.(type) {
+	case []byte:
+		got = v
+	case json.RawMessage:
+		got = []byte(v)
+	default:
+		got, err = json.Marshal(v)
+	}
+
+	return
+}
+
+func getStringVal(val any) (got parquet.ByteArray, err error) {
+	switch v := val.(type) {
+	case string:
+		// Safety: This value is immediately written to the output and never
+		// modified.
+		got = unsafe.Slice(unsafe.StringData(v), len(v))
+	case []byte:
+		got = v
+	case json.RawMessage:
+		got = []byte(v)
+	case bool:
+		got = []byte(strconv.FormatBool(v))
+	case int64:
+		got = []byte(strconv.Itoa(int(v)))
+	case uint64:
+		got = []byte(strconv.FormatUint(v, 10))
+	case float64:
+		got = []byte(strconv.FormatFloat(v, 'f', -1, 64))
+	default:
+		err = fmt.Errorf("getStringVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getUuidVal(val any) (got parquet.FixedLenByteArray, err error) {
+	switch v := val.(type) {
+	case string:
+		if p, parseErr := uuid.Parse(v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as UUID: %w", v, parseErr)
+		} else if b, marshalErr := p.MarshalBinary(); marshalErr != nil {
+			err = fmt.Errorf("failed to marshal string %q as binary: %w", v, marshalErr)
+		} else {
+			got = b
+		}
+	default:
+		err = fmt.Errorf("getUuidVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getDateVal(val any) (got int32, err error) {
+	switch v := val.(type) {
+	case string:
+		if d, parseErr := time.Parse(time.DateOnly, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as time.DateOnly: %w", v, parseErr)
+		} else {
+			unixSeconds := d.Unix()
+			unixDays := unixSeconds / 60 / 60 / 24
+			got = int32(unixDays)
+		}
+	default:
+		err = fmt.Errorf("getDateVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getTimeVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case string:
+		v = strings.Replace(v, "z", "Z", 1)
+		if parsed, parseErr := time.Parse("15:04:05.999999999Z07:00", v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as time: %w", v, parseErr)
+		} else {
+			year, month, day := parsed.UTC().Date()
+			midnight := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+			got = parsed.UnixMicro() - midnight.UnixMicro()
+		}
+	default:
+		err = fmt.Errorf("getTimeVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getTimestampVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case string:
+		v = strings.Replace(v, "z", "Z", 1)
+		if d, parseErr := time.Parse(time.RFC3339Nano, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as timestamp: %w", v, parseErr)
+		} else {
+			got = d.UnixMicro()
+		}
+	default:
+		err = fmt.Errorf("getTimestampVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getIntervalVal(val any) (got parquet.FixedLenByteArray, err error) {
+	switch v := val.(type) {
+	case string:
+		if d, parseErr := iso8601.ParseISO8601(v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as ISO8601 duration string: %w", v, parseErr)
+		} else {
+			months := uint32(d.Y*12 + d.M)
+			days := uint32(d.W*7 + d.D)
+			millis := uint32(d.TH*60*60*1000 + d.TM*60*1000 + d.TS*1000)
+
+			val := make([]byte, 0, 12)
+			val = binary.LittleEndian.AppendUint32(val, months)
+			val = binary.LittleEndian.AppendUint32(val, days)
+			val = binary.LittleEndian.AppendUint32(val, millis)
+
+			got = val
+		}
+	default:
+		err = fmt.Errorf("getIntervalVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getTimestampNanosVal(val any) (got int64, err error) {
+	switch v := val.(type) {
+	case string:
+		v = strings.Replace(v, "z", "Z", 1)
+		if d, parseErr := time.Parse(time.RFC3339Nano, v); parseErr != nil {
+			err = fmt.Errorf("unable to parse string %q as timestamp: %w", v, parseErr)
+		} else {
+			got = d.UnixNano()
+		}
+	default:
+		err = fmt.Errorf("getTimestampNanosVal unhandled type: %T", v)
+	}
+
+	return
+}
+
+func getDecimalVal(val any) (got parquet.FixedLenByteArray, err error) {
+	switch v := val.(type) {
+	case decimal128.Num:
+		got = slices.Grow(got, 16)[:16]
+		// Big Endian, 2's compliment encoding.
+		binary.BigEndian.PutUint64(got, uint64(v.HighBits()))
+		binary.BigEndian.PutUint64(got[8:], v.LowBits())
+	default:
+		err = fmt.Errorf("getDecimalVal unhandled type: %T", v)
+	}
+
+	return
+}

--- a/materialize-snowflake/bdecparquet/parquet_schema.go
+++ b/materialize-snowflake/bdecparquet/parquet_schema.go
@@ -1,0 +1,383 @@
+package bdecparquet
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	m "github.com/estuary/connectors/go/materialize"
+	pf "github.com/estuary/flow/go/protocols/flow"
+)
+
+// ParquetSchema consists of ParquetSchemaElement which represent the column name, if the column is
+// required, and what are representation of the data type should be.
+type ParquetSchema []ParquetSchemaElement
+
+type ParquetSchemaElement struct {
+	Name     string
+	DataType ParquetDataType
+	Required bool
+	FieldId  *int32
+	Scale    int32 // only applicable to LogicalTypeDecimal
+
+	// VariantStringType is the type given to string values of a
+	// LogicalTypeVariant column, so that a string carrying a format annotation
+	// is stored with the variant type it would have had as a column of its own.
+	// Types with no variant counterpart, and the zero value, store the string
+	// as a variant string.
+	VariantStringType ParquetDataType
+}
+
+// ParquetDataType provides a mapping for the JSON types we support to an appropriate parquet data
+// type. We make use a both primitive and logical types for this.
+//
+// Primitive types are the basic data types of Parquet. We don't have a use for the INT32 or FLOAT32
+// primitive types as-is, and we don't use INT96 which has been deprecated, although it would be
+// nice to store very large integers otherwise. Logical types extend primitive types with metadata
+// annotations for indicating different kinds of values that are represented by the underlying
+// primitive type.
+//
+// Time and Timestamp logical types annotate INT64 primitive types to represent microseconds since
+// midnight and the Unix epoch, respectively. We use microseconds instead of nanoseconds to maximize
+// compatibility, since nanosecond resolution is new to the parquet specification and not widely
+// supported.
+//
+// UUIDs are the binary representation of a 16 byte UUID, an annotate a FIXED_LEN_BYTE_ARRAY of the
+// requisite length.
+//
+// Decimals use a FIXED_LEN_BYTE_ARRAY of length 16. They always have a precision of 38, and the
+// scale is configurable. Values should be provided using the decimal128 type exported by the
+// arrow-go package. This data type is intended to allow storing large exact-precision numeric values,
+// often integers that would overflow an int64, and for that case would use a scale of 0.
+//
+// Intervals use a FIXED_LEN_BYTE_ARRAY of length 12 to store as three little-endian unsigned
+// integers that represent durations at different granularities of time. The first stores a number
+// in months, the second stores a number in days, and the third stores a number in milliseconds.
+//
+// Variants store semi-structured data as an unshredded Parquet Variant V1 group of two required
+// BYTE_ARRAY fields: metadata and value. Values must be provided as JSON, and are encoded to the
+// variant binary form as they are written. Column statistics are not written for variant columns,
+// since byte-wise min/max values of the binary encoding are meaningless and potentially large.
+//
+// Values for integers and numbers may be provided as strings, as long as those strings can be
+// parsed into their numeric values, as with strings with numeric format annotations in their JSON
+// schemas. Similarly, values for binary columns must be provided as base64-encoded strings. Date,
+// time, timestamp, UUID, and interval should must be provided as strings in their respective
+// formats.
+type ParquetDataType int
+
+const (
+	PrimitiveTypeInteger      ParquetDataType = iota // INT64 primitive type
+	PrimitiveTypeNumber                              // DOUBLE primitive type, which is a 64-bit float
+	PrimitiveTypeBoolean                             // BOOLEAN primitive type
+	PrimitiveTypeBinary                              // BYTE_ARRAY primitive type
+	LogicalTypeString                                // Extends BYTE_ARRAY
+	LogicalTypeJson                                  // Extends BYTE_ARRAY
+	LogicalTypeDate                                  // Extends BYTE_ARRAY
+	LogicalTypeTime                                  // Extends INT64
+	LogicalTypeTimestamp                             // Extends INT64, microsecond precision
+	LogicalTypeTimestampNanos                        // Extends INT64, nanosecond precision
+	LogicalTypeUuid                                  // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeDecimal                               // Extends FIXED_LEN_BYTE_ARRAY, with a length of 16 bytes
+	LogicalTypeInterval                              // Extends FIXED_LEN_BYTE_ARRAY, with a length of 12 bytes
+	LogicalTypeVariant                               // Group of required BYTE_ARRAY metadata and value fields
+	LogicalTypeUnknown                               // Must always be nil
+)
+
+// makeNode translates a ParquetSchemaElement into an actual parquet schema node.
+func makeNode(e ParquetSchemaElement) schema.Node {
+	repetition := parquet.Repetitions.Required
+	if !e.Required {
+		repetition = parquet.Repetitions.Optional
+	}
+	fieldId := int32(-1)
+	if e.FieldId != nil {
+		fieldId = *e.FieldId
+	}
+
+	switch e.DataType {
+	case PrimitiveTypeInteger:
+		return schema.NewInt64Node(e.Name, repetition, fieldId)
+	case PrimitiveTypeNumber:
+		return schema.NewFloat64Node(e.Name, repetition, fieldId)
+	case PrimitiveTypeBoolean:
+		return schema.NewBooleanNode(e.Name, repetition, fieldId)
+	case PrimitiveTypeBinary:
+		return schema.NewByteArrayNode(e.Name, repetition, fieldId)
+	case LogicalTypeString:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.StringLogicalType{},
+			parquet.Types.ByteArray,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeUuid:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.UUIDLogicalType{},
+			parquet.Types.FixedLenByteArray,
+			16,
+			fieldId,
+		))
+	case LogicalTypeJson:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.JSONLogicalType{},
+			parquet.Types.ByteArray,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeDate:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.DateLogicalType{},
+			parquet.Types.Int32,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeTime:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewTimeLogicalType(true, schema.TimeUnitMicros),
+			parquet.Types.Int64,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeTimestamp:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewTimestampLogicalType(true, schema.TimeUnitMicros),
+			parquet.Types.Int64,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeTimestampNanos:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewTimestampLogicalType(true, schema.TimeUnitNanos),
+			parquet.Types.Int64,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeVariant:
+		// An unshredded Parquet Variant V1 group: the group node carries the
+		// column's field ID, while the metadata and value sub-fields are part
+		// of the variant encoding rather than columns of the table schema and
+		// so carry no field IDs.
+		return schema.Must(schema.NewGroupNodeLogical(
+			e.Name,
+			repetition,
+			schema.FieldList{
+				schema.MustPrimitive(schema.NewPrimitiveNode("metadata", parquet.Repetitions.Required, parquet.Types.ByteArray, -1, -1)),
+				schema.MustPrimitive(schema.NewPrimitiveNode("value", parquet.Repetitions.Required, parquet.Types.ByteArray, -1, -1)),
+			},
+			schema.VariantLogicalType{},
+			fieldId,
+		))
+	case LogicalTypeInterval:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.IntervalLogicalType{},
+			parquet.Types.FixedLenByteArray,
+			12,
+			fieldId,
+		))
+	case LogicalTypeUnknown:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.UnknownLogicalType{},
+			parquet.Types.Undefined,
+			-1,
+			fieldId,
+		))
+	case LogicalTypeDecimal:
+		return schema.Must(schema.NewPrimitiveNodeLogical(
+			e.Name,
+			repetition,
+			schema.NewDecimalLogicalType(38, e.Scale),
+			parquet.Types.FixedLenByteArray,
+			16,
+			fieldId,
+		))
+	default:
+		panic(fmt.Sprintf("makeNode unknown type: %d", e.DataType))
+	}
+}
+
+type parquetSchemaConfig struct {
+	durationAsString bool
+	arrayAsString    bool
+	objectAsString   bool
+	timeAsString     bool
+	uuidAsString     bool
+	timestampAsNanos bool
+	jsonAsVariant    bool
+}
+
+// jsonDataType resolves the data type of a JSON-shaped location (array,
+// object, or multiple types). Variant takes precedence over an as-string
+// option: connectors that can't store the JSON logical type set both, and the
+// variant encoding is only produced when explicitly requested.
+func (cfg parquetSchemaConfig) jsonDataType(asString bool) ParquetDataType {
+	if cfg.jsonAsVariant {
+		return LogicalTypeVariant
+	}
+	return typeOrString(LogicalTypeJson, asString)
+}
+
+type ParquetSchemaOption func(*parquetSchemaConfig)
+
+func WithParquetSchemaDurationAsString() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.durationAsString = true
+	}
+}
+
+func WithParquetSchemaArrayAsString() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.arrayAsString = true
+	}
+}
+
+func WithParquetSchemaObjectAsString() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.objectAsString = true
+	}
+}
+
+func WithParquetTimeAsString() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.timeAsString = true
+	}
+}
+
+func WithParquetUUIDAsString() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.uuidAsString = true
+	}
+}
+
+func WithParquetTimestampAsNanoseconds() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.timestampAsNanos = true
+	}
+}
+
+func WithParquetSchemaJSONAsVariant() ParquetSchemaOption {
+	return func(cfg *parquetSchemaConfig) {
+		cfg.jsonAsVariant = true
+	}
+}
+
+func ProjectionToParquetSchemaElement(p pf.Projection, castToString bool, opts ...ParquetSchemaOption) ParquetSchemaElement {
+	cfg := parquetSchemaConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	out := ParquetSchemaElement{
+		Name:     p.Field,
+		Required: !slices.Contains(p.Inference.Types, "null") && (p.Inference.Exists == pf.Inference_MUST || p.Inference.DefaultJson != nil),
+	}
+
+	if castToString {
+		out.DataType = LogicalTypeString
+		return out
+	}
+
+	if numFormat, ok := m.AsFormattedNumeric(&p); ok {
+		if numFormat == m.StringFormatInteger {
+			out.DataType = PrimitiveTypeInteger
+		} else {
+			out.DataType = PrimitiveTypeNumber
+		}
+
+		return out
+	}
+
+	hadType := false
+	for _, t := range p.Inference.Types {
+		if t == "null" {
+			continue
+		}
+
+		if hadType {
+			out.DataType = cfg.jsonDataType(cfg.objectAsString)
+			break
+		}
+
+		hadType = true
+
+		switch t {
+		case "array":
+			out.DataType = cfg.jsonDataType(cfg.arrayAsString)
+		case "object":
+			out.DataType = cfg.jsonDataType(cfg.objectAsString)
+		case "boolean":
+			out.DataType = PrimitiveTypeBoolean
+		case "integer":
+			out.DataType = PrimitiveTypeInteger
+		case "number":
+			out.DataType = PrimitiveTypeNumber
+		case "string":
+			out.DataType = cfg.stringDataType(p.Inference.String_)
+		}
+	}
+
+	if !hadType {
+		out.DataType = LogicalTypeUnknown
+	}
+
+	// A variant column stores its string values with the type they would have
+	// had as a column of their own, which is the same resolution applied here
+	// so that the connector's as-string options apply equally to both.
+	if out.DataType == LogicalTypeVariant && p.Inference.String_ != nil {
+		out.VariantStringType = cfg.stringDataType(p.Inference.String_)
+	}
+
+	return out
+}
+
+// stringDataType resolves the data type of a string location from its content
+// encoding and format annotations.
+func (cfg parquetSchemaConfig) stringDataType(s *pf.Inference_String) ParquetDataType {
+	if s.ContentEncoding == "base64" {
+		return PrimitiveTypeBinary
+	}
+
+	switch s.Format {
+	case "date":
+		return LogicalTypeDate
+	case "date-time":
+		if cfg.timestampAsNanos {
+			return LogicalTypeTimestampNanos
+		}
+		return LogicalTypeTimestamp
+	case "duration":
+		return typeOrString(LogicalTypeInterval, cfg.durationAsString)
+	case "time":
+		return typeOrString(LogicalTypeTime, cfg.timeAsString)
+	case "uuid":
+		return typeOrString(LogicalTypeUuid, cfg.uuidAsString)
+	default:
+		return LogicalTypeString
+	}
+}
+
+func typeOrString[T ParquetDataType](base T, shouldString bool) T {
+	if shouldString {
+		return T(LogicalTypeString)
+	}
+	return base
+}

--- a/materialize-snowflake/bdecparquet/scratch_fadvise_linux.go
+++ b/materialize-snowflake/bdecparquet/scratch_fadvise_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package bdecparquet
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// dropPageCache hints to the kernel that f's cached pages can be released immediately, rather
+// than lingering as reclaimable-but-unreclaimed page cache. Page cache from scratch file I/O is
+// charged against the process's cgroup memory limit the same as heap memory, but the kernel has
+// no reason to prioritize reclaiming it until it's under memory pressure -- which can be too late
+// against a hard cgroup memory.max with no throttling runway.
+func dropPageCache(f *os.File) {
+	_ = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED)
+}
+
+// flushAndDropPageCache forces writeback of f's dirty pages and then drops them from the page
+// cache. FADV_DONTNEED skips dirty pages, so the writeback must complete first for the drop to
+// take effect on a freshly written file. Calling this after each row group written to the scratch
+// file caps the file's resident page cache at roughly one buffer's worth, rather than letting it
+// grow to the full scratch file size.
+func flushAndDropPageCache(f *os.File) {
+	_ = unix.SyncFileRange(int(f.Fd()), 0, 0, // whole file
+		unix.SYNC_FILE_RANGE_WAIT_BEFORE|unix.SYNC_FILE_RANGE_WRITE|unix.SYNC_FILE_RANGE_WAIT_AFTER)
+	_ = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED)
+}
+
+// dropPageCacheRange drops a byte range of f from the page cache. It only works on clean pages,
+// so it is suited to ranges that were read back from a file already synced by
+// flushAndDropPageCache. The kernel rounds the range inward to whole pages.
+func dropPageCacheRange(f *os.File, off, length int64) {
+	_ = unix.Fadvise(int(f.Fd()), off, length, unix.FADV_DONTNEED)
+}

--- a/materialize-snowflake/bdecparquet/scratch_fadvise_other.go
+++ b/materialize-snowflake/bdecparquet/scratch_fadvise_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package bdecparquet
+
+import "os"
+
+// dropPageCache is a no-op outside of Linux; connectors only run in Linux containers in
+// production, and fadvise has no portable equivalent worth pursuing for local dev/test builds.
+func dropPageCache(f *os.File) {}
+
+func flushAndDropPageCache(f *os.File) {}
+
+func dropPageCacheRange(f *os.File, off, length int64) {}


### PR DESCRIPTION
**Description:**

The Snowflake bdec write path now uses `materialize-snowflake/bdecparquet`, a verbatim, frozen copy of the `go/writer` parquet writer. All other connectors keep using `go/writer`, which can now change without risking bdec. The copy is deleted when bdec is removed.

**Workflow steps:**

No user-facing change.

**Notes for reviewers:**

`bdecparquet` is a byte-for-byte copy of the parquet files in `go/writer` (package name aside). The only other diff is the import swap in `bdec.go`.

**Checklist:**

- [ ] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]