### PR TITLE
materialize-snowflake: only use to_json if the flow_document is a variant column

### DIFF
--- a/materialize-snowflake/CHANGELOG.md
+++ b/materialize-snowflake/CHANGELOG.md
@@ -1,5 +1,12 @@
 # materialize-snowflake
 
+## 2026-09-12
+
+### Fixed
+- Support loading the `flow_document` from non-variant columns.  This can be
+  used along with a custom DDL and castToString to store the flow_document as a
+  string, which may be required if the document contains certain values.
+
 ## 2026-09-11
 
 ### Fixed

--- a/materialize-snowflake/sqlgen.go
+++ b/materialize-snowflake/sqlgen.go
@@ -281,7 +281,7 @@ ALTER TABLE {{$.Identifier}} ALTER COLUMN
 
 {{ define "loadQuery" }}
 {{ if $.Table.Document -}}
-SELECT {{ $.Table.Binding }}, TO_JSON({{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }})
+SELECT {{ $.Table.Binding }}, {{ if eq $.Table.Document.BareDDL "VARIANT" }}TO_JSON({{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}){{ else }}{{ $.Table.Identifier }}.{{ $.Table.Document.Identifier }}{{ end }}
 	FROM {{ $.Table.Identifier }}
 	JOIN (
 		SELECT {{ range $ind, $bound := $.Bounds }}


### PR DESCRIPTION
**Description:**

This is a workaround for the issue of Snowflake rounding large floats up and outside the range that can be parsed into a float64.

If the `flow_document` isn't a variant type, try to load it without passing it through `TO_JSON`.  When combined with TEXT as a field `DDL` and `castToString`, this allows storing the `flow_document` as a string and avoid the issue with float rounding.

**Workflow steps:**

To workaround the Snowflake float rounding issue.  Use DDL and castToString.
```
      fields:
        require:
          flow_document:
            DDL: TEXT
            castToString: true
```

Backfill is required if the table contains the problematic float.  If the table is already created, you will also need `feature_flags: always_drop_tables_on_backfill` so that the table is recreated instead of truncated on backfill.

**Notes for reviewers:**




**Checklist:**

- [x] If fixing a regression, I have linked the PR that introduced the regression: [insert link]
- [x] If there are user-visible changes, `CHANGELOG.md` has been updated (see [CONTRIBUTING.md](../CONTRIBUTING.md#changelog-entries))
- [x] If there are user-facing behavior changes, documentation has been updated (see [documentation conventions](https://docs.google.com/document/d/1SRC9VS9zyCzWl3n4HXHbc4wPB1eLxJHkA2rtu9ZNokM/edit?usp=sharing)), or the docs PR is linked here: [insert link]
