### PR TITLE
Docs: Reformat connector lists in reference docs

### DIFF
--- a/docs/reference/Connectors/capture-connectors/README.md
+++ b/docs/reference/Connectors/capture-connectors/README.md
@@ -18,303 +18,105 @@ These connectors are created by Estuary. We prioritize high-scale technology sys
 
 All Estuary connectors capture data in real time, as it appears in the source system.
 
-- Ada
-  - [Configuration](./ada.md)
-  - Package - ghcr.io/estuary/source-ada:v1
-- Airtable
-  - [Configuration](./airtable-native.md)
-  - Package - ghcr.io/estuary/source-airtable-native:v1
-- AlloyDB
-  - [Configuration](./alloydb.md)
-  - Package - ghcr.io/estuary/source-alloydb:v3
-- Alpaca
-  - [Configuration](./alpaca.md)
-  - Package - ghcr.io/estuary/source-alpaca:v1
-- Amazon DocumentDB
-  - [Configuration](./MongoDB/amazon-documentdb.md)
-  - Package - ghcr.io/estuary/source-amazon-documentdb:v3
-- Amazon Dynamodb
-  - [Configuration](./amazon-dynamodb.md)
-  - Package - ghcr.io/estuary/source-dynamodb:v1
-- Amazon Kinesis
-  - [Configuration](./amazon-kinesis.md)
-  - Package — ghcr.io/estuary/source-kinesis:v1
-- Amazon RDS SQL Server
-  - [Configuration](./SQLServer/amazon-rds-sqlserver.md)
-  - Package - ghcr.io/estuary/source-amazon-rds-sqlserver:v0
-- Amazon Redshift
-  - [Configuration](./redshift-batch.md)
-  - Package - ghcr.io/estuary/source-redshift-batch:v1
-- Amazon S3
-  - [Configuration](./amazon-s3.md)
-  - Package — ghcr.io/estuary/source-s3:v2
-- Amazon SQS
-  - [Configuration](./amazon-sqs-native.md)
-  - Package - ghcr.io/estuary/source-sqs:v1
-- Apache Kafka
-  - [Configuration](./apache-kafka.md)
-  - Package — ghcr.io/estuary/source-kafka:v1
-- Apple App Store
-  - [Configuration](./apple-app-store.md)
-  - Package - ghcr.io/estuary/source-apple-app-store:v1
-- AppsFlyer
-  - [Configuration](./appsflyer.md)
-  - Package - ghcr.io/estuary/source-appsflyer:v1
-- Asana
-  - [Configuration](./asana.md)
-  - Package - ghcr.io/estuary/source-asana:v1
-- Ashby
-  - [Configuration](./ashby.md)
-  - Package - ghcr.io/estuary/source-ashby:v1
-- Azure Blob Storage
-  - [Configuration](./azure-blob-storage.md)
-  - Package — ghcr.io/estuary/azure-blob-storage:v1
-- Azure Cosmos DB
-  - [Configuration](./MongoDB/azure-cosmosdb.md)
-  - Package - ghcr.io/estuary/source-cosmosdb-mongodb:v3
-- Azure SQL Server
-  - [Configuration](./SQLServer/)
-  - Package - ghcr.io/estuary/source-azure-sqlserver:v0
-- BigQuery
-  - [Configuration](./bigquery-batch.md)
-  - Package — ghcr.io/estuary/source-bigquery-batch:v1
-- Braintree
-  - [Configuration](./braintree.md)
-  - Package - ghcr.io/estuary/source-braintree-native:v1
-- Brevo
-  - [Configuration](./brevo.md)
-  - Package - ghcr.io/estuary/source-brevo:v2
-- Calendly
-  - [Configuration](./calendly.md)
-  - Package - ghcr.io/estuary/source-calendly:v1
-- Chargebee
-  - [Configuration](./chargebee-native.md)
-  - Package - ghcr.io/estuary/source-chargebee-native:v1
-- Commercetools
-  - [Configuration](./commercetools.md)
-  - Package - ghcr.io/estuary/source-commercetools:v1
-- Criteo
-  - [Configuration](./criteo.md)
-  - Package - ghcr.io/estuary/source-criteo:v1
-- Datadog
-  - [Configuration](./datadog.md)
-  - Package - ghcr.io/estuary/source-datadog:v1
-- Datadog ingest (webhook)
-  - [Configuration](./http-ingest/datadog-ingest.md)
-  - Package - ghcr.io/estuary/source-datadog-ingest:v1
-- Dropbox
-  - [Configuration](./dropbox.md)
-  - Package - ghcr.io/estuary/source-dropbox:v1
-- Facebook Marketing
-  - [Configuration](./facebook-marketing-native.md)
-  - Package - ghcr.io/estuary/source-facebook-marketing-native:v1
-- Front
-  - [Configuration](./front.md)
-  - Package - ghcr.io/estuary/source-front:v3
-- Gainsight NXT
-  - [Configuration](./gainsight-nxt.md)
-  - Package - ghcr.io/estuary/source-gainsight-nxt:v1
-- Genesys
-  - [Configuration](./genesys.md)
-  - Package - ghcr.io/estuary/source-genesys:v1
-- GitHub
-  - [Configuration](./github.md)
-  - Package - ghcr.io/estuary/source-github:v2
-- Gladly
-  - [Configuration](./gladly.md)
-  - Package - ghcr.io/estuary/source-gladly:v1
-- Gong
-  - [Configuration](./gong.md)
-  - Package - ghcr.io/estuary/source-gong:v1
-- Google Ads
-  - [Configuration](./google-ads.md)
-  - Package - ghcr.io/estuary/source-google-ads:v2
-- Google Analytics BigQuery Exports
-  - [Configuration](./google-analytics-4-bigquery-exports.md)
-  - Package - ghcr.io/estuary/source-ga4-bigquery:v1
-- Google Analytics Data API
-  - [Configuration](./google-analytics-data-api-native.md)
-  - Package - ghcr.io/estuary/source-google-analytics-data-api-native:v1
-- Google Cloud Storage
-  - [Configuration](./gcs.md)
-  - Package — ghcr.io/estuary/source-gcs:v2
-- Google Firestore
-  - [Configuration](./google-firestore.md)
-  - Package - ghcr.io/estuary/source-firestore:v3
-- Google Cloud Pub/Sub
-  - [Configuration](./google-pubsub.md)
-  - Package — ghcr.io/estuary/source-google-pubsub:v1
-- Google Cloud SQL Server
-  - [Configuration](./SQLServer/google-cloud-sql-sqlserver.md)
-  - Package - ghcr.io/estuary/source-google-cloud-sql-sqlserver:v0
-- Google Drive
-  - [Configuration](./google-drive.md)
-  - Package - ghcr.io/estuary/source-google-drive:v1
-- Google Play
-  - [Configuration](./google-play.md)
-  - Package - ghcr.io/estuary/source-google-play:v1
-- Google Sheets
-  - [Configuration](./google-sheets.md)
-  - Package - ghcr.io/estuary/source-google-sheets-native:v1
-- Greenhouse
-  - [Configuration](./greenhouse-native.md)
-  - Package - ghcr.io/estuary/source-greenhouse-native:v1
-- HTTP file
-  - [Configuration](./http-file.md)
-  - Package - ghcr.io/estuary/source-http-file:v1
-- HTTP ingest (webhook)
-  - [Configuration](./http-ingest/http-ingest.md)
-  - Package - ghcr.io/estuary/source-http-ingest:v1
-- Hubspot (Real-Time)
-  - [Configuration](./HubSpot-real-time.md)
-  - Package - ghcr.io/estuary/source-hubspot-native:v1
-- IBM Db2 Batch
-  - [Configuration](./db2-batch.md)
-  - Package - ghcr.io/estuary/source-db2-batch:v1
-- Impact
-  - [Configuration](./impact.md)
-  - Package - ghcr.io/estuary/source-impact-native:v2
-- Incident.io
-  - [Configuration](./incident-io.md)
-  - Package - ghcr.io/estuary/source-incident-io:v1
-- Intercom
-  - [Configuration](./intercom-native.md)
-  - Package - ghcr.io/estuary/source-intercom-native:v1
-- Intercom ingest (webhook)
-  - [Configuration](./http-ingest/intercom-ingest.md)
-  - Package - ghcr.io/estuary/source-intercom-ingest:v1
-- Iterable
-  - [Configuration](./iterable-native.md)
-  - Package - ghcr.io/estuary/source-iterable-native:v1
-- Iterate
-  - [Configuration](./iterate.md)
-  - Package - ghcr.io/estuary/source-iterate:v1
-- Jira
-  - [Configuration](./jira-native.md)
-  - Package - ghcr.io/estuary/source-jira-native:v3
-- Jira ingest (webhook)
-  - [Configuration](./http-ingest/jira-ingest.md)
-  - Package - ghcr.io/estuary/source-jira-ingest:v1
-- Klaviyo
-  - [Configuration](./klaviyo-native.md)
-  - Package - ghcr.io/estuary/source-klaviyo-native:v1
-- LinkedIn Pages
-  - [Configuration](./linkedin-pages.md)
-  - Package - ghcr.io/estuary/source-linkedin-pages:v1
-- Looker
-  - [Configuration](./looker.md)
-  - Package - ghcr.io/estuary/source-looker:v1
-- Mailchimp
-  - [Configuration](./mailchimp-native.md)
-  - Package - ghcr.io/estuary/source-mailchimp-native:v1
-- MariaDB
-  - [Configuration](./MariaDB/)
-  - Package - ghcr.io/estuary/source-mariadb:v3
-- Microsoft Dynamics 365 Finance and Operations
-  - [Configuration](./dynamics-365-finance-and-operations.md)
-  - Package - ghcr.io/estuary/source-dynamics-365-finance-and-operations:v1
-- Microsoft SQL Server
-  - [Configuration](./SQLServer/)
-  - Package - ghcr.io/estuary/source-sqlserver:v0
-- Microsoft SQL Server Batch
-  - [Configuration](./SQLServer/sqlserver-batch.md)
-  - Package - ghcr.io/estuary/source-sqlserver-batch:v1
-- Monday
-  - [Configuration](./monday.md)
-  - Package - ghcr.io/estuary/source-monday:v1
-- MongoDB
-  - [Configuration](./MongoDB/mongodb.md)
-  - Package - ghcr.io/estuary/source-mongodb:v3
-- MySQL
-  - [Configuration](./MySQL/)
-  - Package - ghcr.io/estuary/source-mysql:v3
-- MySQL Batch
-  - [Configuration](./MySQL/mysql-batch.md)
-  - Package - ghcr.io/estuary/source-mysql-batch:v1
-- Navan
-  - [Configuration](./navan.md)
-  - Package - ghcr.io/estuary/source-navan:v1
-- NetSuite SuiteAnalytics
-  - [Configuration](./netsuite-suiteanalytics.md)
-  - Package - ghcr.io/estuary/source-netsuite-v2:v4
-- NetSuite SuiteQL
-  - [Configuration](./netsuite-suiteql.md)
-  - Package - ghcr.io/estuary/source-netsuite-suiteql:dev
-- OneDrive
-  - [Configuration](./onedrive.md)
-  - Package - ghcr.io/estuary/source-onedrive:v1
-- OracleDB
-  - [Configuration](./OracleDB/)
-  - Package - ghcr.io/estuary/source-oracle:v1
-- OracleDB Batch
-  - [Configuration](./OracleDB/oracle-batch.md)
-  - Package - ghcr.io/estuary/source-oracle-batch:v1
-- Outreach
-  - [Configuration](./outreach.md)
-  - Package - ghcr.io/estuary/source-outreach:v1
-- Pendo
-  - [Configuration](./pendo.md)
-  - Package - ghcr.io/estuary/source-pendo:v2
-- PostgreSQL
-  - [Configuration](./PostgreSQL/)
-  - Package — ghcr.io/estuary/source-postgres:v3
-- PostgreSQL Batch
-  - [Configuration](./PostgreSQL/postgres-batch.md)
-  - Package - ghcr.io/estuary/source-postgres-batch:v1
-- Qualtrics
-  - [Configuration](./qualtrics.md)
-  - Package - ghcr.io/estuary/source-qualtrics:v1
-- QuickBooks
-  - [Configuration](./quickbooks.md)
-  - Package - ghcr.io/estuary/source-quickbooks:v1
-- RingCentral
-  - [Configuration](./ringcentral.md)
-  - Package - ghcr.io/estuary/source-ringcentral:v1
-- Sage Intacct
-  - [Configuration](./sage-intacct.md)
-  - Package — ghcr.io/estuary/source-sage-intacct:v1
-- Salesforce
-  - [Configuration](./Salesforce/salesforce-native.md)
-  - Package - ghcr.io/estuary/source-salesforce-native:v1
-- Sentry
-  - [Configuration](./sentry.md)
-  - Package - ghcr.io/estuary/source-sentry:v2
-- SFTP
-  - [Configuration](./sftp.md)
-  - Package - ghcr.io/estuary/source-sftp:v1
-- SharePoint
-  - [Configuration](./sharepoint.md)
-  - Package - ghcr.io/estuary/source-sharepoint:v1
-- Shopify
-  - [Configuration](./shopify-native.md)
-  - Package - ghcr.io/estuary/source-shopify-native:v2
-- Smartsheet
-  - [Configuration](./smartsheet.md)
-  - Package - ghcr.io/estuary/source-smartsheet:v1
-- Snowflake
-  - [Configuration](./snowflake.md)
-  - Package - ghcr.io/estuary/source-snowflake:v1
-- Stripe Real-time
-  - [Configuration](./stripe-realtime.md)
-  - Package - ghcr.io/estuary/source-stripe-native:v1
-- Twilio
-  - [Configuration](./twilio.md)
-  - Package - ghcr.io/estuary/source-twilio:v2
-- Twilio ingest (webhook)
-  - [Configuration](./http-ingest/twilio-ingest.md)
-  - Package - ghcr.io/estuary/source-twilio-ingest:v1
-- Zendesk Chat
-  - [Configuration](./zendesk-chat.md)
-  - Package - ghcr.io/estuary/source-zendesk-chat:v1
-- Zendesk Support Real-Time
-  - [Configuration](./zendesk-support-native.md)
-  - Package - ghcr.io/estuary/source-zendesk-support-native:v1
-- Zoho CRM
-  - [Configuration](./zoho-crm.md)
-  - Package - ghcr.io/estuary/source-zoho:v1
-- Zuora
-  - [Configuration](./zuora.md)
-  - Package - ghcr.io/estuary/source-zuora:v1
+- [Ada](./ada.md)
+- [Airtable](./airtable-native.md)
+- [AlloyDB](./alloydb.md)
+- [Alpaca](./alpaca.md)
+- [Amazon DocumentDB](./MongoDB/amazon-documentdb.md)
+- [Amazon Dynamodb](./amazon-dynamodb.md)
+- [Amazon Kinesis](./amazon-kinesis.md)
+- [Amazon RDS SQL Server](./SQLServer/amazon-rds-sqlserver.md)
+- [Amazon Redshift](./redshift-batch.md)
+- [Amazon S3](./amazon-s3.md)
+- [Amazon SQS](./amazon-sqs-native.md)
+- [Apache Kafka](./apache-kafka.md)
+- [Apple App Store](./apple-app-store.md)
+- [AppsFlyer](./appsflyer.md)
+- [Asana](./asana.md)
+- [Ashby](./ashby.md)
+- [Azure Blob Storage](./azure-blob-storage.md)
+- [Azure Cosmos DB](./MongoDB/azure-cosmosdb.md)
+- [Azure SQL Server](./SQLServer/)
+- [BigQuery](./bigquery-batch.md)
+- [Braintree](./braintree.md)
+- [Brevo](./brevo.md)
+- [Calendly](./calendly.md)
+- [Chargebee](./chargebee-native.md)
+- [Commercetools](./commercetools.md)
+- [Criteo](./criteo.md)
+- [Datadog](./datadog.md)
+- [Datadog ingest (webhook)](./http-ingest/datadog-ingest.md)
+- [Dropbox](./dropbox.md)
+- [Facebook Marketing](./facebook-marketing-native.md)
+- [Front](./front.md)
+- [Gainsight NXT](./gainsight-nxt.md)
+- [Genesys](./genesys.md)
+- [GitHub](./github.md)
+- [Gladly](./gladly.md)
+- [Gong](./gong.md)
+- [Google Ads](./google-ads.md)
+- [Google Analytics BigQuery Exports](./google-analytics-4-bigquery-exports.md)
+- [Google Analytics Data API](./google-analytics-data-api-native.md)
+- [Google Cloud Storage](./gcs.md)
+- [Google Firestore](./google-firestore.md)
+- [Google Cloud Pub/Sub](./google-pubsub.md)
+- [Google Cloud SQL Server](./SQLServer/google-cloud-sql-sqlserver.md)
+- [Google Drive](./google-drive.md)
+- [Google Play](./google-play.md)
+- [Google Sheets](./google-sheets.md)
+- [Greenhouse](./greenhouse-native.md)
+- [HTTP file](./http-file.md)
+- [HTTP ingest (webhook)](./http-ingest/http-ingest.md)
+- [Hubspot](./HubSpot-real-time.md)
+- [IBM Db2 Batch](./db2-batch.md)
+- [Impact](./impact.md)
+- [Incident.io](./incident-io.md)
+- [Intercom](./intercom-native.md)
+- [Intercom ingest (webhook)](./http-ingest/intercom-ingest.md)
+- [Iterable](./iterable-native.md)
+- [Iterate](./iterate.md)
+- [Jira](./jira-native.md)
+- [Jira ingest (webhook)](./http-ingest/jira-ingest.md)
+- [Klaviyo](./klaviyo-native.md)
+- [LinkedIn Pages](./linkedin-pages.md)
+- [Looker](./looker.md)
+- [Mailchimp](./mailchimp-native.md)
+- [MariaDB](./MariaDB/)
+- [Microsoft Dynamics 365 Finance and Operations](./dynamics-365-finance-and-operations.md)
+- [Microsoft SQL Server](./SQLServer/)
+- [Microsoft SQL Server Batch](./SQLServer/sqlserver-batch.md)
+- [Monday](./monday.md)
+- [MongoDB](./MongoDB/mongodb.md)
+- [MySQL](./MySQL/)
+- [MySQL Batch](./MySQL/mysql-batch.md)
+- [Navan](./navan.md)
+- [NetSuite SuiteAnalytics](./netsuite-suiteanalytics.md)
+- [NetSuite SuiteQL](./netsuite-suiteql.md)
+- [OneDrive](./onedrive.md)
+- [OracleDB](./OracleDB/)
+- [OracleDB Batch](./OracleDB/oracle-batch.md)
+- [Outreach](./outreach.md)
+- [Pendo](./pendo.md)
+- [PostgreSQL](./PostgreSQL/)
+- [PostgreSQL Batch](./PostgreSQL/postgres-batch.md)
+- [Qualtrics](./qualtrics.md)
+- [QuickBooks](./quickbooks.md)
+- [RingCentral](./ringcentral.md)
+- [Sage Intacct](./sage-intacct.md)
+- [Salesforce](./Salesforce/salesforce-native.md)
+- [Sentry](./sentry.md)
+- [SFTP](./sftp.md)
+- [SharePoint](./sharepoint.md)
+- [Shopify](./shopify-native.md)
+- [Smartsheet](./smartsheet.md)
+- [Snowflake](./snowflake.md)
+- [Stripe](./stripe-realtime.md)
+- [Twilio](./twilio.md)
+- [Twilio ingest (webhook)](./http-ingest/twilio-ingest.md)
+- [Zendesk Chat](./zendesk-chat.md)
+- [Zendesk Support](./zendesk-support-native.md)
+- [Zoho CRM](./zoho-crm.md)
+- [Zuora](./zuora.md)
 
 ### Third party connectors
 
@@ -324,87 +126,31 @@ within the limitations set by the connector itself.
 
 Typically, we enable SaaS connectors from third parties to allow more diverse data flows.
 
-- Aircall
-  - [Configuration](./aircall.md)
-  - Package - ghcr.io/estuary/source-aircall:v1
-- Amazon Ads
-  - [Configuration](./amazon-ads.md)
-  - Package - ghcr.io/estuary/source-amazon-ads:v2
-- Amplitude
-  - [Configuration](./amplitude.md)
-  - Package - ghcr.io/estuary/source-amplitude:v2
-- Bing Ads
-  - [Configuration](./bing-ads.md)
-  - Package - ghcr.io/estuary/source-bing-ads:v2
-- Braze
-  - [Configuration](./braze.md)
-  - Package - ghcr.io/estuary/source-braze:v1
-- Confluence
-  - [Configuration](./confluence.md)
-  - Package - ghcr.io/estuary/source-confluence:v1
-- Exchange Rates API
-  - [Configuration](./exchange-rates.md)
-  - Package - ghcr.io/estuary/source-exchange-rates:dev
-- Freshdesk
-  - [Configuration](./freshdesk.md)
-  - Package - ghcr.io/estuary/source-freshdesk:v1
-- GitLab
-  - [Configuration](./gitlab.md)
-  - Package - ghcr.io/estuary/source-gitlab:v1
-- Google Analytics 4
-  - [Configuration](./google-analytics-4.md)
-  - Package - ghcr.io/estuary/source-google-analytics-data-api:v3
-- Google Universal Analytics
-  - [Configuration](./google-analytics.md)
-  - Package - ghcr.io/estuary/source-google-analytics-ua:v2
-- Google Search Console
-  - [Configuration](./google-search-console.md)
-  - Package - ghcr.io/estuary/source-google-search-console:v2
-- Harvest
-  - [Configuration](./harvest.md)
-  - Package - ghcr.io/estuary/source-harvest:v1
-- Instagram
-  - [Configuration](./instagram.md)
-  - Package - ghcr.io/estuary/source-instagram:v1
-- LinkedIn Ads
-  - [Configuration](./linkedin-ads.md)
-  - Package - ghcr.io/estuary/source-linkedin-ads:v2
-- Marketo
-  - [Configuration](./marketo.md)
-  - Package - ghcr.io/estuary/source-marketo:v1
-- MixPanel
-  - [Configuration](./mixpanel.md)
-  - Package - ghcr.io/estuary/source-mixpanel:v1
-- Notion
-  - [Configuration](./notion.md)
-  - Package - ghcr.io/estuary/source-notion:v2
-- Paypal Transaction
-  - [Configuration](./paypal-transaction.md)
-  - Package - ghcr.io/estuary/source-paypal-transaction:v1
-- Pinterest
-  - [Configuration](./pinterest.md)
-  - Package - ghcr.io/estuary/source-pinterest:v1
-- Recharge
-  - [Configuration](./recharge.md)
-  - Package - ghcr.io/estuary/source-recharge:v1
-- SendGrid
-  - [Configuration](./sendgrid.md)
-  - Package - ghcr.io/estuary/source-sendgrid:v1
-- Slack
-  - [Configuration](./slack.md)
-  - Package - ghcr.io/estuary/source-slack:v2
-- Snapchat
-  - [Configuration](./snapchat.md)
-  - Package - ghcr.io/estuary/source-snapchat-marketing:v1
-- SurveyMonkey
-  - [Configuration](./survey-monkey.md)
-  - Package - ghcr.io/estuary/source-surveymonkey:v2
-- TikTok Marketing
-  - [Configuration](./tiktok.md)
-  - Package - ghcr.io/estuary/source-tiktok-marketing:v2
-- WooCommerce
-  - [Configuration](./woocommerce.md)
-  - Package - ghcr.io/estuary/source-woocommerce:v1
-- YouTube Analytics
-  - [Configuration](./youtube-analytics.md)
-  - Package - ghcr.io/estuary/source-youtube-analytics:v1
+- [Aircall](./aircall.md)
+- [Amazon Ads](./amazon-ads.md)
+- [Amplitude](./amplitude.md)
+- [Bing Ads](./bing-ads.md)
+- [Braze](./braze.md)
+- [Confluence](./confluence.md)
+- [Exchange Rates API](./exchange-rates.md)
+- [Freshdesk](./freshdesk.md)
+- [GitLab](./gitlab.md)
+- [Google Analytics 4](./google-analytics-4.md)
+- [Google Universal Analytics](./google-analytics.md)
+- [Google Search Console](./google-search-console.md)
+- [Harvest](./harvest.md)
+- [Instagram](./instagram.md)
+- [LinkedIn Ads](./linkedin-ads.md)
+- [Marketo](./marketo.md)
+- [MixPanel](./mixpanel.md)
+- [Notion](./notion.md)
+- [Paypal Transaction](./paypal-transaction.md)
+- [Pinterest](./pinterest.md)
+- [Recharge](./recharge.md)
+- [SendGrid](./sendgrid.md)
+- [Slack](./slack.md)
+- [Snapchat](./snapchat.md)
+- [SurveyMonkey](./survey-monkey.md)
+- [TikTok Marketing](./tiktok.md)
+- [WooCommerce](./woocommerce.md)
+- [YouTube Analytics](./youtube-analytics.md)

--- a/docs/reference/Connectors/capture-connectors/README.md
+++ b/docs/reference/Connectors/capture-connectors/README.md
@@ -24,9 +24,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Airtable
   - [Configuration](./airtable-native.md)
   - Package - ghcr.io/estuary/source-airtable-native:v1
-- Airtable (deprecated)
-  - [Configuration](./airtable.md)
-  - Package - ghcr.io/estuary/source-airtable:v1
 - AlloyDB
   - [Configuration](./alloydb.md)
   - Package - ghcr.io/estuary/source-alloydb:v3
@@ -51,6 +48,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Amazon S3
   - [Configuration](./amazon-s3.md)
   - Package — ghcr.io/estuary/source-s3:v2
+- Amazon SQS
+  - [Configuration](./amazon-sqs-native.md)
+  - Package - ghcr.io/estuary/source-sqs:v1
 - Apache Kafka
   - [Configuration](./apache-kafka.md)
   - Package — ghcr.io/estuary/source-kafka:v1
@@ -186,15 +186,9 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Iterable
   - [Configuration](./iterable-native.md)
   - Package - ghcr.io/estuary/source-iterable-native:v1
-- Iterable (deprecated)
-  - [Configuration](./iterable.md)
-  - Package - ghcr.io/estuary/source-iterable:v2
 - Iterate
   - [Configuration](./iterate.md)
   - Package - ghcr.io/estuary/source-iterate:v1
-- Jira (legacy)
-  - [Configuration](./jira-legacy.md)
-  - Package - ghcr.io/estuary/source-jira-legacy:v2
 - Jira
   - [Configuration](./jira-native.md)
   - Package - ghcr.io/estuary/source-jira-native:v3
@@ -282,9 +276,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Salesforce
   - [Configuration](./Salesforce/salesforce-native.md)
   - Package - ghcr.io/estuary/source-salesforce-native:v1
-- Salesforce - Real-time data (deprecated)
-  - [Configuration](./Salesforce/)
-  - Package - ghcr.io/estuary/source-salesforce-next:v1
 - Sentry
   - [Configuration](./sentry.md)
   - Package - ghcr.io/estuary/source-sentry:v2
@@ -297,9 +288,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Shopify
   - [Configuration](./shopify-native.md)
   - Package - ghcr.io/estuary/source-shopify-native:v2
-- Shopify (deprecated)
-  - [Configuration](./shopify.md)
-  - Package - ghcr.io/estuary/source-shopify:v1
 - Smartsheet
   - [Configuration](./smartsheet.md)
   - Package - ghcr.io/estuary/source-smartsheet:v1
@@ -309,9 +297,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Stripe Real-time
   - [Configuration](./stripe-realtime.md)
   - Package - ghcr.io/estuary/source-stripe-native:v1
-- Stripe (deprecated)
-  - [Configuration](./stripe.md)
-  - Package - ghcr.io/estuary/source-stripe:v3
 - Twilio
   - [Configuration](./twilio.md)
   - Package - ghcr.io/estuary/source-twilio:v2
@@ -321,9 +306,6 @@ All Estuary connectors capture data in real time, as it appears in the source sy
 - Zendesk Chat
   - [Configuration](./zendesk-chat.md)
   - Package - ghcr.io/estuary/source-zendesk-chat:v1
-- Zendesk Support (deprecated)
-  - [Configuration](./zendesk-support.md)
-  - Package - ghcr.io/estuary/source-zendesk-support:v2
 - Zendesk Support Real-Time
   - [Configuration](./zendesk-support-native.md)
   - Package - ghcr.io/estuary/source-zendesk-support-native:v1
@@ -348,12 +330,6 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Amazon Ads
   - [Configuration](./amazon-ads.md)
   - Package - ghcr.io/estuary/source-amazon-ads:v2
-- Amazon SQS
-  - [Configuration](./amazon-sqs-native.md)
-  - Package - ghcr.io/estuary/source-sqs:v1
-- Amazon SQS (deprecated)
-  - [Configuration](./amazon-sqs.md)
-  - Package - ghcr.io/estuary/source-amazon-sqs:v1
 - Amplitude
   - [Configuration](./amplitude.md)
   - Package - ghcr.io/estuary/source-amplitude:v2
@@ -363,9 +339,6 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Braze
   - [Configuration](./braze.md)
   - Package - ghcr.io/estuary/source-braze:v1
-- Chargebee (deprecated)
-  - [Configuration](./chargebee.md)
-  - Package - ghcr.io/estuary/source-chargebee:v1
 - Confluence
   - [Configuration](./confluence.md)
   - Package - ghcr.io/estuary/source-confluence:v1
@@ -387,30 +360,15 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Google Search Console
   - [Configuration](./google-search-console.md)
   - Package - ghcr.io/estuary/source-google-search-console:v2
-- Greenhouse (deprecated)
-  - [Configuration](./greenhouse.md)
-  - Package - ghcr.io/estuary/source-greenhouse:v1
 - Harvest
   - [Configuration](./harvest.md)
   - Package - ghcr.io/estuary/source-harvest:v1
 - Instagram
   - [Configuration](./instagram.md)
   - Package - ghcr.io/estuary/source-instagram:v1
-- Intercom (deprecated)
-  - [Configuration](./intercom.md)
-  - Package - ghcr.io/estuary/source-intercom:v1
-- Jira (deprecated)
-  - [Configuration](./jira.md)
-  - Package - ghcr.io/estuary/source-jira:v1
-- Klaviyo (deprecated)
-  - [Configuration](./klaviyo.md)
-  - Package - ghcr.io/estuary/source-klaviyo:v1
 - LinkedIn Ads
   - [Configuration](./linkedin-ads.md)
   - Package - ghcr.io/estuary/source-linkedin-ads:v2
-- Mailchimp (deprecated)
-  - [Configuration](./mailchimp.md)
-  - Package - ghcr.io/estuary/source-mailchimp:v3
 - Marketo
   - [Configuration](./marketo.md)
   - Package - ghcr.io/estuary/source-marketo:v1
@@ -429,9 +387,6 @@ Typically, we enable SaaS connectors from third parties to allow more diverse da
 - Recharge
   - [Configuration](./recharge.md)
   - Package - ghcr.io/estuary/source-recharge:v1
-- Salesforce - Historical data (deprecated)
-  - [Configuration](./Salesforce/)
-  - Package - ghcr.io/estuary/source-salesforce:v1
 - SendGrid
   - [Configuration](./sendgrid.md)
   - Package - ghcr.io/estuary/source-sendgrid:v1

--- a/docs/reference/Connectors/capture-connectors/README.md
+++ b/docs/reference/Connectors/capture-connectors/README.md
@@ -4,119 +4,161 @@ description: Browse Estuary's list of capture connectors for databases, SaaS app
 
 # Capture Connectors
 
-Estuary's available capture connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.
-
-Also listed are links to the most recent Docker images for each connector. You'll need these to write Data Flow specifications manually (if you're [developing locally](../../../concepts/flowctl.md)). If you're using the Estuary web app, they aren't necessary.
+Estuary's available capture connectors are listed in this section. Each connector has a unique set of requirements for configuration; follow the connector link for a full reference on the system's requirements, properties, and best practices.
 
 Estuary is actively developing new connectors, so check back regularly for the latest additions. We’re prioritizing the development of high-scale technological systems, as well as client needs.
 
 ## Available capture connectors
 
-### Estuary connectors
+### SQL CDC connectors
 
-These connectors are created by Estuary. We prioritize high-scale technology systems for development.
+The SQL CDC group of database connectors share some common features, from
+real-time CDC ingestion to [extra backfill options](/reference/backfilling-data/#resource-configuration-backfill-modes)
+and other [advanced features](/guides/customize-dataflows/#sql-captures).
 
-All Estuary connectors capture data in real time, as it appears in the source system.
-
-- [Ada](./ada.md)
-- [Airtable](./airtable-native.md)
 - [AlloyDB](./alloydb.md)
-- [Alpaca](./alpaca.md)
+- [Amazon RDS SQL Server](./SQLServer/amazon-rds-sqlserver.md)
+- [Azure SQL Server](./SQLServer/)
+- [Google Cloud SQL Server](./SQLServer/google-cloud-sql-sqlserver.md)
+- [MariaDB](./MariaDB/)
+- [Microsoft SQL Server](./SQLServer/)
+- [MySQL](./MySQL/)
+- [OracleDB](./OracleDB/)
+- [PostgreSQL](./PostgreSQL/)
+
+### Other database connectors
+
+Besides [SQL CDC](#sql-cdc-connectors) databases, Estuary also provides capture
+connectors for batch and NoSQL databases.
+
 - [Amazon DocumentDB](./MongoDB/amazon-documentdb.md)
 - [Amazon Dynamodb](./amazon-dynamodb.md)
-- [Amazon Kinesis](./amazon-kinesis.md)
-- [Amazon RDS SQL Server](./SQLServer/amazon-rds-sqlserver.md)
+- [Azure Cosmos DB](./MongoDB/azure-cosmosdb.md)
+- [Google Firestore](./google-firestore.md)
+- [IBM Db2 Batch](./db2-batch.md)
+- [Microsoft SQL Server Batch](./SQLServer/sqlserver-batch.md)
+- [MongoDB](./MongoDB/mongodb.md)
+- [MySQL Batch](./MySQL/mysql-batch.md)
+- [OracleDB Batch](./OracleDB/oracle-batch.md)
+- [PostgreSQL Batch](./PostgreSQL/postgres-batch.md)
+
+### Data warehouse connectors
+
 - [Amazon Redshift](./redshift-batch.md)
+- [BigQuery](./bigquery-batch.md)
+- [Snowflake](./snowflake.md)
+
+### File connectors
+
+File connectors share features like parser configuration. Except for the
+spreadsheet-specific connectors, supported file types include Avro, JSON, CSV,
+Protobuf, W3C Extended Log, and Parquet.
+
 - [Amazon S3](./amazon-s3.md)
+- [Azure Blob Storage](./azure-blob-storage.md)
+- [Dropbox](./dropbox.md)
+- [Google Cloud Storage](./gcs.md)
+- [Google Drive](./google-drive.md)
+- [Google Sheets](./google-sheets.md)
+- [HTTP file](./http-file.md)
+- [OneDrive](./onedrive.md)
+- [SFTP](./sftp.md)
+- [SharePoint](./sharepoint.md)
+- [Smartsheet](./smartsheet.md)
+
+### Event connectors
+
+Integrations with streaming systems, queue services, and webhooks.
+
+- [Amazon Kinesis](./amazon-kinesis.md)
 - [Amazon SQS](./amazon-sqs-native.md)
 - [Apache Kafka](./apache-kafka.md)
-- [Apple App Store](./apple-app-store.md)
-- [AppsFlyer](./appsflyer.md)
-- [Asana](./asana.md)
-- [Ashby](./ashby.md)
-- [Azure Blob Storage](./azure-blob-storage.md)
-- [Azure Cosmos DB](./MongoDB/azure-cosmosdb.md)
-- [Azure SQL Server](./SQLServer/)
-- [BigQuery](./bigquery-batch.md)
-- [Braintree](./braintree.md)
-- [Brevo](./brevo.md)
-- [Calendly](./calendly.md)
-- [Chargebee](./chargebee-native.md)
-- [Commercetools](./commercetools.md)
-- [Criteo](./criteo.md)
-- [Datadog](./datadog.md)
 - [Datadog ingest (webhook)](./http-ingest/datadog-ingest.md)
-- [Dropbox](./dropbox.md)
+- [Google Cloud Pub/Sub](./google-pubsub.md)
+- [HTTP ingest (webhook)](./http-ingest/http-ingest.md)
+- [Intercom ingest (webhook)](./http-ingest/intercom-ingest.md)
+- [Jira ingest (webhook)](./http-ingest/jira-ingest.md)
+- [Twilio ingest (webhook)](./http-ingest/twilio-ingest.md)
+
+### SaaS connectors
+
+#### Marketing, ads, and socials
+
+- [AppsFlyer](./appsflyer.md)
+- [Brevo](./brevo.md)
+- [Criteo](./criteo.md)
 - [Facebook Marketing](./facebook-marketing-native.md)
+- [Google Ads](./google-ads.md)
+- [Impact](./impact.md)
+- [Iterable](./iterable-native.md)
+- [Klaviyo](./klaviyo-native.md)
+- [LinkedIn Pages](./linkedin-pages.md)
+- [Mailchimp](./mailchimp-native.md)
+
+#### BI and analytics
+
+- [Google Analytics BigQuery Exports](./google-analytics-4-bigquery-exports.md)
+- [Google Analytics Data API](./google-analytics-data-api-native.md)
+- [Looker](./looker.md)
+- [NetSuite SuiteAnalytics](./netsuite-suiteanalytics.md)
+- [NetSuite SuiteQL](./netsuite-suiteql.md)
+
+#### CRMs, sales, and support
+
+- [Ada](./ada.md)
 - [Front](./front.md)
 - [Gainsight NXT](./gainsight-nxt.md)
 - [Genesys](./genesys.md)
-- [GitHub](./github.md)
-- [Gladly](./gladly.md)
 - [Gong](./gong.md)
-- [Google Ads](./google-ads.md)
-- [Google Analytics BigQuery Exports](./google-analytics-4-bigquery-exports.md)
-- [Google Analytics Data API](./google-analytics-data-api-native.md)
-- [Google Cloud Storage](./gcs.md)
-- [Google Firestore](./google-firestore.md)
-- [Google Cloud Pub/Sub](./google-pubsub.md)
-- [Google Cloud SQL Server](./SQLServer/google-cloud-sql-sqlserver.md)
-- [Google Drive](./google-drive.md)
-- [Google Play](./google-play.md)
-- [Google Sheets](./google-sheets.md)
-- [Greenhouse](./greenhouse-native.md)
-- [HTTP file](./http-file.md)
-- [HTTP ingest (webhook)](./http-ingest/http-ingest.md)
 - [Hubspot](./HubSpot-real-time.md)
-- [IBM Db2 Batch](./db2-batch.md)
-- [Impact](./impact.md)
-- [Incident.io](./incident-io.md)
 - [Intercom](./intercom-native.md)
-- [Intercom ingest (webhook)](./http-ingest/intercom-ingest.md)
-- [Iterable](./iterable-native.md)
-- [Iterate](./iterate.md)
-- [Jira](./jira-native.md)
-- [Jira ingest (webhook)](./http-ingest/jira-ingest.md)
-- [Klaviyo](./klaviyo-native.md)
-- [LinkedIn Pages](./linkedin-pages.md)
-- [Looker](./looker.md)
-- [Mailchimp](./mailchimp-native.md)
-- [MariaDB](./MariaDB/)
-- [Microsoft Dynamics 365 Finance and Operations](./dynamics-365-finance-and-operations.md)
-- [Microsoft SQL Server](./SQLServer/)
-- [Microsoft SQL Server Batch](./SQLServer/sqlserver-batch.md)
-- [Monday](./monday.md)
-- [MongoDB](./MongoDB/mongodb.md)
-- [MySQL](./MySQL/)
-- [MySQL Batch](./MySQL/mysql-batch.md)
-- [Navan](./navan.md)
-- [NetSuite SuiteAnalytics](./netsuite-suiteanalytics.md)
-- [NetSuite SuiteQL](./netsuite-suiteql.md)
-- [OneDrive](./onedrive.md)
-- [OracleDB](./OracleDB/)
-- [OracleDB Batch](./OracleDB/oracle-batch.md)
 - [Outreach](./outreach.md)
-- [Pendo](./pendo.md)
-- [PostgreSQL](./PostgreSQL/)
-- [PostgreSQL Batch](./PostgreSQL/postgres-batch.md)
-- [Qualtrics](./qualtrics.md)
-- [QuickBooks](./quickbooks.md)
 - [RingCentral](./ringcentral.md)
-- [Sage Intacct](./sage-intacct.md)
 - [Salesforce](./Salesforce/salesforce-native.md)
-- [Sentry](./sentry.md)
-- [SFTP](./sftp.md)
-- [SharePoint](./sharepoint.md)
-- [Shopify](./shopify-native.md)
-- [Smartsheet](./smartsheet.md)
-- [Snowflake](./snowflake.md)
-- [Stripe](./stripe-realtime.md)
-- [Twilio](./twilio.md)
-- [Twilio ingest (webhook)](./http-ingest/twilio-ingest.md)
 - [Zendesk Chat](./zendesk-chat.md)
 - [Zendesk Support](./zendesk-support-native.md)
 - [Zoho CRM](./zoho-crm.md)
+
+#### Commerce and payments
+
+- [Alpaca](./alpaca.md)
+- [Braintree](./braintree.md)
+- [Chargebee](./chargebee-native.md)
+- [Commercetools](./commercetools.md)
+- [Gladly](./gladly.md)
+- [QuickBooks](./quickbooks.md)
+- [Shopify](./shopify-native.md)
+- [Stripe](./stripe-realtime.md)
 - [Zuora](./zuora.md)
+
+#### Finance, hiring, and operations
+
+- [Ashby](./ashby.md)
+- [Greenhouse](./greenhouse-native.md)
+- [Microsoft Dynamics 365 Finance and Operations](./dynamics-365-finance-and-operations.md)
+- [Sage Intacct](./sage-intacct.md)
+
+#### Workflow and incidents
+
+- [Airtable](./airtable-native.md)
+- [Asana](./asana.md)
+- [Calendly](./calendly.md)
+- [Datadog](./datadog.md)
+- [GitHub](./github.md)
+- [Incident.io](./incident-io.md)
+- [Jira](./jira-native.md)
+- [Monday](./monday.md)
+- [Navan](./navan.md)
+- [Sentry](./sentry.md)
+
+#### Other applications
+
+- [Apple App Store](./apple-app-store.md)
+- [Google Play](./google-play.md)
+- [Iterate](./iterate.md)
+- [Pendo](./pendo.md)
+- [Qualtrics](./qualtrics.md)
+- [Twilio](./twilio.md)
 
 ### Third party connectors
 

--- a/docs/reference/Connectors/materialization-connectors/README.md
+++ b/docs/reference/Connectors/materialization-connectors/README.md
@@ -15,163 +15,58 @@ In the future, other open-source materialization connectors from third parties c
 
 ## Available materialization connectors
 
-* AlloyDB
-  * [Configuration](./alloydb.md)
-  * Package - ghcr.io/estuary/materialize-alloydb:v5
-* Amazon DynamoDB
-  * [Configuration](./amazon-dynamodb.md)
-  * Package - ghcr.io/estuary/materialize-dynamodb:v1
-* Amazon EventBridge
-  * [Configuration](./amazon-eventbridge.md)
-  * Package - ghcr.io/estuary/materialize-eventbridge:v1
-* Amazon MySQL
-  * [Configuration](./MySQL/amazon-rds-mysql.md)
-  * Package - ghcr.io/estuary/materialize-amazon-rds-mysql:v2
-* Amazon PostgreSQL
-  * [Configuration](./PostgreSQL/amazon-rds-postgres.md)
-  * Package - ghcr.io/estuary/materialize-amazon-rds-postgres:v5
-* Amazon Redshift
-  * [Configuration](./amazon-redshift.md)
-  * Package - ghcr.io/estuary/materialize-redshift:v2
-* Amazon SNS
-  * [Configuration](./amazon-sns.md)
-  * Package - ghcr.io/estuary/materialize-sns:v1
-* Amazon SQL Server
-  * [Configuration](./SQLServer/amazon-rds-sqlserver.md)
-  * Package - ghcr.io/estuary/materialize-amazon-rds-sqlserver:v2
-* Apache Iceberg Tables
-  * [Configuration](./apache-iceberg/apache-iceberg.md)
-  * Package — ghcr.io/estuary/materialize-iceberg:v1
-* Apache Iceberg Tables in S3 (delta updates)
-  * [Configuration](./amazon-s3-iceberg.md)
-  * Package — ghcr.io/estuary/materialize-s3-iceberg:v2
-* Apache Kafka
-  * [Configuration](./apache-kafka.md)
-  * Package — ghcr.io/estuary/materialize-kafka:v1
-* Apache Parquet Files in Azure Blob Storage
-  * [Configuration](./azure-blob-parquet.md)
-  * Package — ghcr.io/estuary/materialize-azure-blob-parquet:v1
-* Apache Parquet Files in GCS
-  * [Configuration](./google-gcs-parquet.md)
-  * Package — ghcr.io/estuary/materialize-gcs-parquet:v1
-* Apache Parquet Files in S3
-  * [Configuration](./amazon-s3-parquet.md)
-  * Package — ghcr.io/estuary/materialize-s3-parquet:v3
-* Azure Fabric Warehouse
-  * [Configuration](./azure-fabric-warehouse.md)
-  * Package - ghcr.io/estuary/materialize-azure-fabric-warehouse:v1
-* Azure SQL Server
-  * [Configuration](./SQLServer/)
-  * Package - ghcr.io/estuary/materialize-sqlserver:v2
-* Bauplan
-  * [Configuration](./apache-iceberg/bauplan.md)
-  * Package - ghcr.io/estuary/materialize-bauplan:v1
-* Bytewax
-  * [Configuration](./Dekaf/bytewax.md)
-* ClickHouse
-  * [Configuration](./ClickHouse.md)
-  * Package - ghcr.io/estuary/materialize-clickhouse:v1
-* ClickHouse (Dekaf)
-  * [Configuration](./Dekaf/clickhouse.md)
-* CSV Files in GCS
-  * [Configuration](./google-gcs-csv.md)
-  * Package — ghcr.io/estuary/materialize-gcs-csv:v1
-* CSV Files in S3
-  * [Configuration](./amazon-s3-csv.md)
-  * Package — ghcr.io/estuary/materialize-s3-csv:v1
-* Databricks
-  * [Configuration](./databricks.md)
-  * Package — ghcr.io/estuary/materialize-databricks:v3
-* Dekaf
-  * [Configuration](./Dekaf/dekaf.md)
-* Dremio
-  * [Configuration](./apache-iceberg/dremio.md)
-  * Package - ghcr.io/estuary/materialize-dremio:v1
-* Elasticsearch
-  * [Configuration](./Elasticsearch/Elasticsearch.md)
-  * Package — ghcr.io/estuary/materialize-elasticsearch:v3
-* Google BigQuery
-  * [Configuration](./BigQuery.md)
-  * Package — ghcr.io/estuary/materialize-bigquery:v3
-* Google Cloud Bigtable
-  * [Configuration](./google-bigtable.md)
-  * Package — ghcr.io/estuary/materialize-bigtable:v1
-* Google Cloud MySQL
-  * [Configuration](./MySQL/google-cloud-sql-mysql.md)
-  * Package - ghcr.io/estuary/materialize-google-cloud-sql-mysql:v2
-* Google Cloud PostgreSQL
-  * [Configuration](./PostgreSQL/google-cloud-sql-postgres.md)
-  * Package - ghcr.io/estuary/materialize-google-cloud-sql-postgres:v5
-* Google Cloud Pub/Sub
-  * [Configuration](./google-pubsub.md)
-  * Package - ghcr.io/estuary/materialize-google-pubsub:v1
-* Google Cloud SQL Server
-  * [Configuration](./SQLServer/google-cloud-sql-sqlserver.md)
-  * Package - ghcr.io/estuary/materialize-google-cloud-sql-sqlserver:v2
-* Google Sheets
-  * [Configuration](./Google-sheets.md)
-  * Package - ghcr.io/estuary/materialize-google-sheets:v2
-* Google Spanner
-  * [Configuration](./google-spanner.md)
-  * Package - ghcr.io/estuary/materialize-spanner:v1
-* HTTP Webhook
-  * [Configuration](./http-webhook.md)
-  * Package - ghcr.io/estuary/materialize-webhook:v1
-* HubSpot
-  * [Configuration](./hubspot.md)
-  * Package - ghcr.io/estuary/materialize-hubspot:v1
-* Imply Polaris
-  * [Configuration](./Dekaf/imply-polaris.md)
-* Materialize
-  * [Configuration](./Dekaf/materialize.md)
-* MongoDB
-  * [Configuration](./mongodb.md)
-  * Package - ghcr.io/estuary/materialize-mongodb:v1
-* MotherDuck
-  * [Configuration](./motherduck.md)
-  * Package - ghcr.io/estuary/materialize-motherduck:v4
-* MySQL
-  * [Configuration](./MySQL/)
-  * Package - ghcr.io/estuary/materialize-mysql:v2
-* MySQL Heatwave
-  * [Configuration](./mysql-heatwave.md)
-  * Package - ghcr.io/estuary/materialize-mysql-heatwave:v2
-* OpenSearch
-  * [Configuration](./Elasticsearch/opensearch.md)
-  * Package - ghcr.io/estuary/materialize-opensearch:v3
-* Pinecone
-  * [Configuration](./pinecone.md)
-  * Package — ghcr.io/estuary/materialize-pinecone:v1
-* PostgreSQL
-  * [Configuration](./PostgreSQL/)
-  * Package — ghcr.io/estuary/materialize-postgres:v5
-* Rockset (Deprecated)
-  * [Configuration](./Rockset.md)
-  * Package — ghcr.io/estuary/materialize-rockset:v2
-* SingleStore
-  * [Configuration](./MySQL/singlestore-mysql.md)
-  * Package - ghcr.io/estuary/materialize-singlestore:v2
-* SingleStore (Dekaf)
-  * [Configuration](./Dekaf/singlestore.md)
-* Slack
-  * [Configuration](./slack.md)
-  * Package - ghcr.io/estuary/materialize-slack:v1
-* Snowflake
-  * [Configuration](./Snowflake.md)
-  * Package — ghcr.io/estuary/materialize-snowflake:v4
-* SQLite
-  * [Configuration](./SQLite.md)
-  * Package — ghcr.io/estuary/materialize-sqlite:v1
-* SQL Server
-  * [Configuration](./SQLServer/)
-  * Package - ghcr.io/estuary/materialize-sqlserver:v2
-* Startree
-  * [Configuration](./Dekaf/startree.md)
-* Supabase
-  * [Configuration](./PostgreSQL/supabase.md)
-  * Package - ghcr.io/estuary/materialize-supabase-postgres:v5
-* TimescaleDB
-  * [Configuration](./timescaledb.md)
-  * Package - ghcr.io/estuary/materialize-timescaledb:v5
-* Tinybird
-  * [Configuration](./Dekaf/tinybird.md)
+* [AlloyDB](./alloydb.md)
+* [Amazon DynamoDB](./amazon-dynamodb.md)
+* [Amazon EventBridge](./amazon-eventbridge.md)
+* [Amazon MySQL](./MySQL/amazon-rds-mysql.md)
+* [Amazon PostgreSQL](./PostgreSQL/amazon-rds-postgres.md)
+* [Amazon Redshift](./amazon-redshift.md)
+* [Amazon SNS](./amazon-sns.md)
+* [Amazon SQL Server](./SQLServer/amazon-rds-sqlserver.md)
+* [Apache Iceberg Tables](./apache-iceberg/apache-iceberg.md)
+* [Apache Iceberg Tables in S3 (delta updates)](./amazon-s3-iceberg.md)
+* [Apache Kafka](./apache-kafka.md)
+* [Apache Parquet Files in Azure Blob Storage](./azure-blob-parquet.md)
+* [Apache Parquet Files in GCS](./google-gcs-parquet.md)
+* [Apache Parquet Files in S3](./amazon-s3-parquet.md)
+* [Azure Fabric Warehouse](./azure-fabric-warehouse.md)
+* [Azure SQL Server](./SQLServer/)
+* [Bauplan](./apache-iceberg/bauplan.md)
+* [Bytewax](./Dekaf/bytewax.md)
+* [ClickHouse](./ClickHouse.md)
+* [ClickHouse (Dekaf)](./Dekaf/clickhouse.md)
+* [CSV Files in GCS](./google-gcs-csv.md)
+* [CSV Files in S3](./amazon-s3-csv.md)
+* [Databricks](./databricks.md)
+* [Dekaf](./Dekaf/dekaf.md)
+* [Dremio](./apache-iceberg/dremio.md)
+* [Elasticsearch](./Elasticsearch/Elasticsearch.md)
+* [Google BigQuery](./BigQuery.md)
+* [Google Cloud Bigtable](./google-bigtable.md)
+* [Google Cloud MySQL](./MySQL/google-cloud-sql-mysql.md)
+* [Google Cloud PostgreSQL](./PostgreSQL/google-cloud-sql-postgres.md)
+* [Google Cloud Pub/Sub](./google-pubsub.md)
+* [Google Cloud SQL Server](./SQLServer/google-cloud-sql-sqlserver.md)
+* [Google Sheets](./Google-sheets.md)
+* [Google Spanner](./google-spanner.md)
+* [HTTP Webhook](./http-webhook.md)
+* [HubSpot](./hubspot.md)
+* [Imply Polaris (Dekaf)](./Dekaf/imply-polaris.md)
+* [Materialize (Dekaf)](./Dekaf/materialize.md)
+* [MongoDB](./mongodb.md)
+* [MotherDuck](./motherduck.md)
+* [MySQL](./MySQL/)
+* [MySQL Heatwave](./mysql-heatwave.md)
+* [OpenSearch](./Elasticsearch/opensearch.md)
+* [Pinecone](./pinecone.md)
+* [PostgreSQL](./PostgreSQL/)
+* [SingleStore](./MySQL/singlestore-mysql.md)
+* [SingleStore (Dekaf)](./Dekaf/singlestore.md)
+* [Slack](./slack.md)
+* [Snowflake](./Snowflake.md)
+* [SQLite](./SQLite.md)
+* [SQL Server](./SQLServer/)
+* [Startree (Dekaf)](./Dekaf/startree.md)
+* [Supabase](./PostgreSQL/supabase.md)
+* [TimescaleDB](./timescaledb.md)
+* [Tinybird (Dekaf)](./Dekaf/tinybird.md)

--- a/docs/reference/Connectors/materialization-connectors/README.md
+++ b/docs/reference/Connectors/materialization-connectors/README.md
@@ -4,9 +4,7 @@ description: Browse Estuary's list of materialization connectors for warehouses,
 
 # Materialization Connectors
 
-Estuary's available materialization connectors are listed in this section. Each connector has a unique set of requirements for configuration; these are linked below the connector name.
-
-Also listed are links to the most recent Docker images for each connector. You'll need these to write Data Flow specifications manually (if you're [developing locally](../../../concepts/flowctl.md)). If you're using the Estuary web app, they aren't necessary.
+Estuary's available materialization connectors are listed in this section. Each connector has a unique set of requirements for configuration; follow the connector link for a full reference on the system's requirements, properties, and best practices.
 
 Estuary is actively developing new connectors, so check back regularly for the latest additions. We’re prioritizing the development of high-scale technological systems, as well as client needs.
 
@@ -15,58 +13,84 @@ In the future, other open-source materialization connectors from third parties c
 
 ## Available materialization connectors
 
+### Data warehouse and OLAP connectors
+
+* [Amazon Redshift](./amazon-redshift.md)
+* [Azure Fabric Warehouse](./azure-fabric-warehouse.md)
+* [ClickHouse](./ClickHouse.md)
+* [Databricks](./databricks.md)
+* [Google BigQuery](./BigQuery.md)
+* [MotherDuck](./motherduck.md)
+* [Snowflake](./Snowflake.md)
+
+### Database connectors
+
 * [AlloyDB](./alloydb.md)
 * [Amazon DynamoDB](./amazon-dynamodb.md)
-* [Amazon EventBridge](./amazon-eventbridge.md)
 * [Amazon MySQL](./MySQL/amazon-rds-mysql.md)
 * [Amazon PostgreSQL](./PostgreSQL/amazon-rds-postgres.md)
-* [Amazon Redshift](./amazon-redshift.md)
-* [Amazon SNS](./amazon-sns.md)
 * [Amazon SQL Server](./SQLServer/amazon-rds-sqlserver.md)
-* [Apache Iceberg Tables](./apache-iceberg/apache-iceberg.md)
-* [Apache Iceberg Tables in S3 (delta updates)](./amazon-s3-iceberg.md)
-* [Apache Kafka](./apache-kafka.md)
-* [Apache Parquet Files in Azure Blob Storage](./azure-blob-parquet.md)
-* [Apache Parquet Files in GCS](./google-gcs-parquet.md)
-* [Apache Parquet Files in S3](./amazon-s3-parquet.md)
-* [Azure Fabric Warehouse](./azure-fabric-warehouse.md)
 * [Azure SQL Server](./SQLServer/)
-* [Bauplan](./apache-iceberg/bauplan.md)
-* [Bytewax](./Dekaf/bytewax.md)
-* [ClickHouse](./ClickHouse.md)
-* [ClickHouse (Dekaf)](./Dekaf/clickhouse.md)
-* [CSV Files in GCS](./google-gcs-csv.md)
-* [CSV Files in S3](./amazon-s3-csv.md)
-* [Databricks](./databricks.md)
-* [Dekaf](./Dekaf/dekaf.md)
-* [Dremio](./apache-iceberg/dremio.md)
-* [Elasticsearch](./Elasticsearch/Elasticsearch.md)
-* [Google BigQuery](./BigQuery.md)
 * [Google Cloud Bigtable](./google-bigtable.md)
 * [Google Cloud MySQL](./MySQL/google-cloud-sql-mysql.md)
 * [Google Cloud PostgreSQL](./PostgreSQL/google-cloud-sql-postgres.md)
-* [Google Cloud Pub/Sub](./google-pubsub.md)
 * [Google Cloud SQL Server](./SQLServer/google-cloud-sql-sqlserver.md)
-* [Google Sheets](./Google-sheets.md)
 * [Google Spanner](./google-spanner.md)
-* [HTTP Webhook](./http-webhook.md)
-* [HubSpot](./hubspot.md)
-* [Imply Polaris (Dekaf)](./Dekaf/imply-polaris.md)
-* [Materialize (Dekaf)](./Dekaf/materialize.md)
 * [MongoDB](./mongodb.md)
-* [MotherDuck](./motherduck.md)
 * [MySQL](./MySQL/)
 * [MySQL Heatwave](./mysql-heatwave.md)
-* [OpenSearch](./Elasticsearch/opensearch.md)
 * [Pinecone](./pinecone.md)
 * [PostgreSQL](./PostgreSQL/)
 * [SingleStore](./MySQL/singlestore-mysql.md)
-* [SingleStore (Dekaf)](./Dekaf/singlestore.md)
-* [Slack](./slack.md)
-* [Snowflake](./Snowflake.md)
 * [SQLite](./SQLite.md)
 * [SQL Server](./SQLServer/)
-* [Startree (Dekaf)](./Dekaf/startree.md)
 * [Supabase](./PostgreSQL/supabase.md)
 * [TimescaleDB](./timescaledb.md)
-* [Tinybird (Dekaf)](./Dekaf/tinybird.md)
+
+### Lakehouse connectors
+
+* [Apache Iceberg Tables](./apache-iceberg/apache-iceberg.md)
+* [Apache Iceberg Tables in S3 (delta updates)](./amazon-s3-iceberg.md)
+* [Bauplan](./apache-iceberg/bauplan.md)
+* [Dremio](./apache-iceberg/dremio.md)
+
+### File connectors
+
+* [Apache Parquet Files in Azure Blob Storage](./azure-blob-parquet.md)
+* [Apache Parquet Files in GCS](./google-gcs-parquet.md)
+* [Apache Parquet Files in S3](./amazon-s3-parquet.md)
+* [CSV Files in GCS](./google-gcs-csv.md)
+* [CSV Files in S3](./amazon-s3-csv.md)
+* [Google Sheets](./Google-sheets.md)
+
+### Event connectors
+
+Integrations with streaming services, queues, and event-based systems outside
+of Estuary's [Dekaf connectors](#dekaf-connectors).
+
+* [Amazon EventBridge](./amazon-eventbridge.md)
+* [Amazon SNS](./amazon-sns.md)
+* [Apache Kafka](./apache-kafka.md)
+* [Elasticsearch](./Elasticsearch/Elasticsearch.md)
+* [Google Cloud Pub/Sub](./google-pubsub.md)
+* [HTTP Webhook](./http-webhook.md)
+* [OpenSearch](./Elasticsearch/opensearch.md)
+
+### SaaS/reverse ETL connectors
+
+* [HubSpot](./hubspot.md)
+* [Slack](./slack.md)
+
+### Dekaf connectors
+
+[Dekaf](../dekaf/) is Estuary's Kafka-compatible API. Materializations using
+Dekaf send data to destinations via the destination's Kafka integration.
+
+* [Bytewax](./Dekaf/bytewax.md)
+* [ClickHouse (Dekaf)](./Dekaf/clickhouse.md)
+* [Dekaf](./Dekaf/dekaf.md)
+* [Imply Polaris](./Dekaf/imply-polaris.md)
+* [Materialize](./Dekaf/materialize.md)
+* [SingleStore (Dekaf)](./Dekaf/singlestore.md)
+* [Startree](./Dekaf/startree.md)
+* [Tinybird](./Dekaf/tinybird.md)

--- a/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-iceberg/bauplan.md
@@ -21,3 +21,35 @@ Bauplan exposes a standard Iceberg REST catalog endpoint. When configuring the m
 - **Catalog Authentication**: Select **OAuth 2.0 Client Credentials** and supply the client ID and secret from your Bauplan account
 
 For all other configuration options (EMR Serverless compute, staging bucket, IAM roles, bindings), refer to the [Apache Iceberg connector docs](./apache-iceberg.md).
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-bauplan:v1
+        config:
+          url: https://api.use1.aprod.bauplanlabs.com/iceberg
+          warehouse: default
+          namespace: <namespace>
+          base_location: s3://<bucket>/iceberg
+          credentials:
+            auth_type: OAuth 2.0 Client Credentials
+            oauth2_server_uri: v1/oauth/tokens
+            credential: <client-id>:<client-secret>
+          compute:
+            region: us-east-1
+            application_id: <emr-app-id>
+            execution_role_arn: <emr-arn>
+            bucket: <bucket>
+            credentials:
+              auth_type: AWSAccessKey
+              aws_access_key_id: <aws-access-key-id>
+              aws_secret_access_key: <aws-secret-access-key>
+    bindings:
+      - resource:
+          table: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```

--- a/docs/reference/Connectors/materialization-connectors/apache-iceberg/dremio.md
+++ b/docs/reference/Connectors/materialization-connectors/apache-iceberg/dremio.md
@@ -1,3 +1,7 @@
+---
+description: Materialize data into a Dremio data lake. This variation of Estuary's Apache Iceberg connector uses the Dremio Cloud catalog.
+---
+
 # Dremio
 
 [Dremio](https://www.dremio.com) is a lakehouse platform with a built-in
@@ -55,3 +59,36 @@ fail when the token expires. Use a service user for production deployments.
 For all other configuration options (EMR Serverless compute, staging bucket,
 IAM roles, bindings), refer to the [Apache Iceberg connector
 docs](./apache-iceberg.md).
+
+### Sample
+
+```yaml
+materializations:
+  ${PREFIX}/${mat_name}:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-dremio:v1
+        config:
+          url: https://catalog.dremio.cloud/api/iceberg
+          warehouse: <dremio-catalog-name>
+          namespace: <namespace>
+          base_location: s3://<bucket>
+          credentials:
+            auth_type: OAuth 2.0 Client Credentials
+            oauth2_server_uri: https://login.dremio.cloud/oauth/token
+            credential: <client-id>:<client-secret>
+            scope: dremio.all
+          compute:
+            region: us-east-1
+            application_id: <emr-app-id>
+            execution_role_arn: <emr-arn>
+            bucket: <bucket>
+            credentials:
+              auth_type: AWSAccessKey
+              aws_access_key_id: <aws-access-key-id>
+              aws_secret_access_key: <aws-secret-access-key>
+    bindings:
+      - resource:
+          table: ${COLLECTION_NAME}
+        source: ${PREFIX}/${COLLECTION_NAME}
+```


### PR DESCRIPTION
**Description:**

We've been using the same list style for our capture and materialization connector landing pages for a while now and it no longer really works for us.

One issue is that each connector includes the image name and tag. Whenever the default connector tag gets updated, the list needs to be updated as well. The detail doesn't really make sense to include on these pages; it's not presented in the order someone using the product would actually need it, and connector pages should generally be providing this as part of the spec example.

The other issue is that the list, as-is, is mostly redundant. The sidebar also lists all the available connectors. The landing page should provide unique information that a user would find helpful.

To address these issues, I've:
* Streamlined the connector lists: removing the extraneous image/tag info as well as removing deprecated connectors from the list for a cleaner experience.
* Grouped connectors by category. So if someone is particularly interested in database connectors, they can specifically look at that section, or commerce/payment SaaS connectors or whatever. This provides an at-a-glance spread of our different integration options.
* There was also a slight side-quest to add spec examples to Dremio and Bauplan pages to ensure they had their image names and tags.

For example, currently-served version is at the left, proposed changes on the right:

<img width="1400" height="787" alt="connector-landing-page-lists" src="https://github.com/user-attachments/assets/2c1f5e84-531f-45a9-ad13-1a80922c1b74" />

Docs-only change; no code updates.

**Notes for reviewers:**

Looking for feedback from the integrations team. Does this seem helpful? Any reservations about maintaining category lists? And please let me know if you have any thoughts about the categories themselves, or if you think any connectors should be categorized elsewhere.

Thanks for reviewing!