### PR TITLE
materialize-redshift: lock the checkpoints table first and retry serialization failures

### DIFF
--- a/materialize-redshift/CHANGELOG.md
+++ b/materialize-redshift/CHANGELOG.md
@@ -1,5 +1,16 @@
 # materialize-redshift
 
+## 2026-09-11
+
+### Fixed
+- Materializations sharing a metadata schema on a database using
+  `SERIALIZABLE` isolation failed with `ERROR: 1023` (serializable isolation
+  violation) when they committed concurrently, because the checkpoints table
+  lock was taken after the transaction's snapshot. The lock is now the commit
+  transaction's first statement, as it was before the post-commit apply
+  change, and a serialization failure or deadlock during the commit is
+  retried instead of failing the task.
+
 ## 2026-08-29
 
 ### Changed

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -1082,10 +1082,8 @@ func (d *transactor) commit(ctx context.Context, pending connectorState, legacyC
 		}
 	}
 
-	// A serialization failure rolls the transaction back without applying
-	// anything, so the same staged files are simply applied again.
 	var affected map[*commitGroup]int64
-	if err := retryOnSerializationFailure(ctx, func() error {
+	if err := retry(ctx, func() error {
 		var err error
 		affected, err = d.applyStaged(ctx, conn, groups, tokensMap, legacyCheckpoint)
 		return err
@@ -1109,9 +1107,8 @@ func (d *transactor) commit(ctx context.Context, pending connectorState, legacyC
 	return nil
 }
 
-// applyStaged runs one Redshift transaction applying every group's staged
-// files to its table and recording their tokens, and returns the target rows
-// each group's statements reported touching.
+// applyStaged applies the groups in one transaction and returns the target
+// rows each touched.
 func (d *transactor) applyStaged(ctx context.Context, conn *pgx.Conn, groups []*commitGroup, tokensMap checkpointTokensMap, legacyCheckpoint []byte) (map[*commitGroup]int64, error) {
 	txn, err := conn.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {

--- a/materialize-redshift/driver.go
+++ b/materialize-redshift/driver.go
@@ -959,29 +959,30 @@ func lastCopyCount(ctx context.Context, txn pgx.Tx) (int64, error) {
 	return n, err
 }
 
+// commitGroup is one binding's pending transactions from every shard, merged
+// into one, with manifests written for the commit.
+type commitGroup struct {
+	binding                       *binding
+	merged                        stateItem
+	storeManifest, deleteManifest string
+	// round is this shard's own entry's round when it has one, else the
+	// first merged entry's; a multi-shard commit is unchecked anyway.
+	round    int
+	hasRound bool
+}
+
 // commit runs the staged transactions of pending as one Redshift
 // transaction, skipping any whose token is already committed. legacyCheckpoint,
 // when non-nil, is mirrored into the checkpoints row alongside the tokens.
 func (d *transactor) commit(ctx context.Context, pending connectorState, legacyCheckpoint []byte) error {
-	// group is one binding's pending transactions from every shard, merged
-	// into one, with manifests written for the commit.
-	type group struct {
-		binding                       *binding
-		merged                        stateItem
-		storeManifest, deleteManifest string
-		// round is this shard's own entry's round when it has one, else the
-		// first merged entry's; a multi-shard commit is unchecked anyway.
-		round    int
-		hasRound bool
-	}
-	var groups []*group
+	var groups []*commitGroup
 	var tokensMap = make(checkpointTokensMap)
 	for _, b := range d.bindings {
 		var bucket = pending[b.target.StateKey]
 		if len(bucket) == 0 {
 			continue
 		}
-		var g = &group{binding: b}
+		var g = &commitGroup{binding: b}
 		for rk, e := range bucket {
 			if d.committedTokens[e.ID] {
 				log.WithFields(log.Fields{
@@ -1081,18 +1082,51 @@ func (d *transactor) commit(ctx context.Context, pending connectorState, legacyC
 		}
 	}
 
+	// A serialization failure rolls the transaction back without applying
+	// anything, so the same staged files are simply applied again.
+	var affected map[*commitGroup]int64
+	if err := retryOnSerializationFailure(ctx, func() error {
+		var err error
+		affected, err = d.applyStaged(ctx, conn, groups, tokensMap, legacyCheckpoint)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	for _, g := range groups {
+		stats := m.TotalRowStats(affected[g])
+		if g.merged.Rows > 0 {
+			stats = stats.WithStaged(g.merged.Rows)
+		}
+		d.be.ReportRowStats(g.round, g.binding.target.Path, stats)
+	}
+	for _, bucket := range tokensMap {
+		for _, token := range bucket {
+			d.committedTokens[token] = true
+		}
+	}
+
+	return nil
+}
+
+// applyStaged runs one Redshift transaction applying every group's staged
+// files to its table and recording their tokens, and returns the target rows
+// each group's statements reported touching.
+func (d *transactor) applyStaged(ctx context.Context, conn *pgx.Conn, groups []*commitGroup, tokensMap checkpointTokensMap, legacyCheckpoint []byte) (map[*commitGroup]int64, error) {
 	txn, err := conn.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return fmt.Errorf("store BeginTx: %w", err)
+		return nil, fmt.Errorf("store BeginTx: %w", err)
 	}
 	defer txn.Rollback(ctx)
 
+	if err := d.checkpointsTable.lock(ctx, txn); err != nil {
+		return nil, err
+	}
+
+	var affected = make(map[*commitGroup]int64)
 	for _, g := range groups {
 		var b = g.binding
 		d.be.StartedResourceCommit(b.target.Path)
-		// affected sums the target rows each statement reports touching, for
-		// the transaction health report.
-		var affected int64
 
 		if g.deleteManifest != "" {
 			// Create the temporary table for staging values to delete from the target table.
@@ -1103,19 +1137,19 @@ func (d *transactor) commit(ctx context.Context, pending connectorState, legacyC
 				Target:            &b.target,
 				VarcharColumnMeta: b.varcharColumnMetas,
 			}); err != nil {
-				return fmt.Errorf("evaluating create delete table template: %w", err)
+				return nil, fmt.Errorf("evaluating create delete table template: %w", err)
 			} else if _, err := txn.Exec(ctx, createDeleteTableSQL.String()); err != nil {
-				return fmt.Errorf("creating delete table: %w", err)
+				return nil, fmt.Errorf("creating delete table: %w", err)
 			}
 
 			if copySQL, err := d.copyFromS3(fmt.Sprintf("flow_temp_table_%d_deleted", b.target.Binding), g.deleteManifest, false); err != nil {
-				return err
+				return nil, err
 			} else if _, err := txn.Exec(ctx, copySQL); err != nil {
-				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.DeleteFiles, b.target.Identifier, err)
+				return nil, handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.DeleteFiles, b.target.Identifier, err)
 			} else if tag, err := txn.Exec(ctx, b.deleteQuerySQL); err != nil {
-				return fmt.Errorf("deleting from table '%s': %w", b.target.Identifier, err)
+				return nil, fmt.Errorf("deleting from table '%s': %w", b.target.Identifier, err)
 			} else {
-				affected += tag.RowsAffected()
+				affected[g] += tag.RowsAffected()
 			}
 		}
 
@@ -1130,60 +1164,49 @@ func (d *transactor) commit(ctx context.Context, pending connectorState, legacyC
 				Target:            &b.target,
 				VarcharColumnMeta: b.varcharColumnMetas,
 			}); err != nil {
-				return fmt.Errorf("evaluating create store table template: %w", err)
+				return nil, fmt.Errorf("evaluating create store table template: %w", err)
 			} else if _, err := txn.Exec(ctx, createStoreTableSQL.String()); err != nil {
-				return fmt.Errorf("creating store table: %w", err)
+				return nil, fmt.Errorf("creating store table: %w", err)
 			}
 
 			if copySQL, err := d.copyFromS3(fmt.Sprintf("flow_temp_table_%d", b.target.Binding), g.storeManifest, true); err != nil {
-				return err
+				return nil, err
 			} else if _, err := txn.Exec(ctx, copySQL); err != nil {
-				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.StoreFiles, b.target.Identifier, err)
+				return nil, handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.StoreFiles, b.target.Identifier, err)
 			} else if n, err := lastCopyCount(ctx, txn); err != nil {
-				return fmt.Errorf("reading rows staged for table '%s': %w", b.target.Identifier, err)
+				return nil, fmt.Errorf("reading rows staged for table '%s': %w", b.target.Identifier, err)
 			} else if _, err := txn.Exec(ctx, b.mergeIntoSQL); err != nil {
-				return fmt.Errorf("merging to table '%s': %w", b.target.Identifier, err)
+				return nil, fmt.Errorf("merging to table '%s': %w", b.target.Identifier, err)
 			} else {
 				// MERGE's command tag counts only the rows it inserted, so
 				// the rows COPY loaded into the staging table stand in for
 				// the target rows: each matches or inserts exactly one.
-				affected += n
+				affected[g] += n
 			}
 		} else {
 			// Can copy directly into the target table since all values are new.
 			if copySQL, err := d.copyFromS3(b.target.Identifier, g.storeManifest, true); err != nil {
-				return err
+				return nil, err
 			} else if _, err := txn.Exec(ctx, copySQL); err != nil {
-				return handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.StoreFiles, b.target.Identifier, err)
+				return nil, handleCopyIntoErr(ctx, txn, d.cfg.Bucket, g.merged.StoreFiles, b.target.Identifier, err)
 			} else if n, err := lastCopyCount(ctx, txn); err != nil {
-				return fmt.Errorf("reading rows loaded into table '%s': %w", b.target.Identifier, err)
+				return nil, fmt.Errorf("reading rows loaded into table '%s': %w", b.target.Identifier, err)
 			} else {
-				affected += n
+				affected[g] += n
 			}
 		}
 
-		stats := m.TotalRowStats(affected)
-		if g.merged.Rows > 0 {
-			stats = stats.WithStaged(g.merged.Rows)
-		}
-		d.be.ReportRowStats(g.round, b.target.Path, stats)
 		d.be.FinishedResourceCommit(b.target.Path)
 	}
 
 	// Written in the same transaction as the data: a committed token proves
 	// the data committed, and a rolled-back commit leaves no token.
 	if err := d.checkpointsTable.write(ctx, txn, tokensMap, legacyCheckpoint); err != nil {
-		return err
+		return nil, err
 	} else if err := txn.Commit(ctx); err != nil {
-		return fmt.Errorf("committing store transaction: %w", err)
+		return nil, fmt.Errorf("committing store transaction: %w", err)
 	}
-	for _, bucket := range tokensMap {
-		for _, token := range bucket {
-			d.committedTokens[token] = true
-		}
-	}
-
-	return nil
+	return affected, nil
 }
 
 // putManifest writes a manifest listing files under a fresh key, or returns

--- a/materialize-redshift/driver_unit_test.go
+++ b/materialize-redshift/driver_unit_test.go
@@ -24,7 +24,7 @@ func TestSpecification(t *testing.T) {
 	cupaloy.SnapshotT(t, formatted)
 }
 
-func TestIsSerializationFailure(t *testing.T) {
+func TestIsRetriable(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
@@ -39,17 +39,17 @@ func TestIsSerializationFailure(t *testing.T) {
 		{"column exists", &pgconn.PgError{Code: "42701"}, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, isSerializationFailure(tc.err))
+			require.Equal(t, tc.want, isRetriable(tc.err))
 		})
 	}
 }
 
-func TestRetryOnSerializationFailure(t *testing.T) {
-	serializationRetryDelay = 0
+func TestRetry(t *testing.T) {
+	retryDelay = 0
 	var violation = &pgconn.PgError{Code: "XX000", Message: "1023"}
 
 	var calls int
-	require.NoError(t, retryOnSerializationFailure(context.Background(), func() error {
+	require.NoError(t, retry(context.Background(), func() error {
 		calls++
 		if calls < 3 {
 			return fmt.Errorf("writing applied tokens: %w", violation)
@@ -59,15 +59,15 @@ func TestRetryOnSerializationFailure(t *testing.T) {
 	require.Equal(t, 3, calls)
 
 	calls = 0
-	require.ErrorIs(t, retryOnSerializationFailure(context.Background(), func() error {
+	require.ErrorIs(t, retry(context.Background(), func() error {
 		calls++
 		return violation
 	}), violation)
-	require.Equal(t, maxTxnAttempts, calls)
+	require.Equal(t, maxAttempts, calls)
 
 	calls = 0
 	var other = errors.New("not transient")
-	require.ErrorIs(t, retryOnSerializationFailure(context.Background(), func() error {
+	require.ErrorIs(t, retry(context.Background(), func() error {
 		calls++
 		return other
 	}), other)

--- a/materialize-redshift/driver_unit_test.go
+++ b/materialize-redshift/driver_unit_test.go
@@ -3,10 +3,13 @@ package connector
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
 	pm "github.com/estuary/flow/go/protocols/materialize"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +22,54 @@ func TestSpecification(t *testing.T) {
 	require.NoError(t, err)
 
 	cupaloy.SnapshotT(t, formatted)
+}
+
+func TestIsSerializationFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain", errors.New("boom"), false},
+		{"1023", &pgconn.PgError{Severity: "ERROR", Code: "XX000", Message: "1023", Detail: "Serializable isolation violation on table - 1, transactions forming the cycle are: 2, 3 (pid:4)"}, true},
+		{"wrapped 1023", fmt.Errorf("writing applied tokens: %w", &pgconn.PgError{Code: "XX000", Message: "1023"}), true},
+		{"deadlock", &pgconn.PgError{Code: "40P01", Message: "deadlock detected"}, true},
+		{"other internal", &pgconn.PgError{Code: "XX000", Message: "1018"}, false},
+		{"column exists", &pgconn.PgError{Code: "42701"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isSerializationFailure(tc.err))
+		})
+	}
+}
+
+func TestRetryOnSerializationFailure(t *testing.T) {
+	serializationRetryDelay = 0
+	var violation = &pgconn.PgError{Code: "XX000", Message: "1023"}
+
+	var calls int
+	require.NoError(t, retryOnSerializationFailure(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("writing applied tokens: %w", violation)
+		}
+		return nil
+	}))
+	require.Equal(t, 3, calls)
+
+	calls = 0
+	require.ErrorIs(t, retryOnSerializationFailure(context.Background(), func() error {
+		calls++
+		return violation
+	}), violation)
+	require.Equal(t, maxTxnAttempts, calls)
+
+	calls = 0
+	var other = errors.New("not transient")
+	require.ErrorIs(t, retryOnSerializationFailure(context.Background(), func() error {
+		calls++
+		return other
+	}), other)
+	require.Equal(t, 1, calls)
 }

--- a/materialize-redshift/retry.go
+++ b/materialize-redshift/retry.go
@@ -9,38 +9,44 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const maxTxnAttempts = 5
+const maxAttempts = 5
 
-// serializationRetryDelay is the backoff unit between attempts: attempt n
-// waits n times this.
-var serializationRetryDelay = 5 * time.Second
+var retryDelay = 5 * time.Second
 
-// isSerializationFailure reports whether err is Redshift's serializable
-// isolation violation (ERROR: 1023, raised as an internal error whose message
-// is the code) or a deadlock. Both roll the transaction back, and Redshift's
-// documented remedy is to run it again.
-func isSerializationFailure(err error) bool {
+type pgErrorMatch struct {
+	code, message string
+}
+
+var retriableErrors = []pgErrorMatch{
+	{code: "XX000", message: "1023"}, // serializable isolation violation
+	{code: "40P01"},                  // deadlock detected
+}
+
+func isRetriable(err error) bool {
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) {
 		return false
 	}
-	return (pgErr.Code == "XX000" && pgErr.Message == "1023") || pgErr.Code == "40P01"
+	for _, m := range retriableErrors {
+		if pgErr.Code == m.code && (m.message == "" || pgErr.Message == m.message) {
+			return true
+		}
+	}
+	return false
 }
 
-// retryOnSerializationFailure runs fn, one Redshift transaction, again after
-// a serialization failure, with backoff, up to maxTxnAttempts times.
-func retryOnSerializationFailure(ctx context.Context, fn func() error) error {
+func retry(ctx context.Context, fn func() error) error {
 	for attempt := 1; ; attempt++ {
 		err := fn()
-		if err == nil || !isSerializationFailure(err) || attempt == maxTxnAttempts {
+		if err == nil || !isRetriable(err) || attempt == maxAttempts {
 			return err
 		}
-		var delay = time.Duration(attempt) * serializationRetryDelay
+		var delay = time.Duration(attempt) * retryDelay
 		log.WithFields(log.Fields{
 			"attempt": attempt,
 			"retryIn": delay.String(),
 			"error":   err,
-		}).Warn("transaction rolled back by a serialization failure and will be retried")
+		}).Warn("transaction rolled back by a retriable error and will be retried")
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/materialize-redshift/retry.go
+++ b/materialize-redshift/retry.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	log "github.com/sirupsen/logrus"
+)
+
+const maxTxnAttempts = 5
+
+// serializationRetryDelay is the backoff unit between attempts: attempt n
+// waits n times this.
+var serializationRetryDelay = 5 * time.Second
+
+// isSerializationFailure reports whether err is Redshift's serializable
+// isolation violation (ERROR: 1023, raised as an internal error whose message
+// is the code) or a deadlock. Both roll the transaction back, and Redshift's
+// documented remedy is to run it again.
+func isSerializationFailure(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return (pgErr.Code == "XX000" && pgErr.Message == "1023") || pgErr.Code == "40P01"
+}
+
+// retryOnSerializationFailure runs fn, one Redshift transaction, again after
+// a serialization failure, with backoff, up to maxTxnAttempts times.
+func retryOnSerializationFailure(ctx context.Context, fn func() error) error {
+	for attempt := 1; ; attempt++ {
+		err := fn()
+		if err == nil || !isSerializationFailure(err) || attempt == maxTxnAttempts {
+			return err
+		}
+		var delay = time.Duration(attempt) * serializationRetryDelay
+		log.WithFields(log.Fields{
+			"attempt": attempt,
+			"retryIn": delay.String(),
+			"error":   err,
+		}).Warn("transaction rolled back by a serialization failure and will be retried")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}

--- a/materialize-redshift/state.go
+++ b/materialize-redshift/state.go
@@ -214,20 +214,26 @@ func (s *checkpointsTable) readAll(ctx context.Context, conn *pgx.Conn) (map[str
 	return applied, legacyCheckpoint, crossedOver, nil
 }
 
+// lock takes an exclusive lock on the table for the rest of txn, and must be
+// txn's first statement. Materializations sharing a metadata schema update
+// this table concurrently, and under SERIALIZABLE isolation a write from a
+// snapshot older than a concurrent commit fails with ERROR: 1023 even when
+// the rows differ. Redshift takes the snapshot at the first DML statement,
+// so a lock before any of them waits out every concurrent commit first.
+func (s *checkpointsTable) lock(ctx context.Context, txn pgx.Tx) error {
+	if _, err := txn.Exec(ctx, fmt.Sprintf("lock %s;", s.table)); err != nil {
+		return fmt.Errorf("obtaining checkpoints table lock: %w", err)
+	}
+	return nil
+}
+
 // write records the tokens of just-applied transactions in the row, within
-// txn. When legacyCheckpoint is non-nil, it's mirrored into the legacy
+// txn, which must hold the table lock. When legacyCheckpoint is non-nil, it's mirrored into the legacy
 // checkpoint column too, so a downgraded connector can resume from it; the
 // caller passes one only once every entry that was pending is settled by
 // this call, so the mirror never claims a checkpoint whose data is only
 // partially applied.
 func (s *checkpointsTable) write(ctx context.Context, txn pgx.Tx, applied checkpointTokensMap, legacyCheckpoint []byte) error {
-	// Materializations sharing a metadata schema update the same table
-	// concurrently, which raises serializable isolation violations even for
-	// different rows. All applies take this one lock in the same order.
-	if _, err := txn.Exec(ctx, fmt.Sprintf("lock %s;", s.table)); err != nil {
-		return fmt.Errorf("obtaining checkpoints table lock: %w", err)
-	}
-
 	if s.payload == nil {
 		s.payload = make(checkpointTokensMap)
 	}

--- a/materialize-redshift/state.go
+++ b/materialize-redshift/state.go
@@ -214,12 +214,9 @@ func (s *checkpointsTable) readAll(ctx context.Context, conn *pgx.Conn) (map[str
 	return applied, legacyCheckpoint, crossedOver, nil
 }
 
-// lock takes an exclusive lock on the table for the rest of txn, and must be
-// txn's first statement. Materializations sharing a metadata schema update
-// this table concurrently, and under SERIALIZABLE isolation a write from a
-// snapshot older than a concurrent commit fails with ERROR: 1023 even when
-// the rows differ. Redshift takes the snapshot at the first DML statement,
-// so a lock before any of them waits out every concurrent commit first.
+// lock must be txn's first statement: Redshift snapshots at the first DML,
+// and under SERIALIZABLE isolation writing this shared table from a snapshot
+// older than another task's commit fails with ERROR: 1023.
 func (s *checkpointsTable) lock(ctx context.Context, txn pgx.Tx) error {
 	if _, err := txn.Exec(ctx, fmt.Sprintf("lock %s;", s.table)); err != nil {
 		return fmt.Errorf("obtaining checkpoints table lock: %w", err)


### PR DESCRIPTION
**Description:**

Materializations sharing a metadata schema on a Redshift database with `SERIALIZABLE` isolation failed with `ERROR: 1023` (serializable isolation violation) when they committed concurrently, because the checkpoints table lock was taken after the transaction's snapshot. The lock is now the commit transaction's first statement, and a serialization failure or deadlock during the commit is retried instead of failing the task.

**Workflow steps:**

No change.

**Notes for reviewers:**

Reproduced against a database created with `ISOLATION LEVEL SERIALIZABLE` on the test workgroup; the shared `dev` database uses `SNAPSHOT` isolation, where the conflict cannot occur.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: https://github.com/estuary/connectors/pull/5185
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [ ] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
