### PR TITLE
materialize-snowflake: only use queryID channel for one query

### DIFF
--- a/materialize-snowflake/CHANGELOG.md
+++ b/materialize-snowflake/CHANGELOG.md
@@ -1,5 +1,10 @@
 # materialize-snowflake
 
+## 2026-09-11
+
+### Fixed
+- Fix channel closed panic when debug logging is enabled.
+
 ## 2026-08-25
 
 ### Added

--- a/materialize-snowflake/snowflake.go
+++ b/materialize-snowflake/snowflake.go
@@ -1190,11 +1190,12 @@ func (d *transactor) Acknowledge(ctx context.Context, statePatches []json.RawMes
 func (d *transactor) runStoreQuery(ctx context.Context, item *checkpointItem, path []string) error {
 	isMerge := strings.HasPrefix(item.Query, "\nMERGE INTO")
 
+	queryCtx := ctx
 	queryIDs := make(chan string, 1)
 	if isMerge {
-		ctx = sf.WithQueryIDChan(ctx, queryIDs)
+		queryCtx = sf.WithQueryIDChan(ctx, queryIDs)
 	}
-	rows, err := d.db.QueryContext(ctx, item.Query)
+	rows, err := d.db.QueryContext(queryCtx, item.Query)
 	if err != nil {
 		return fmt.Errorf("running ack query: %w", err)
 	}


### PR DESCRIPTION
This channel attached to the context can only be used for a single query since it is closed after being written to.  Save the original context for additional calls in this function.

**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: https://github.com/estuary/connectors/pull/5200
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
